### PR TITLE
Unsubscribe flow UI updates

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -36,8 +36,7 @@ h2.pref-headline.breach-summary {
 }
 
 .pref.remove {
-  margin-top: 2rem;
-  padding-bottom: 4rem;
+  margin: 6rem 0;
 }
 
 .pref .col-9 {
@@ -61,6 +60,7 @@ button.resend-email {
   color: var(--alertRed);
   font-weight: 700;
   align-items: center;
+  font-size: 1.3rem;
 }
 
 .remove-fxm .arrow-head-right path {

--- a/public/css/forms.css
+++ b/public/css/forms.css
@@ -167,6 +167,7 @@ input[type="submit"] {
   color: rgba(255, 255, 255, 1);
   font-weight: 700;
   border-color: var(--blue3);
+  letter-spacing: 0.03em;
 }
 
 form.invalid input[type="submit"]:focus {
@@ -186,6 +187,11 @@ input.email-add-submit {
   color: rgba(255, 255, 255, 1);
   border-color: var(--blue3);
   font-weight: 500;
+}
+
+input.unsub {
+  padding: 0;
+  cursor: pointer;
 }
 
 /* radio buttons */

--- a/views/partials/subpages/remove_fxm.hbs
+++ b/views/partials/subpages/remove_fxm.hbs
@@ -1,5 +1,5 @@
 <section id="unsubscribe" class="half">
     <h3 class="pref-section-headline remove">{{ getString "remove-fxm" }}</h3>
     <p class="subhead">{{ getString "remove-fxm-blurb" }}</p>
-    <button class="remove-fxm subhead flx" data-form-action="remove-fxm" data-primary-token="{{ primaryToken }}" data-primary-hash="{{ primaryHash }}" href="#">{{ getString "remove-fxm" }}{{> svg/arrow-head-right }}</button>
+    <button class="remove-fxm flx" data-form-action="remove-fxm" data-primary-token="{{ primaryToken }}" data-primary-hash="{{ primaryHash }}" href="#">{{ getString "remove-fxm" }}{{> svg/arrow-head-right }}</button>
 </section>

--- a/views/partials/subpages/unsubscribe.hbs
+++ b/views/partials/subpages/unsubscribe.hbs
@@ -5,7 +5,7 @@
     <input type="hidden" name="token" value="{{ token }}">
     <input type="hidden" name="emailHash" value="{{ hash }}">
     <div class="input-group-button">
-      <input type="submit" class="button submit transparent-button" value="{{getString "unsub-button"}}" data-server-url="{{ SERVER_URL }}">
+      <input type="submit" class="button submit unsub" value="{{getString "unsub-button"}}" data-server-url="{{ SERVER_URL }}">
       <img class="loader" src="/img/loader.gif" alt="" />
     </div>
   </form>


### PR DESCRIPTION
- Vertically centers unsubscribe button text
- Adds more spacing between the Add Another Email form and Remove Firefox Monitor button on the preferences dashboard.
- Related letter-spacing/font-size tweaks.

Waiting to hear from Ryan and Betsy about what should happen as far as a visual "You've been unsubscribed" cue after clicking "Remove Firefox Monitor".