### PR TITLE
Uniform CTA formatting on /about page.

### DIFF
--- a/public/css/footer-about.css
+++ b/public/css/footer-about.css
@@ -1,6 +1,5 @@
 .how-fxm-works {
   flex-direction: row;
-  justify-content: space-between;
 }
 
 .how-fxm-works-blurb {
@@ -8,9 +7,7 @@
 }
 
 .about-fxm {
-  min-height: 60vh;
   color: rgba(255, 255, 255, 1);
-  padding-bottom: 4rem;
   background-color: #20123aa3;
 }
 
@@ -22,36 +19,26 @@
   background-size: auto 100%;
 }
 
-.how-fxm-headline {
-  margin: 0.75rem 0 0 0;
-}
-
 .fx-monitor-svg {
   background-image: url("/img/svg/fx-monitor.svg");
   background-repeat: no-repeat;
   background-position: bottom left;
   background-size: contain;
-  width: 3.5rem;
+  width: 3rem;
   height: 6rem;
-  margin-bottom: 1rem;
-  content: "";
+  margin-bottom: var(--padding);
 }
 
-.fxm-card {
-  border-radius: 1rem;
-  padding-right: 2rem;
-  margin: 1rem auto 2rem auto;
+.fxm-card-wrap {
+  flex: 1;
+  padding: 0 calc(var(--padding) * 2) calc(var(--padding) * 2) 0;
+}
+
+.about-cta {
+  align-self: flex-start;
 }
 
 @media screen and (max-width: 1100px) {
-  .about-fxm {
-    background-color: #20123aa3;
-  }
-
-  .about-row .col-12 {
-    flex: 1 1 66.66666667%;
-  }
-
   .about-row {
     justify-content: center;
   }
@@ -68,14 +55,7 @@
 }
 
 @media screen and (max-width: 800px) {
-  .fx-monitor-svg {
-    width: 3rem;
-  }
-
   .about-row .content-wrap {
-    min-width: 100%;
     max-width: 100%;
-    flex: 1 1 100%;
-    width: 100%;
   }
 }

--- a/template-helpers/footer.js
+++ b/template-helpers/footer.js
@@ -32,24 +32,27 @@ function getAboutPageStrings(args) {
     {
       headline:"how-fxm-1-headline",
       subhead: "how-fxm-1-blurb",
-      scan: LocaleUtils.fluentFormat(locales, "scan-submit"),
+      localizedCta: LocaleUtils.fluentFormat(locales, "scan-submit"),
+      href: "/",
     },
     {
       headline:"how-fxm-2-headline",
       subhead: "how-fxm-2-blurb",
-      signUp: LocaleUtils.fluentFormat(locales, "sign-up-for-alerts"),
+      ctaId: "signUp",
+      localizedCta: LocaleUtils.fluentFormat(locales, "sign-up-for-alerts"),
     },
     {
       headline:"how-fxm-3-headline",
       subhead: "how-fxm-3-blurb",
-      download: LocaleUtils.fluentFormat(locales, "download-firefox-banner-button"),
+      localizedCta: LocaleUtils.fluentFormat(locales, "download-firefox-banner-button"),
+      href: "https://www.mozilla.org/firefox",
     },
   ];
 
-  aboutPageStrings.forEach(aboutBlurb => {
-    aboutBlurb.headline = LocaleUtils.fluentFormat(locales, aboutBlurb.headline);
-    aboutBlurb.subhead = LocaleUtils.fluentFormat(locales, aboutBlurb.subhead);
-    aboutBlurb.cta = LocaleUtils.fluentFormat(locales, aboutBlurb.cta);
+  aboutPageStrings.forEach(aboutBlock => {
+    aboutBlock.headline = LocaleUtils.fluentFormat(locales, aboutBlock.headline);
+    aboutBlock.subhead = LocaleUtils.fluentFormat(locales, aboutBlock.subhead);
+    aboutBlock.localizedCta = LocaleUtils.fluentFormat(locales, aboutBlock.localizedCta);
   });
   return aboutPageStrings;
 }

--- a/views/about.hbs
+++ b/views/about.hbs
@@ -1,7 +1,7 @@
  
  
  <div class="about-noodles">
-  <main class="clear-header about-fxm" data-page-label="About Firefox Monitor">
+  <main class="clear-header about-fxm container" data-page-label="About Firefox Monitor">
       <div class="row about-row">
         <div class="col-8">
           <div class="fx-monitor-svg"></div>
@@ -17,23 +17,21 @@
         <div class="col-12">
           <h3>{{ getString "how-fxm-works" }}</h3>
         </div>
-        <div class="col-12 how-fxm-works no-vertical-padding">
+        <div class="col-12 how-fxm-works no-vertical-padding space-between">
           {{#each (getAboutPageStrings) }}
-            <div class="fxm-card-wrap">
-              <div class="fxm-card">
-                <h4 class="how-fxm-headline">{{ this.headline }}</h4>
-                <p class="how-fxm-works-blurb">{{ this.subhead }}</p>
-                {{#if this.scan }}
-                  <a class="text-link" href="/">{{ this.scan }}</a>    
-                {{/if}}
-                {{#if this.signUp }}
-                  <button {{> analytics/fxa id="fx-monitor-about-page-sign-up" }} data-event-category="About Page SignUp" class="text-link open-oauth">
-                    {{ this.signUp }}
-                  </button>    
-                {{/if}}
-                {{#if this.download }}
-                  <a class="text-link" target="_blank" href="https://www.mozilla.org/firefox">{{ this.download }}</a>  
-                {{/if}}
+            <div class="fxm-card-wrap flx">
+              <div class="fxm-card flx flx-col space-between">
+                <div>
+                  <h4 class="how-fxm-headline">{{ this.headline }}</h4>
+                  <p class="how-fxm-works-blurb">{{ this.subhead }}</p>
+                </div>
+                  {{#ifCompare this.ctaId "===" "signUp"}} 
+                    <button {{> analytics/fxa id="fx-monitor-about-page-sign-up" }} data-event-category="About Page SignUp" class="btn-grey open-oauth about-cta">
+                      {{ this.localizedCta }}
+                    </button>
+                  {{else}}
+                    <a class="btn-grey demi about-cta" target="_blank" href="{{ this.href }}">{{ this.localizedCta }}</a>
+                  {{/ifCompare}}
               </div>
             </div>
           {{/each}}


### PR DESCRIPTION
- Restyle the /about page CTAs into buttons instead of links.
- Fix strange formatting of text blocks in more verbose locales (German, specifically).

Fixes #1083
Fixes #1010 