### PR TITLE
#204 - Wrongly Marked Emails Fix

### DIFF
--- a/hibp.js
+++ b/hibp.js
@@ -14,7 +14,7 @@ const HIBP = {
   async getBreachesForEmail(sha1) {
     let foundBreaches = [];
 
-    const sha1Prefix = sha1.slice(0, 6);
+    const sha1Prefix = sha1.slice(0, 6).toUpperCase();
     const url = `${AppConstants.HIBP_STAGE_API_ROOT}/breachedaccount/range/${sha1Prefix}?code=${encodeURIComponent(AppConstants.HIBP_STAGE_API_TOKEN)}`;
     const headers = {
       "User-Agent": HIBP_USER_AGENT,


### PR DESCRIPTION
- Fixes #204 
adds .toUpperCase() to sha1Prefix to correct mismatched hashes and breached emails returning as safe.