### PR TITLE
Update README to include information on creating a test database

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ To create the database tables ...
 
    ```sh
    createdb blurts
+   createdb test-blurts # for tests
    ```
 
 2. Update the `DATABASE_URL` value in your `.env` file with your local db


### PR DESCRIPTION
When I tried to run the tests for the first time, I got the following error.

```
error: database "test-blurts" does not exist
```

This PR adds instructions to setup a test database.