### PR TITLE
Add and use new string for the subject of breach alert emails.

### DIFF
--- a/controllers/email-l10n.js
+++ b/controllers/email-l10n.js
@@ -27,7 +27,7 @@ function getEmailMockUps(req, res) {
       emailSubject = req.fluentFormat("user-verify-email-report-subject");
       if(emailType === "breachAlert") {
         breachAlert = unsafeBreachesForEmail[0];
-        emailSubject = req.fluentFormat("hibp-notify-email-subject");
+        emailSubject = req.fluentFormat("breach-alert-subject");
       }
     } else if (emailType === "multipleBreaches") {
       const breachArray = ["Experian", "Dropbox", "Apollo"];

--- a/controllers/hibp.js
+++ b/controllers/hibp.js
@@ -90,7 +90,7 @@ async function notify (req, res) {
       {defaultLocale: "en"}
     );
 
-    const subject = LocaleUtils.fluentFormat(supportedLocales, "hibp-notify-email-subject");
+    const subject = LocaleUtils.fluentFormat(supportedLocales, "breach-alert-subject");
     const template = "default_email";
     if (!notifiedRecipients.includes(breachedEmail)) {
       await EmailUtils.sendEmail(

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -850,6 +850,3 @@ join-firefox = There is a way to protect your privacy. Join {-brand-name}.
 
 # Link title
 learn-more-link = Learn more.
-
-
-breach-alert-subject = {-product-name} found your email in a new data breach.

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -31,8 +31,6 @@ error-hibp-connect = Error connecting to {-brand-HIBP}.
 error-hibp-load-breaches = Could not load breaches.
 error-must-be-signed-in = You must be signed in to your {-brand-fxa}.
 
-hibp-notify-email-subject = {-product-name} Alert: Your account was involved in a breach.
-
 home-title = {-product-name}
 home-not-found = Page not found.
 
@@ -852,3 +850,6 @@ join-firefox = There is a way to protect your privacy. Join {-brand-name}.
 
 # Link title
 learn-more-link = Learn more.
+
+
+breach-alert-subject = {-product-name} found your email in a new data breach.

--- a/tests/controllers/hibp.test.js
+++ b/tests/controllers/hibp.test.js
@@ -59,7 +59,7 @@ async function checkNotifyCallsEverythingItShould(breachedEmail, recipientEmail)
   expect (mockFluentFormatCalls.length).toBe(1);
   const mockFluentFormatCallArgs = mockFluentFormatCalls[0];
   expect (mockFluentFormatCallArgs[0]).toEqual(["en"]);
-  expect (mockFluentFormatCallArgs[1]).toBe("hibp-notify-email-subject");
+  expect (mockFluentFormatCallArgs[1]).toBe("breach-alert-subject");
 
   const mockSendEmailCalls = EmailUtils.sendEmail.mock.calls;
   expect (mockSendEmailCalls.length).toBe(1);


### PR DESCRIPTION
This change should have been made when we updated the breach alert emails, but got lost in the shuffle.