### PR TITLE
fix bug 1521724 - disable default helmet hsts

### DIFF
--- a/server.js
+++ b/server.js
@@ -61,7 +61,10 @@ try {
 })();
 
 // Use helmet to set security headers
-app.use(helmet());
+// disable default HSTS; Ops handles it in stage & prod configs
+app.use(helmet({
+  hsts: false,
+}));
 
 const SCRIPT_SOURCES = ["'self'", "https://www.google-analytics.com/analytics.js"];
 const STYLE_SOURCES = ["'self'", "https://code.cdn.mozilla.net/fonts/"];


### PR DESCRIPTION
Ops sets HSTS for stage & prod, so the helmet header is redundant and may cause agents to incorrectly apply the HSTS policy.