### PR TITLE
Add utm parameters to CTA buttons and unsubscribe links in emails.

### DIFF
--- a/controllers/hibp.js
+++ b/controllers/hibp.js
@@ -47,6 +47,9 @@ async function notify (req, res) {
   const hashes = req.body.hashSuffixes.map(suffix=>reqHashPrefix + suffix.toLowerCase());
   const subscribers = await DB.getSubscribersByHashes(hashes);
 
+  const utmID = "breach-alert";
+  const buttonHref = EmailUtils.getScanAnotherEmailUrl(utmID);
+
 
   log.info("notification", { length: subscribers.length, breachAlertName: breachAlert.Name });
 
@@ -62,7 +65,6 @@ async function notify (req, res) {
       req.app.locals.AVAILABLE_LANGUAGES,
       {defaultLocale: "en"}
     );
-    const unsubscribeUrl = EmailUtils.unsubscribeUrl(subscriber);
 
     if (!notifiedSubscribers.includes(email)) {
       await EmailUtils.sendEmail(
@@ -73,10 +75,11 @@ async function notify (req, res) {
           email,
           supportedLocales,
           date: HBSHelpers.prettyDate(supportedLocales, new Date()),
-          unsubscribeUrl,
           breachAlert,
           SERVER_URL: req.app.locals.SERVER_URL,
           buttonValue: LocaleUtils.fluentFormat(supportedLocales, "report-scan-another-email"),
+          buttonHref: buttonHref,
+          unsubscribeUrl: EmailUtils.getUnsubscribeUrl(subscriber, utmID),
           whichView: "email_partials/report",
         },
       );

--- a/controllers/hibp.js
+++ b/controllers/hibp.js
@@ -48,7 +48,7 @@ async function notify (req, res) {
   const subscribers = await DB.getSubscribersByHashes(hashes);
 
   const utmID = "breach-alert";
-  const buttonHref = EmailUtils.getScanAnotherEmailUrl(utmID);
+  const scanAnotherEmailHref = EmailUtils.getScanAnotherEmailUrl(utmID);
 
 
   log.info("notification", { length: subscribers.length, breachAlertName: breachAlert.Name });
@@ -77,8 +77,7 @@ async function notify (req, res) {
           date: HBSHelpers.prettyDate(supportedLocales, new Date()),
           breachAlert,
           SERVER_URL: req.app.locals.SERVER_URL,
-          buttonValue: LocaleUtils.fluentFormat(supportedLocales, "report-scan-another-email"),
-          buttonHref: buttonHref,
+          scanAnotherEmailHref: scanAnotherEmailHref,
           unsubscribeUrl: EmailUtils.getUnsubscribeUrl(subscriber, utmID),
           whichView: "email_partials/report",
         },

--- a/controllers/oauth.js
+++ b/controllers/oauth.js
@@ -85,8 +85,7 @@ async function confirmed(req, res, next, client = FxAOAuthClient) {
       supportedLocales: req.supportedLocales,
       date: HBSHelpers.prettyDate(req.supportedLocales, new Date()),
       unsafeBreachesForEmail: unsafeBreachesForEmail,
-      buttonValue: req.fluentFormat("report-scan-another-email"),
-      buttonHref: EmailUtils.getScanAnotherEmailUrl(utmID),
+      scanAnotherEmailHref: EmailUtils.getScanAnotherEmailUrl(utmID),
       unsubscribeUrl: unsubscribeUrl,
       whichView: "email_partials/report",
     }

--- a/controllers/oauth.js
+++ b/controllers/oauth.js
@@ -62,9 +62,10 @@ async function confirmed(req, res, next, client = FxAOAuthClient) {
   log.debug("fxa-confirmed-profile-data", data.body);
   const email = JSON.parse(data.body).email;
   const signupLanguage = req.headers["accept-language"];
-  await DB.addSubscriber(email, signupLanguage, fxaUser.refreshToken, data.body);
+  const subscriber = await DB.addSubscriber(email, signupLanguage, fxaUser.refreshToken, data.body);
 
-  const unsubscribeUrl = ""; // not totally sure yet how this gets handled long-term
+  const utmID = "report";
+  const unsubscribeUrl = await EmailUtils.getUnsubscribeUrl(subscriber[0], utmID);
 
   // duping some of user/verify for now
   let unsafeBreachesForEmail = [];
@@ -80,12 +81,13 @@ async function confirmed(req, res, next, client = FxAOAuthClient) {
     req.fluentFormat("user-verify-email-report-subject"),
     "default_email",
     {
-      supportedLocales: req.supportedLocales,
       email: email,
+      supportedLocales: req.supportedLocales,
       date: HBSHelpers.prettyDate(req.supportedLocales, new Date()),
       unsafeBreachesForEmail: unsafeBreachesForEmail,
-      unsubscribeUrl: unsubscribeUrl,
       buttonValue: req.fluentFormat("report-scan-another-email"),
+      buttonHref: EmailUtils.getScanAnotherEmailUrl(utmID),
+      unsubscribeUrl: unsubscribeUrl,
       whichView: "email_partials/report",
     }
   );

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -27,8 +27,7 @@ async function add(req, res) {
     "default_email",
     { email,
       supportedLocales: req.supportedLocales,
-      buttonValue: req.fluentFormat("verify-my-email"),
-      buttonHref: EmailUtils.getVerificationUrl(unverifiedSubscriber),
+      verificationHref: EmailUtils.getVerificationUrl(unverifiedSubscriber),
       unsubscribeUrl: EmailUtils.getUnsubscribeUrl(unverifiedSubscriber, "account-verification-email"),
       whichView: "email_partials/email_verify",
     });
@@ -43,8 +42,7 @@ async function verify(req, res) {
   if (!req.query.token) {
     throw new FluentError("user-verify-token-error");
   }
-  const token = req.query.token.toString().replace(/\?utm_.*/g, "");
-  const verifiedEmailHash = await DB.verifyEmailHash(token);
+  const verifiedEmailHash = await DB.verifyEmailHash(req.query.token);
 
   let unsafeBreachesForEmail = [];
   unsafeBreachesForEmail = await HIBP.getBreachesForEmail(
@@ -64,7 +62,7 @@ async function verify(req, res) {
       supportedLocales: req.supportedLocales,
       date: HBSHelpers.prettyDate(req.supportedLocales, new Date()),
       unsafeBreachesForEmail: unsafeBreachesForEmail,
-      buttonHref: EmailUtils.getScanAnotherEmailUrl(utmID),
+      scanAnotherEmailHref: EmailUtils.getScanAnotherEmailUrl(utmID),
       unsubscribeUrl: EmailUtils.getUnsubscribeUrl(verifiedEmailHash, utmID),
       whichView: "email_partials/report",
     }
@@ -98,7 +96,7 @@ async function getUnsubscribe(req, res) {
     subhead: req.fluentFormat("unsub-blurb"),
     whichPartial: "subpages/unsubscribe",
     token: req.query.token,
-    hash: req.query.hash.toString().replace(/\?utm_.*/g, ""),
+    hash: req.query.hash,
   });
 }
 

--- a/email-utils.js
+++ b/email-utils.js
@@ -78,15 +78,26 @@ const EmailUtils = {
     });
   },
 
-  verifyUrl (subscriber) {
-    return `${AppConstants.SERVER_URL}/user/verify?token=${encodeURIComponent(subscriber.verification_token)}`;
+  utmParams(campaign, content) {
+    return `?utm_source=fx-monitor-emails&utm_medium=email&utm_campaign=${campaign}&utm_content=${content}`;
   },
 
-  unsubscribeUrl (subscriber) {
-    return `${AppConstants.SERVER_URL}/user/unsubscribe?token=${encodeURIComponent(subscriber.verification_token)}&hash=${encodeURIComponent(subscriber.sha1)}`;
+  getScanAnotherEmailUrl(emailType) {
+    return `${AppConstants.SERVER_URL}${this.utmParams("scan-another-email", emailType)}`;
   },
 
-  getShareByEmail (req) {
+  getVerificationUrl(subscriber) {
+    const utmParams = this.utmParams("verified subscribers", "account-verification-email");
+    return `${AppConstants.SERVER_URL}/user/verify?token=${encodeURIComponent(subscriber.verification_token)}${utmParams}`;
+  },
+
+  getUnsubscribeUrl(subscriber, emailType) {
+    const unsubUserParams = `?token=${encodeURIComponent(subscriber.verification_token)}&hash=${encodeURIComponent(subscriber.sha1)}`;
+    const utmParams = this.utmParams("unsubscribe", emailType);
+    return `${AppConstants.SERVER_URL}/user/unsubscribe${unsubUserParams}${utmParams}`;
+  },
+
+  getShareByEmail(req) {
     const subject = encodeURIComponent(req.fluentFormat("share-by-email-subject"));
     const body = encodeURIComponent(req.fluentFormat("share-by-email-message"));
 

--- a/email-utils.js
+++ b/email-utils.js
@@ -1,4 +1,5 @@
 "use strict";
+const { URL } = require("url");
 
 const AppConstants = require("./app-constants");
 
@@ -78,23 +79,38 @@ const EmailUtils = {
     });
   },
 
-  utmParams(campaign, content) {
-    return `?utm_source=fx-monitor-emails&utm_medium=email&utm_campaign=${campaign}&utm_content=${content}`;
+  appendUtmParams(url, campaign, content) {
+    const utmParameters = {
+      utm_source: "fx-monitor-emails",
+      utm_medium: "email",
+      utm_campaign: campaign,
+      utm_content: content,
+    };
+    for (const param in utmParameters) {
+      url.searchParams.append(param, utmParameters[param]);
+    }
+    return url;
   },
 
   getScanAnotherEmailUrl(emailType) {
-    return `${AppConstants.SERVER_URL}${this.utmParams("scan-another-email", emailType)}`;
+    let url = new URL(AppConstants.SERVER_URL);
+    url = this.appendUtmParams(url, "scan-another-email", emailType);
+    return url;
   },
 
   getVerificationUrl(subscriber) {
-    const utmParams = this.utmParams("verified subscribers", "account-verification-email");
-    return `${AppConstants.SERVER_URL}/user/verify?token=${encodeURIComponent(subscriber.verification_token)}${utmParams}`;
+    let url = new URL(`${AppConstants.SERVER_URL}/user/verify`);
+    url.searchParams.append("token", encodeURIComponent(subscriber.verification_token));
+    url = this.appendUtmParams(url, "verified-subscribers", "account-verification-email");
+    return url;
   },
 
   getUnsubscribeUrl(subscriber, emailType) {
-    const unsubUserParams = `?token=${encodeURIComponent(subscriber.verification_token)}&hash=${encodeURIComponent(subscriber.sha1)}`;
-    const utmParams = this.utmParams("unsubscribe", emailType);
-    return `${AppConstants.SERVER_URL}/user/unsubscribe${unsubUserParams}${utmParams}`;
+    let url = new URL(`${AppConstants.SERVER_URL}/user/unsubscribe`);
+    url.searchParams.append("token", encodeURIComponent(subscriber.verification_token));
+    url.searchParams.append("hash", encodeURIComponent(subscriber.sha1));
+    url = this.appendUtmParams(url, "unsubscribe", emailType);
+    return url;
   },
 
   getShareByEmail(req) {

--- a/public/js/analytics_tracking_protection.js
+++ b/public/js/analytics_tracking_protection.js
@@ -29,14 +29,6 @@ function browserName() {
 }
 
 
-function removeUtms() {
-  const win = window;
-  const loc = win.location;
-  if (loc.search.includes("utm_") && win.history.replaceState) {
-    win.history.replaceState({}, "", loc.pathname);
-  }
-}
-
 
 if (browserName() === "firefox") {
   if (document.getElementById("download-firefox") || document.getElementById("download-firefox-bar")) {
@@ -67,5 +59,5 @@ if(typeof(ga) !== "undefined") {
     ga("set", "page", pageValue);
   }
 
-	ga("send", "pageview", {"hitCallback": removeUtms});
+	ga("send", "pageview");
 }

--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -434,6 +434,10 @@ document.addEventListener("touchstart", function(){}, true);
 window.addEventListener("pageshow", function() {
   ga_sendPing("Pageview", false);
 
+  if (window.location.search.includes("utm_") && window.history.replaceState) {
+    window.history.replaceState({}, "", window.location.toString().replace(/\?utm_.*/g, ""));
+  }
+
   if (document.forms) {
     restoreInputs();
   }

--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -435,7 +435,7 @@ window.addEventListener("pageshow", function() {
   ga_sendPing("Pageview", false);
 
   if (window.location.search.includes("utm_") && window.history.replaceState) {
-    window.history.replaceState({}, "", window.location.toString().replace(/\?utm_.*/g, ""));
+    window.history.replaceState({}, "", window.location.toString().replace(/[?&]utm_.*/g, ""));
   }
 
   if (document.forms) {

--- a/tests/controllers/hibp.test.js
+++ b/tests/controllers/hibp.test.js
@@ -55,7 +55,7 @@ test("notify POST with breach, subscriber hash prefix and suffixes should call s
   await hibp.notify(mockRequest, mockResponse);
 
   const mockFluentFormatCalls = LocaleUtils.fluentFormat.mock.calls;
-  expect (mockFluentFormatCalls.length).toBe(2);
+  expect (mockFluentFormatCalls.length).toBe(1);
   const mockFluentFormatCallArgs = mockFluentFormatCalls[0];
   expect (mockFluentFormatCallArgs[0]).toEqual(["en"]);
   expect (mockFluentFormatCallArgs[1]).toBe("hibp-notify-email-subject");

--- a/tests/controllers/user.test.js
+++ b/tests/controllers/user.test.js
@@ -102,7 +102,7 @@ test("user unsubscribe GET request with valid token returns error", async () => 
   const validToken = "0e2cb147-2041-4e5b-8ca9-494e773b2cf0";
 
   // Set up mocks
-  const req = { fluentFormat: jest.fn(), query: { token: validToken, hash: "testHash" } };
+  const req = { fluentFormat: jest.fn(), query: { token: validToken, hash: "ad9c69bcc69b3399775d2ddbe9b0b229369fca42" } };
   const resp = httpMocks.createResponse();
 
   // Call code-under-test

--- a/tests/controllers/user.test.js
+++ b/tests/controllers/user.test.js
@@ -102,7 +102,7 @@ test("user unsubscribe GET request with valid token returns error", async () => 
   const validToken = "0e2cb147-2041-4e5b-8ca9-494e773b2cf0";
 
   // Set up mocks
-  const req = { fluentFormat: jest.fn(), query: { token: validToken } };
+  const req = { fluentFormat: jest.fn(), query: { token: validToken, hash: "testHash" } };
   const resp = httpMocks.createResponse();
 
   // Call code-under-test

--- a/views/partials/email_partials/email_button.hbs
+++ b/views/partials/email_partials/email_button.hbs
@@ -5,8 +5,12 @@
         <table>
           <tr>
             <td class="email-button-wrapper" align="center" bgcolor="#0060df" style="width: 100%; max-width: 530px; border-radius: 2px;">
-              <a class="email-button" href="{{ buttonHref }}" rel="noopener" style="text-align: center; text-decoration: none; color: #ffffff; padding-top: 12px; padding-right: 30px; padding-left: 30px; padding-bottom: 12px; border: 1px solid #0060df; display: inline-block; font-size: 13px;">
-               {{ buttonValue }}
+              <a class="email-button" href="{{ scanAnotherEmailHref }}{{ verificationHref }}" rel="noopener" style="text-align: center; text-decoration: none; color: #ffffff; padding-top: 12px; padding-right: 30px; padding-left: 30px; padding-bottom: 12px; border: 1px solid #0060df; display: inline-block; font-size: 13px;">
+                {{#ifCompare whichView "===" "email_partials/email_verify"}}
+                  {{fluentFormat supportedLocales "verify-my-email" }}
+                {{else}}
+                  {{fluentFormat supportedLocales "report-scan-another-email"}}
+                {{/ifCompare}}
               </a>
             </td>
           </tr>

--- a/views/partials/email_partials/email_button.hbs
+++ b/views/partials/email_partials/email_button.hbs
@@ -5,7 +5,7 @@
         <table>
           <tr>
             <td class="email-button-wrapper" align="center" bgcolor="#0060df" style="width: 100%; max-width: 530px; border-radius: 2px;">
-              <a class="email-button" href="{{ href }}" rel="noopener" style="text-align: center; text-decoration: none; color: #ffffff; padding-top: 12px; padding-right: 30px; padding-left: 30px; padding-bottom: 12px; border: 1px solid #0060df; display: inline-block; font-size: 13px;">
+              <a class="email-button" href="{{ buttonHref }}" rel="noopener" style="text-align: center; text-decoration: none; color: #ffffff; padding-top: 12px; padding-right: 30px; padding-left: 30px; padding-bottom: 12px; border: 1px solid #0060df; display: inline-block; font-size: 13px;">
                {{ buttonValue }}
               </a>
             </td>

--- a/views/partials/email_partials/email_button.hbs
+++ b/views/partials/email_partials/email_button.hbs
@@ -5,12 +5,8 @@
         <table>
           <tr>
             <td class="email-button-wrapper" align="center" bgcolor="#0060df" style="width: 100%; max-width: 530px; border-radius: 2px;">
-              <a class="email-button" href="{{ scanAnotherEmailHref }}{{ verificationHref }}" rel="noopener" style="text-align: center; text-decoration: none; color: #ffffff; padding-top: 12px; padding-right: 30px; padding-left: 30px; padding-bottom: 12px; border: 1px solid #0060df; display: inline-block; font-size: 13px;">
-                {{#ifCompare whichView "===" "email_partials/email_verify"}}
-                  {{fluentFormat supportedLocales "verify-my-email" }}
-                {{else}}
-                  {{fluentFormat supportedLocales "report-scan-another-email"}}
-                {{/ifCompare}}
+              <a class="email-button" href="{{ href }}" rel="noopener" style="text-align: center; text-decoration: none; color: #ffffff; padding-top: 12px; padding-right: 30px; padding-left: 30px; padding-bottom: 12px; border: 1px solid #0060df; display: inline-block; font-size: 13px;">
+                {{fluentFormat supportedLocales fluentStringID}}
               </a>
             </td>
           </tr>

--- a/views/partials/email_partials/email_verify.hbs
+++ b/views/partials/email_partials/email_verify.hbs
@@ -12,7 +12,7 @@
   <table border="0" cellspacing="0" cellpadding="0" width="100%" style="width: 100%; padding-top: 30px; padding-bottom: 30px;">
     <tr>
       <td>
-        {{>email_partials/email_button}}
+        {{>email_partials/email_button href=verificationHref fluentStringID="verify-my-email"}}
       </td>
     </tr> 
   </table>

--- a/views/partials/email_partials/email_verify.hbs
+++ b/views/partials/email_partials/email_verify.hbs
@@ -12,7 +12,7 @@
   <table border="0" cellspacing="0" cellpadding="0" width="100%" style="width: 100%; padding-top: 30px; padding-bottom: 30px;">
     <tr>
       <td>
-        {{>email_partials/email_button href=verifyUrl}}
+        {{>email_partials/email_button}}
       </td>
     </tr> 
   </table>

--- a/views/partials/email_partials/report.hbs
+++ b/views/partials/email_partials/report.hbs
@@ -37,7 +37,7 @@
   <table class="table-button" border="0" cellpadding="0" cellspacing="0" width="100%" style="padding-top: 20px; padding-bottom: 20px; margin: 0px;">
     <tr>
       <td>
-        {{> email_partials/email_button}}
+        {{> email_partials/email_button href=scanAnotherEmailHref fluentStringID="report-scan-another-email"}}
       </td>
     </tr>
   </table>

--- a/views/partials/email_partials/report.hbs
+++ b/views/partials/email_partials/report.hbs
@@ -37,7 +37,7 @@
   <table class="table-button" border="0" cellpadding="0" cellspacing="0" width="100%" style="padding-top: 20px; padding-bottom: 20px; margin: 0px;">
     <tr>
       <td>
-        {{> email_partials/email_button href=SERVER_URL}}
+        {{> email_partials/email_button}}
       </td>
     </tr>
   </table>


### PR DESCRIPTION
- Adds utm parameters to the CTA buttons and unsubscribe links in emails.
- Moves and updates the function responsible for clipping out utm parameters from the url to prevent`hash=` and `token=` in unsubscribe routes from also getting clipped.

Fixes #636, fixes #650, closes #439 
