### PR TITLE
Disable Unicode isolation

### DIFF
--- a/locale-utils.js
+++ b/locale-utils.js
@@ -40,7 +40,7 @@ const LocaleUtils = {
     });
     for (const lang of languageDirectories) {
       try {
-        const langBundle = new FluentBundle(lang);
+        const langBundle = new FluentBundle(lang, {useIsolating: false});
         const ftlFiles = fs.readdirSync(path.join(localesDir, lang)).filter(item => {
           return (item.endsWith(".ftl"));
         });

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -645,6 +645,8 @@ h5,
 
 .bold {
   font-weight: 600;
+  direction: ltr;
+  unicode-bidi: embed;
 }
 
 /* internal link styling  */


### PR DESCRIPTION
This disables Unicode isolation and gets rid of "PDI" and "FSI" boxes all over the place in Edge. What are the potential negative ramifications of setting { useIsolating: false } for all browsers?

Our current situation in Edge:
<img width="1444" alt="before" src="https://user-images.githubusercontent.com/22355127/47463145-077fde00-d7ab-11e8-9014-d0fbd4dde668.png">
