### PR TITLE
Use Title instead of Name for breach

### DIFF
--- a/views/partials/featured_breach.hbs
+++ b/views/partials/featured_breach.hbs
@@ -4,7 +4,7 @@
       <div class="image-wrap">
         <img alt="{{ featuredBreach.Title }}" src="img/logos/{{ featuredBreach.Name }}.{{ featuredBreach.LogoType }}">
       </div>
-      <span class="breach-headline">{{ featuredBreach.Name }} Breach</span>
+      <span class="breach-headline">{{ featuredBreach.Title }}</span>
     </div>
     <span class="breach-info"><span class="medium">Breach Date</span> {{prettyDate featuredBreach.BreachDate }}</span>
     <span class="breach-info"><span class="medium">Compromised Accounts</span> {{localeString featuredBreach.PwnCount }}</span>


### PR DESCRIPTION
Now, the only place `{{ Name }}` is used is in `<img src="">` attributes and an `<input type="hidden">` and nothing user facing.

```sh
$ git grep "Name }}"

views/partials/breach_listing.hbs:        <img alt="{{ Title }}" src="img/logos/{{ Name }}.{{ LogoType }}" />
views/partials/featured_breach.hbs:        <img alt="{{ featuredBreach.Title }}" src="img/logos/{{ featuredBreach.Name }}.{{ featuredBreach.LogoType }}">
views/partials/scan_form.hbs:      <input id="featured" type="hidden" name="featuredBreach" value="{{ featuredBreach.Name }}"/>
```

```sh
$ git grep "Title }}"

views/email/breach_notification.hbs:  Uh-oh, {{ email }} was involved in {{ breach.Title }} data breach.
views/monitor.hbs:          <p class="demi">See if your account was exposed in the <span class="bold">{{ featuredBreach.Title }}</span> breach or other data breaches.</p>
views/partials/breach_listing.hbs:        <img alt="{{ Title }}" src="img/logos/{{ Name }}.{{ LogoType }}" />
views/partials/breach_listing.hbs:        <h4>{{ Title }}</h4>
views/partials/featured_breach.hbs:        <img alt="{{ featuredBreach.Title }}" src="img/logos/{{ featuredBreach.Name }}.{{ featuredBreach.LogoType }}">
views/partials/featured_breach.hbs:      <span class="breach-headline">{{ featuredBreach.Title }}</span>
views/partials/featured_compromised_account_headline.hbs:      The account you scanned was compromised in the {{ featuredBreach.Title }} breach.
views/partials/featured_compromised_account_headline.hbs:      Your account wasn't compromised in the {{ featuredBreach.Title }} breach.
```
