### PR TITLE
fix #992: destroy access and refresh tokens on Remove

### DIFF
--- a/controllers/oauth.js
+++ b/controllers/oauth.js
@@ -80,7 +80,7 @@ async function confirmed(req, res, next, client = FxAOAuthClient) {
     // req.session.newUser determines whether or not we show "fxa_new_user_bar" in template
     req.session.newUser = true;
     const signupLanguage = req.headers["accept-language"];
-    const verifiedSubscriber = await DB.addSubscriber(email, signupLanguage, fxaUser.refreshToken, data.body);
+    const verifiedSubscriber = await DB.addSubscriber(email, signupLanguage, fxaUser.accessToken, fxaUser.refreshToken, data.body);
 
     // duping some of user/verify for now
     let unsafeBreachesForEmail = [];
@@ -110,7 +110,10 @@ async function confirmed(req, res, next, client = FxAOAuthClient) {
       }
     );
     req.session.user = verifiedSubscriber;
+    return res.redirect("/user/dashboard");
   }
+  // Update existing user's FxA data
+  await DB._updateFxAData(existingUser, fxaUser.accessToken, fxaUser.refreshToken, data.body);
   res.redirect("/user/dashboard");
 }
 

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -275,7 +275,7 @@ async function getRemoveFxm(req, res) {
 async function postRemoveFxm(req, res) {
   const sessionUser = _requireSessionUser(req);
   await DB.removeSubscriber(sessionUser);
-  await FXA.revokeOAuthToken(sessionUser.fxa_refresh_token);
+  await FXA.revokeOAuthTokens(sessionUser);
 
   req.session.reset();
   res.redirect("/");
@@ -299,7 +299,7 @@ async function postUnsubscribe(req, res) {
     await DB.removeOneSecondaryEmail(emailAddress.id);
     return res.redirect("/user/preferences");
   }
-  await FXA.revokeOAuthToken(unsubscribedUser.fxa_refresh_token);
+  await FXA.revokeOAuthTokens(unsubscribedUser);
   req.session.reset();
   res.redirect("/");
 }

--- a/db/DB.js
+++ b/db/DB.js
@@ -148,16 +148,18 @@ const DB = {
    * 3. For FxA subscriber, add refresh token and profile data
    *
    * @param {string} email to add
+   * @param {string} signupLanguage from Accept-Language
+   * @param {string} fxaAccessToken from Firefox Account Oauth
    * @param {string} fxaRefreshToken from Firefox Account Oauth
    * @param {string} fxaProfileData from Firefox Account
    * @returns {object} subscriber knex object added to DB
    */
-  async addSubscriber(email, signupLanguage, fxaRefreshToken=null, fxaProfileData=null) {
+  async addSubscriber(email, signupLanguage, fxaAccessToken=null, fxaRefreshToken=null, fxaProfileData=null) {
     const emailHash = await this._addEmailHash(getSha1(email), email, signupLanguage, true);
     const verified = await this._verifySubscriber(emailHash);
     const verifiedSubscriber = Array.isArray(verified) ? verified[0] : null;
     if (fxaRefreshToken || fxaProfileData) {
-      return this._updateFxAData(verifiedSubscriber, fxaRefreshToken, fxaProfileData);
+      return this._updateFxAData(verifiedSubscriber, fxaAccessToken, fxaRefreshToken, fxaProfileData);
     }
     return verifiedSubscriber;
   },
@@ -218,16 +220,18 @@ const DB = {
    * Update fxa_refresh_token and fxa_profile_json for subscriber
    *
    * @param {object} subscriber knex object in DB
+   * @param {string} fxaAccessToken from Firefox Account Oauth
    * @param {string} fxaRefreshToken from Firefox Account Oauth
    * @param {string} fxaProfileData from Firefox Account
    * @returns {object} updated subscriber knex object in DB
    */
-  async _updateFxAData(subscriber, fxaRefreshToken, fxaProfileData) {
+  async _updateFxAData(subscriber, fxaAccessToken, fxaRefreshToken, fxaProfileData) {
     const fxaUID = JSON.parse(fxaProfileData).uid;
     const updated = await knex("subscribers")
     .where("id", "=", subscriber.id)
     .update({
       fxa_uid: fxaUID,
+      fxa_access_token: fxaAccessToken,
       fxa_refresh_token: fxaRefreshToken,
       fxa_profile_json: fxaProfileData,
     })

--- a/db/migrations/20190523152919_add_fxa_access_token_to_subscribers.js
+++ b/db/migrations/20190523152919_add_fxa_access_token_to_subscribers.js
@@ -1,0 +1,13 @@
+"use strict";
+
+exports.up = function(knex, Promise) {
+  return knex.schema.table("subscribers", table => {
+    table.string("fxa_access_token");
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.table("subscribers", table => {
+    table.dropColumn("fxa_access_token");
+  });
+};

--- a/db/seeds/test_subscribers.js
+++ b/db/seeds/test_subscribers.js
@@ -10,6 +10,7 @@ exports.TEST_SUBSCRIBERS = {
     primary_email: "firefoxaccount@test.com",
     primary_verification_token: "0e2cb147-2041-4e5b-8ca9-494e773b2cf1",
     primary_verified: true,
+    fxa_access_token: "4a4792b89434153f1a6262fbd6a4510c00834ff842585fc4f4d972da158f0fc0",
     fxa_refresh_token: "4a4792b89434153f1a6262fbd6a4510c00834ff842585fc4f4d972da158f0fc1",
     fxa_uid: 12345,
     fxa_profile_json: {},

--- a/lib/fxa.js
+++ b/lib/fxa.js
@@ -11,10 +11,10 @@ const log = mozlog("fxa");
 
 const FXA = {
 
-  async revokeOAuthToken(fxaRefreshToken) {
+  async destroyOAuthToken(token) {
     const fxaTokenOrigin = new URL(AppConstants.OAUTH_TOKEN_URI).origin;
     const tokenDestroyUrl = `${fxaTokenOrigin}/v1/destroy`;
-    const tokenDestroyParams = { refresh_token: fxaRefreshToken };
+    const tokenDestroyParams = token;
     const tokenDestroyOptions = {
       method: "POST",
       headers: {"Authorization": `Bearer ${AppConstants.OAUTH_CLIENT_SECRET}`},
@@ -25,8 +25,13 @@ const FXA = {
     try {
       return await got(tokenDestroyUrl, tokenDestroyOptions);
     } catch (e) {
-      log.error("revokeOAuthToken", {stack: e.stack});
+      log.error("destroyOAuthToken", {stack: e.stack});
     }
+  },
+
+  async revokeOAuthTokens(subscriber) {
+    await this.destroyOAuthToken({ token: subscriber.fxa_access_token });
+    await this.destroyOAuthToken({ refresh_token: subscriber.fxa_refresh_token });
   },
 
 };

--- a/tests/controllers/ses.test.js
+++ b/tests/controllers/ses.test.js
@@ -94,10 +94,11 @@ test("ses notification with invalid signature responds with error and doesn't ch
 test("sns notification for FxA account delete deletes monitor subscriber record", async () => {
   const testEmail = "fxa-deleter@mailinator.com";
   const testSignupLanguage = "en";
+  const testFxaAccessToken = "abcdef123456789";
   const testFxaRefreshToken = "abcdef123456789";
   const testFxaUID = "3b1a9d27f85b4a4c977f3a84838f9116";
   const testFxaProfileData = JSON.stringify({uid: testFxaUID});
-  await DB.addSubscriber(testEmail, testSignupLanguage, testFxaRefreshToken, testFxaProfileData);
+  await DB.addSubscriber(testEmail, testSignupLanguage, testFxaAccessToken, testFxaRefreshToken, testFxaProfileData);
 
   let subscribers = await DB.getSubscribersByHashes([getSha1(testEmail)]);
   expect(subscribers.length).toEqual(1);

--- a/tests/controllers/user.test.js
+++ b/tests/controllers/user.test.js
@@ -375,7 +375,7 @@ test("user/remove-fxm POST request with invalid session returns error", async ()
 test("user remove-fxm POST request with valid session removes from DB and revokes FXA OAuth token", async () => {
   const req = { fluentFormat: jest.fn(), session: { user: TEST_SUBSCRIBERS.firefox_account, reset: jest.fn() }};
   const resp = httpMocks.createResponse();
-  FXA.revokeOAuthToken = jest.fn();
+  FXA.revokeOAuthTokens = jest.fn();
 
   await user.postRemoveFxm(req, resp);
 
@@ -383,7 +383,7 @@ test("user remove-fxm POST request with valid session removes from DB and revoke
   expect(resp._getRedirectUrl()).toEqual("/");
   const subscriber = await DB.getEmailByToken(TEST_SUBSCRIBERS.firefox_account.primary_verification_token);
   expect(subscriber).toBeUndefined();
-  expect(FXA.revokeOAuthToken).toHaveBeenCalledTimes(1);
+  expect(FXA.revokeOAuthTokens).toHaveBeenCalledTimes(1);
   expect(req.session.reset).toHaveBeenCalledTimes(1);
 });
 

--- a/tests/fxa.test.js
+++ b/tests/fxa.test.js
@@ -10,14 +10,20 @@ jest.mock("got");
 
 
 test("revokeOAuthToken calls oauth destroy with fxa_refresh_token", async () => {
-  const token = TEST_SUBSCRIBERS.firefox_account.fxa_refresh_token;
+  const subscriber = TEST_SUBSCRIBERS.firefox_account;
 
-  await FXA.revokeOAuthToken(token);
+  await FXA.revokeOAuthTokens(subscriber);
 
   const gotCalls = got.mock.calls;
-  expect(gotCalls.length).toEqual(1);
-  const gotCallArgs = gotCalls[0];
-  expect(gotCallArgs[0]).toContain("/v1/destroy");
-  const gotCallOptions = gotCallArgs[1];
-  expect(gotCallOptions.body.refresh_token).toEqual(token);
+  expect(gotCalls.length).toEqual(2);
+
+  const accessGotCallArgs = gotCalls[0];
+  expect(accessGotCallArgs[0]).toContain("/v1/destroy");
+  const accessGotCallOptions = accessGotCallArgs[1];
+  expect(accessGotCallOptions.body.token).toEqual(subscriber.fxa_access_token);
+
+  const refreshGotCallArgs = gotCalls[1];
+  expect(refreshGotCallArgs[0]).toContain("/v1/destroy");
+  const refreshGotCallOptions = refreshGotCallArgs[1];
+  expect(refreshGotCallOptions.body.refresh_token).toEqual(subscriber.fxa_refresh_token);
 });


### PR DESCRIPTION
This could be a fast-follow after release if we think it's too risky to land before. This code:

1. Adds a db column to hold the FxA access token in addition to the refresh token
2. Updates the OAuth code to store the access token it receives from FxA
3. Updates the OAuth code to update existing subscribers' FxA data every time they sign in (to get existing subscribers' access tokens, and this should help update their avatar images too.)
4. During `removeFxm` calls FxA `/destroy` endpoint for both the access token and the refresh token