### PR TITLE
fix #966: start error-must-be-signed-in message

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -14,7 +14,7 @@ const sha1 = require("../sha1-utils");
 async function _requireSessionUser(req,res) {
   if (!req.session || !req.session.user) {
     // TODO: can we do a nice redirect to sign in instead of an error?
-    throw new FluentError("must-be-signed-in");
+    throw new FluentError("error-must-be-signed-in");
   }
   // make sure the user object has all subscribers and email_addresses properties
   const sessionUser = await DB.getSubscriberById(req.session.user.id);

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -29,6 +29,7 @@ error-not-subscribed = This email address is not subscribed to {-product-name}.
 error-hibp-throttled = Too many connections to {-brand-HIBP}.
 error-hibp-connect = Error connecting to {-brand-HIBP}.
 error-hibp-load-breaches = Could not load breaches.
+error-must-be-signed-in = You must be signed in to your {-brand-fxa}.
 
 hibp-notify-email-subject = {-product-name} Alert: Your account was involved in a breach.
 

--- a/tests/controllers/user.test.js
+++ b/tests/controllers/user.test.js
@@ -162,7 +162,7 @@ test("user verify request with valid token but no session throws error", async (
   const resp = httpMocks.createResponse();
 
   // Call code-under-test
-  await expect(user.verify(req, resp)).rejects.toThrow("must-be-signed-in");
+  await expect(user.verify(req, resp)).rejects.toThrow("error-must-be-signed-in");
 
   const emailAddress = await DB.getEmailByToken(validToken);
   expect(emailAddress.verified).toBeFalsy();
@@ -345,7 +345,7 @@ test("user/remove-fxm GET request with invalid session returns error", async () 
   });
   const resp = httpMocks.createResponse();
 
-  await expect(user.getRemoveFxm(req, resp)).rejects.toThrow("must-be-signed-in");
+  await expect(user.getRemoveFxm(req, resp)).rejects.toThrow("error-must-be-signed-in");
 });
 
 
@@ -368,7 +368,7 @@ test("user/remove-fxm POST request with invalid session returns error", async ()
   const resp = httpMocks.createResponse();
 
   // Call code-under-test
-  await expect(user.postRemoveFxm(req, resp)).rejects.toThrow("must-be-signed-in");
+  await expect(user.postRemoveFxm(req, resp)).rejects.toThrow("error-must-be-signed-in");
 });
 
 


### PR DESCRIPTION
This adds the first sentence of the error message.

@lesleyjanenorton - do you know how we can include [the second sentence of the error message](https://github.com/mozilla/blurts-server/issues/966#issuecomment-496970649) in the generic error subpage template?