### PR TITLE
fix pre-FxA unsubscribe links

### DIFF
--- a/db/seeds/test_subscribers.js
+++ b/db/seeds/test_subscribers.js
@@ -11,6 +11,8 @@ exports.TEST_SUBSCRIBERS = {
     primary_verification_token: "0e2cb147-2041-4e5b-8ca9-494e773b2cf1",
     primary_verified: true,
     fxa_refresh_token: "4a4792b89434153f1a6262fbd6a4510c00834ff842585fc4f4d972da158f0fc1",
+    fxa_uid: 12345,
+    fxa_profile_json: {},
     breaches_last_shown: "2019-04-24 13:27:08.421-05",
   },
   all_emails_to_primary: {


### PR DESCRIPTION
I couldn't catch this until https://github.com/mozilla/blurts-server/pull/982 landed on https://fx-breach-alerts.herokuapp.com/ where we have pre-FxA subscribers.

I dug up one of those old pre-FxA subscriber emails and clicked its "unsubscribe" link. It incorrectly tried to redirect to `/users/preferences`.

So I updated a localhost user to match that old pre-FxA record and updated the `getUnsubscribe` code to fix that.