### PR TITLE
Send analytics ping on HIBP clicks.

### DIFF
--- a/views/partials/hibp_attribution.hbs
+++ b/views/partials/hibp_attribution.hbs
@@ -1,1 +1,3 @@
-<span class="source-info">{{{fluentFormat req.supportedLocales "hibp-attribution" hibp-link='<a id="hibp-link" href="https://www.haveibeenpwned.com" target="_blank" rel="noopener noreferrer">Have I Been Pwned</a>'}}}</span>
+<span class="source-info">
+  {{{fluentFormat req.supportedLocales "hibp-attribution" hibp-link='<a id="hibp-link" href="https://www.haveibeenpwned.com" data-analytics-event="Link" data-analytics-label="Clicked HIBP" target="_blank" rel="noopener noreferrer">Have I Been Pwned</a>'}}}
+</span>


### PR DESCRIPTION
Sends a ping anytime a user clicks on the HIBP attribution link. I'm sure we were collecting these clicks at one point but I think the analytics attributes were mistakenly left out during localization.