### PR TITLE
Fix paragraph width / wrapping issue in Download Firefox top bar.

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -672,6 +672,10 @@ h5,
   font-size: 15px;
 }
 
+.download-firefox-bar p {
+  width: 100%;
+}
+
 .download-firefox-bar .section-wrapper {
   padding-top: 15px;
   padding-bottom: 15px;


### PR DESCRIPTION
Fixes #588 