### PR TITLE
Check if login-btn exists before adding class.

### DIFF
--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -497,7 +497,7 @@ if (document.body.dataset.fxaEnabled === "fxa-enabled") {
     });
   }
   // capitalize the sign in button for en-US only.
-  if (window.navigator.language.includes("en")) {
+  if (window.navigator.language.includes("en") && document.getElementById("login-btn")) {
     document.getElementById("login-btn").classList.add("capitalize");
   }
 }


### PR DESCRIPTION
Prevents line 501 from throwing an error when a user is signed in and `#login-btn` doesn't exist.