### PR TITLE
Use LogoPath instead of LogoType.

### DIFF
--- a/hibp.js
+++ b/hibp.js
@@ -85,9 +85,8 @@ const HIBP = {
       const breaches = [];
 
       for (const breach of breachesResponse.body) {
-        // const breach = breachesResponse.body[breachIndex];
-        // convert data class strings to Fluent IDs
         breach.DataClasses = this.formatDataClassesArray(breach.DataClasses);
+        breach.LogoPath = /[^/]*$/.exec(breach.LogoPath)[0];
         breaches.push(breach);
       }
       app.locals.breaches = breaches;

--- a/views/partials/breach_listing.hbs
+++ b/views/partials/breach_listing.hbs
@@ -1,6 +1,6 @@
 <div class="account wrap-row">
   <div class="image-wrap">
-    <img alt="" src="/img/logos/{{ Name }}.{{ LogoType }}" />
+    <img alt="" src="/img/logos/{{ LogoPath }}" />
   </div>
   <div class="breach-info-wrap">
     <h4 class="medium">{{ Title }}</h4>

--- a/views/partials/featured_breach.hbs
+++ b/views/partials/featured_breach.hbs
@@ -1,7 +1,7 @@
 {{#if featuredBreach }}
   <div id="featured-breach" class="account wrap-row">
       <div class="image-wrap">
-        <img alt="" src="/img/logos/{{ featuredBreach.Name }}.{{ featuredBreach.LogoType }}">
+        <img alt="" src="/img/logos/{{ LogoPath }}">
       </div>
     <div class="breach-info-wrap">
       <span class="breach-headline medium">{{ featuredBreach.Title }}</span>


### PR DESCRIPTION
Clips down breach.LogoPath when we load in breaches and uses new LogoPath in templates.