### PR TITLE
Replace `setupTestFrameworkScriptFile` with `setupFilesAfterEnv` in Jest config

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,9 @@
       "!loadtests/**/**.js",
       "!.eslintrc.js"
     ],
-    "setupTestFrameworkScriptFile": "./tests/jest.setup.js"
+    "setupFilesAfterEnv": [
+      "./tests/jest.setup.js"
+    ]
   },
   "private": true,
   "repository": {


### PR DESCRIPTION
Fixes https://github.com/mozilla/blurts-server/issues/918