### PR TITLE
Show more of footer on error and subs.

### DIFF
--- a/controllers/home.js
+++ b/controllers/home.js
@@ -22,7 +22,7 @@ function home(req, res) {
 
 function notFound(req, res) {
   res.status(404);
-  res.render("404");
+  res.render("error", { message: "Page not found." });
 }
 
 module.exports = {

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -225,7 +225,7 @@ img {
   align-items: center;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  min-height: 85vh;
   margin-top: -10vh;
 }
 
@@ -1252,7 +1252,7 @@ footer .copyright-info a {
   position: relative;
   height: 100%;
   pointer-events: none;
-  min-height: 100vh;
+  min-height: 75vh;
 }
 
 .content-wrap > * {

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -220,17 +220,22 @@ img {
   display: none !important;
 }
 
-.sub-page-content {
+.sub-page-content,
+.error-page-content {
   justify-content: center;
   align-items: center;
   display: flex;
   flex-direction: column;
-  min-height: 85vh;
+  min-height: 75vh;
+  margin-top: 0;
+}
+
+.error-page-content {
   margin-top: -10vh;
 }
 
 .sub-page-content .section-wrapper {
-  margin: 0 0 0 0;
+  margin: 0 0 var(--columnSpacing) 0;
 }
 
 .centered-content {

--- a/tests/hibp.test.js
+++ b/tests/hibp.test.js
@@ -26,7 +26,7 @@ test("notify POST with breach, subscriber hash prefix and suffixes should call s
   expect (mockSendEmailCalls.length).toBe(1);
   const mockSendEmailCallArgs = mockSendEmailCalls[0];
   expect (mockSendEmailCallArgs[0]).toBe(testEmail);
-  expect (mockSendEmailCallArgs[2]).toBe("breach_notification");
+  expect (mockSendEmailCallArgs[2]).toBe("report");
   const mockStatusCallArgs = mockResponse.status.mock.calls[0];
   expect(mockStatusCallArgs[0]).toBe(200);
   const mockJsonCallArgs = mockResponse.json.mock.calls[0];

--- a/tests/home.test.js
+++ b/tests/home.test.js
@@ -48,5 +48,5 @@ test("notFound set status 404 and renders 404", () => {
   const mockStatusCallArgs = mockResponse.status.mock.calls[0];
   const mockRenderCallArgs = mockResponse.render.mock.calls[0];
   expect(mockStatusCallArgs[0]).toBe(404);
-  expect(mockRenderCallArgs[0]).toBe("404");
+  expect(mockRenderCallArgs[0]).toBe("error");
 });

--- a/views/404.hbs
+++ b/views/404.hbs
@@ -1,5 +1,0 @@
-{{!< default }}
-<div class="error-page-content section-wrapper">
-    <h2>404: Page not found.</h2>
-</div>
-

--- a/views/404.hbs
+++ b/views/404.hbs
@@ -1,5 +1,5 @@
 {{!< default }}
-<div class="sub-page-content section-wrapper">
+<div class="error-page-content section-wrapper">
     <h2>404: Page not found.</h2>
 </div>
 

--- a/views/error.hbs
+++ b/views/error.hbs
@@ -1,6 +1,5 @@
 {{!< default }}
-<div class="sub-page-content section-wrapper">
+<div class="error-page-content section-wrapper">
     <h2>Error</h2>
     <p> {{ message }} </p>
 </div>
-


### PR DESCRIPTION
Makes footer more visible on page load for error, 404, confirmation, and unsubscribe pages until we have other content for a less dead-endy error and/or 404. 