### PR TITLE
Set GA transport mechanism to "beacon".

### DIFF
--- a/public/js/analytics_tracking_protection.js
+++ b/public/js/analytics_tracking_protection.js
@@ -46,8 +46,9 @@ if (!_dntEnabled()) {
 }
 
 if(typeof(ga) !== "undefined") {
-	ga("create", "UA-77033033-16");
-	ga("set", "anonymizeIp", true);
+  ga("create", "UA-77033033-16");
+  ga("set", "anonymizeIp", true);
+  ga("set", "transport", "beacon");
 
 
   // Strip token and hash values from pings sent to GA


### PR DESCRIPTION
Fixes #822

I created a test event locally and it turned up in the GA dashboard as expected. None of the other events appear to have been altered/negatively impacted. 

<img width="1040" alt="beacon test" src="https://user-images.githubusercontent.com/22355127/54162313-0fbb7b80-4423-11e9-9341-144134a40538.png">
