### PR TITLE
fix #270 fix #245: serve breach data to clients

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,27 +1,40 @@
+# dev, heroku, stage, production
 NODE_ENV=dev
-DISABLE_DOCKERFLOW=
 SERVER_URL=http://localhost:6060
 PORT=6060
-
 COOKIE_SECRET=3895d33b5f9730f5eb2a2067fe0a690e298f55f5e382c032fd3656863412
 
+# 1: disables the dockerflow endpoints
+# see: https://github.com/mozilla-services/Dockerflow#containerized-app-requirements
+DISABLE_DOCKERFLOW=
+
+# Database server
 DATABASE_URL="postgres://postgres@localhost:5432/blurts"
 
+# Email server
 SMTP_URL=""
-
+# From: address used in emails
 EMAIL_FROM=""
+# https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-configuration-sets.html
 SES_CONFIG_SET=""
+# username and password to authenticate messages coming back from SES
 SES_USERNAME=""
 SES_PASSWORD=""
-SES_NOTIFICATION_LOG_ONLY=""
+# 1: only log messages coming back from SES
+SES_NOTIFICATION_LOG_ONLY=
 
+# Firefox Accounts OAuth
 OAUTH_CLIENT_ID=cb1bef9d06bb9bc9
 OAUTH_CLIENT_SECRET=f5fb99de6e0af18ab17e013ac1d439903179a97a1c510fc10bc3bd50bbce089b
 OAUTH_AUTHORIZATION_URI="https://oauth-stable.dev.lcip.org/v1/authorization"
 OAUTH_PROFILE_URI="https://stable.dev.lcip.org/profile/v1/profile"
 OAUTH_TOKEN_URI="https://oauth-stable.dev.lcip.org/v1/token"
 
+# HIBP API for breach data
 HIBP_API_ROOT="https://stage.haveibeenpwned.com/api/v2/"
 HIBP_API_TOKEN=""
+# How many seconds to wait before refreshing upstream breach data from HIBP
+HIBP_RELOAD_BREACHES_TIMER=600
+# HIBP API for range search and subscription
 HIBP_KANON_API_ROOT="https://api.haveibeenpwned.com"
 HIBP_KANON_API_TOKEN=""

--- a/app-constants.js
+++ b/app-constants.js
@@ -26,6 +26,7 @@ const kEnvironmentVariables = [
   "HIBP_KANON_API_TOKEN",
   "HIBP_API_ROOT",
   "HIBP_API_TOKEN",
+  "HIBP_RELOAD_BREACHES_TIMER",
   "DATABASE_URL",
 ];
 

--- a/hibp.js
+++ b/hibp.js
@@ -49,6 +49,8 @@ const HIBP = {
         breaches.push(breach);
       }
       app.locals.breaches = breaches;
+      app.locals.breachesLoadedDateTime = Date.now();
+      app.locals.mostRecentBreachDateTime = this.getLatestBreachDateTime(breaches);
     } catch (error) {
       console.error(error);
     }
@@ -76,8 +78,31 @@ const HIBP = {
     } catch (error) {
       console.error(error);
     }
-    return foundBreaches.filter(breach => breach.IsVerified && !breach.IsRetired && !breach.IsSensitive && !breach.IsSpamList);
+    return this.filterOutUnsafeBreaches(foundBreaches);
   },
+
+
+  filterOutUnsafeBreaches(breaches) {
+    return breaches.filter(
+      breach => breach.IsVerified && 
+                !breach.IsRetired && 
+                !breach.IsSensitive &&
+                !breach.IsSpamList
+    );
+  },
+
+
+  getLatestBreachDateTime(breaches) {
+    let latestBreachDateTime = new Date(0);
+    for (const breach of breaches) {
+      const breachAddedDate = new Date(breach.AddedDate);
+      if (breachAddedDate > latestBreachDateTime) {
+        latestBreachDateTime = breachAddedDate;
+      }
+    }
+    return latestBreachDateTime;
+  },
+
 
   async subscribeHash(sha1) {
     const sha1Prefix = sha1.slice(0, 6).toUpperCase();

--- a/routes/hibp.js
+++ b/routes/hibp.js
@@ -4,12 +4,13 @@ const express = require("express");
 const bodyParser = require("body-parser");
 
 const {asyncMiddleware} = require("../middleware");
-const {notify} = require("../controllers/hibp");
+const {notify, breaches} = require("../controllers/hibp");
 
 
 const router = express.Router();
 const jsonParser = bodyParser.json();
 
 router.post("/notify", jsonParser, asyncMiddleware(notify));
+router.get("/breaches", jsonParser, asyncMiddleware(breaches));
 
 module.exports = router;


### PR DESCRIPTION
Client may send a GET request to `/hibp/breaches` with `If-Modified-Since` header value of its most recent breach DateTime.

If the server has a breach that is newer than the client's `If-Modified-Since` value, it will respond with the full breach JSON data and a new `Last-Modified` value for the client to store. Otherwise, it will respond with an empty `304` response.

After sending the response to the client, the server checks to see if it has loaded upstream breach data from HIBP within the last `HIBP_RELOAD_BREACHES_TIMER` milliseconds (Default 60000 or 10 min.). If not, it reloads upstream breach data and sets the appropriate state for `If-Modified-Since` checks and `Last-Modified` values.