### PR TITLE
for #55: redirect non-dev environments to https

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,3 +1,4 @@
+NODE_ENV=dev
 SERVER_URL=http://localhost:6060
 PORT=6060
 

--- a/app-constants.js
+++ b/app-constants.js
@@ -6,6 +6,7 @@ const path = require("path");
 require("dotenv").load({path: path.join(__dirname, ".env")});
 
 const kEnvironmentVariables = [
+  "NODE_ENV",
   "SERVER_URL",
   "PORT",
   "COOKIE_SECRET",

--- a/server.js
+++ b/server.js
@@ -19,6 +19,21 @@ const UserRoutes = require("./routes/user");
 
 
 const app = express();
+
+// Redirect non-dev environments to HTTPS
+app.enable("trust proxy");
+
+if (app.get("env") !== "dev") {
+  app.use( (req, res, next) => {
+    if (req.secure) {
+      next();
+    } else {
+      res.redirect("https://" + req.headers.host + req.url);
+    }
+  });
+}
+
+// Use helmet to set security headers
 app.use(helmet());
 app.use(helmet.contentSecurityPolicy({
   directives: {


### PR DESCRIPTION
This should get us up to an A+ on https://observatory.mozilla.org/analyze/fx-breach-alerts.herokuapp.com