### PR TITLE
Freeze exported AppConstants

### DIFF
--- a/app-constants.js
+++ b/app-constants.js
@@ -32,4 +32,4 @@ for (const v of kEnvironmentVariables) {
   AppConstants[v] = process.env[v];
 }
 
-module.exports = AppConstants;
+module.exports = Object.freeze(AppConstants);


### PR DESCRIPTION
Fixes #58 

Attempting to overwrite an `AppConstant.*` will now fail w/ the following:

```sh
$ npm start

> blurts-server@0.0.1 start /Users/pdehaan/dev/github/mozilla/blurts-server
> node server.js

/Users/pdehaan/dev/github/mozilla/blurts-server/server.js:13
AppConstants.PORT = 9096;
                  ^

TypeError: Cannot assign to read only property 'PORT' of object '#<Object>'
    at Object.<anonymous> (/Users/pdehaan/dev/github/mozilla/blurts-server/server.js:13:19)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    ...
```