### PR TITLE
 fix #1044: ensure session user always has email_addresses 

### DIFF
--- a/db/DB.js
+++ b/db/DB.js
@@ -50,6 +50,18 @@ const DB = {
     return res;
   },
 
+  async getSubscriberById(id) {
+    const [subscriber] = await knex("subscribers").where({
+      "id": id,
+    });
+    if (subscriber) {
+      subscriber.email_addresses = await knex("email_addresses").where({
+        "subscriber_id": subscriber.id,
+      });
+    }
+    return subscriber;
+  },
+
   async getSubscriberByEmail(email) {
     const [subscriber] = await knex("subscribers").where({
       "primary_email": email,


### PR DESCRIPTION
#1044 happened because some objects assigned to `req.sesion.user =` were the return of functions that did not join the `subscribers` table with the `email_addresses` table. This code updates the `requireSessionUser` call to always join the `email_addresses` records onto the user object.