### PR TITLE
Add data-no-csrf attribute

### DIFF
--- a/views/partials/scan_form.hbs
+++ b/views/partials/scan_form.hbs
@@ -1,4 +1,4 @@
-  <form action="/scan" class="email-scan" method="post">
+  <form action="/scan" class="email-scan" method="post" data-no-csrf>
       <div class="input-group">
           <input class="input-group-field email-to-hash" type="email" name="email" placeholder="Enter Email Address">
           <input type="hidden" name="emailHash">


### PR DESCRIPTION
This is an indication to ZAP (and potentially other security tools) that an anti CSRF token has deliberately not been added to this form.
An attacker will be able to submit an email address on behalf of the user but it wont cause any problems for anyone.
The data-no-csrf attribute doesnt make this any more secure, but it does allow us to ignore it and therefore not report this as a potential problem.
This should help the server pass the baseline scan as referenced in #55