### PR TITLE
fix #77: enable subscribe-email-input and button

### DIFF
--- a/public/js/test.js
+++ b/public/js/test.js
@@ -45,6 +45,22 @@ function doOauth() {
   window.open("/oauth/init");
 }
 
+function isValidEmail(val) {
+  // https://stackoverflow.com/a/46181
+  const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  return re.test(String(val).toLowerCase());
+}
+
+function enableBtnIfEmailValid(e) {
+  const emailBtn = document.getElementById("subscribe-email-btn");
+  if (isValidEmail(e.target.value)) {
+    emailBtn.disabled = false;
+  } else {
+    emailBtn.disabled = true;
+  }
+}
+
 $(document).foundation();
 
 document.querySelector("#subscribe-fxa-btn").addEventListener("click", doOauth);
+document.querySelector("#subscribe-email-input").addEventListener("input", enableBtnIfEmailValid);

--- a/routes/user.js
+++ b/routes/user.js
@@ -17,8 +17,9 @@ const ResponseCodes = Object.freeze({
 
 const router = express.Router();
 const jsonParser = bodyParser.json();
+const urlEncodedParser = bodyParser.urlencoded({ extended: false });
 
-router.post("/add", jsonParser, async (req, res) => {
+router.post("/add", urlEncodedParser, async (req, res) => {
   const user = await models.Subscriber.create({ email: req.body.email });
   const url = `${AppConstants.SERVER_URL}/user/verify?state=${encodeURIComponent(user.verificationToken)}&email=${encodeURIComponent(user.email)}`;
 
@@ -26,11 +27,9 @@ router.post("/add", jsonParser, async (req, res) => {
     await EmailUtils.sendEmail(user.email, "Firefox Breach Alert",
       `Visit this link to subscribe: ${url}`);
 
-    res.status(202).json({
-      info: "Sent verification link",
-      // Send the would-be link back to the client in dummy mode.
-      // eslint-disable-next-line no-process-env
-      link: process.env.DEBUG_DUMMY_SMTP ? url : undefined,
+    res.render("add", {
+      title: "Verify email",
+      email: user.email,
     });
   } catch (e) {
     console.log(e);

--- a/views/add.hbs
+++ b/views/add.hbs
@@ -1,0 +1,22 @@
+{{!< default }}
+    <div class="top-bar">
+      <div class="top-bar-left">
+        <h1><a href="/">Firefox Breach Alert</a></h1>
+      </div>
+      <div class="top-bar-right">
+        <ul class="menu">
+          <li><a href="/">About</a></li>
+          <li><a href="#tips">Tips</a></li>
+          <li><a class="button" data-open="subscribe-modal">Subscribe</a></li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="grid-x grid-margin-x grid-padding-x grid-margin-y grid-padding-y">
+      <div class="cell">
+        <h2>Email verification sent</h2>
+      </div>
+
+      <div class="cell">
+        <p>We've emailed <strong>{{ email }}</strong>. Please confirm your email address by visiting the link in the email.</p>
+      </div>

--- a/views/layouts/default.hbs
+++ b/views/layouts/default.hbs
@@ -49,9 +49,9 @@
         <br>
 
         <div class="cell grid-x">
-          <form class="cell small-12" action="/subscribe" method="post">
-            <input type="email" name="email" placeholder="Enter Email">
-            <button type="submit" class="button cell" disabled>Subscribe with Email Account</button>
+          <form class="cell small-12" action="/user/add" method="post">
+            <input id="subscribe-email-input" type="email" name="email" placeholder="Enter Email">
+            <button id="subscribe-email-btn" type="submit" class="button cell" disabled>Subscribe with Email Account</button>
           </form>
         </div>
         <br>


### PR DESCRIPTION
This actually enables the "Subscribe with Email Account" button, and puts the user onto a verification page when they click it.

Note: you need to unset `DEBUG_DUMMY_SMTP` and working `SMTP_*` environment variables for the email verification to actually send. https://fx-breach-alerts.herokuapp.com/ is set up with a demo account of Mailgun that is only authorized to send emails to lcrouch at mozilla dot com and nhnt11 at gmail dot com.