### PR TITLE
Remove yellow background / white text on mobile autofill

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -336,8 +336,7 @@ input[type="text"]:hover {
 }
 
 input:-webkit-autofill {
-  -webkit-box-shadow: none;
-  -webkit-text-fill-color: #fff !important;
+  -webkit-box-shadow: inset 0 0 0px 9999px #ffffff;
 }
 
 /* RADIO BUTTONS  */


### PR DESCRIPTION
Prevents input backgrounds from turning yellow after auto-filling in mobile safari. 