### PR TITLE
Show breach cards on desktop dashboard.

### DIFF
--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -173,6 +173,7 @@ function toggleMobileFeatures(topNavBar) {
       emailCards.forEach(card => {
         card.classList.add("active");
       });
+      return;
     }
 
   const closeActiveEmailCards = document.querySelectorAll(".col-9.email-card.active");


### PR DESCRIPTION
Fix for breach cards not showing up on the user dashboard (issue is on desktop only). 