### PR TITLE
Update fluentNestedBold helper.

### DIFF
--- a/hbs-helpers.js
+++ b/hbs-helpers.js
@@ -42,13 +42,27 @@ function localizedBreachDataClasses(supportedLocales, dataClasses, args) {
 
 
 function fluentNestedBold(supportedLocales, id, args) {
-  if (args.hash.breachName) {
-    args.hash.breachName = `<span class="medium">${args.hash.breachName}</span>`;
-  }
+  const saveArgs = JSON.parse(JSON.stringify(args.hash));
+  const stringIds = Object.keys(saveArgs).filter(key => key !== "breachCount");
+
+  const addMarkup = (word) => {
+    return `<span class="medium"> ${word} </span>`;
+  };
+
+  stringIds.forEach(stringId => {
+    args.hash[stringId] = stringId;
+  });
+
   let localizedStrings = LocaleUtils.fluentFormat(supportedLocales, id, args.hash);
+
   if (args.hash.breachCount) {
-    localizedStrings = localizedStrings.replace(/\d+/, `<span class="medium">${args.hash.breachCount}</span>`);
+    localizedStrings = localizedStrings.replace(/(\s[\d]+\s)/, addMarkup(args.hash.breachCount));
   }
+
+  stringIds.forEach(stringId => {
+    localizedStrings = localizedStrings.replace(stringId, addMarkup(saveArgs[stringId]));
+  });
+
   return localizedStrings;
 }
 

--- a/hbs-helpers.js
+++ b/hbs-helpers.js
@@ -43,13 +43,13 @@ function localizedBreachDataClasses(supportedLocales, dataClasses, args) {
 
 function fluentNestedBold(supportedLocales, id, args) {
   const saveArgs = JSON.parse(JSON.stringify(args.hash));
-  const stringIds = Object.keys(saveArgs).filter(key => key !== "breachCount");
+  const nonNumericStringIds = Object.keys(saveArgs).filter(key => key !== "breachCount");
 
   const addMarkup = (word) => {
-    return `<span class="medium"> ${word} </span>`;
+    return ` <span class="medium">${word}</span> `;
   };
 
-  stringIds.forEach(stringId => {
+  nonNumericStringIds.forEach(stringId => {
     args.hash[stringId] = stringId;
   });
 
@@ -59,7 +59,7 @@ function fluentNestedBold(supportedLocales, id, args) {
     localizedStrings = localizedStrings.replace(/(\s[\d]+\s)/, addMarkup(args.hash.breachCount));
   }
 
-  stringIds.forEach(stringId => {
+  nonNumericStringIds.forEach(stringId => {
     localizedStrings = localizedStrings.replace(stringId, addMarkup(saveArgs[stringId]));
   });
 


### PR DESCRIPTION
-Fixes #806 

Updates the `fluentNestedBold` helper so that it doesn't incorrectly overwrite `{ $userEmail }`
 and `{ $breachName }`.
 
Now, `fluentNestedBold`:

- Makes copy of `args.hash`
- Sets any non-`breachCount` value in args.hash equal to its key. "000webhost" would become "breachName", for instance.
- Grabs translated string with correct `breachCount` value and any other placeholder args. 
- Checks returned strings for the `breachCount` numeral (looks for digit(s) surrounded by whitespace) and adds markup.
- Replaces placeholder vars with saved values, adds markup, and sends to template.

To check this, I created a new mailinator account (123monitor_testing_number_1-@mailinator.com) and gave myself some breaches locally.

<img width="613" alt="screen shot" src="https://user-images.githubusercontent.com/22355127/53291531-2fdc1100-377a-11e9-857a-acf9f9d16416.png">
