### PR TITLE
Removes duplicate "scan-email" ID.

### DIFF
--- a/views/partials/scan_form.hbs
+++ b/views/partials/scan_form.hbs
@@ -8,7 +8,7 @@
     <input id="featured" type="hidden" name="featuredBreach" value="{{ featuredBreach.Name }}"/>
   {{/if}}
   <div class="input-group-button">
-    <input id="scan-email" type="submit" class="button submit transparent-button" value="Scan" tabindex="0"/>
+    <input type="submit" class="button submit transparent-button" value="Scan" tabindex="0"/>
     <img class="loader" src="/img/loader.gif" alt="loading data" />
   </div>
 </form>


### PR DESCRIPTION
"scan-email" is currently used twice in the scan form.