### PR TITLE
Capitalize the sign in button in en locales.

### DIFF
--- a/public/css/fxa.css
+++ b/public/css/fxa.css
@@ -107,6 +107,10 @@ ul {
   padding: 0;
 }
 
+.capitalize {
+  text-transform: capitalize;
+}
+
 ul {
   list-style-type: none;
 }

--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -496,6 +496,10 @@ if (document.body.dataset.fxaEnabled === "fxa-enabled") {
       document.getElementById("fxa-new-user-bar").classList.toggle("close");
     });
   }
+  // capitalize the sign in button for en-US only.
+  if (window.navigator.language.includes("en")) {
+    document.getElementById("login-btn").classList.add("capitalize");
+  }
 }
 
 if (document.getElementById("subpage")) {


### PR DESCRIPTION
To bring us into greater accord with the spec without imposing capitalization on other locales.

<img width="370" alt="the button" src="https://user-images.githubusercontent.com/22355127/52654412-895d5980-2eb7-11e9-9e8a-7a9e3e2662bc.png">
