### PR TITLE
fix #799: Add markup to { $breachCount } after grabbing localized strings.

### DIFF
--- a/hbs-helpers.js
+++ b/hbs-helpers.js
@@ -42,12 +42,14 @@ function localizedBreachDataClasses(supportedLocales, dataClasses, args) {
 
 
 function fluentNestedBold(supportedLocales, id, args) {
-  for (const key in args.hash) {
-    if (["breachName", "breachCount"].includes(key)) {
-      args.hash[key] = `<span class="medium">${args.hash[key]}</span>`;
-    }
+  if (args.hash.breachName) {
+    args.hash.breachName = `<span class="medium">${args.hash.breachName}</span>`;
   }
-  return LocaleUtils.fluentFormat(supportedLocales, id, args.hash);
+  let localizedStrings = LocaleUtils.fluentFormat(supportedLocales, id, args.hash);
+  if (args.hash.breachCount) {
+    localizedStrings = localizedStrings.replace(/\d+/, `<span class="medium">${args.hash.breachCount}</span>`);
+  }
+  return localizedStrings;
 }
 
 


### PR DESCRIPTION
This grabs the localized copy before wrapping `{$ breachCount }` in `<span class="medium"></span>`.
Fluent doesn't interpret `{ $breachCount }` when it's wrapped in markup and the default `*[other]` string is currently being returned no matter the actual `{ $breachCount }`.
<img width="626" alt="screen shot 2019-02-21 at 10 17 11 am" src="https://user-images.githubusercontent.com/22355127/53184393-91f21600-35c2-11e9-91c4-36626a0f47cc.png">
