### PR TITLE
Highlight "Home" navigation when signed in.

### DIFF
--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -160,6 +160,22 @@ function toggleHeaderStates(header, win) {
   }
 }
 
+function styleActiveLink(locationHref) {
+  let queryString = `.nav-link[href='${locationHref}']`;
+  const activeLink = document.querySelector(queryString);
+  if (activeLink) {
+    return activeLink.classList.add("active-link");
+  }
+
+  if (~locationHref.indexOf("/dashboard")) {
+    queryString = queryString.replace("user/dashboard", "");
+    return document.querySelector(queryString).classList.add("active-link");
+  }
+  if (~locationHref.indexOf("/security-tips")) {
+    return document.querySelector(".nav-link[href*='/security-tips']").classList.add("active-link");
+  }
+}
+
 ( async() => {
   document.addEventListener("touchstart", function(){}, true);
   const win = window;
@@ -169,14 +185,7 @@ function toggleHeaderStates(header, win) {
     if (previousActiveLink) {
       previousActiveLink.classList.remove("active-link");
     }
-    const navLinks = document.querySelectorAll(".nav-link");
-
-    navLinks.forEach(link => {
-      if (link.href === win.location.href) {
-        link.classList.add("active-link");
-      }
-    });
-
+    styleActiveLink(win.location.href);
     if (win.location.search.includes("utm_") && win.history.replaceState) {
       win.history.replaceState({}, "", win.location.toString().replace(/[?&]utm_.*/g, ""));
     }
@@ -186,7 +195,6 @@ function toggleHeaderStates(header, win) {
     document.forms ? (restoreInputs(), addFormListeners()) : null;
   });
 
-  // toggleMobileFeatures();
   win.addEventListener("resize", () => {
     toggleMobileFeatures();
     toggleArticles();

--- a/template-helpers/header.js
+++ b/template-helpers/header.js
@@ -12,22 +12,23 @@ function getSignedInAs(args) {
 }
 
 function navLinks(args) {
+  const serverUrl = args.data.root.constants.SERVER_URL;
   const locales = args.data.root.req.supportedLocales;
   const links = [
     {
       title: "Home",
       stringId: "home",
-      href: "/",
+      href: `${serverUrl}/`,
     },
     {
       title: "Breaches",
       stringId: "breaches",
-      href: "/breaches",
+      href: `${serverUrl}/breaches`,
     },
     {
       title: "Security Tips",
       stringId: "security-tips",
-      href: "/security-tips",
+      href: `${serverUrl}/security-tips`,
     },
   ];
 


### PR DESCRIPTION
- Adds highlighted "home" navigation for signed in users on the "/user/dashboard" page.
- Fixes bug where the "Security Tips" link does not appear highlighted if the user navigates to that page via one of the article links on another page.

Fixes #1027 