### PR TITLE
Forward utms to fxa

### DIFF
--- a/public/js/fxa-analytics.js
+++ b/public/js/fxa-analytics.js
@@ -49,15 +49,38 @@ async function sendPing(el, eventAction, eventLabel = null) {
   }
 }
 
+
 function getFxaUtms(url) {
-  const utmSource = encodeURIComponent(document.body.dataset.serverUrl.replace(/(^\w+:|^)\/\//g, ""));
-  url.searchParams.append("utm_source", utmSource);
-  url.searchParams.append("utm_campaign", document.body.dataset.utmCampaign);
+  const bodyDataset = document.body.dataset;
+  getUTMNames().forEach(param => {
+    if (bodyDataset[param]) {
+      url.searchParams.append(param, encodeURIComponent(bodyDataset[param]));
+    }
+  });
   url.searchParams.append("form_type", "email");
   return url;
 }
 
+function saveReferringPageData(utmParams) {
+  const bodyDataset = document.body.dataset;
+  getUTMNames().forEach(param => {
+    if (utmParams.has(param)) {
+      const cleanParam = utmParams.get(param);
+      bodyDataset[param] = cleanParam.replace(/[&<>"',.`=\/]/g, "");
+    }
+  });
+}
+
+function getUTMNames() {
+  return ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"];
+}
+
 (() => {
+  const win = window;
+  if (win.location.search.includes("utm_") && win.history.replaceState) {
+    saveReferringPageData(new URL(win.location).searchParams);
+    win.history.replaceState({}, "", win.location.toString().replace(/[?&]utm_.*/g, ""));
+  }
 
   const setMetricsIds = (el) => {
     if (hasParent(el, "scan-another-email")) {
@@ -78,11 +101,13 @@ function getFxaUtms(url) {
 
   document.querySelectorAll(".open-oauth").forEach( async(el) => {
     const fxaUrl = new URL("/metrics-flow?", document.body.dataset.fxaAddress);
-
-    const response = await fetch(fxaUrl, {credentials: "omit"});
+    let response = {};
+    try {
+      response = await fetch(fxaUrl, {credentials: "omit"});
+    } catch(e) {}
 
     fxaUrl.searchParams.append("entrypoint", encodeURIComponent(el.dataset.entrypoint));
-    if (response.status === 200) {
+    if (response && response.status === 200) {
       const {flowId, flowBeginTime} = await response.json();
       el.dataset.flowId = flowId;
       el.dataset.flowBeginTime = flowBeginTime;

--- a/public/js/fxa-analytics.js
+++ b/public/js/fxa-analytics.js
@@ -66,7 +66,7 @@ function saveReferringPageData(utmParams) {
   getUTMNames().forEach(param => {
     if (utmParams.has(param)) {
       const cleanParam = utmParams.get(param);
-      bodyDataset[param] = cleanParam.replace(/[&<>"',.`=\/]/g, "");
+      bodyDataset[param] = cleanParam.replace(/[&<>"',.`=:/]/g, "");
     }
   });
 }
@@ -101,16 +101,17 @@ function getUTMNames() {
 
   document.querySelectorAll(".open-oauth").forEach( async(el) => {
     const fxaUrl = new URL("/metrics-flow?", document.body.dataset.fxaAddress);
-    let response = {};
-    try {
-      response = await fetch(fxaUrl, {credentials: "omit"});
-    } catch(e) {}
 
-    fxaUrl.searchParams.append("entrypoint", encodeURIComponent(el.dataset.entrypoint));
-    if (response && response.status === 200) {
-      const {flowId, flowBeginTime} = await response.json();
-      el.dataset.flowId = flowId;
-      el.dataset.flowBeginTime = flowBeginTime;
+    try {
+      const response = await fetch(fxaUrl, {credentials: "omit"});
+      fxaUrl.searchParams.append("entrypoint", encodeURIComponent(el.dataset.entrypoint));
+      if (response && response.status === 200) {
+        const {flowId, flowBeginTime} = await response.json();
+        el.dataset.flowId = flowId;
+        el.dataset.flowBeginTime = flowBeginTime;
+      }
+    } catch(e) {
+      // should we do anything with this?
     }
   });
 

--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -221,9 +221,6 @@ function styleActiveLink(locationHref) {
       previousActiveLink.classList.remove("active-link");
     }
     styleActiveLink(win.location.href);
-    if (win.location.search.includes("utm_") && win.history.replaceState) {
-      win.history.replaceState({}, "", win.location.toString().replace(/[?&]utm_.*/g, ""));
-    }
     toggleMobileFeatures(topNavigation);
     toggleArticles();
     toggleHeaderStates(header, win);

--- a/views/partials/analytics/default_dataset.hbs
+++ b/views/partials/analytics/default_dataset.hbs
@@ -1,13 +1,12 @@
 data-server-url="{{ SERVER_URL }}"
 
-{{#if FXA_ENABLED}}
-  data-fxa-enabled="fxa-enabled"
-  data-fxa-address={{ getFxaUrl }}
-  data-utm-campaign="fx-monitor-fxa-integration"
+data-fxa-enabled="fxa-enabled"
+data-fxa-address={{ getFxaUrl }}
+data-utm_source="{{ SERVER_URL }}"
+data-utm_campaign="fx-monitor-fxa-integration"
   
-  {{#if req.session.user}}
-    data-signed-in-user="true"
-  {{else}}
-    data-signed-in-user="false"
-  {{/if}}
+{{#if req.session.user}}
+  data-signed-in-user="true"
+{{else}}
+  data-signed-in-user="false"
 {{/if}}


### PR DESCRIPTION
This saves the UTM parameters of referring sites and forwards them to FxA when a user clicks one of the FxA entrypoints (sign in / log in links and buttons) from the landing page.

Closes #844