### PR TITLE
Fixes #514  - clipped Firefox mark in download banner

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -715,6 +715,7 @@ header a h1 {
   background: url("/img/gradient-sprites.png") -331px 0;
   background-repeat: no-repeat;
   background-size: cover;
+  min-width: 55px;
   width: 55px;
   height: 55px;
 }


### PR DESCRIPTION
Prevents Firefox logomark in the download banner from getting clipped on small Safari and Chrome screens.

fixes #514 