### PR TITLE
update hibp api url path

### DIFF
--- a/hibp.js
+++ b/hibp.js
@@ -17,7 +17,7 @@ const HIBP = {
 
     const sha1 = getSha1(email);
     const sha1Prefix = sha1.slice(0, 6);
-    const url = `${AppConstants.HIBP_STAGE_API_ROOT}/range/${sha1Prefix}?code=${encodeURIComponent(AppConstants.HIBP_STAGE_API_TOKEN)}`;
+    const url = `${AppConstants.HIBP_STAGE_API_ROOT}/breachedaccount/range/${sha1Prefix}?code=${encodeURIComponent(AppConstants.HIBP_STAGE_API_TOKEN)}`;
     const headers = {
       "User-Agent": HIBP_USER_AGENT,
     };


### PR DESCRIPTION
Troy has moved the `range` query endpoint under `breachedaccount/` in his API.