### PR TITLE
Remove semi-colon from list item heading

### DIFF
--- a/locales/en-CA/app.ftl
+++ b/locales/en-CA/app.ftl
@@ -239,7 +239,7 @@ your-info-was-discovered-headline = Your information was discovered in a new dat
 your-info-was-discovered-blurb =
     You’re signed up to receive { -product-name } alerts 
     when your email appears in a data breach. Here’s what we know about this breach.
-what-to-do-after-breach = What to do after a data breach:
+what-to-do-after-breach = What to do after a data breach
 ba-next-step-1 = Change your password to a strong, unique password.
 ba-next-step-blurb-1 =
     A strong password uses a combination of upper and lowercase letters, 

--- a/locales/en-GB/app.ftl
+++ b/locales/en-GB/app.ftl
@@ -239,7 +239,7 @@ your-info-was-discovered-headline = Your information was discovered in a new dat
 your-info-was-discovered-blurb =
     You’re signed up to receive { -product-name } alerts 
     when your email appears in a data breach. Here’s what we know about this breach.
-what-to-do-after-breach = What to do after a data breach:
+what-to-do-after-breach = What to do after a data breach
 ba-next-step-1 = Change your password to a strong, unique password.
 ba-next-step-blurb-1 =
     A strong password uses a combination of upper and lowercase letters, 

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -315,7 +315,7 @@ your-info-was-discovered-headline = Your information was discovered in a new dat
 your-info-was-discovered-blurb = You’re signed up to receive {-product-name} alerts 
   when your email appears in a data breach. Here’s what we know about this breach.
 
-what-to-do-after-breach = What to do after a data breach:
+what-to-do-after-breach = What to do after a data breach
 
 ba-next-step-1 = Change your password to a strong, unique password.
 ba-next-step-blurb-1 =


### PR DESCRIPTION
This is a super minor PR removing the semi-colon from "What to do after a data breach:". The motivation is to keep the list item headings consistent.

**Before**

![image](https://user-images.githubusercontent.com/7039523/61054163-873eee80-a3b4-11e9-998d-65b3f1dacc32.png)

**After**

![image](https://user-images.githubusercontent.com/7039523/61054360-e7ce2b80-a3b4-11e9-8584-efc082e510ac.png)
