### PR TITLE
GA reference error fix

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -749,7 +749,6 @@ span.breach-info {
   list-style: none;
   background-color: #0021753a;
   padding: calc(15px + 0.5vh + 0.5vw);
-  width: 100%;
   min-width: 250px;
   max-width: 400px;
 }

--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -41,7 +41,7 @@ function getLocation() {
 }
 
 function handleEvents(string) {
-  if(ga) {
+  if(typeof(ga) !== "undefined") {
     const eventLocation = getLocation();
     const event = events[string];
     const eventCategory = event["eventCategory"];

--- a/views/partials/false_door.hbs
+++ b/views/partials/false_door.hbs
@@ -2,7 +2,7 @@
   <div class="section-container">
     <h4>Thank you for trying Firefox Monitor</h4>
     <p>Firefox Monitor is a concept we are testing. During this test, we are not storing email addresses. This means that while we will use your email to give you real results about data breaches, we will not keep your email to alert you in case of future breaches</p>
-    <p>We hope to provide this service soon, but in the meantime, you can stay up-to-date on Firefox Monitor and other new features when you sign up for the <a href='https://www.mozilla.org/newsletter/firefox/'>Firefox newsletter.</a></p>
+    <p>We hope to provide this service soon, but in the meantime, you can stay up-to-date on Firefox Monitor and other new features when you sign up for the <a href="https://www.mozilla.org/newsletter/firefox/">Firefox newsletter.</a></p>
     <button class="button" id="close-false-door">Close</button>
   </div>
 </div>

--- a/views/partials/false_door.hbs
+++ b/views/partials/false_door.hbs
@@ -1,8 +1,8 @@
 <div id="false-door" class="hidden">
-  <div class='section-container'>
+  <div class="section-container">
     <h4>Thank you for trying Firefox Monitor</h4>
     <p>Firefox Monitor is a concept we are testing. During this test, we are not storing email addresses. This means that while we will use your email to give you real results about data breaches, we will not keep your email to alert you in case of future breaches</p>
     <p>We hope to provide this service soon, but in the meantime, you can stay up-to-date on Firefox Monitor and other new features when you sign up for the <a href='https://www.mozilla.org/newsletter/firefox/'>Firefox newsletter.</a></p>
-    <button class='button' id='close-false-door'>Close</button>
+    <button class="button" id="close-false-door">Close</button>
   </div>
 </div>


### PR DESCRIPTION
Fixes GA reference error that crops up when sign up button is clicked while tracking protection is enabled (in Nightly private window) and blocks the false-door from displaying. Also fixes UI issue on the What to Do list width.