### PR TITLE
fix #688: add csrf & encrypted page tokens for scans

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -18,6 +18,9 @@ DATABASE_URL="postgres://postgres@localhost:5432/blurts"
 # How many seconds can unverified subscribers remain in the database
 DELETE_UNVERIFIED_SUBSCRIBERS_TIMER=86400
 
+# How many seconds until page tokens expire?
+PAGE_TOKEN_TIMER=0
+
 # Email server
 SMTP_URL=""
 # From: address used in emails

--- a/app-constants.js
+++ b/app-constants.js
@@ -33,6 +33,7 @@ const kEnvironmentVariables = [
   "HIBP_THROTTLE_MAX_TRIES",
   "HIBP_NOTIFY_TOKEN",
   "DATABASE_URL",
+  "PAGE_TOKEN_TIMER",
   "SENTRY_DSN",
   "SERVER_URL",
   "SUPPORTED_LOCALES",

--- a/controllers/home.js
+++ b/controllers/home.js
@@ -34,7 +34,7 @@ async function home(req, res) {
   let authenticatedUser = false;
 
   // for #688: use a page token to check for bot scans
-  const encryptedPageToken = AppConstants.PAGE_TOKEN_TIMER > 0 ? _generatePageToken(req) : "";
+  const pageToken = AppConstants.PAGE_TOKEN_TIMER > 0 ? _generatePageToken(req) : "";
 
   if (req.query.breach) {
     const reqBreachName = req.query.breach.toLowerCase();
@@ -83,7 +83,7 @@ async function home(req, res) {
   res.render("monitor", {
     title: req.fluentFormat("home-title"),
     csrfToken: req.csrfToken(),
-    encryptedPageToken: encryptedPageToken,
+    pageToken: pageToken,
     featuredBreach: featuredBreach,
     scanFeaturedBreach,
     foundBreaches,

--- a/controllers/home.js
+++ b/controllers/home.js
@@ -59,6 +59,7 @@ async function home(req, res) {
 
   res.render("monitor", {
     title: req.fluentFormat("home-title"),
+    csrfToken: req.csrfToken(),
     featuredBreach: featuredBreach,
     scanFeaturedBreach,
     foundBreaches,

--- a/controllers/home.js
+++ b/controllers/home.js
@@ -12,7 +12,7 @@ const sha1 = require("../sha1-utils");
 function _generatePageToken(req) {
   const pageToken = {ip: req.ip, date: new Date(), nonce: uuidv4()};
   const cipher = crypto.createCipher("aes-256-cbc", AppConstants.COOKIE_SECRET);
-  const encryptedPageToken = [cipher.update(JSON.stringify(pageToken), "utf8", "hex"), cipher.final("hex")].join("");
+  const encryptedPageToken = [cipher.update(JSON.stringify(pageToken), "utf8", "base64"), cipher.final("base64")].join("");
   return encryptedPageToken;
 
   /* TODO: block on scans-per-ip instead of scans-per-timespan

--- a/controllers/home.js
+++ b/controllers/home.js
@@ -1,9 +1,29 @@
 "use strict";
 
+const crypto = require("crypto");
 const { URL } = require("url");
+const uuidv4 = require("uuid/v4");
 
+const AppConstants = require("../app-constants");
 const HIBP = require("../hibp");
 const sha1 = require("../sha1-utils");
+
+
+function _generatePageToken(req) {
+  const pageToken = {ip: req.ip, date: new Date(), nonce: uuidv4()};
+  const cipher = crypto.createCipher("aes-256-cbc", AppConstants.COOKIE_SECRET);
+  const encryptedPageToken = [cipher.update(JSON.stringify(pageToken), "utf8", "hex"), cipher.final("hex")].join("");
+  return encryptedPageToken;
+
+  /* TODO: block on scans-per-ip instead of scans-per-timespan
+  if (req.session.scans === undefined){
+    console.log("session scans undefined");
+    req.session.scans = [];
+  }
+  req.session.numScans = req.session.scans.length;
+  */
+}
+
 
 async function home(req, res) {
 
@@ -12,6 +32,9 @@ async function home(req, res) {
   let foundBreaches = [];
   let userAccountCompromised = false;
   let authenticatedUser = false;
+
+  // for #688: use a page token to check for bot scans
+  const encryptedPageToken = AppConstants.PAGE_TOKEN_TIMER > 0 ? _generatePageToken(req) : "";
 
   if (req.query.breach) {
     const reqBreachName = req.query.breach.toLowerCase();
@@ -60,6 +83,7 @@ async function home(req, res) {
   res.render("monitor", {
     title: req.fluentFormat("home-title"),
     csrfToken: req.csrfToken(),
+    encryptedPageToken: encryptedPageToken,
     featuredBreach: featuredBreach,
     scanFeaturedBreach,
     foundBreaches,

--- a/controllers/scan.js
+++ b/controllers/scan.js
@@ -20,7 +20,7 @@ function _decryptPageToken(encryptedPageToken) {
 
 
 function _validatePageToken(pageToken, req) {
-  const requestIP = req.ip;
+  const requestIP = req.headers["x-real-ip"] || req.ip;
   const pageTokenIP = pageToken.ip;
   if (pageToken.ip !== requestIP) {
     log.error("_validatePageToken", {msg: "IP mis-match", pageTokenIP, requestIP});

--- a/controllers/scan.js
+++ b/controllers/scan.js
@@ -14,7 +14,7 @@ const log = mozlog("controllers.scan");
 
 function _decryptPageToken(encryptedPageToken) {
   const decipher = crypto.createDecipher("aes-256-cbc", AppConstants.COOKIE_SECRET);
-  const decryptedPageToken = JSON.parse([decipher.update(encryptedPageToken, "hex", "utf8"), decipher.final("utf8")].join(""));
+  const decryptedPageToken = JSON.parse([decipher.update(encryptedPageToken, "base64", "utf8"), decipher.final("utf8")].join(""));
   return decryptedPageToken;
 }
 

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -21,6 +21,7 @@ about-firefox-alerts = About Firefox Alerts
 give-feedback = Give Feedback
 terms-and-privacy = Terms and Privacy
 
+error-scan-page-token = You tried to scan too many email addresses in a short time period. For security reasons, we’ve temporarily blocked you from new searches. You’ll be able to try again later.
 error-could-not-add-email = Could not add email address to database.
 error-not-subscribed = This email address is not subscribed to {-product-name}.
 error-hibp-throttled = Too many connections to {-brand-HIBP}.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2053,6 +2053,16 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
+    "csrf": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
+      "integrity": "sha1-thEg3c7q/JHnbtUxO7XAsmZ7cQo=",
+      "requires": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.5",
+        "uid-safe": "2.1.4"
+      }
+    },
     "cssom": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
@@ -2064,6 +2074,34 @@
       "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
       "requires": {
         "cssom": "0.3.x"
+      }
+    },
+    "csurf": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.9.0.tgz",
+      "integrity": "sha1-SdLGkl/87Ht95VlZfBU/pTM2QTM=",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "csrf": "~3.0.3",
+        "http-errors": "~1.5.0"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+          "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
+          "requires": {
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.2",
+            "statuses": ">= 1.3.1 < 2"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+          "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg="
+        }
       }
     },
     "currently-unhandled": {
@@ -2421,7 +2459,8 @@
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -2654,30 +2693,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
-    "event-stream": {
-      "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
-      },
-      "dependencies": {
-        "split": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-          "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-          "requires": {
-            "through": "2"
-          }
-        }
-      }
     },
     "exec-sh": {
       "version": "0.2.2",
@@ -3347,11 +3362,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-    },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "from2": {
       "version": "2.3.0",
@@ -6822,11 +6832,6 @@
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
     },
-    "map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
-    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -7960,14 +7965,6 @@
         }
       }
     },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "requires": {
-        "through": "~2.3"
-      }
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -8731,6 +8728,11 @@
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
+    },
     "randomatic": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
@@ -9189,6 +9191,11 @@
       "requires": {
         "glob": "^7.0.5"
       }
+    },
+    "rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
     },
     "rsvp": {
       "version": "3.6.2",
@@ -9707,14 +9714,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
-    },
-    "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "requires": {
-        "duplexer": "~0.1.1"
-      }
     },
     "strftime": {
       "version": "0.10.0",
@@ -10374,6 +10373,11 @@
       "integrity": "sha512-FHkoUZvG6Egrv9XZAyYGKEyb1JMsFphgPjoczkZC2y6W93U1jswcVURB8MUvtsahEPEVACyxD47JAL63vF4JsQ==",
       "dev": true
     },
+    "tsscmp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
+      "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc="
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -10439,6 +10443,14 @@
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
+    },
+    "uid-safe": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
+      "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
+      "requires": {
+        "random-bytes": "~1.0.0"
+      }
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "client-oauth2": "^4.2.1",
     "client-sessions": "^0.8.0",
     "cpr": "^3.0.1",
+    "csurf": "^1.9.0",
     "dompurify": "^1.0.4",
     "dotenv": "^5.0.1",
     "express": "^4.16.2",

--- a/routes/home.js
+++ b/routes/home.js
@@ -1,13 +1,15 @@
 "use strict";
 
 const express = require("express");
+const csrf = require("csurf");
 
 const {home, notFound} = require("../controllers/home");
 
 
 const router = express.Router();
+const csrfProtection = csrf();
 
-router.get("/", home);
+router.get("/", csrfProtection, home);
 router.use(notFound);
 
 module.exports = router;

--- a/routes/scan.js
+++ b/routes/scan.js
@@ -2,6 +2,7 @@
 
 const express = require("express");
 const bodyParser = require("body-parser");
+const csrf = require("csurf");
 
 const {asyncMiddleware} = require("../middleware");
 const {post, get, getFullReport, getLatestBreaches} = require("../controllers/scan");
@@ -9,8 +10,9 @@ const {post, get, getFullReport, getLatestBreaches} = require("../controllers/sc
 
 const router = express.Router();
 const urlEncodedParser = bodyParser.urlencoded({ extended: false });
+const csrfProtection = csrf();
 
-router.post("/", urlEncodedParser, asyncMiddleware(post));
+router.post("/", urlEncodedParser, csrfProtection, asyncMiddleware(post));
 router.get("/", get);
 router.get("/full_report", getFullReport);
 router.get("/latest_breaches", getLatestBreaches);

--- a/server.js
+++ b/server.js
@@ -33,9 +33,6 @@ const EmailL10nRoutes= require("./routes/email-l10n");
 const log = mozlog("server");
 const app = express();
 
-// Redirect non-dev environments to HTTPS
-app.enable("trust proxy");
-
 if (app.get("env") !== "dev") {
   app.use( (req, res, next) => {
     if (req.secure) {
@@ -133,11 +130,6 @@ app.set("view engine", "hbs");
 
 const cookie = {httpOnly: true, sameSite: "lax"};
 
-if (app.get("env") === "dev") {
-  app.set("trust proxy", false);
-} else {
-  app.set("trust proxy", true);
-}
 
 app.locals.FXA_ENABLED = AppConstants.FXA_ENABLED;
 app.locals.SERVER_URL = AppConstants.SERVER_URL;

--- a/tests/controllers/home.test.js
+++ b/tests/controllers/home.test.js
@@ -3,7 +3,7 @@
 const home = require("../../controllers/home");
 
 
-let mockRequest = { fluentFormat: jest.fn() };
+let mockRequest = { fluentFormat: jest.fn(), csrfToken: jest.fn() };
 
 function addBreachesToMockRequest(mockRequest) {
   const mockBreaches = [
@@ -13,6 +13,7 @@ function addBreachesToMockRequest(mockRequest) {
   mockRequest.app = { locals: { breaches: mockBreaches } };
   return mockRequest;
 }
+
 
 test("home GET without breach renders monitor without breach", () => {
   mockRequest.query = { breach: null };

--- a/tests/controllers/scan.test.js
+++ b/tests/controllers/scan.test.js
@@ -39,6 +39,7 @@ test("scan POST with hash should render scan with foundBreaches", async () => {
   mockRequest.body = { emailHash: sha1(testEmail) };
   mockRequest.app = { locals: { breaches: testBreaches } };
   mockRequest.session = { user: null };
+  mockRequest.csrfToken = jest.fn();
   const mockResponse = { render: jest.fn() };
   HIBP.getBreachesForEmail.mockResolvedValue(testFoundBreaches);
 

--- a/views/partials/scan_form.hbs
+++ b/views/partials/scan_form.hbs
@@ -1,4 +1,4 @@
-<form action="/scan" class="email-scan form-group" method="post" data-no-csrf novalidate>
+<form action="/scan" class="email-scan form-group" method="post" novalidate>
   <input type="hidden" name="_csrf" value="{{csrfToken}}">
   <input type="hidden" name="pageToken" value="{{encryptedPageToken}}">
   <div class="input-group">

--- a/views/partials/scan_form.hbs
+++ b/views/partials/scan_form.hbs
@@ -1,4 +1,5 @@
 <form action="/scan" class="email-scan form-group" method="post" data-no-csrf novalidate>
+  <input type="hidden" name="_csrf" value="{{csrfToken}}">
   <div class="input-group">
     <input id="scan-email" class="input-group-field email-to-hash" type="email" name="email" placeholder="{{fluentFormat req.supportedLocales "scan-placeholder"}}" aria-label="{{fluentFormat req.supportedLocales "scan-placeholder"}}" tabindex="0" autocomplete="off" />
     <span id="invalid-email-message" class="error-message">{{fluentFormat req.supportedLocales "scan-error"}}</span>

--- a/views/partials/scan_form.hbs
+++ b/views/partials/scan_form.hbs
@@ -1,5 +1,6 @@
 <form action="/scan" class="email-scan form-group" method="post" data-no-csrf novalidate>
   <input type="hidden" name="_csrf" value="{{csrfToken}}">
+  <input type="hidden" name="pageToken" value="{{encryptedPageToken}}">
   <div class="input-group">
     <input id="scan-email" class="input-group-field email-to-hash" type="email" name="email" placeholder="{{fluentFormat req.supportedLocales "scan-placeholder"}}" aria-label="{{fluentFormat req.supportedLocales "scan-placeholder"}}" tabindex="0" autocomplete="off" />
     <span id="invalid-email-message" class="error-message">{{fluentFormat req.supportedLocales "scan-error"}}</span>

--- a/views/partials/scan_form.hbs
+++ b/views/partials/scan_form.hbs
@@ -1,6 +1,6 @@
 <form action="/scan" class="email-scan form-group" method="post" novalidate>
   <input type="hidden" name="_csrf" value="{{csrfToken}}">
-  <input type="hidden" name="pageToken" value="{{encryptedPageToken}}">
+  <input type="hidden" name="pageToken" value="{{pageToken}}">
   <div class="input-group">
     <input id="scan-email" class="input-group-field email-to-hash" type="email" name="email" placeholder="{{fluentFormat req.supportedLocales "scan-placeholder"}}" aria-label="{{fluentFormat req.supportedLocales "scan-placeholder"}}" tabindex="0" autocomplete="off" />
     <span id="invalid-email-message" class="error-message">{{fluentFormat req.supportedLocales "scan-error"}}</span>


### PR DESCRIPTION
Note: This breaks the "Scan another email" form at the bottom of the `/scan` results. Not sure yet how to un-break it, but I need some other eyes on this ASAP.