### PR TITLE
Implement a script to add breaches missing from Remote Settings.

### DIFF
--- a/scripts/updatekinto.js
+++ b/scripts/updatekinto.js
@@ -1,10 +1,21 @@
 "use strict";
 
+const DEBUG = true;
+
 const got = require("got");
 
 const SERVER = "https://settings-writer.prod.mozaws.net/v1";
 const CID = "fxmonitor-breaches";
-const DEBUG = true;
+/* eslint-disable-next-line no-process-env */
+const USERNAME = process.env.KINTO_USERNAME;
+/* eslint-disable-next-line no-process-env */
+const PASSWORD = process.env.KINTO_PASSWORD;
+if (!USERNAME || !PASSWORD) {
+  console.error("Please set credentials in the environment.");
+  return;
+}
+
+const AUTH = Buffer.from(`${USERNAME}:${PASSWORD}`).toString("base64");
 
 async function run() {
   const RemoteSettingsBreachesSet = new Set((await got(
@@ -48,7 +59,7 @@ async function run() {
       await got.post(`${SERVER}/buckets/main-workspace/collections/${CID}/records`, {
         headers: {
           "Content-Type": "application/json",
-          "authorization": "Bearer <insert token here>",
+          "authorization": `Basic ${AUTH}`,
         },
         body: JSON.stringify({data: data}),
       });

--- a/scripts/updatekinto.js
+++ b/scripts/updatekinto.js
@@ -1,0 +1,62 @@
+"use strict";
+
+const got = require("got");
+
+const SERVER = "https://settings-writer.prod.mozaws.net/v1";
+const CID = "fxmonitor-breaches";
+const DEBUG = true;
+
+async function run() {
+  const RemoteSettingsBreachesSet = new Set((await got(
+    "https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/fxmonitor-breaches/records",
+    { json: true }
+  )).body.data.map(b => b.Name));
+
+  const hibp_breaches = (await got(
+    "https://haveibeenpwned.com/api/v2/breaches",
+    { json: true }
+  )).body;
+
+  const new_breaches = [];
+
+  for (const breach of hibp_breaches) {
+    if (breach.IsSpamList || breach.IsRetired || !breach.IsVerified || !breach.Domain) {
+      continue;
+    }
+
+    if (RemoteSettingsBreachesSet.has(breach.Name)) {
+      continue;
+    }
+
+    new_breaches.push(breach);
+  }
+  for (const breach of new_breaches) {
+    const data = {
+      Name: breach.Name,
+      Domain: breach.Domain,
+      BreachDate: breach.BreachDate,
+      PwnCount: breach.PwnCount,
+      AddedDate: breach.AddedDate,
+    };
+
+    if (DEBUG) {
+      console.log(data);
+      continue;
+    }
+
+    try {
+      await got.post(`${SERVER}/buckets/main-workspace/collections/${CID}/records`, {
+        headers: {
+          "Content-Type": "application/json",
+          "authorization": "Bearer <insert token here>",
+        },
+        body: JSON.stringify({data: data}),
+      });
+    } catch (e) {
+      console.log(e);
+      return;
+    }
+  }
+}
+
+run();


### PR DESCRIPTION
This is my script to diff the breaches in the fxmonitor-breaches Remote Settings collection against HIBP's breach list, and add the missing ones.

I modified my script to use `got` which is already a dependency in this repo.

The post request to actually add records is untested at the moment after converting from `request-promise` to `got`.

This needs to be updated to use credentials from the environment instead of a pasted bearer token.