### PR TITLE
Remove check for en-us.

### DIFF
--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -194,12 +194,6 @@ function toggleHeaderStates(header, win) {
 
   document.addEventListener("scroll", () => toggleHeaderStates(header, win));
 
-
-  // capitalize the sign in button for en-US only.
-  if (win.navigator.language.includes("en") && document.getElementById("sign-in-btn")) {
-    document.getElementById("sign-in-btn").classList.add("capitalize");
-  }
-
   document.querySelectorAll(".breach-img").forEach(logo => {
     logo.addEventListener("error", (missingLogo) => {
       missingLogo.target.src = "/img/logos/missing-logo-icon.png";


### PR DESCRIPTION
Remove the check for `en-US` and stop adding the `"capitalize"` class to `sign-in-btn`.  We don't need to do this now that we've updated this string.