### PR TITLE
for #471: update error message for expired tokens

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -2,9 +2,11 @@
 
 const crypto = require("crypto");
 const isemail = require("isemail");
-const HIBP = require("../hibp");
+
 const DB = require("../db/DB");
+const HIBP = require("../hibp");
 const EmailUtils = require("../email-utils");
+const ERRORS = require("../errors");
 const HBSHelpers = require("../hbs-helpers");
 const UNSUB_REASONS = require("../unsubscribe_reasons");
 const sha1 = require("../sha1-utils");
@@ -76,7 +78,7 @@ async function getUnsubscribe(req, res) {
   const subscriber = await DB.getSubscriberByToken(req.query.token);
   //throws error if user backs into and refreshes unsubscribe page
   if (!subscriber) {
-    throw new Error("This email address is not subscribed to Firefox Monitor.");
+    throw new Error(ERRORS["404"].message);
   }
 
   res.render("unsubscribe", {
@@ -94,7 +96,7 @@ async function postUnsubscribe(req, res) {
   const unsubscribedUser = await DB.removeSubscriberByToken(req.body.token, req.body.emailHash);
   // if user backs into unsubscribe page and clicks "unsubscribe" again
   if (!unsubscribedUser) {
-    throw new Error("This email address is not subscribed to Firefox Monitor.");
+    throw new Error(ERRORS["404"].message);
   }
 
   const surveyTicket = crypto.randomBytes(40).toString("hex");
@@ -107,7 +109,7 @@ async function postUnsubscribe(req, res) {
 function getUnsubSurvey(req, res) {
   //throws error if user refreshes unsubscribe survey page after they have submitted an answer
   if(!req.session.unsub) {
-    throw new Error("This email address is not subscribed to Firefox Monitor.");
+    throw new Error(ERRORS["404"].message);
   }
   res.render("unsubscribe_survey", {
   title: "Firefox Monitor: Unsubscribe Survey",

--- a/db/DB.js
+++ b/db/DB.js
@@ -6,6 +6,7 @@ const uuidv4 = require("uuid/v4");
 const Knex = require("knex");
 
 const AppConstants = require("../app-constants");
+const ERRORS = require("../errors");
 const HIBP = require("../hibp");
 const Basket = require("../basket");
 const getSha1 = require("../sha1-utils");
@@ -55,7 +56,7 @@ const DB = {
   async verifyEmailHash(token) {
     const unverifiedSubscriber = await this.getSubscriberByToken(token);
     if (!unverifiedSubscriber) {
-      throw new Error("This email address is not subscribed to Firefox Monitor.");
+      throw new Error(ERRORS["404"].message);
     }
     const verifiedSubscriber = await this._verifySubscriber(unverifiedSubscriber);
     return verifiedSubscriber[0];

--- a/errors.js
+++ b/errors.js
@@ -1,0 +1,8 @@
+"use strict";
+
+
+const ERRORS = {
+  "404": { code: 404, message: "This email address is not subscribed to Firefox Monitor. You can sign up again and select your verification link within 24 hours to complete your subscription." },
+};
+
+module.exports = ERRORS;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -224,7 +224,6 @@ footer img {
 .sub-page-content,
 .error-page-content {
   justify-content: center;
-  align-items: center;
   display: flex;
   flex-direction: column;
   min-height: 75vh;

--- a/tests/controllers/user.test.js
+++ b/tests/controllers/user.test.js
@@ -4,6 +4,7 @@ const httpMocks = require("node-mocks-http");
 
 const DB = require("../../db/DB");
 const EmailUtils = require("../../email-utils");
+const ERRORS = require("../../errors");
 const getSha1 = require("../../sha1-utils");
 const user = require("../../controllers/user");
 
@@ -91,7 +92,7 @@ test("user verify request with invalid token returns error", async () => {
   });
   const resp = httpMocks.createResponse();
 
-  await expect(user.verify(req, resp)).rejects.toThrow("This email address is not subscribed to Firefox Monitor.");
+  await expect(user.verify(req, resp)).rejects.toThrow(ERRORS["404"].message);
 });
 
 
@@ -134,7 +135,7 @@ test("user unsubscribe GET request with invalid token returns error", async () =
   });
   const resp = httpMocks.createResponse();
 
-  await expect(user.getUnsubscribe(req, resp)).rejects.toThrow("This email address is not subscribed to Firefox Monitor.");
+  await expect(user.getUnsubscribe(req, resp)).rejects.toThrow(ERRORS["404"].message);
 });
 
 
@@ -145,5 +146,5 @@ test("user unsubscribe POST request with invalid token and throws error", async 
   const req = { body: { token: invalidToken, emailHash: invalidHash } };
   const resp = { redirect: jest.fn() };
 
-  await expect(user.postUnsubscribe(req, resp)).rejects.toThrow("This email address is not subscribed to Firefox Monitor.");
+  await expect(user.postUnsubscribe(req, resp)).rejects.toThrow(ERRORS["404"].message);
 });


### PR DESCRIPTION
This is also gets a start on #464, which will be necessary (or at least helpful) when we start adding localization to all messages.