### PR TITLE
Use dimension1 any time we are logging event location.

### DIFF
--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -96,9 +96,9 @@ function ga_sendPing(eventDescription, eventLabel) {
         return ga("send", "event", eventCategory, eventAction, eventLabel, "", {"dimension1": ga_getLocation()});
       }
       if (eventDescription.includes("Social")) {
-        return ga("send", "event", eventCategory, eventAction, eventLabel, "", {"dimension2": ga_getLocation()});
+        return ga("send", "event", eventCategory, eventAction, eventLabel, "", {"dimension1": ga_getLocation()});
       }
-      return ga("send", "event", eventCategory, eventAction, eventLabel, "", {"dimension3": ga_getLocation()});
+      return ga("send", "event", eventCategory, eventAction, eventLabel, "", {"dimension1": ga_getLocation()});
     }
 
     eventLabel = ga_getLocation();


### PR DESCRIPTION

Use custom dimension -  'dimension1' - for storing event location information on all event categories (except Errors) where event label is already in use and location information is necessary. 