### PR TITLE
DNM yet: Handle unsubscribe flow refreshes/unsub form resubmits

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const crypto = require("crypto");
 const isemail = require("isemail");
 const HIBP = require("../hibp");
 const DB = require("../db/DB");
@@ -8,7 +9,6 @@ const HBSHelpers = require("../hbs-helpers");
 const UNSUB_REASONS = require("../unsubscribe_reasons");
 const sha1 = require("../sha1-utils");
 const TIPS = require("../tips");
-const crypto = require("crypto");
 
 
 async function add(req, res) {
@@ -84,7 +84,7 @@ async function postUnsubscribe(req, res) {
   const unsubscribedUser = await DB.removeSubscriberByToken(req.body.token, req.body.emailHash);
   // if user backs into unsubscribe page and clicks "unsubscribe" again
   if (!unsubscribedUser) {
-    throw new Error("This email address is not subscribed to Firefox Monitor");
+    throw new Error("This email address is not subscribed to Firefox Monitor.");
   }
   
   const surveyTicket = crypto.randomBytes(40).toString("hex");
@@ -94,7 +94,7 @@ async function postUnsubscribe(req, res) {
 }
 
 
-async function getUnsubSurvey(req, res) {
+function getUnsubSurvey(req, res) {
   //throws error if user refreshes unsubscribe survey page after they have submitted an answer
   if(!req.session.unsub) {
     throw new Error("This email address is not subscribed to Firefox Monitor.");
@@ -106,7 +106,7 @@ async function getUnsubSurvey(req, res) {
 }
 
 
-async function postUnsubSurvey(req, res) {
+function postUnsubSurvey(req, res) {
   //clear session in case a user subscribes / unsubscribes multiple times or with multiple email addresses.
   req.session.reset();
   res.send({

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -8,6 +8,7 @@ const HBSHelpers = require("../hbs-helpers");
 const UNSUB_REASONS = require("../unsubscribe_reasons");
 const sha1 = require("../sha1-utils");
 const TIPS = require("../tips");
+const crypto = require("crypto");
 
 
 async function add(req, res) {
@@ -66,6 +67,7 @@ async function verify(req, res) {
 
 async function getUnsubscribe(req, res) {
   const subscriber = await DB.getSubscriberByToken(req.query.token);
+  //throws error if user backs into and refreshes unsubscribe page
   if (!subscriber) {
     throw new Error("This email address is not subscribed to Firefox Monitor.");
   }
@@ -79,17 +81,36 @@ async function getUnsubscribe(req, res) {
 
 
 async function postUnsubscribe(req, res) {
-
   const unsubscribedUser = await DB.removeSubscriberByToken(req.body.token, req.body.emailHash);
-
+  // if user backs into unsubscribe page and clicks "unsubscribe" again
   if (!unsubscribedUser) {
-    res.redirect("/");
-    return;
+    throw new Error("This email address is not subscribed to Firefox Monitor");
   }
-  res.render("unsubscribe", {
-    title: "Firefox Monitor: Unsubscribe",
-    unsubscribed: unsubscribedUser,
-    UNSUB_REASONS,
+  
+  const surveyTicket = crypto.randomBytes(40).toString("hex");
+  req.session.unsub = surveyTicket;
+
+  res.redirect("unsubscribe_survey");
+}
+
+
+async function getUnsubSurvey(req, res) {
+  //throws error if user refreshes unsubscribe survey page after they have submitted an answer
+  if(!req.session.unsub) {
+    throw new Error("This email address is not subscribed to Firefox Monitor.");
+  }
+  res.render("unsubscribe_survey", {
+  title: "Firefox Monitor: Unsubscribe Survey",
+  UNSUB_REASONS,
+  });
+}
+
+
+async function postUnsubSurvey(req, res) {
+  //clear session in case a user subscribes / unsubscribes multiple times or with multiple email addresses.
+  req.session.reset();
+  res.send({
+    title: "Firefox Monitor: Unsubscribed",
   });
 }
 
@@ -99,4 +120,6 @@ module.exports = {
   verify,
   getUnsubscribe,
   postUnsubscribe,
+  getUnsubSurvey,
+  postUnsubSurvey,
 };

--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -231,6 +231,16 @@ const addUser = (formEvent) => {
     .catch(error => console.error(error));
 };
 
+const unsubscribeSurvey = (formEvent) => {
+  const unsubSurvey = formEvent.target;
+  ga_sendPing("unsubscribeSurvey", unsubSurvey.querySelector("input[type='radio']:checked").value);
+  const surveyObject = {};
+  postData(unsubSurvey.action, surveyObject)
+    .then( () => {
+      unsubSurvey.classList.add("show-thankyou");
+    });
+};
+
 const postData = (url, data = {}) => {
   return fetch(url, {
       method: "POST", // *GET, POST, PUT, DELETE, etc.
@@ -312,8 +322,7 @@ function handleFormSubmits(formEvent) {
       formEvent.target.classList.add("invalid");
       return;
     }
-    formEvent.target.classList.add("show-thankyou");
-    ga_sendPing("unsubscribeSurvey", formEvent.target.querySelector("input[type='radio']:checked").value);
+    unsubscribeSurvey(formEvent);
     return;
   }
   const thisForm = formEvent.target;

--- a/routes/user.js
+++ b/routes/user.js
@@ -4,7 +4,7 @@ const express = require("express");
 const bodyParser = require("body-parser");
 
 const { asyncMiddleware } = require("../middleware");
-const { add, verify, getUnsubscribe, postUnsubscribe } = require("../controllers/user");
+const { add, verify, getUnsubscribe, postUnsubscribe, getUnsubSurvey, postUnsubSurvey } = require("../controllers/user");
 
 const router = express.Router();
 const jsonParser = bodyParser.json();
@@ -16,6 +16,7 @@ router.get("/verify", jsonParser, asyncMiddleware(verify));
 router.use("/unsubscribe", urlEncodedParser);
 router.get("/unsubscribe", asyncMiddleware(getUnsubscribe));
 router.post("/unsubscribe", asyncMiddleware(postUnsubscribe));
-
+router.get("/unsubscribe_survey", asyncMiddleware(getUnsubSurvey));
+router.post("/unsubscribe_survey", jsonParser, asyncMiddleware(postUnsubSurvey));
 
 module.exports = router;

--- a/routes/user.js
+++ b/routes/user.js
@@ -16,7 +16,7 @@ router.get("/verify", jsonParser, asyncMiddleware(verify));
 router.use("/unsubscribe", urlEncodedParser);
 router.get("/unsubscribe", asyncMiddleware(getUnsubscribe));
 router.post("/unsubscribe", asyncMiddleware(postUnsubscribe));
-router.get("/unsubscribe_survey", asyncMiddleware(getUnsubSurvey));
-router.post("/unsubscribe_survey", jsonParser, asyncMiddleware(postUnsubSurvey));
+router.get("/unsubscribe_survey", getUnsubSurvey);
+router.post("/unsubscribe_survey", jsonParser, postUnsubSurvey);
 
 module.exports = router;

--- a/tests/controllers/user.test.js
+++ b/tests/controllers/user.test.js
@@ -109,13 +109,13 @@ test("user unsubscribe POST request with valid hash and token unsubscribes user"
   const validToken = "0e2cb147-2041-4e5b-8ca9-494e773b2cf0";
   const validHash = getSha1("unverifiedemail@test.com");
   // Set up mocks
-  const req = { body: { token: validToken, emailHash: validHash } };
+  const req = { body: { token: validToken, emailHash: validHash }, session: {}};
   const resp = httpMocks.createResponse();
 
   // Call code-under-test
   await user.postUnsubscribe(req, resp);
 
-  expect(resp.statusCode).toEqual(200);
+  expect(resp.statusCode).toEqual(302);
   const subscriber = await DB.getSubscriberByToken(validToken);
   expect(subscriber).toBeUndefined();
 });
@@ -134,15 +134,12 @@ test("user unsubscribe GET request with invalid token returns error", async () =
 });
 
 
-test("user unsubscribe POST request with invalid token and hash redirects home", async () => {
+test("user unsubscribe POST request with invalid token and throws error", async () => {
   const invalidToken = "123456789";
   const invalidHash = "0123456789abcdef";
 
   const req = { body: { token: invalidToken, emailHash: invalidHash } };
   const resp = { redirect: jest.fn() };
 
-  await user.postUnsubscribe(req, resp);
-
-  const mockRedirectCallArgs = resp.redirect.mock.calls[0];
-  expect(mockRedirectCallArgs[0]).toBe("/");
+  await expect(user.postUnsubscribe(req, resp)).rejects.toThrow("This email address is not subscribed to Firefox Monitor.");
 });

--- a/tests/hibp.test.js
+++ b/tests/hibp.test.js
@@ -17,7 +17,7 @@ test("req adds hibp api root, token, and standard options", async() => {
   expect(gotCalls.length).toEqual(1);
   const gotCallArgs = gotCalls[0];
   expect(gotCallArgs[0]).toContain(`${AppConstants.HIBP_API_ROOT}/some-path`);
-  expect(gotCallArgs[0]).toContain(`?code=${AppConstants.HIBP_API_TOKEN}`);
+  expect(gotCallArgs[0]).toContain(`?code=${encodeURIComponent(AppConstants.HIBP_API_TOKEN)}`);
   expect(gotCallArgs[1].headers["User-Agent"]).toContain("blurts-server");
   expect(gotCallArgs[1].json).toBe(true);
 });

--- a/views/unsubscribe.hbs
+++ b/views/unsubscribe.hbs
@@ -1,50 +1,19 @@
 {{!< default }}
 <div class="sub-page-content">
-  {{#if unsubscribed }}
-    <section class="unsubscribe-content section-wrapper">
-      <h2 class="section-headline whole">
-      You are no longer subscribed.
-      </h2>
-      <p class="whole sub-head">
-      Your email is unsubscribed from Firefox Monitor. Thank you for using this service. Will you take a moment to answer one question about your experience?
-      </p>
-    </section><!--.unsubscribe-content.section-wrapper-->
-    <section class="unsubscribe-survey section-wrapper drop-shadow">
-      <div class="whole">
-        <form action="" method="post" id="unsubscribe-survey-form" class="form-group">
-          <span class="secondary-title whole" tabindex="1">Why are you unsubscribing from Firefox Monitor alerts?</span>
-          {{#each UNSUB_REASONS}}
-            <div class="radio-button-group" tabindex="1">
-              <input id="reason{{ id_number }}" type="radio" name="unsubscribe-reason" value="{{ value }}" />
-              <span class="radio-dot"></span>
-              <label for="reason{{ id_number }}">{{ value }}</label>
-            </div>
-          {{/each}}
-          <div class="input-group-button">
-            <span class="thank-you-message">Thank you for your feedback.</span>
-            <span class="error-message">Please select one.</span>
-            <input id="unsubscribe-survey-submit" type="submit" class="button submit transparent-button" value="Unsubscribe" tabindex="1" />
-            <img class="loader" src="/img/loader.gif" alt="loading data" />
-          </div>
-        </form>
-      </div>
-    </section>
-  {{ else }}
-    <section class="unsubscribe-content section-wrapper">
-      <h2 class="section-headline whole" tabindex="1">Unsubscribe from Firefox Monitor</h2>
-      <p class="whole sub-head" tabindex="1">
-        This will remove your email from the Firefox Monitor list and you will no longer receive alerts when new breaches are announced.
-      </p>
-      <div class="half">
-        <form action="/user/unsubscribe" class="form-group" method="post" id="unsubscribe-form">
-          <input type="hidden" name="token" value="{{ token }}">
-          <input type="hidden" name="emailHash" value="{{ hash }}">
-          <div class="input-group-button">
-            <input type="submit" class="button submit transparent-button" value="Unsubscribe" data-server-url="{{ SERVER_URL }}">
-            <img class="loader" src="/img/loader.gif" alt="loading data" />
-          </div>
-        </form>
-      </div>
-    </section>
-  {{/if}}
+  <section class="unsubscribe-content section-wrapper">
+    <h2 class="section-headline whole" tabindex="1">Unsubscribe from Firefox Monitor</h2>
+    <p class="whole sub-head" tabindex="1">
+      This will remove your email from the Firefox Monitor list and you will no longer receive alerts when new breaches are announced.
+    </p>
+    <div class="half">
+      <form action="/user/unsubscribe" class="form-group" method="post" id="unsubscribe-form">
+        <input type="hidden" name="token" value="{{ token }}">
+        <input type="hidden" name="emailHash" value="{{ hash }}">
+        <div class="input-group-button">
+          <input type="submit" class="button submit transparent-button" value="Unsubscribe" data-server-url="{{ SERVER_URL }}">
+          <img class="loader" src="/img/loader.gif" alt="loading data" />
+        </div>
+      </form>
+    </div>
+  </section>
 </div>

--- a/views/unsubscribe_survey.hbs
+++ b/views/unsubscribe_survey.hbs
@@ -1,0 +1,31 @@
+{{!< default }}
+<div class="sub-page-content">
+  <section class="unsubscribe-content section-wrapper">
+    <h2 class="section-headline whole">
+    You are no longer subscribed.
+    </h2>
+    <p class="whole sub-head">
+    Your email is unsubscribed from Firefox Monitor. Thank you for using this service. Will you take a moment to answer one question about your experience?
+    </p>
+  </section><!--.unsubscribe-content.section-wrapper-->
+  <section class="unsubscribe-survey section-wrapper drop-shadow">
+    <div class="whole">
+      <form action="" method="post" id="unsubscribe-survey-form" class="form-group">
+        <span class="secondary-title whole" tabindex="1">Why are you unsubscribing from Firefox Monitor alerts?</span>
+        {{#each UNSUB_REASONS}}
+          <div class="radio-button-group" tabindex="1">
+            <input id="reason{{ id_number }}" type="radio" name="unsubscribe-reason" value="{{ value }}" />
+            <span class="radio-dot"></span>
+            <label for="reason{{ id_number }}">{{ value }}</label>
+          </div>
+        {{/each}}
+        <div class="input-group-button">
+          <span class="thank-you-message">Thank you for your feedback.</span>
+          <span class="error-message">Please select one.</span>
+          <input id="unsubscribe-survey-submit" type="submit" class="button submit transparent-button" value="Unsubscribe" tabindex="1" />
+          <img class="loader" src="/img/loader.gif" alt="loading data" />
+        </div>
+      </form>
+    </div>
+  </section>
+</div>


### PR DESCRIPTION
- Moves unsubscribe survey into separate template
- Allows user to refresh unanswered survey form without being redirected to ("/");
- Prevents multiple survey form submissions
- Throws "this email is not subscribed to Firefox Monitor" error when answered unsubscribe survey form page is refreshed (maybe it makes more sense to redirect to landing page?)  