### PR TITLE
Use LogoPath in email templates.

### DIFF
--- a/views/partials/email_partials/email_single_breach.hbs
+++ b/views/partials/email_partials/email_single_breach.hbs
@@ -1,6 +1,6 @@
     <tr class="email-breach-listing">
       <td class="email-breach-image" valign="top" style="padding-top: 13px; padding-bottom: 10px; width: 55px;">
-        <img src="{{ SERVER_URL }}/img/logos/{{ this.Name }}.png" width="40" style="width: 40px" />
+        <img src="{{ SERVER_URL }}/img/logos/{{ LogoPath }}" width="40" style="width: 40px" />
       </td>
       <td valign="top" style="vertical-align: top; padding-top: 7px; padding-right: 20px; padding-bottom: 10px;">
         <p class="body-copy medium" style="padding: 0px; margin: 0px; color: #333333; margin: 0px; font-weight: 500; font-size: 16px;">{{ this.Title }}</p>


### PR DESCRIPTION
Breach images in emails are still displaying correctly (provided we have them) but for the sake of uniformity, this updates `img-src=` in email_single_breach.hbs to also use `{{ LogoPath }}` instead of `{{ this.Name }}.png`. 