### PR TITLE
Fix top of funnel FxA pings.

### DIFF
--- a/public/js/fxa-analytics.js
+++ b/public/js/fxa-analytics.js
@@ -63,10 +63,10 @@ const getFxaUtms = (url) => {
     setMetricsIds(el);
   });
 
-  let fxaUrl = new URL("/metrics-flow?", document.body.dataset.fxaAddress);
-  fxaUrl = getFxaUtms(fxaUrl);
 
   document.querySelectorAll(".open-oauth").forEach( async(el) => {
+    let fxaUrl = new URL("/metrics-flow?", document.body.dataset.fxaAddress);
+    fxaUrl = getFxaUtms(fxaUrl);
     fxaUrl.searchParams.append("entrypoint", encodeURIComponent(el.dataset.entrypoint));
     const response = await fetch(fxaUrl, {credentials: "omit"});
 

--- a/views/partials/analytics/default_dataset.hbs
+++ b/views/partials/analytics/default_dataset.hbs
@@ -2,12 +2,12 @@ data-server-url="{{ SERVER_URL }}"
 
 {{#if FXA_ENABLED}}
   data-fxa-enabled="fxa-enabled"
-  data-fxa-address={{getFxaUrl}}
+  data-fxa-address="{{getFxaUrl}}"
   data-utm-campaign="fx-monitor-fxa-integration"
   
   {{#if req.session.user}}
-    data-signed-in-user="true";
+    data-signed-in-user="true"
   {{else}}
-    data-signed-in-user="false";
+    data-signed-in-user="false"
   {{/if}}
 {{/if}}


### PR DESCRIPTION
- Moves the `let fxaUrl` assignment into the following `.forEach` loop. The current implementation repeatedly appends the `entrypoint` param and results in only the first request firing correctly.

- Also cleans out some punctation muckying up the `default_dataset` helper.

To test locally, use PORT 8000 and make sure FXA_SETTINGS_URL is set to `https://stable.dev.lcip.org`