### PR TITLE
Update to fluent 0.10

### DIFF
--- a/locales/ru/app.ftl
+++ b/locales/ru/app.ftl
@@ -9,7 +9,7 @@
 -brand-Quantum = Firefox Quantum
 -brand-Mozilla = Mozilla
 -brand-HIBP =
-    {
+    { $case ->
         [nominative] Сервис Have I Been Pwned
         [genitive] Сервисом Have I Been Pwned
        *[dative] Сервису Have I Been Pwned
@@ -23,8 +23,8 @@ about-firefox-alerts = Об уведомлениях Firefox
 give-feedback = Оставить отзыв
 terms-and-privacy = Условия и конфиденциальность
 error-not-subscribed = Этот адрес электронной почты не подписан на { -product-name }.
-error-hibp-throttled = Слишком много попыток соединения с { -brand-HIBP[genitive] }.
-error-hibp-connect = Ошибка подключения к { -brand-HIBP[dative] }.
+error-hibp-throttled = Слишком много попыток соединения с { -brand-HIBP(case: "genitive") }.
+error-hibp-connect = Ошибка подключения к { -brand-HIBP(case: "dative") }.
 error-hibp-load-breaches = Не удалось загрузить информацию по угрозам.
 hibp-notify-email-subject = Предупреждение { -product-name }: Ваш аккаунт под угрозой.
 home-title = { -product-name }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3278,9 +3278,9 @@
       }
     },
     "fluent": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/fluent/-/fluent-0.8.1.tgz",
-      "integrity": "sha512-hVlyzl3N9okoqqQUd6cExsBAOmxBeaxP3JFmBBPkYqSRQs4d2U2y2a5KxwMSvno1m9nmwM4CsjeBWdJ9wSYWsA=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/fluent/-/fluent-0.10.0.tgz",
+      "integrity": "sha512-2I6xaHecA76FiGavw6eKurXaHd6p25eenAgRYKSaMwJEpbvWpAlwFWAnC+BGzrGIKINUHwDlCQRtRenJvlbqQQ=="
     },
     "fluent-langneg": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.2",
     "express-bearer-token": "^2.2.0",
     "express-handlebars": "^3.0.0",
-    "fluent": "^0.8.1",
+    "fluent": "^0.10.0",
     "fluent-langneg": "^0.1.0",
     "full-icu": "^1.2.1",
     "git-rev-sync": "^1.12.0",


### PR DESCRIPTION
Please update to the newest version of `fluent`. It supports the new features of the Fluent Syntax, introduced in [versions 0.7 and 0.8](https://github.com/projectfluent/fluent/releases) of the spec. The `fluent` package on npm is [versioned independently](https://github.com/projectfluent/fluent.js/blob/master/fluent/CHANGELOG.md) of the spec versions, but the gist is that `fluent` 0.10 supports the most recent syntax spec.

This is important to us because we'd like to roll out the support for these new features in Pontoon soon. Once available, localizers will be free to use them in their translations. I'd like to make sure `blurts-server` is ready for any such updated translations.

I tested this locally briefly, i.e. without creating a DB nor connecting to HIBP. The landing page and some error pages showed up localized as expected. Thanks!