### PR TITLE
start FxA fixes for new templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,24 @@
 language: node_js
+
+dist: trusty
+
 node_js:
   - "node"
   - "lts/*"
+
 services:
   - postgresql
+
+addons:
+  postgresql: 9.6
+
 env:
   - NODE_ENV=tests
+
 install:
   - sudo pip install compare-locales
   - npm install
+
 before_script:
   - compare-locales --validate l10n.toml .
   - compare-locales l10n.toml . `ls locales`

--- a/basket.js
+++ b/basket.js
@@ -3,6 +3,10 @@
 const got = require("got");
 
 const AppConstants = require("./app-constants");
+const mozlog = require("./log");
+
+
+const log = mozlog("basket");
 
 
 const Basket = {
@@ -21,9 +25,15 @@ const Basket = {
       form: true,
       body: params,
     };
-    await got(url, reqOptions);
+
+    try {
+      await got(url, reqOptions);
+    } catch (e) {
+      log.error("subscribe", {stack: e.stack});
+    }
   },
 
 };
+
 
 module.exports = Basket;

--- a/controllers/oauth.js
+++ b/controllers/oauth.js
@@ -6,6 +6,7 @@ const got = require("got");
 
 const AppConstants = require("../app-constants");
 const DB = require("../db/DB");
+const EmailUtils = require("../email-utils");
 const { FluentError } = require("../locale-utils");
 
 
@@ -53,9 +54,12 @@ async function confirmed(req, res, next, client = FxAOAuthClient) {
   const email = JSON.parse(data.body).email;
   await DB.addSubscriber(email);
 
-  res.render("confirm", {
-    title: req.fluentFormat("oauth-confirmed-title"),
-    email: email,
+  res.render("subpage", {
+    headline: req.fluentFormat("confirmation-headline"),
+    subhead: req.fluentFormat("confirmation-blurb"),
+    title: req.fluentFormat("user-verify-title"),
+    whichPartial: "subpages/confirm",
+    emailLinks: EmailUtils.getShareByEmail(req),
   });
 }
 

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -38,34 +38,6 @@ async function add(req, res) {
   });
 }
 
-function getShareByEmail(req) {
-
-  const subject = encodeURIComponent(req.fluentFormat("share-by-email-subject"));
-  const body = encodeURIComponent(req.fluentFormat("share-by-email-message"));
-
-  return {
-    "gmail" : {
-      client: "Gmail",
-      class: "gmail",
-      href: `https://mail.google.com/mail/?view=cm&fs=1&su=${subject}&body=${body}`,
-    },
-    "yahoo" : {
-      client: "Yahoo",
-      class: "yahoo",
-      href: `https://compose.mail.yahoo.com/?subject=${subject}&body=${body}`,
-    },
-    "outlook" : {
-      client: "Outlook",
-      class: "outlook",
-      href: `https://outlook.live.com/owa/?path=/mail/action/compose&subject=${subject}&body=${body}`,
-    },
-    "default-email" : {
-      client: req.fluentFormat("share-other"),
-      class: "default-email-client",
-      href: `mailto:?subject=${subject}&body=${body}`,
-    },
-  };
-}
 
 async function verify(req, res) {
   if (!req.query.token) {
@@ -102,7 +74,7 @@ async function verify(req, res) {
     subhead: req.fluentFormat("confirmation-blurb"),
     title: req.fluentFormat("user-verify-title"),
     whichPartial: "subpages/confirm",
-    emailLinks: getShareByEmail(req),
+    emailLinks: EmailUtils.getShareByEmail(req),
   });
 }
 

--- a/db/DB.js
+++ b/db/DB.js
@@ -101,18 +101,40 @@ const DB = {
     });
   },
 
-  async addSubscriber(email) {
+  /**
+   * Add a subscriber:
+   * 1. Add a record to subscribers
+   * 2. Immediately call _verifySubscriber
+   * 3. For FxA subscriber, add refresh token and profile data
+   *
+   * @param {string} email to add
+   * @param {string} fxaRefreshToken from Firefox Account Oauth
+   * @param {string} fxaProfileData from Firefox Account
+   * @returns {object} subscriber knex object added to DB
+   */
+  async addSubscriber(email, fxaRefreshToken=null, fxaProfileData=null) {
     const emailHash = await this._addEmailHash(getSha1(email), email, true);
-    const verifiedSubscriber = await this._verifySubscriber(emailHash);
-    return verifiedSubscriber[0];
+    const verified = await this._verifySubscriber(emailHash);
+    const verifiedSubscriber = verified[0];
+    if (fxaRefreshToken || fxaProfileData) {
+      return this._updateFxAData(verifiedSubscriber, fxaRefreshToken, fxaProfileData);
+    }
+    return verifiedSubscriber;
   },
 
+  /**
+   * When an email is verified, convert it into a subscriber:
+   * 1. Subscribe the hash to HIBP
+   * 2. Update our subscribers record to verified
+   * 3. (if opted in) Subscribe the email to Fx newsletter
+   *
+   * @param {object} emailHash knex object in DB
+   * @returns {object} verified subscriber knex object in DB
+   */
   async _verifySubscriber(emailHash) {
-    // Subscribe user to HIBP
     // TODO: move this "up" into controllers/users ?
     await HIBP.subscribeHash(emailHash.sha1);
 
-    // Update our subscriber record to verified
     const verifiedSubscriber = await knex("subscribers")
       .where("email", "=", emailHash.email)
       .update({
@@ -121,13 +143,31 @@ const DB = {
       })
       .returning("*");
 
-    // If the user opted in, send newsletter subscription request to basket
     // TODO: move this "up" into controllers/users ?
     if (emailHash.fx_newsletter) {
       Basket.subscribe(emailHash.email);
     }
 
     return verifiedSubscriber;
+  },
+
+  /**
+   * Update fxa_refresh_token and fxa_profile_json for subscriber
+   *
+   * @param {object} subscriber knex object in DB
+   * @param {string} fxaRefreshToken from Firefox Account Oauth
+   * @param {string} fxaProfileData from Firefox Account
+   * @returns {object} updated subscriber knex object in DB
+   */
+  async _updateFxAData(subscriber, fxaRefreshToken, fxaProfileData) {
+    const updatedSubscriber = await knex("subscribers")
+    .where("id", "=", subscriber.id)
+    .update({
+      fxa_refresh_token: fxaRefreshToken,
+      fxa_profile_json: fxaProfileData,
+    })
+    .returning("*");
+    return updatedSubscriber;
   },
 
   async removeSubscriberByEmail(email) {

--- a/db/migrations/20181227100332_add_fxa_columns.js
+++ b/db/migrations/20181227100332_add_fxa_columns.js
@@ -1,0 +1,15 @@
+"use strict";
+
+exports.up = function(knex, Promise) {
+  return knex.schema.table("subscribers", table => {
+    table.string("fxa_refresh_token");
+    table.jsonb("fxa_profile_json");
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table("subscribers", table => {
+    table.dropColumn("fxa_refresh_token");
+    table.dropColumn("fxa_profile_json");
+  });
+};

--- a/email-utils.js
+++ b/email-utils.js
@@ -112,7 +112,7 @@ const EmailUtils = {
         href: `mailto:?subject=${subject}&body=${body}`,
       },
     };
-  }
+  },
 
 };
 

--- a/email-utils.js
+++ b/email-utils.js
@@ -86,6 +86,34 @@ const EmailUtils = {
     return `${AppConstants.SERVER_URL}/user/unsubscribe?token=${encodeURIComponent(subscriber.verification_token)}&hash=${encodeURIComponent(subscriber.sha1)}`;
   },
 
+  getShareByEmail (req) {
+    const subject = encodeURIComponent(req.fluentFormat("share-by-email-subject"));
+    const body = encodeURIComponent(req.fluentFormat("share-by-email-message"));
+
+    return {
+      "gmail" : {
+        client: "Gmail",
+        class: "gmail",
+        href: `https://mail.google.com/mail/?view=cm&fs=1&su=${subject}&body=${body}`,
+      },
+      "yahoo" : {
+        client: "Yahoo",
+        class: "yahoo",
+        href: `https://compose.mail.yahoo.com/?subject=${subject}&body=${body}`,
+      },
+      "outlook" : {
+        client: "Outlook",
+        class: "outlook",
+        href: `https://outlook.live.com/owa/?path=/mail/action/compose&subject=${subject}&body=${body}`,
+      },
+      "default-email" : {
+        client: req.fluentFormat("share-other"),
+        class: "default-email-client",
+        href: `mailto:?subject=${subject}&body=${body}`,
+      },
+    };
+  }
+
 };
 
 module.exports = EmailUtils;

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -19,6 +19,7 @@ about-firefox-alerts = About Firefox Alerts
 give-feedback = Give Feedback
 terms-and-privacy = Terms and Privacy
 
+error-could-not-add-email = Could not add email address to database.
 error-not-subscribed = This email address is not subscribed to {-product-name}.
 error-hibp-throttled = Too many connections to {-brand-HIBP}.
 error-hibp-connect = Error connecting to {-brand-HIBP}.

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -234,6 +234,7 @@ form,
   width: 100%;
 }
 
+.modal-container.fxa-enabled .modal-content-wrap button,
 button.internal-link,
 button.close-modal,
 input.transparent-button,
@@ -969,6 +970,19 @@ body.show-subscribe-modal .modal-container {
   position: relative;
 }
 
+.modal-container.fxa-enabled .modal-content-wrap {
+  min-height: 200px;
+}
+
+.modal-container.fxa-enabled .modal-content-wrap .blue-button {
+  margin-top: var(--columnSpacing);
+}
+
+.modal-container.fxa-enabled .modal-content-wrap .blue-button,
+.modal-container.fxa-enabled .modal-content-wrap .internal-link {
+  margin-bottom: 0;
+}
+
 .modal-content h3,
 .modal-content p,
 .modal-content label,
@@ -1674,6 +1688,7 @@ form.show-thankyou span.thank-you-message {
     max-width: 100%;
   }
 
+  .modal-container.fxa-enabled .modal-content-wrap button,
   button.internal-link,
   button.close-modal,
   input.transparent-button,
@@ -1840,6 +1855,7 @@ form.show-thankyou span.thank-you-message {
     --gap: 15px;
   }
 
+  .modal-container.fxa-enabled .modal-content-wrap button,
   .radio-button-group label,
   button.internal-link,
   input.transparent-button,

--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -165,6 +165,9 @@ const focusFirstInput = function(e) {
 function closeModalWindow() {
   document.body.classList.remove("show-subscribe-modal");
   document.getElementById("subscribe-to-ffxm").classList.remove("show");
+  if (document.getElementById("subscribe-modal").classList.contains("fxa-enabled")) {
+    return;
+  }
   document.getElementById("confirm-your-account").classList.remove("show", "sending", "sent");
   document.getElementById("subscribe-form").classList.remove("invalid");
   document.getElementById("subscribe-email-input").value = "";
@@ -177,6 +180,9 @@ function openModalWindow() {
   document.body.classList.add("show-subscribe-modal");
   document.getElementById("subscribe-to-ffxm").classList.add("show");
   setModalTabbing();
+  if (subscribeModal.classList.contains("fxa-enabled")) {
+    return;
+  }
   document.getElementById("subscribe-form").classList.remove("loading-data");
   subscribeModal.addEventListener("transitionend", (e) => focusFirstInput(e));
   subscribeModal.addEventListener("click", function closeWrapper(e) {

--- a/tests/controllers/oauth.test.js
+++ b/tests/controllers/oauth.test.js
@@ -18,14 +18,15 @@ jest.mock("got");
 const mockRequest = { fluentFormat: jest.fn() };
 
 
-test("init request sets session cookie and redirects", () => {
+test("init request sets session cookie and redirects with access_type=offline", () => {
   mockRequest.session = { };
   const mockResponse = { redirect: jest.fn() };
 
   init(mockRequest, mockResponse);
 
   const mockRedirectCallArgs = mockResponse.redirect.mock.calls[0];
-  expect(mockRedirectCallArgs[0]).toMatch(AppConstants.OAUTH_AUTHORIZATION_URI);
+  expect(mockRedirectCallArgs[0].href).toMatch(AppConstants.OAUTH_AUTHORIZATION_URI);
+  expect(mockRedirectCallArgs[0].href).toMatch("access_type=offline");
 });
 
 

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -63,6 +63,13 @@ test("verifyEmailHash accepts token and returns verified subscriber", async () =
 });
 
 
+test("addSubscriber invalid argument", async () => {
+  const testEmail = "test".repeat(255);
+
+  await expect(DB.addSubscriber(testEmail)).rejects.toThrow("error-could-not-add-email");
+});
+
+
 test("addSubscriber accepts email and returns verified subscriber", async () => {
   const testEmail = "newFirefoxAccount@test.com";
 

--- a/views/partials/subscribe_modal/subscribe_modal_wrapper.hbs
+++ b/views/partials/subscribe_modal/subscribe_modal_wrapper.hbs
@@ -1,4 +1,6 @@
-<section id="subscribe-modal" class="modal-container">
-  {{> subscribe_modal/confirm_your_account}}
+<section id="subscribe-modal" class="modal-container {{#if FXA_ENABLED}}fxa-enabled{{/if}}">
+  {{#unless FXA_ENABLED}}
+    {{> subscribe_modal/confirm_your_account}}
+  {{/unless}}
   {{> subscribe_modal/subscribe_to_ffxm}}
 </section>

--- a/views/partials/subscribe_modal/subscribe_to_ffxm.hbs
+++ b/views/partials/subscribe_modal/subscribe_to_ffxm.hbs
@@ -6,25 +6,24 @@
         {{{fluentFormat req.supportedLocales "terms-and-privacy"}}}
       </a>
     </p>
-  
-    {{#if FXA_ENABLED }}
-      <button id="subscribe-fxa-btn" class="button">{{fluentFormat req.supportedLocales "signup-with-fxa"}}</button>
-    {{/if}}
-  
-    <form action="/user/add" id="subscribe-form" class="form-group" method="post" novalidate data-no-csrf>
-      <div class="input-group">
-        <input id="subscribe-email-input" class="input-group-field" type="email" name="email" placeholder="{{fluentFormat req.supportedLocales "form-signup-placeholder"}}" minlength="1" aria-label="{{fluentFormat req.supportedLocales "form-signup-placeholder"}}"  autocomplete="off" />
-        <span id="invalid-signup-email-message" class="error-message">{{fluentFormat req.supportedLocales "form-signup-error"}}</span>
-      </div>
-      <div class="checkbox-group">
-        <input id="additional-emails-checkbox" type="checkbox" name="additional-emails" value="additional-emails" />
-        <label for="additional-emails-checkbox">{{fluentFormat req.supportedLocales "form-signup-checkbox"}}</label>
-      </div>
-      <div class="input-group-button">
-        <img class="loader" src="/img/loader.gif" alt="" />
-        <input id="subscribe-submit" type="submit" class="button submit-email blue-button" value="{{fluentFormat req.supportedLocales "sign-up"}}"  />
-      </div>
-    </form>
+      {{#if FXA_ENABLED}}
+        <button id="subscribe-fxa-btn" class="blue-button">{{fluentFormat req.supportedLocales "signup-with-fxa"}}</button>
+      {{else}}
+        <form action="/user/add" id="subscribe-form" class="form-group" method="post" novalidate data-no-csrf>
+          <div class="input-group">
+            <input id="subscribe-email-input" class="input-group-field" type="email" name="email" placeholder="{{fluentFormat req.supportedLocales "form-signup-placeholder"}}" minlength="1" aria-label="{{fluentFormat req.supportedLocales "form-signup-placeholder"}}"  autocomplete="off" />
+            <span id="invalid-signup-email-message" class="error-message">{{fluentFormat req.supportedLocales "form-signup-error"}}</span>
+          </div>
+          <div class="checkbox-group">
+            <input id="additional-emails-checkbox" type="checkbox" name="additional-emails" value="additional-emails" />
+            <label for="additional-emails-checkbox">{{fluentFormat req.supportedLocales "form-signup-checkbox"}}</label>
+          </div>
+          <div class="input-group-button">
+            <img class="loader" src="/img/loader.gif" alt="" />
+            <input id="subscribe-submit" type="submit" class="button submit-email blue-button" value="{{fluentFormat req.supportedLocales "sign-up"}}"  />
+          </div>
+        </form>
+      {{/if}}
     <button data-analytics-label="Before Sign Up" class="close-modal internal-link">{{fluentFormat req.supportedLocales "signup-modal-close"}}</button>
   </div>
 </div>


### PR DESCRIPTION
We still need to ...

* [x] Change our OAuth client to request `profile` scope and not just `profile:email` (needs FxA team to approve)
  * [x] Store the full `profile` JSON in our DB
* [x] Include `access_type=offline` in our query params to get a long-life refresh token
  * [x] Store the refresh token in our DB