### PR TITLE
Add email subject to /email-l10n

### DIFF
--- a/controllers/email-l10n.js
+++ b/controllers/email-l10n.js
@@ -6,6 +6,7 @@ const HBSHelpers = require("../hbs-helpers");
 function getEmailMockUps(req, res) {
   const unsafeBreachesForEmail = [];
   const email = "example@email.com";
+  let emailSubject = req.fluentFormat("user-add-email-verify-subject");
   let breachAlert;
   let buttonValue = req.fluentFormat("verify-my-email");
 
@@ -25,8 +26,10 @@ function getEmailMockUps(req, res) {
     buttonValue = req.fluentFormat("report-scan-another-email");
     if(emailType === "singleBreach" || emailType === "breachAlert") {
       unsafeBreachesForEmail.push(req.app.locals.breaches.filter(breach => breach.Name === "Experian")[0]);
+      emailSubject = req.fluentFormat("user-verify-email-report-subject");
       if(emailType === "breachAlert") {
         breachAlert = unsafeBreachesForEmail[0];
+        emailSubject = req.fluentFormat("hibp-notify-email-subject");
       }
     } else if (emailType === "multipleBreaches") {
       const breachArray = ["Experian", "Dropbox", "Apollo"];
@@ -44,6 +47,7 @@ function getEmailMockUps(req, res) {
     date: HBSHelpers.prettyDate(req.supportedLocales, new Date()),
     buttonValue,
     breachAlert,
+    emailSubject,
     email,
   });
 }

--- a/public/css/email_l10n_testing.css
+++ b/public/css/email_l10n_testing.css
@@ -159,6 +159,7 @@ td.email-pwt-image img {
   min-width: 50px;
 }
 
+.email-subject,
 .verify-email,
 .email-main-copy,
 table.table-button,

--- a/views/layouts/email_l10n_mockups.hbs
+++ b/views/layouts/email_l10n_mockups.hbs
@@ -17,10 +17,11 @@
   <body data-server-url="{{ SERVER_URL }}" class="email-locale-testing">
     <section class="section-wrapper">
       <section class="email-test-wrapper">
+          <p class="email-subject">
+            <span class="bold">Subject: </span>{{ emailSubject }}
+          </p>
         <div class="email-content">
-
             {{> email_partials/email_logo}}
-
           <section class="email-body">
             {{> (lookup . 'whichPartial')}}
           </section>


### PR DESCRIPTION
Adds the subject of emails to /email-l10n views and fixes #580 