### PR TITLE
Consolidate scan result logic for easier current/future templating. 

### DIFF
--- a/controllers/home.js
+++ b/controllers/home.js
@@ -1,8 +1,16 @@
 "use strict";
 
+const AppConstants = require("../app-constants");
 const scanResult = require("../scan-results");
+const { generatePageToken } = require("./utils");
+
 
 async function home(req, res) {
+
+  const formTokens = {
+    pageToken: AppConstants.PAGE_TOKEN_TIMER > 0 ? generatePageToken(req) : "",
+    csrfToken: req.csrfToken(),
+  };
 
   let featuredBreach = null;
   let scanFeaturedBreach = false;
@@ -20,8 +28,9 @@ async function home(req, res) {
     }
 
     const scanRes = await scanResult(req);
-    if (scanRes.doorhangerScan === true) {
-      return res.render("scan", scanRes);
+
+    if (scanRes.doorhangerScan) {
+      return res.render("scan", Object.assign(scanRes, formTokens));
     }
     scanFeaturedBreach = true;
   }
@@ -30,6 +39,8 @@ async function home(req, res) {
     title: req.fluentFormat("home-title"),
     featuredBreach: featuredBreach,
     scanFeaturedBreach,
+    pageToken: formTokens.pageToken,
+    csrfToken: formTokens.csrfToken,
   });
 }
 

--- a/controllers/home.js
+++ b/controllers/home.js
@@ -1,68 +1,35 @@
 "use strict";
 
-const { URL } = require("url");
-
-const HIBP = require("../hibp");
-const sha1 = require("../sha1-utils");
+const scanResult = require("../scan-results");
 
 async function home(req, res) {
 
   let featuredBreach = null;
   let scanFeaturedBreach = false;
-  let foundBreaches = [];
-  let userAccountCompromised = false;
-  let authenticatedUser = false;
+
+  if (req.session.user && !req.query.breach) {
+    return res.redirect("/scan/user_dashboard");
+  }
 
   if (req.query.breach) {
     const reqBreachName = req.query.breach.toLowerCase();
     featuredBreach = req.app.locals.breaches.find(breach => breach.Name.toLowerCase() === reqBreachName);
+
     if (!featuredBreach) {
       return notFound(req, res);
     }
 
-    scanFeaturedBreach = true;
-
-    const url = new URL(req.url, req.app.locals.SERVER_URL);
-
-    // Checks if the user is 1.) arriving via the doorhanger and 2.) already signed in to Monitor.
-    // If so, we automatically scan their email and check the results for the breach associated with
-    // the website they were on when they clicked the doorhanger.
-    if (req.session.user && url.searchParams.has("utm_source") && url.searchParams.get("utm_source") === "firefox") {
-      authenticatedUser = true;
-      const emailHash = sha1(req.session.user.email);
-
-      foundBreaches = await HIBP.getBreachesForEmail(emailHash, req.app.locals.breaches, true);
-      const findFeaturedBreach = foundBreaches.findIndex(breach => breach.Name === featuredBreach.Name);
-      if (findFeaturedBreach !== -1) {
-        userAccountCompromised = true;
-        // move featured breach to the front of the list so that it appears first.
-        if (foundBreaches.length > 1) {
-          foundBreaches.splice(findFeaturedBreach, 1);
-          foundBreaches.unshift(featuredBreach);
-        }
-      }
-      return res.render("scan", {
-        title: req.fluentFormat("scan-title"),
-        foundBreaches,
-        authenticatedUser,
-        userAccountCompromised,
-        featuredBreach,
-      });
+    const scanRes = await scanResult(req);
+    if (scanRes.doorhangerScan === true) {
+      return res.render("scan", scanRes);
     }
-  }
-  // redirect signed in users to dashboard if they are not
-  // coming from the doorhanger and not attempting to reach
-  // a detailed breach page.
-  if (req.session.user && !req.query.breach) {
-      return res.redirect("/scan/latest_breaches");
+    scanFeaturedBreach = true;
   }
 
   res.render("monitor", {
     title: req.fluentFormat("home-title"),
     featuredBreach: featuredBreach,
     scanFeaturedBreach,
-    foundBreaches,
-    userAccountCompromised,
   });
 }
 

--- a/controllers/oauth.js
+++ b/controllers/oauth.js
@@ -106,7 +106,7 @@ async function confirmed(req, res, next, client = FxAOAuthClient) {
   }
 
   req.session.user = JSON.parse(data.body);
-  res.redirect("/scan/latest_breaches");
+  res.redirect("/scan/user_dashboard");
 }
 
 module.exports = {

--- a/controllers/scan.js
+++ b/controllers/scan.js
@@ -1,21 +1,81 @@
 "use strict";
 
-const sha1 = require("../sha1-utils");
+const crypto = require("crypto");
+
+const AppConstants = require("../app-constants");
+const { FluentError } = require("../locale-utils");
+const { generatePageToken } = require("./utils");
+const mozlog = require("../log");
 const scanResult = require("../scan-results");
+const sha1 = require("../sha1-utils");
+
+const log = mozlog("controllers.scan");
+
+function _decryptPageToken(encryptedPageToken) {
+  const decipher = crypto.createDecipher("aes-256-cbc", AppConstants.COOKIE_SECRET);
+  const decryptedPageToken = JSON.parse([decipher.update(encryptedPageToken, "base64", "utf8"), decipher.final("utf8")].join(""));
+  return decryptedPageToken;
+}
+
+
+function _validatePageToken(pageToken, req) {
+  const requestIP = req.headers["x-real-ip"] || req.ip;
+  const pageTokenIP = pageToken.ip;
+  if (pageToken.ip !== requestIP) {
+    log.error("_validatePageToken", {msg: "IP mis-match", pageTokenIP, requestIP});
+    return false;
+  }
+  if (Date.now() - new Date(pageToken.date) >= AppConstants.PAGE_TOKEN_TIMER * 1000) {
+    log.error("_validatePageToken", {msg: "expired pageToken"});
+    return false;
+  }
+  /* TODO: block on scans-per-ip instead of scans-per-timespan
+  if (req.session.scans.length > 5) {
+    console.log("too many scans this session");
+    return res.render("error");
+  }
+  if (!req.session.scans.includes(emailHash)) {
+    console.log(`adding ${emailHash} to session scans`);
+    req.session.scans.push(emailHash);
+  }
+  */
+  return pageToken;
+}
 
 
 async function post (req, res) {
   const emailHash = req.body.emailHash;
+  const encryptedPageToken = req.body.pageToken;
+  let validPageToken = false;
+
+  // for #688: use a page token to check that scans come from real pages
+  if (AppConstants.PAGE_TOKEN_TIMER > 0) {
+    if (!encryptedPageToken) {
+      throw new FluentError("error-scan-page-token");
+    }
+    const decryptedPageToken = _decryptPageToken(encryptedPageToken);
+    validPageToken = _validatePageToken(decryptedPageToken, req);
+
+    if (!validPageToken) {
+      throw new FluentError("error-scan-page-token");
+    }
+  }
 
   if (!emailHash || emailHash === sha1("")) {
     return res.redirect("/");
   }
 
   const scanRes = await scanResult(req);
+
+  const formTokens = {
+    pageToken: encryptedPageToken,
+    csrfToken: req.csrfToken(),
+  };
+
   if (req.session.user && scanRes.selfScan && !req.body.featuredBreach) {
     return res.redirect("/scan/user_dashboard");
   }
-  res.render("scan", scanRes);
+  res.render("scan", Object.assign(scanRes, formTokens));
 }
 
 
@@ -23,15 +83,23 @@ async function getFullReport(req, res) {
   if (!req.session.user) {
     return res.redirect("/");
   }
+
   const scanRes = await scanResult(req, true);
   res.render("scan", scanRes);
 }
 
 
+
 async function getUserDashboard(req, res) {
+
   if (!req.session.user) {
     return res.redirect("/");
   }
+
+  const formTokens = {
+    pageToken: AppConstants.PAGE_TOKEN_TIMER > 0 ? generatePageToken(req) : "",
+    csrfToken: req.csrfToken(),
+  };
 
   const scanRes = await scanResult(req, true);
   scanRes.newUser = false;
@@ -41,7 +109,7 @@ async function getUserDashboard(req, res) {
     req.session.newUser = false;
   }
 
-  res.render("scan", scanRes);
+  return res.render("scan", Object.assign(scanRes, formTokens));
 }
 
 

--- a/controllers/utils.js
+++ b/controllers/utils.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const crypto = require("crypto");
+const uuidv4 = require("uuid/v4");
+
+const AppConstants = require("../app-constants");
+
+
+function generatePageToken(req) {
+  const pageToken = {ip: req.ip, date: new Date(), nonce: uuidv4()};
+  const cipher = crypto.createCipher("aes-256-cbc", AppConstants.COOKIE_SECRET);
+  const encryptedPageToken = [cipher.update(JSON.stringify(pageToken), "utf8", "base64"), cipher.final("base64")].join("");
+  return encryptedPageToken;
+
+  /* TODO: block on scans-per-ip instead of scans-per-timespan
+  if (req.session.scans === undefined){
+    console.log("session scans undefined");
+    req.session.scans = [];
+  }
+  req.session.numScans = req.session.scans.length;
+  */
+}
+
+module.exports = {
+  generatePageToken,
+};

--- a/public/css/fxa.css
+++ b/public/css/fxa.css
@@ -1013,6 +1013,10 @@ main .sensitive-breach-email-required {
   max-width: 300px;
 }
 
+main a.see-full-report-button {
+  min-width: 220px;
+}
+
 main .section-headline,
 main p {
   max-width: 500px;
@@ -1028,6 +1032,17 @@ main span.demi.form-desc {
 
 main.scan-results .third {
   justify-content: flex-end;
+}
+
+main.scan-results .single-breach {
+  display: block;
+  margin-top: 0px;
+}
+
+main.scan-results .single-breach .half {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0px;
 }
 
 .button-link-wrapper {

--- a/public/css/fxa.css
+++ b/public/css/fxa.css
@@ -1036,13 +1036,13 @@ main.scan-results .third {
 
 main.scan-results .single-breach {
   display: block;
-  margin-top: 0px;
+  margin-top: 0;
 }
 
 main.scan-results .single-breach .half {
   margin-left: 0;
   margin-right: 0;
-  margin-top: 0px;
+  margin-top: 0;
 }
 
 .button-link-wrapper {

--- a/routes/scan.js
+++ b/routes/scan.js
@@ -2,6 +2,7 @@
 
 const express = require("express");
 const bodyParser = require("body-parser");
+const csrf = require("csurf");
 
 const {asyncMiddleware} = require("../middleware");
 const {post, get, getFullReport, getUserDashboard} = require("../controllers/scan");
@@ -9,10 +10,12 @@ const {post, get, getFullReport, getUserDashboard} = require("../controllers/sca
 
 const router = express.Router();
 const urlEncodedParser = bodyParser.urlencoded({ extended: false });
+const csrfProtection = csrf();
 
-router.post("/", urlEncodedParser, asyncMiddleware(post));
+ 
+router.post("/", urlEncodedParser, csrfProtection, asyncMiddleware(post));
 router.get("/", get);
 router.get("/full_report", getFullReport);
-router.get("/user_dashboard", getUserDashboard);
+router.get("/user_dashboard", urlEncodedParser, csrfProtection, asyncMiddleware(getUserDashboard));
 
 module.exports = router;

--- a/routes/scan.js
+++ b/routes/scan.js
@@ -4,7 +4,7 @@ const express = require("express");
 const bodyParser = require("body-parser");
 
 const {asyncMiddleware} = require("../middleware");
-const {post, get, getFullReport, getLatestBreaches} = require("../controllers/scan");
+const {post, get, getFullReport, getUserDashboard} = require("../controllers/scan");
 
 
 const router = express.Router();
@@ -13,6 +13,6 @@ const urlEncodedParser = bodyParser.urlencoded({ extended: false });
 router.post("/", urlEncodedParser, asyncMiddleware(post));
 router.get("/", get);
 router.get("/full_report", getFullReport);
-router.get("/latest_breaches", getLatestBreaches);
+router.get("/user_dashboard", getUserDashboard);
 
 module.exports = router;

--- a/scan-results.js
+++ b/scan-results.js
@@ -5,11 +5,13 @@ const { URL } = require("url");
 const HIBP = require("./hibp");
 const sha1 = require("./sha1-utils");
 
+
 const scanResult = async(req, selfScan=false) => {
 
   const allBreaches = req.app.locals.breaches;
   let scannedEmail = null;
 
+  const title = req.fluentFormat("scan-title");
   let foundBreaches = [];
   let specificBreach = null;
   let doorhangerScan = false;
@@ -26,33 +28,28 @@ const scanResult = async(req, selfScan=false) => {
   // Checks if the user scanning their own verified email.
   if (req.body && req.body.emailHash) {
     scannedEmail = req.body.emailHash;
-    if (!selfScan && signedInUser) {
-      if (sha1(signedInUser.email).toUpperCase() === req.body.emailHash) {
-        selfScan = true;
-      }
+    if (!selfScan && signedInUser && sha1(signedInUser.email) === req.body.emailHash) {
+      selfScan = true;
     }
   }
 
   const url = new URL(req.url, req.app.locals.SERVER_URL);
+  const thisBreach = (breach) => {
+    return (element) => element.Name.toLowerCase() === breach.toLowerCase();
+  };
 
   // Checks for a signedInUser arriving from doorhanger.
-  if (signedInUser) {
-    if (url.searchParams.has("utm_source") && url.searchParams.get("utm_source") === "firefox") {
-      doorhangerScan = true, selfScan = true;
-      specificBreach = allBreaches.find(breach => breach.Name.toLowerCase() === req.query.breach.toLowerCase());
-    }
+  if (signedInUser && url.searchParams.has("utm_source") && url.searchParams.get("utm_source") === "firefox") {
+    doorhangerScan = true, selfScan = true;
+    specificBreach = allBreaches.find(thisBreach(req.query.breach));
   }
 
-  if (url.pathname === "/full_report") {
-    fullReport = true;
-  }
+  fullReport = url.pathname === "/full_report";
 
-  if (url.pathname === "/user_dashboard") {
-    userDash = true;
-  }
+  userDash = url.pathname === "/user_dashboard";
 
   if (selfScan) {
-    scannedEmail = sha1(signedInUser.email).toUpperCase();
+    scannedEmail = sha1(signedInUser.email);
   }
 
   if (scannedEmail) {
@@ -62,7 +59,7 @@ const scanResult = async(req, selfScan=false) => {
 
   // Checks if scan originated from a breach detail/"featured breach" page.
   if (req.body && req.body.featuredBreach) {
-    specificBreach = allBreaches.find(breach => breach.Name.toLowerCase() === req.body.featuredBreach.toLowerCase());
+    specificBreach = allBreaches.find(thisBreach(req.body.featuredBreach));
   }
 
   if (doorhangerScan || specificBreach) {
@@ -72,23 +69,21 @@ const scanResult = async(req, selfScan=false) => {
     // brings specificBreach to front of foundBreaches list.
     if (specificBreachIndex !== -1) {
       userCompromised = true;
-      if (foundBreaches.length > 1) {
-        foundBreaches.splice(specificBreachIndex, 1);
-        foundBreaches.unshift(specificBreach);
-      }
+      foundBreaches.splice(specificBreachIndex, 1);
+      foundBreaches.unshift(specificBreach);
     }
   }
 
   return {
-    foundBreaches: foundBreaches,
-    specificBreach: specificBreach,
-    doorhangerScan: doorhangerScan,
-    userCompromised: userCompromised,
-    signedInUser: signedInUser,
-    selfScan: selfScan,
-    fullReport: fullReport,
-    userDash: userDash,
-    title: req.fluentFormat("scan-title"),
+    title,
+    foundBreaches,
+    specificBreach,
+    doorhangerScan,
+    userCompromised,
+    signedInUser,
+    selfScan,
+    fullReport,
+    userDash,
   };
 };
 

--- a/scan-results.js
+++ b/scan-results.js
@@ -1,0 +1,95 @@
+"use strict";
+
+const { URL } = require("url");
+
+const HIBP = require("./hibp");
+const sha1 = require("./sha1-utils");
+
+const scanResult = async(req, selfScan=false) => {
+
+  const allBreaches = req.app.locals.breaches;
+  let scannedEmail = null;
+
+  let foundBreaches = [];
+  let specificBreach = null;
+  let doorhangerScan = false;
+  let userCompromised = false;
+  let signedInUser = null;
+  let fullReport = false;
+  let userDash = false;
+
+
+  if (req.session.user) {
+    signedInUser = req.session.user;
+  }
+
+  // Checks if the user scanning their own verified email.
+  if (req.body && req.body.emailHash) {
+    scannedEmail = req.body.emailHash;
+    if (!selfScan && signedInUser) {
+      if (sha1(signedInUser.email).toUpperCase() === req.body.emailHash) {
+        selfScan = true;
+      }
+    }
+  }
+
+  const url = new URL(req.url, req.app.locals.SERVER_URL);
+
+  // Checks for a signedInUser arriving from doorhanger.
+  if (signedInUser) {
+    if (url.searchParams.has("utm_source") && url.searchParams.get("utm_source") === "firefox") {
+      doorhangerScan = true, selfScan = true;
+      specificBreach = allBreaches.find(breach => breach.Name.toLowerCase() === req.query.breach.toLowerCase());
+    }
+  }
+
+  if (url.pathname === "/full_report") {
+    fullReport = true;
+  }
+
+  if (url.pathname === "/user_dashboard") {
+    userDash = true;
+  }
+
+  if (selfScan) {
+    scannedEmail = sha1(signedInUser.email).toUpperCase();
+  }
+
+  if (scannedEmail) {
+    // Gets sensitive breaches only if selfScan === true
+    foundBreaches = await HIBP.getBreachesForEmail(scannedEmail, allBreaches, selfScan);
+  }
+
+  // Checks if scan originated from a breach detail/"featured breach" page.
+  if (req.body && req.body.featuredBreach) {
+    specificBreach = allBreaches.find(breach => breach.Name.toLowerCase() === req.body.featuredBreach.toLowerCase());
+  }
+
+  if (doorhangerScan || specificBreach) {
+    const specificBreachIndex = foundBreaches.findIndex(breach => breach.Name === specificBreach.Name);
+
+    // Checks foundBreaches for specificBreach and if found,
+    // brings specificBreach to front of foundBreaches list.
+    if (specificBreachIndex !== -1) {
+      userCompromised = true;
+      if (foundBreaches.length > 1) {
+        foundBreaches.splice(specificBreachIndex, 1);
+        foundBreaches.unshift(specificBreach);
+      }
+    }
+  }
+
+  return {
+    foundBreaches: foundBreaches,
+    specificBreach: specificBreach,
+    doorhangerScan: doorhangerScan,
+    userCompromised: userCompromised,
+    signedInUser: signedInUser,
+    selfScan: selfScan,
+    fullReport: fullReport,
+    userDash: userDash,
+    title: req.fluentFormat("scan-title"),
+  };
+};
+
+module.exports = scanResult;

--- a/sha1-utils.js
+++ b/sha1-utils.js
@@ -3,7 +3,7 @@
 const crypto = require("crypto");
 
 function getSha1(email) {
-  return crypto.createHash("sha1").update(email).digest("hex").toUpperCase();
+  return crypto.createHash("sha1").update(email).digest("hex");
 }
 
 module.exports = getSha1;

--- a/sha1-utils.js
+++ b/sha1-utils.js
@@ -3,7 +3,7 @@
 const crypto = require("crypto");
 
 function getSha1(email) {
-  return crypto.createHash("sha1").update(email).digest("hex");
+  return crypto.createHash("sha1").update(email).digest("hex").toUpperCase();
 }
 
 module.exports = getSha1;

--- a/tests/controllers/home.test.js
+++ b/tests/controllers/home.test.js
@@ -1,7 +1,8 @@
 "use strict";
 
+const AppConstants = require("../../app-constants");
 const home = require("../../controllers/home");
-
+const scanResult = require("../../scan-results");
 
 let mockRequest = { fluentFormat: jest.fn() };
 
@@ -28,17 +29,21 @@ test("home GET without breach renders monitor without breach", () => {
 });
 
 
-test("home GET with breach renders monitor with breach", () => {
+test("home GET with breach renders monitor with breach", async() => {
   const testBreach = {Name: "Test"};
   mockRequest.query = { breach: testBreach.Name };
   mockRequest = addBreachesToMockRequest(mockRequest);
-  mockRequest.url = "https://www.mozilla.com";
   mockRequest.session = { user: null };
-  const mockResponse = { render: jest.fn() };
+  mockRequest.url = { url: "https://www.mozilla.com" };
+  mockRequest.app.locals.SERVER_URL = AppConstants.SERVER_URL;
 
 
+  const mockResponse = { render: jest.fn(), redirect: jest.fn() };
   home.home(mockRequest, mockResponse);
+  const scanRes = await scanResult(mockRequest);
 
+  expect(scanRes.doorhangerScan).toBe(false);
+  expect(scanRes.selfScan).toBe(false);
   const mockRenderCallArgs = mockResponse.render.mock.calls[0];
   expect(mockRenderCallArgs[0]).toBe("monitor");
   expect(mockRenderCallArgs[1].featuredBreach).toEqual(testBreach);

--- a/tests/controllers/oauth.test.js
+++ b/tests/controllers/oauth.test.js
@@ -67,7 +67,7 @@ test("confirmed request checks session cookie, calls FXA for token and email, ad
   expect(subscribers[0].signup_language).toBe(userAddLanguages);
 
   const mockRedirectCallArgs = mockResponse.redirect.mock.calls[0];
-  expect(mockRedirectCallArgs[0]).toBe("/scan/latest_breaches");
+  expect(mockRedirectCallArgs[0]).toBe("/scan/user_dashboard");
 });
 
 

--- a/tests/controllers/scan.test.js
+++ b/tests/controllers/scan.test.js
@@ -1,5 +1,5 @@
 "use strict";
-
+const AppConstants = require("../../app-constants");
 const sha1 = require("../../sha1-utils");
 const HIBP = require("../../hibp");
 const scan = require("../../controllers/scan");
@@ -39,6 +39,8 @@ test("scan POST with hash should render scan with foundBreaches", async () => {
   mockRequest.body = { emailHash: sha1(testEmail) };
   mockRequest.app = { locals: { breaches: testBreaches } };
   mockRequest.session = { user: null };
+  mockRequest.url = { url: "https://www.mozilla.com" };
+  mockRequest.app.locals.SERVER_URL = AppConstants.SERVER_URL;
   const mockResponse = { render: jest.fn() };
   HIBP.getBreachesForEmail.mockResolvedValue(testFoundBreaches);
 

--- a/tests/controllers/scan.test.js
+++ b/tests/controllers/scan.test.js
@@ -39,7 +39,7 @@ test("scan POST with hash should render scan with foundBreaches", async () => {
   mockRequest.body = { emailHash: sha1(testEmail) };
   mockRequest.app = { locals: { breaches: testBreaches } };
   mockRequest.session = { user: null };
-  mockRequest.url = { url: "https://www.mozilla.com" };
+  mockRequest.url = { url: AppConstants.SERVER_URL };
   mockRequest.app.locals.SERVER_URL = AppConstants.SERVER_URL;
   const mockResponse = { render: jest.fn() };
   HIBP.getBreachesForEmail.mockResolvedValue(testFoundBreaches);

--- a/views/partials/fxa_enabled/fxa_new_user_bar.hbs
+++ b/views/partials/fxa_enabled/fxa_new_user_bar.hbs
@@ -1,7 +1,7 @@
 <div id="fxa-new-user-bar" class="fxa-new-user-bar top-bar">
   <div class="row-wrapper">
     <p class="bold">{{fluentFormat req.supportedLocales "fxa-welcome-headline"}}</p>
-    <p>{{fluentFormat req.supportedLocales "fxa-welcome-blurb" userEmail=req.session.user.email}}</p>
+    <p>{{fluentFormat req.supportedLocales "fxa-welcome-blurb" userEmail=signedInUser.email}}</p>
   </div>
   <div id="x-close" class="x-close">
   </div>

--- a/views/partials/fxa_enabled/fxa_scan.hbs
+++ b/views/partials/fxa_enabled/fxa_scan.hbs
@@ -28,18 +28,29 @@
   {{#if signedInUser}}
     {{> banners/download_firefox_banner}}
   {{else}}
-    {{> banners/sign_up_banner class="extra-margin"}}
+    {{> banners/sign_up_banner}}
   {{/if}}
 {{else}}
+
   {{#if fullReport}}
     {{> what_to_do class="extra-margin"}}
   {{else}}
-    {{> what_to_do}}
+    {{#ifCompare foundBreaches.length "===" 1}}
+      {{> banners/sign_up_banner class="extra-margin"}}
+      {{> what_to_do}}
+      {{> scan_another_email}}
+      {{> banners/download_firefox_banner}}
+    {{/ifCompare}}
+
+    {{#ifCompare foundBreaches.length ">" 1}}
+      {{> what_to_do}}
+      {{> scan_another_email}}
+        {{#if signedInUser}}
+          {{> banners/download_firefox_banner}}
+        {{else}}
+          {{> banners/sign_up_banner}}
+        {{/if}}
+    {{/ifCompare}}
   {{/if}}
-  {{> scan_another_email}}
-  {{#if signedInUser}}
-    {{> banners/download_firefox_banner}}
-  {{else}}
-    {{> banners/sign_up_banner}}
-  {{/if}}
+
 {{/ifCompare}}

--- a/views/partials/fxa_enabled/fxa_scan.hbs
+++ b/views/partials/fxa_enabled/fxa_scan.hbs
@@ -5,9 +5,9 @@
       {{> fxa_enabled/scan_results/result_headline}}
       {{> fxa_enabled/scan_results/result_subhead}}
       <!-- append "see full report", but only if it's a signed in user scanning from a feautred breach page, with scan results greater than one. -->
-      {{#if featuredBreach}}
+      {{#if specificBreach}}
         {{#ifCompare foundBreaches.length ">" 1}}
-          {{#ifCompare authenticatedUser "&&" userAccountCompromised}}
+          {{#ifCompare selfScan "&&" userCompromised}}
             {{> fxa_enabled/see_full_report_button}}
           {{/ifCompare}}
         {{/ifCompare}}
@@ -16,7 +16,7 @@
     <!--scan results page right -->
     {{> fxa_enabled/scan_results/result_page_right}}
 
-    {{#ifCompare featuredBreach "!|" authenticatedUser}}
+    {{#ifCompare specificBreach "!|" selfScan}}
       {{> compromised_accounts }}
     {{/ifCompare}}
   </div>
@@ -25,16 +25,21 @@
 {{#ifCompare foundBreaches.length "===" 0}}
   {{> scan_another_email}}
   {{> password_tips}}
-{{else}}
-  {{#ifCompare foundBreaches.length ">=" 1}}
+  {{#if signedInUser}}
+    {{> banners/download_firefox_banner}}
+  {{else}}
     {{> banners/sign_up_banner class="extra-margin"}}
-  {{/ifCompare}}
+  {{/if}}
+{{else}}
   {{#if fullReport}}
     {{> what_to_do class="extra-margin"}}
   {{else}}
     {{> what_to_do}}
   {{/if}}
   {{> scan_another_email}}
+  {{#if signedInUser}}
+    {{> banners/download_firefox_banner}}
+  {{else}}
+    {{> banners/sign_up_banner}}
+  {{/if}}
 {{/ifCompare}}
-
-{{> banners/download_firefox_banner}}

--- a/views/partials/fxa_enabled/scan_results/fxa_compromised_accounts.hbs
+++ b/views/partials/fxa_enabled/scan_results/fxa_compromised_accounts.hbs
@@ -18,8 +18,8 @@
             {{/eachFromTo}}
           </div>
           <div class="whole">
-            {{#if latestBreaches}} <!-- show Full Report button on latest breaches page -->
-              {{> fxa_enabled/see_full_report_button}}
+            {{#if userDash}} <!-- show Full Report button on latest breaches page -->
+              {{> fxa_enabled/see_full_report_button class="whole"}}
             {{else}}
               <button id="show-additional-breaches" class="button transparent-button">{{fluentFormat req.supportedLocales "show-all"}}</button>
             {{/if}}

--- a/views/partials/fxa_enabled/scan_results/result_headline.hbs
+++ b/views/partials/fxa_enabled/scan_results/result_headline.hbs
@@ -1,9 +1,9 @@
   {{#ifCompare foundBreaches.length "===" 0}}
-    {{#ifCompare userDash "||" fullReport}}
+    {{#if selfScan}}
       <h3 id="latest-breaches" class="section-headline">{{fluentFormat req.supportedLocales "user-zero-breaches-headline" userEmail=signedInUser.email}}</h3>
     {{else}}
       <h3 id="no-breaches" class="section-headline">{{fluentFormat req.supportedLocales "guest-zero-breaches-headline"}}</h3>
-    {{/ifCompare}}
+    {{/if}}
   {{else}}
     <h3 id="scan-results-headline" class="section-headline scan-results-headline">
       {{#if userCompromised}}

--- a/views/partials/fxa_enabled/scan_results/result_headline.hbs
+++ b/views/partials/fxa_enabled/scan_results/result_headline.hbs
@@ -1,20 +1,20 @@
   {{#ifCompare foundBreaches.length "===" 0}}
-    {{#ifCompare latestBreaches "||" fullReport}}
-      <h3 id="latest-breaches" class="section-headline">{{fluentFormat req.supportedLocales "user-zero-breaches-headline" userEmail=req.session.user.email}}</h3>
+    {{#ifCompare userDash "||" fullReport}}
+      <h3 id="latest-breaches" class="section-headline">{{fluentFormat req.supportedLocales "user-zero-breaches-headline" userEmail=signedInUser.email}}</h3>
     {{else}}
       <h3 id="no-breaches" class="section-headline">{{fluentFormat req.supportedLocales "guest-zero-breaches-headline"}}</h3>
     {{/ifCompare}}
   {{else}}
     <h3 id="scan-results-headline" class="section-headline scan-results-headline">
-      {{#if userAccountCompromised}}
-        {{#if authenticatedUser}}
-          {{{fluentNestedBold req.supportedLocales "user-fb-compromised-headline" breachName=featuredBreach.Title userEmail=req.session.user.email}}}
+      {{#if userCompromised}}
+        {{#if selfScan}}
+          {{{fluentNestedBold req.supportedLocales "user-fb-compromised-headline" breachName=specificBreach.Title userEmail=signedInUser.email}}}
         {{else}}
-          {{{fluentNestedBold req.supportedLocales "guest-fb-compromised-headline" breachName=featuredBreach.Title}}}
+          {{{fluentNestedBold req.supportedLocales "guest-fb-compromised-headline" breachName=specificBreach.Title}}}
         {{/if}}
       {{else}}
-        {{#if authenticatedUser}}
-          {{{fluentFormat req.supportedLocales "user-scan-results-headline" breachCount=foundBreaches.length userEmail=req.session.user.email}}}
+        {{#if selfScan}}
+          {{{fluentFormat req.supportedLocales "user-scan-results-headline" breachCount=foundBreaches.length userEmail=signedInUser.email}}}
         {{else}}
           {{{fluentFormat req.supportedLocales "guest-scan-results-headline" breachCount=foundBreaches.length}}}
         {{/if}}

--- a/views/partials/fxa_enabled/scan_results/result_page_right.hbs
+++ b/views/partials/fxa_enabled/scan_results/result_page_right.hbs
@@ -1,6 +1,6 @@
     {{#ifCompare foundBreaches.length "===" 0}}
-      {{#if req.session.user}}
-        {{#if authenticatedUser}}
+      {{#if signedInUser}}
+        {{#if selfScan}}
           <div class="subscribe-icon stack"><!--subscribe-icon--></div>
         {{/if}}
       {{else}}
@@ -8,38 +8,32 @@
       {{/if}}
     {{/ifCompare}}
 
-    {{#ifCompare foundBreaches.length "===" 1}}
-      {{#if authenticatedUser}}
-        {{#if userAccountCompromised}}
-          {{> fxa_enabled/scan_results/single_breach}}
-        {{else}}
-          {{#ifCompare foundBreaches "!!" latestBreaches}}
-            <div class="third">
-              {{> fxa_enabled/see_full_report_button}}
-            </div>
-          {{/ifCompare}}
-        {{/if}}
-      {{else}}
+   {{#ifCompare foundBreaches.length "===" 1}}
+    {{#if specificBreach}}
+      {{#if userCompromised}}
         {{> fxa_enabled/scan_results/single_breach}}
+      {{else}}  
+        {{#if selfScan}}
+          {{> fxa_enabled/see_full_report_button class="third"}}
+        {{else}}
+          {{> fxa_enabled/scan_results/single_breach}}
+        {{/if}}
       {{/if}}
-    {{/ifCompare}}
+    {{else}}
+      {{> fxa_enabled/scan_results/single_breach}}
+    {{/if}}
+   {{/ifCompare}}
 
     {{#ifCompare foundBreaches.length ">" 1}}
-      {{#if authenticatedUser}}
-        {{#if userAccountCompromised}}
+      {{#if selfScan}}
+        {{#if userCompromised}}
           {{> fxa_enabled/scan_results/single_breach}}
         {{else}}
-          {{#ifCompare foundBreaches "!!" latestBreaches}}
-            <div class="third">
-              {{> fxa_enabled/see_full_report_button}}
-            </div>
+          {{#ifCompare userDash "!!" fullReport}}
+            {{> fxa_enabled/see_full_report_button class="third"}}
           {{/ifCompare}}
         {{/if}}
       {{else}}
-        {{#if featuredBreach}}
-          {{> fxa_enabled/sign_up_bundle class="third"}}
-        {{else}} <!--featuredBreach -->
-          {{> fxa_enabled/sign_up_bundle class="third"}}
-        {{/if}}
+        {{> fxa_enabled/sign_up_bundle class="third"}}
       {{/if}}
     {{/ifCompare}}

--- a/views/partials/fxa_enabled/scan_results/result_subhead.hbs
+++ b/views/partials/fxa_enabled/scan_results/result_subhead.hbs
@@ -1,6 +1,6 @@
     {{#ifCompare foundBreaches.length "===" 0}}
-      {{#if req.session.user}}
-        {{#if authenticatedUser}}
+      {{#if signedInUser}}
+        {{#if selfScan}}
           <p>{{fluentFormat req.supportedLocales "user-no-breaches-blurb"}}</p>
         {{else}}
           <p>{{fluentFormat req.supportedLocales "no-breaches-headline"}}</p><!-- legacy stringID, is no longer a headline-->
@@ -9,11 +9,11 @@
         <p>{{fluentFormat req.supportedLocales "guest-no-breaches-blurb"}}</p>
       {{/if}}
     {{else}}
-      {{#if featuredBreach}}
+      {{#if specificBreach}}
         {{#ifCompare foundBreaches.length "===" 1}}
-          {{#if userAccountCompromised}}
-            {{#if req.session.user}}
-              {{#if authenticatedUser}}
+          {{#if userCompromised}}
+            {{#if signedInUser}}
+              {{#if selfScan}}
                 <p>{{fluentFormat req.supportedLocales "user-fb-compromised-single"}}</p>
               {{else}}
                 <p>{{fluentFormat req.supportedLocales "user-generic-fb-compromised-single" breachCount=foundBreaches.length}}</p>
@@ -22,21 +22,21 @@
               <p>{{fluentFormat req.supportedLocales "guest-fb-compromised-single" breachCount=foundBreaches.length}}</p>
             {{/if}}
           {{else}}
-            {{#if req.session.user}}
-              {{#if authenticatedUser}}
-                <p>{{{fluentNestedBold req.supportedLocales "user-fb-not-compromised-blurb" breachCount=foundBreaches.length breachName=featuredBreach.Title userEmail=req.session.user.email}}}</p>
+            {{#if signedInUser}}
+              {{#if selfScan}}
+                <p>{{{fluentNestedBold req.supportedLocales "user-fb-not-compromised-blurb" breachCount=foundBreaches.length breachName=specificBreach.Title userEmail=signedInUser.email}}}</p>
               {{else}}
-                <p>{{{fluentNestedBold req.supportedLocales "user-generic-fb-not-compromised-blurb" breachCount=foundBreaches.length breachName=featuredBreach.Title}}}</p>
+                <p>{{{fluentNestedBold req.supportedLocales "user-generic-fb-not-compromised-blurb" breachCount=foundBreaches.length breachName=specificBreach.Title}}}</p>
               {{/if}}
             {{else}}
-              <p>{{{fluentNestedBold req.supportedLocales "guest-fb-not-compromised-blurb" breachCount=foundBreaches.length breachName=featuredBreach.Title}}}</p>
+              <p>{{{fluentNestedBold req.supportedLocales "guest-fb-not-compromised-blurb" breachCount=foundBreaches.length breachName=specificBreach.Title}}}</p>
             {{/if}}
           {{/if}}
         {{else}}
-          {{#if userAccountCompromised}}
-            {{#if req.session.user}}
-              {{#if authenticatedUser}}
-                <p>{{fluentFormat req.supportedLocales "user-fb-compromised-blurb" breachCount=(breachMath foundBreaches.length "-" 1) userEmail=req.session.user.email}}</p>
+          {{#if userCompromised}}
+            {{#if signedInUser}}
+              {{#if selfScan}}
+                <p>{{fluentFormat req.supportedLocales "user-fb-compromised-blurb" breachCount=(breachMath foundBreaches.length "-" 1) userEmail=signedInUser.email}}</p>
               {{else}}
                 <p>{{fluentFormat req.supportedLocales "user-generic-fb-compromised-blurb" breachCount=(breachMath foundBreaches.length "-" 1)}}</p>
               {{/if}}
@@ -44,20 +44,20 @@
               <p>{{fluentFormat req.supportedLocales "guest-fb-compromised-blurb" breachCount=(breachMath foundBreaches.length "-" 1)}}</p>
             {{/if}}
           {{else}}
-            {{#if req.session.user}}
-              {{#if authenticatedUser}}
-                <p>{{{fluentNestedBold req.supportedLocales "user-fb-not-compromised-blurb" breachCount=foundBreaches.length breachName=featuredBreach.Title userEmail=req.session.user.email}}}</p>
+            {{#if signedInUser}}
+              {{#if selfScan}}
+                <p>{{{fluentNestedBold req.supportedLocales "user-fb-not-compromised-blurb" breachCount=foundBreaches.length breachName=specificBreach.Title userEmail=signedInUser.email}}}</p>
               {{else}}
-                <p>{{{fluentNestedBold req.supportedLocales "user-generic-fb-not-compromised-blurb" breachCount=foundBreaches.length breachName=featuredBreach.Title}}}</p>
+                <p>{{{fluentNestedBold req.supportedLocales "user-generic-fb-not-compromised-blurb" breachCount=foundBreaches.length breachName=specificBreach.Title}}}</p>
               {{/if}}
             {{else}}
-              <p>{{{fluentNestedBold req.supportedLocales "guest-fb-not-compromised-blurb" breachCount=foundBreaches.length breachName=featuredBreach.Title}}}</p>
+              <p>{{{fluentNestedBold req.supportedLocales "guest-fb-not-compromised-blurb" breachCount=foundBreaches.length breachName=specificBreach.Title}}}</p>
             {{/if}}
           {{/if}}
         {{/ifCompare}}
       {{else}}
-        {{#if req.session.user}}
-          {{#if authenticatedUser}}
+        {{#if signedInUser}}
+          {{#if selfScan}}
             <p>{{fluentFormat req.supportedLocales "user-found-breaches-blurb" breachCount=foundBreaches.length}}</p>
           {{else}}
             <p>{{fluentFormat req.supportedLocales "user-generic-found-breaches-blurb" breachCount=foundBreaches.length}}</p>

--- a/views/partials/fxa_enabled/scan_results/single_breach.hbs
+++ b/views/partials/fxa_enabled/scan_results/single_breach.hbs
@@ -1,4 +1,4 @@
-        <div class="half">
+        <div class="half single-breach">
           {{#eachFromTo foundBreaches 0 1}}
             {{> breach_listing req=../req}}
           {{/eachFromTo}}

--- a/views/partials/fxa_enabled/see_full_report_button.hbs
+++ b/views/partials/fxa_enabled/see_full_report_button.hbs
@@ -1,1 +1,3 @@
-<a href="/scan/full_report" class="button see-full-report-button" id="see-full-report-button">{{fluentFormat req.supportedLocales "see-full-report"}}</a>
+<div class="{{ class }}">
+  <a href="/scan/full_report" class="button see-full-report-button" id="see-full-report-button">{{fluentFormat req.supportedLocales "see-full-report"}}</a>
+</div>

--- a/views/partials/legacy/compromised_accounts.hbs
+++ b/views/partials/legacy/compromised_accounts.hbs
@@ -2,7 +2,7 @@
 {{#ifCompare foundBreaches.length ">" 1}}
     <div class="compromised-accounts">
       <div class="section-wrapper">
-        <!--show first 4 breaches-->
+        <!--show first 4 foundBreaches-->
         {{#eachFromTo foundBreaches 0 4 }}
           {{> breach_listing req=../req}}
         {{/eachFromTo}}

--- a/views/partials/legacy/scan.hbs
+++ b/views/partials/legacy/scan.hbs
@@ -8,11 +8,11 @@
         <h3 id="found-breaches" class="section-headline">{{fluentFormat req.supportedLocales "found-breaches-headline"}}</h3>
       {{/ifCompare}}
 
-      {{#if featuredBreach}}
+      {{#if specificBreach}}
         {{#if userAccountCompromised}}
-          <p>{{{fluentFormat req.supportedLocales "featured-breach-results" featuredBreach=featuredBreach.Title breachCount=(breachMath foundBreaches.length "-" 1)}}}</p>
+          <p>{{{fluentFormat req.supportedLocales "featured-breach-results" featuredBreach=specificBreach.Title breachCount=(breachMath foundBreaches.length "-" 1)}}}</p>
         {{else}}
-          <p>{{{fluentFormat req.supportedLocales "featured-breach-not-compromised" featuredBreach=featuredBreach.Title breachCount=foundBreaches.length}}}</p>
+          <p>{{{fluentFormat req.supportedLocales "featured-breach-not-compromised" featuredBreach=specificBreach.Title breachCount=foundBreaches.length}}}</p>
         {{/if}}
       {{else}}
         <p>{{{fluentFormat req.supportedLocales "scan-results" breachCount=foundBreaches.length}}}</p>


### PR DESCRIPTION
- Moves scan logic that was living in various/multiple controllers into standalone `scan-results.js` that returns one big object for sending to the templates.
- Updates templates with new/renamed vars.
   - `latestBreaches` is now `userDash`
   - `authenticatedUser` is now `selfScan`
   - `featuredBreach` is now `specificBreach`  (in `scan-results.js` and various result partials)
- Fixes some logic in the templates unearthed while working on this. Specifically:
   - Single breach results not showing up on `fullReport` and `userDash` pages.
   - Some incorrect response headlines/subheads when signed in users scan emails other than their own from featured breach pages.
   - Fixes rder and appearance of the sign up banner, the download banner, and the what to do tips on result pages.
   - See Full Report incorrectly showing up when a signed in user scans an email that is not their own from a featured breach page.
- Sets us up to move all of the iffing/elsing/unlessing/ifComparing out of the handlebars templates and into something a bit easier to wrangle.
