### PR TITLE
Analytics Update: Add page label to breach detail pages.

### DIFF
--- a/views/breach-detail.hbs
+++ b/views/breach-detail.hbs
@@ -1,6 +1,6 @@
 {{#getBreachDetail}}
 
-  <main id="breach-detail" class="breach-detail container clear-header bg-white">
+  <main id="breach-detail" class="breach-detail container clear-header bg-white" data-page-label="Breach Detail">
     <div class="row jst-cntr">
       <div class="col-9 flx-cntr">
         <div class="breach-detail-logo-wrapper">


### PR DESCRIPTION
This information is stored in the `Event Label` for each event ping and makes it easier to identify from which page the ping originated.