### PR TITLE
Additional breach filtering / Hide non-website breaches everywhere. 

### DIFF
--- a/controllers/hibp.js
+++ b/controllers/hibp.js
@@ -36,6 +36,13 @@ async function notify (req, res) {
       throw new Error("Unrecognized breach: " + reqBreachName);
     }
   }
+  
+  if (breachAlert.IsSpamList || breachAlert.Domain === "" || breachAlert.IsFabricated) {
+    log.info(`${breachAlert.Name} is fabricated, a spam list, or not associated with a website. \n Breach Alert not sent.`);
+    return res.json(
+      {info: "Breach loaded into database."}
+    );
+  }
 
   const hashes = req.body.hashSuffixes.map(suffix=>reqHashPrefix + suffix.toLowerCase());
   const subscribers = await DB.getSubscribersByHashes(hashes);
@@ -49,7 +56,6 @@ async function notify (req, res) {
     log.info("notify", {subscriber});
 
     const email = subscriber.email;
-    // need to create unsubscribe button for these
     const requestedLanguage = subscriber.signup_language ? acceptedLanguages(subscriber.signup_language) : "";
     const supportedLocales = negotiateLanguages(
       requestedLanguage,

--- a/controllers/hibp.js
+++ b/controllers/hibp.js
@@ -37,9 +37,9 @@ async function notify (req, res) {
     }
   }
 
-  if (breachAlert.IsSpamList || breachAlert.Domain === "" || breachAlert.IsFabricated) {
+  if (breachAlert.IsSpamList || breachAlert.Domain === "" || breachAlert.IsFabricated || !breachAlert.IsVerified) {
     log.info(`${breachAlert.Name} is fabricated, a spam list, or not associated with a website. \n Breach Alert not sent.`);
-    return res.json(
+    return res.status(200).json(
       {info: "Breach loaded into database."}
     );
   }

--- a/controllers/hibp.js
+++ b/controllers/hibp.js
@@ -36,7 +36,7 @@ async function notify (req, res) {
       throw new Error("Unrecognized breach: " + reqBreachName);
     }
   }
-  
+
   if (breachAlert.IsSpamList || breachAlert.Domain === "" || breachAlert.IsFabricated) {
     log.info(`${breachAlert.Name} is fabricated, a spam list, or not associated with a website. \n Breach Alert not sent.`);
     return res.json(

--- a/controllers/hibp.js
+++ b/controllers/hibp.js
@@ -40,7 +40,7 @@ async function notify (req, res) {
   if (breachAlert.IsSpamList || breachAlert.Domain === "" || breachAlert.IsFabricated || !breachAlert.IsVerified) {
     log.info(`${breachAlert.Name} is fabricated, a spam list, not associated with a website, or unverified. \n Breach Alert not sent.`);
     return res.status(200).json(
-      {info: "Breach loaded into database."}
+      {info: "Breach loaded into database. Subscribers not notified."}
     );
   }
 

--- a/controllers/hibp.js
+++ b/controllers/hibp.js
@@ -38,7 +38,7 @@ async function notify (req, res) {
   }
 
   if (breachAlert.IsSpamList || breachAlert.Domain === "" || breachAlert.IsFabricated || !breachAlert.IsVerified) {
-    log.info(`${breachAlert.Name} is fabricated, a spam list, or not associated with a website. \n Breach Alert not sent.`);
+    log.info(`${breachAlert.Name} is fabricated, a spam list, not associated with a website, or unverified. \n Breach Alert not sent.`);
     return res.status(200).json(
       {info: "Breach loaded into database."}
     );

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -76,9 +76,10 @@ async function verify(req, res) {
   const verifiedEmailHash = await DB.verifyEmailHash(req.query.token);
   const unsubscribeUrl = EmailUtils.unsubscribeUrl(verifiedEmailHash);
 
-  unsafeBreachesForEmail = await HIBP.getUnsafeBreachesForEmail(
+  unsafeBreachesForEmail = await HIBP.getBreachesForEmail(
     sha1(verifiedEmailHash.email),
-    req.app.locals.breaches
+    req.app.locals.breaches,
+    true,
   );
 
   await EmailUtils.sendEmail(

--- a/hibp.js
+++ b/hibp.js
@@ -98,16 +98,8 @@ const HIBP = {
     log.info("done-loading-breaches");
   },
 
-  async getUnsafeBreachesForEmail(sha1, allBreaches) {
-    const allFoundBreaches = await this.getBreachesForEmail(sha1, allBreaches, true);
-    return allFoundBreaches.filter(
-      breach => !breach.IsSpamList &&
-                !breach.IsFabricated &&
-                breach.Domain !== ""
-    );
-  },
 
-  async getBreachesForEmail(sha1, allBreaches, includeUnsafe = false) {
+  async getBreachesForEmail(sha1, allBreaches, includeSensitive = false) {
     let foundBreaches = [];
     const sha1Prefix = sha1.slice(0, 6).toUpperCase();
     const path = `/breachedaccount/range/${sha1Prefix}`;
@@ -128,23 +120,26 @@ const HIBP = {
       }
     }
 
-    if (includeUnsafe) {
-      return foundBreaches;
+    if (includeSensitive) {
+      return this.filterBreaches(foundBreaches);
     }
-    return this.filterOutUnsafeBreaches(foundBreaches);
+    return this.filterBreaches(foundBreaches).filter(
+      breach => !breach.IsSensitive
+    );
   },
+
 
   getBreachByName(allBreaches, breachName) {
     return allBreaches.find(breach => breach.Name.toLowerCase() === breachName.toLowerCase());
   },
 
 
-  filterOutUnsafeBreaches(breaches) {
+  filterBreaches(breaches) {
     return breaches.filter(
       breach => !breach.IsRetired &&
-                !breach.IsSensitive &&
                 !breach.IsSpamList &&
                 !breach.IsFabricated &&
+                breach.IsVerified &&
                 breach.Domain !== ""
     );
   },

--- a/hibp.js
+++ b/hibp.js
@@ -116,14 +116,15 @@ const HIBP = {
     for (const breachedAccount of response.body) {
       if (sha1.toUpperCase() === sha1Prefix + breachedAccount.hashSuffix) {
         foundBreaches = allBreaches.filter(breach => breachedAccount.websites.includes(breach.Name));
+        foundBreaches = this.filterBreaches(foundBreaches);
         break;
       }
     }
 
     if (includeSensitive) {
-      return this.filterBreaches(foundBreaches);
+      return foundBreaches;
     }
-    return this.filterBreaches(foundBreaches).filter(
+    return foundBreaches.filter(
       breach => !breach.IsSensitive
     );
   },

--- a/hibp.js
+++ b/hibp.js
@@ -101,7 +101,9 @@ const HIBP = {
   async getUnsafeBreachesForEmail(sha1, allBreaches) {
     const allFoundBreaches = await this.getBreachesForEmail(sha1, allBreaches, true);
     return allFoundBreaches.filter(
-      breach => !breach.IsSpamList
+      breach => !breach.IsSpamList &&
+                !breach.IsFabricated &&
+                breach.Domain !== ""
     );
   },
 
@@ -139,10 +141,11 @@ const HIBP = {
 
   filterOutUnsafeBreaches(breaches) {
     return breaches.filter(
-      breach => breach.IsVerified &&
-                !breach.IsRetired &&
+      breach => !breach.IsRetired &&
                 !breach.IsSensitive &&
-                !breach.IsSpamList
+                !breach.IsSpamList &&
+                !breach.IsFabricated &&
+                breach.Domain !== ""
     );
   },
 

--- a/tests/controllers/hibp.test.js
+++ b/tests/controllers/hibp.test.js
@@ -47,7 +47,7 @@ test("notify POST with breach, subscriber hash prefix and suffixes should call s
   const testPrefix = testHash.slice(0, 6).toUpperCase();
   const testSuffix = testHash.slice(6).toUpperCase();
 
-  HIBPLib.getUnsafeBreachesForEmail = jest.fn();
+  HIBPLib.getBreachesForEmail = jest.fn();
 
   const mockRequest = { token: AppConstants.HIBP_NOTIFY_TOKEN, body: { hashPrefix: testPrefix, hashSuffixes: [testSuffix], breachName: "Test" }, app: { locals: { breaches: testBreaches, AVAILABLE_LANGUAGES: ["en"] } } };
   const mockResponse = { status: jest.fn(), json: jest.fn() };

--- a/tests/hibp.test.js
+++ b/tests/hibp.test.js
@@ -40,7 +40,7 @@ test("loadBreachesIntoApp adds app.locals.breaches|breachesLoadedDateTime|mostRe
 });
 
 
-test("filterOutUnsafeBreaches removes sensitive breaches", async() => {
+test("filterBreaches removes retired, spam list, fabricated, unverified, and non-website breaches", async() => {
   let foundSensitive = false;
   for (const breach of testBreaches) {
     if (breach.IsSensitive) {
@@ -51,10 +51,10 @@ test("filterOutUnsafeBreaches removes sensitive breaches", async() => {
   expect(foundSensitive).toBe(true);
 
 
-  const safeBreaches = hibp.filterOutUnsafeBreaches(testBreaches);
+  const safeBreaches = hibp.filterBreaches(testBreaches);
 
   for (const breach of safeBreaches) {
-    expect(breach.IsSensitive).toBe(false);
+    expect(breach.IsFabricated).toBe(false);
     expect(breach.IsSpamList).toBe(false);
     expect(breach.IsRetired).toBe(false);
     expect(breach.IsVerified).toBe(true);

--- a/tests/test-breaches.js
+++ b/tests/test-breaches.js
@@ -8,6 +8,10 @@ const testBreaches = [
     BreachDate: "2012-12-21",
     AddedDate: "2013-01-01",
     DataClasses: [],
+    IsSpamList: false,
+    IsFabricated: false,
+    IsVerified: true,
+    IsRetired: true,
   },
   {
     Title: "Test2",
@@ -16,6 +20,10 @@ const testBreaches = [
     BreachDate: "2016-11-08",
     AddedDate: "2017-01-01",
     DataClasses: [],
+    IsSpamList: false,
+    IsFabricated: false,
+    IsVerified: true,
+    IsRetired: true,
   },
   {
     Title: "Sensitive",
@@ -25,6 +33,10 @@ const testBreaches = [
     AddedDate: "2018-11-08",
     IsSensitive: true,
     DataClasses: [],
+    IsSpamList: false,
+    IsFabricated: false,
+    IsVerified: true,
+    IsRetired: false,
   },
 ];
 


### PR DESCRIPTION
There was a lot of confusion about the "You've Been Scraped" breach alert we sent out on 12/6. Earlier today a decision was made to hide non-website breaches until new content has been created to explain them.
This hides breaches in website scan results, email reports, and prevents the sending of new breach alerts when  `breach.IsFabricated`, `breach.IsSpamList`, and when `breach.Domain === ""`.
