### PR TITLE
fix #1109: inlude BreachDataClasses in remote settings record

### DIFF
--- a/scripts/updatebreaches.js
+++ b/scripts/updatebreaches.js
@@ -35,6 +35,7 @@ if (
       BreachDate: breach.BreachDate,
       PwnCount: breach.PwnCount,
       AddedDate: breach.AddedDate,
+      DataClasses: breach.DataClasses,
     };
 
     console.log("New breach detected: \n", data);


### PR DESCRIPTION
Now that https://github.com/mozilla-services/remote-settings-permissions/pull/62 is merged and deployed, this works on both stage & prod Remote Settings servers.