### PR TITLE
updates csp

### DIFF
--- a/server.js
+++ b/server.js
@@ -38,7 +38,12 @@ app.use(helmet.contentSecurityPolicy({
   directives: {
     baseUri: ["'none'"],
     defaultSrc: ["'none'"],
-    fontSrc: ["https://code.cdn.mozilla.net/fonts/"],
+    connectSrc: [
+      "'self'",
+      "https://code.cdn.mozilla.net/fonts/",
+      "https://www.google-analytics.com"
+    ],
+    fontSrc: ["'self'", "https://code.cdn.mozilla.net/fonts/"],
     frameAncestors: ["'none'"],
     imgSrc: ["'self'", "https://www.google-analytics.com"],
     scriptSrc: ["'self'", "https://www.google-analytics.com/analytics.js"],

--- a/server.js
+++ b/server.js
@@ -41,7 +41,7 @@ app.use(helmet.contentSecurityPolicy({
     connectSrc: [
       "'self'",
       "https://code.cdn.mozilla.net/fonts/",
-      "https://www.google-analytics.com"
+      "https://www.google-analytics.com",
     ],
     fontSrc: ["'self'", "https://code.cdn.mozilla.net/fonts/"],
     frameAncestors: ["'none'"],


### PR DESCRIPTION
Addresses CSP errors noted in safari and potentially the CSP violations previously noted by BobM in the logs (obviously can't test). 
- Adds 'self' to font-src directive since default-src is set to 'none'.
- Adds connect-src directive.