### PR TITLE
disable dockerflow routes on heroku

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,4 +1,5 @@
 NODE_ENV=dev
+DISABLE_DOCKERFLOW=
 SERVER_URL=http://localhost:6060
 PORT=6060
 

--- a/app-constants.js
+++ b/app-constants.js
@@ -7,6 +7,7 @@ require("dotenv").load({path: path.join(__dirname, ".env")});
 
 const kEnvironmentVariables = [
   "NODE_ENV",
+  "DISABLE_DOCKERFLOW",
   "SERVER_URL",
   "PORT",
   "COOKIE_SECRET",

--- a/server.js
+++ b/server.js
@@ -11,7 +11,6 @@ const EmailUtils = require("./email-utils");
 const HBSHelpers = require("./hbs-helpers");
 const HIBP = require("./hibp");
 
-const DockerflowRoutes = require("./routes/dockerflow");
 const HibpRoutes = require("./routes/hibp");
 const HomeRoutes = require("./routes/home");
 const ScanRoutes = require("./routes/scan");
@@ -87,7 +86,10 @@ app.use(sessions({
   cookie: cookie,
 }));
 
-app.use("/", DockerflowRoutes);
+if (!AppConstants.DISABLE_DOCKERFLOW) {
+  const DockerflowRoutes = require("./routes/dockerflow");
+  app.use("/", DockerflowRoutes);
+}
 app.use("/hibp", HibpRoutes);
 app.use("/oauth", OAuthRoutes);
 app.use("/scan", ScanRoutes);


### PR DESCRIPTION
Can now set `DISABLE_DOCKERFLOW` to disable the route that tries to access the git repository. This prevents an error log message in environments (like heroku) where the git repo is not available.