### PR TITLE
fix #1084 fix #1146 - only put ids and emails into user object

### DIFF
--- a/db/DB.js
+++ b/db/DB.js
@@ -52,9 +52,12 @@ const DB = {
 
   async joinEmailAddressesToSubscriber(subscriber) {
     if (subscriber) {
-      subscriber.email_addresses = await knex("email_addresses").where({
+      const emailAddressRecords = await knex("email_addresses").where({
         "subscriber_id": subscriber.id,
       });
+      subscriber.email_addresses = emailAddressRecords.map(
+        emailAddress=>({id: emailAddress.id, email: emailAddress.email})
+      );
     }
     return subscriber;
   },

--- a/scan-results.js
+++ b/scan-results.js
@@ -35,8 +35,13 @@ const scanResult = async(req, selfScan=false) => {
       scannedEmailId = req.body.scannedEmailId;
     }
 
-    if (!selfScan && signedInUser && sha1(signedInUser.email) === req.body.emailHash) {
-      selfScan = true;
+    if (signedInUser) {
+      for (const emailAddress of signedInUser.email_addresses) {
+        if (!selfScan && sha1(emailAddress.email) === req.body.emailHash) {
+          selfScan = true;
+          break;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
When a user adds many email addresses, joining all of their full
email_addresses records data into the session user object makes the
client-sessions object larger than the cookie size limit of Firefox.

This temporary fix joins only the ids and emails of the records, because
they are the only columns we're using. This cuts the object size down by
approx. 70%.

https://github.com/mozilla/blurts-server/issues/1148 tracks moving
session data to the back-end.