### PR TITLE
start saving signup language for future emails

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -18,8 +18,9 @@ async function add(req, res) {
     throw new Error("Invalid Email");
   }
   const fxNewsletter = Boolean(req.body.additionalEmails);
+  const signupLanguage = req.headers["accept-language"];
 
-  const unverifiedSubscriber = await DB.addSubscriberUnverifiedEmailHash(email, fxNewsletter);
+  const unverifiedSubscriber = await DB.addSubscriberUnverifiedEmailHash(email, fxNewsletter, signupLanguage);
   const verifyUrl = EmailUtils.verifyUrl(unverifiedSubscriber);
   const unsubscribeUrl = EmailUtils.unsubscribeUrl(unverifiedSubscriber);
 

--- a/db/DB.js
+++ b/db/DB.js
@@ -40,13 +40,14 @@ const DB = {
       .where("email", "=", email);
   },
 
-  async addSubscriberUnverifiedEmailHash(email, fxNewsletter = false) {
+  async addSubscriberUnverifiedEmailHash(email, fxNewsletter = false, signupLanguage="en") {
     const res = await knex("subscribers").insert({
       email: email,
       sha1: getSha1(email),
       verification_token: uuidv4(),
       verified: false,
       fx_newsletter: fxNewsletter,
+      signup_language: signupLanguage,
     }).returning("*");
     return res[0];
   },

--- a/db/migrations/20180930071926_add_signup_language.js
+++ b/db/migrations/20180930071926_add_signup_language.js
@@ -1,0 +1,13 @@
+"use strict";
+
+exports.up = function(knex, Promise) {
+  return knex.schema.table("subscribers", table => {
+    table.string("signup_language");
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table("subscribers", table => {
+    table.dropColumn("signup_language");
+  });
+};

--- a/package.json
+++ b/package.json
@@ -103,8 +103,8 @@
     "get-hashsets": "node scripts/get-hashsets",
     "server": "nodemon server.js",
     "start": "run-p build:all watch:all server",
-    "test:db:migrate": "knex migrate:latest --knexfile db/knexfile.js --env tests",
-    "test:db:seed": "knex seed:run --knexfile db/knexfile.js --env tests",
+    "test:db:migrate": "NODE_ENV=tests knex migrate:latest --knexfile db/knexfile.js --env tests",
+    "test:db:seed": "NODE_ENV=tests knex seed:run --knexfile db/knexfile.js --env tests",
     "test:tests": "NODE_ENV=tests HIBP_THROTTLE_DELAY=1000 HIBP_THROTTLE_MAX_TRIES=3 jest --runInBand --coverage tests/",
     "test:coveralls": "cat ./coverage/lcov.info | coveralls",
     "test": "run-s test:db:migrate test:db:seed test:tests test:coveralls"

--- a/tests/controllers/user.test.js
+++ b/tests/controllers/user.test.js
@@ -19,6 +19,7 @@ jest.mock("../../hibp");
 test("user add POST with email adds unverified subscriber and sends verification email", async () => {
     // Set up test context
     const userAddEmail = "userAdd@test.com";
+    const userAddLanguages = "en-US,en;q=0.5";
     let subscribers = await DB.getSubscribersByEmail(userAddEmail);
     expect(subscribers.length).toEqual(0);
 
@@ -26,6 +27,7 @@ test("user add POST with email adds unverified subscriber and sends verification
     const req = httpMocks.createRequest({
       method: "POST",
       url: "/user/add",
+      headers: { "accept-language": userAddLanguages },
       body: {email:userAddEmail},
     });
     const resp = httpMocks.createResponse();
@@ -41,6 +43,7 @@ test("user add POST with email adds unverified subscriber and sends verification
     const userAdded = subscribers[0];
     expect(userAdded.email).toEqual(userAddEmail);
     expect(userAdded.verified).toBeFalsy();
+    expect(userAdded.signup_language).toEqual(userAddLanguages);
 
     const mockCalls = EmailUtils.sendEmail.mock.calls;
     expect(mockCalls.length).toEqual(1);


### PR DESCRIPTION
So we can send the right translated emails to subscribers, we need to start saving their `Accept-Language` value when they sign up.

We should merge and deploy this ASAP - the longer we run without this, the more users are going to have to set their language later. 😢 