### PR TITLE
Routing changes

### DIFF
--- a/routes/home.js
+++ b/routes/home.js
@@ -6,7 +6,7 @@ const DBUtils = require("../db/utils");
 
 const router = express.Router();
 
-async function handleIndexRoute(req, res) {
+router.get("/", async (req, res) => {
   let breach = null;
   if (req.query.breach) {
     breach = await DBUtils.getBreachByName(req.query.breach);
@@ -15,9 +15,10 @@ async function handleIndexRoute(req, res) {
     title: "Firefox Monitor",
     breach: breach,
   });
-}
+});
 
-router.get("/", handleIndexRoute);
-router.get("/monitor", handleIndexRoute);
+router.use(async (req, res) => {
+  res.status(404).render("404");
+});
 
 module.exports = router;

--- a/routes/scan.js
+++ b/routes/scan.js
@@ -3,30 +3,33 @@
 const express = require("express");
 const bodyParser = require("body-parser");
 
-const HIBP = require("../hibp");
+const sha1 = require("../sha1-utils");
 
+const HIBP = require("../hibp");
 
 const router = express.Router();
 const urlEncodedParser = bodyParser.urlencoded({ extended: false });
 
-
+const blankStringSha1 = sha1("");
 
 router.post("/", urlEncodedParser, async (req, res) => {
   const emailHash = req.body.emailHash;
-  let foundBreaches = [];
 
-  if (!req.session.scanResults) {
-    req.session.scanResults = {};
+  if (!emailHash || emailHash === blankStringSha1) {
+    res.redirect("/");
+    return;
   }
 
-  if (emailHash) {
-    foundBreaches = await HIBP.getBreachesForEmail(emailHash);
-  }
+  const foundBreaches = await HIBP.getBreachesForEmail(emailHash);
 
   res.render("scan", {
     title: "Firefox Breach Alerts: Scan Results",
-    foundBreaches: foundBreaches,
+    foundBreaches,
   });
+});
+
+router.get("/", async (req, res) => {
+  res.redirect("/");
 });
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -67,11 +67,11 @@ app.use(sessions({
   },
 }));
 
-app.use("/", HomeRoutes);
 app.use("/", DockerflowRoutes);
 app.use("/scan", ScanRoutes);
 // app.use("/oauth", OAuthRoutes);
 // app.use("/user", UserRoutes);
+app.use("/", HomeRoutes);
 
 // EmailUtils.init().then(() => {
   const listener = app.listen(AppConstants.PORT, () => {

--- a/views/404.hbs
+++ b/views/404.hbs
@@ -1,0 +1,11 @@
+{{!< default }}
+<div id="banner-info" class="section-container">
+    <div id="banner-sections-wrapper">
+        <div id="banner-left">
+            <div class="banner-content">
+              <h1>404: Page not found.</h1>
+            </div>
+        </div>
+    </div>
+</div>
+  {{> tips }}


### PR DESCRIPTION
Redirect all unhandled GET paths to index; also do so for POSTs to /scan that don't supply an emailHash or supply the empty string's sha1.

Fixes #183.