### PR TITLE
fix #329: check dataClasses before joining

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -4,6 +4,7 @@ const isemail = require("isemail");
 const HIBP = require("../hibp");
 const DB = require("../db/DB");
 const EmailUtils = require("../email-utils");
+const HBSHelpers = require("../hbs-helpers");
 const UNSUB_REASONS = require("../unsubscribe_reasons");
 const sha1 = require("../sha1-utils");
 const TIPS = require("../tips");
@@ -43,8 +44,8 @@ async function verify(req, res) {
 
   if(unsafeBreachesForEmail) {
     unsafeBreachesForEmail.forEach((breach) => {
-      breach.BreachDate = new Date(breach.BreachDate).toLocaleString("en-US", {year: "numeric", month: "long", day: "numeric"});
-      breach.DataClasses = breach.DataClasses.join(", ");
+      breach.BreachDate = HBSHelpers.prettyDate(breach.BreachDate);
+      breach.DataClasses = HBSHelpers.breachDataClasses(breach.DataClasses);
     });
   }
 

--- a/hbs-helpers.js
+++ b/hbs-helpers.js
@@ -1,82 +1,86 @@
 "use strict";
 
 const HBSHelpers = {
-  init(hbs) {
+  breachDataClasses(dataClasses) {
+    if (dataClasses.constructor === Array) {
+      return dataClasses.join(", ");
+    } else {
+      return "";
+    }
+  },
 
-    hbs.registerHelper("prettyDate", function(date) {
-      const jsDate = new Date(date);
-      return jsDate.toLocaleDateString("en-US", {year: "numeric", month: "long", day: "numeric"});
-    });
+  prettyDate(date) {
+    const jsDate = new Date(date);
+    return jsDate.toLocaleDateString("en-US", {year: "numeric", month: "long", day: "numeric"});
+  },
 
-    hbs.registerHelper("breachDataClasses", function(dataClasses) {
-      if (dataClasses.constructor === Array) {
-        return dataClasses.join(", ");
-      } else {
-        return "";
-      }
-    });
+  localeString(input) {
+    return input.toLocaleString();
+  },
 
-    hbs.registerHelper("localeString", function(input) {
-      return input.toLocaleString();
-    });
-
-    hbs.registerHelper("each_from_to", function(ary, min, max, options) {
-      if(!ary || ary.length === 0)
-          return options.inverse(this);
-
-      const result = [];
-      
-      for (let i = min; i < max && i < ary.length; i++) {
-        result.push(options.fn(ary[i], { data : { itemIndex : i } } ));
-      }
-      return result.join("");
-    });
-
-    //https://stackoverflow.com/questions/28978759/length-check-in-a-handlebars-js-if-conditional
-
-    hbs.registerHelper("if_compare", function (v1, operator, v2, options) {
-      const operators = {
-        ">": v1 > v2 ? true : false,
-        ">=": v1 >= v2 ? true : false,
-        "<": v1 < v2 ? true : false,
-        "<=": v1 <= v2 ? true : false,
-        "===": v1 === v2 ? true : false,
-      };
-      if (operators.hasOwnProperty(operator)) {
-        if (operators[operator]) {
-          return options.fn(this);
-        }
+  eachFromTo(ary, min, max, options) {
+    if(!ary || ary.length === 0)
         return options.inverse(this);
-      }
-      return console.error(`Error: ${operator} not found`);
-    });
 
-    hbs.registerHelper("breachMath", function(lValue, operator, rValue) {
-      lValue = parseFloat(lValue);
-      rValue = parseFloat(rValue);
-      const returnValue = {
-        "+": lValue + rValue,
-        "-": lValue - rValue,
-        "*": lValue * rValue,
-        "/": lValue / rValue,
-        "%": lValue % rValue,
-      }[operator];
-      if (returnValue < 10) {
-        return {
-          1: "one",
-          2: "two",
-          3: "three",
-          4: "four",
-          5: "five",
-          6: "six",
-          7: "seven",
-          8: "eight",
-          9: "nine",
-        }[returnValue];
-      }
-      return returnValue;
-    });
+    const result = [];
 
+    for (let i = min; i < max && i < ary.length; i++) {
+      result.push(options.fn(ary[i], { data : { itemIndex : i } } ));
+    }
+    return result.join("");
+  },
+
+  ifCompare(v1, operator, v2, options) {
+    //https://stackoverflow.com/questions/28978759/length-check-in-a-handlebars-js-if-conditional
+    const operators = {
+      ">": v1 > v2 ? true : false,
+      ">=": v1 >= v2 ? true : false,
+      "<": v1 < v2 ? true : false,
+      "<=": v1 <= v2 ? true : false,
+      "===": v1 === v2 ? true : false,
+    };
+    if (operators.hasOwnProperty(operator)) {
+      if (operators[operator]) {
+        return options.fn(this);
+      }
+      return options.inverse(this);
+    }
+    return console.error(`Error: ${operator} not found`);
+  },
+
+  breachMath(lValue, operator, rValue) {
+    lValue = parseFloat(lValue);
+    rValue = parseFloat(rValue);
+    const returnValue = {
+      "+": lValue + rValue,
+      "-": lValue - rValue,
+      "*": lValue * rValue,
+      "/": lValue / rValue,
+      "%": lValue % rValue,
+    }[operator];
+    if (returnValue < 10) {
+      return {
+        1: "one",
+        2: "two",
+        3: "three",
+        4: "four",
+        5: "five",
+        6: "six",
+        7: "seven",
+        8: "eight",
+        9: "nine",
+      }[returnValue];
+    }
+    return returnValue;
+  },
+
+  register(hbs) {
+    hbs.registerHelper("prettyDate", this.prettyDate);
+    hbs.registerHelper("breachDataClasses", this.breachDataClasses);
+    hbs.registerHelper("localeString", this.localString);
+    hbs.registerHelper("each_from_to", this.eachFromTo);
+    hbs.registerHelper("if_compare", this.ifCompare);
+    hbs.registerHelper("breachMath", this.breachMath);
   },
 };
 

--- a/hbs-helpers.js
+++ b/hbs-helpers.js
@@ -9,7 +9,11 @@ const HBSHelpers = {
     });
 
     hbs.registerHelper("breachDataClasses", function(dataClasses) {
-      return dataClasses.join(", ");
+      if (dataClasses.constructor === Array) {
+        return dataClasses.join(", ");
+      } else {
+        return "";
+      }
     });
 
     hbs.registerHelper("localeString", function(input) {

--- a/server.js
+++ b/server.js
@@ -69,7 +69,7 @@ app.engine("hbs", hbs.express4({
 }));
 app.set("view engine", "hbs");
 app.set("views", __dirname + "/views");
-HBSHelpers.init(hbs);
+HBSHelpers.register(hbs);
 
 const cookie = {httpOnly: true, secureProxy: true};
 

--- a/views/partials/breach_listing.hbs
+++ b/views/partials/breach_listing.hbs
@@ -6,6 +6,8 @@
     <h4 class="medium">{{ Title }}</h4>
     <span class="breach-info"><span class="medium">Breach date:</span> {{prettyDate BreachDate }}</span>
     <span class="breach-info"><span class="medium">Compromised accounts:</span> {{localeString PwnCount }}</span>
+    {{#if DataClasses }}
     <span class="breach-info"><span class="medium">Compromised data:</span> {{breachDataClasses DataClasses }}</span>
+    {{/if}}
   </div>
 </div>

--- a/views/partials/featured_breach.hbs
+++ b/views/partials/featured_breach.hbs
@@ -7,7 +7,9 @@
       <span class="breach-headline medium">{{ featuredBreach.Title }} Breach</span>
       <span class="breach-info breach-date"><span class="medium">Breach Date</span> {{prettyDate featuredBreach.BreachDate }}</span>
       <span class="breach-info"><span class="medium">Compromised Accounts</span> {{localeString featuredBreach.PwnCount }}</span>
+      {{#if featuredBreach.DataClasses }}
       <span class="breach-info"><span class="medium">Compromised Data</span> {{breachDataClasses featuredBreach.DataClasses }}</span>
+      {{/if}}
     </div>
   </div>
 {{/if}}


### PR DESCRIPTION
The refactor moves the handlebars helpers "up" into named functions in `HBSHelpers` so they can be re-used in controller code or in templates.