### PR TITLE
Add website link on breach detail pages.

### DIFF
--- a/public/css/breach-detail.css
+++ b/public/css/breach-detail.css
@@ -3,12 +3,8 @@ main.breach-detail {
   color: var(--grey1);
 }
 
-.breach-type {
-  color: var(--grey6);
-}
-
 .breach-domain-link {
-  margin-block-end: .5rem;
+  margin-block-end: 0.5rem;
 }
 
 .breach-type:hover {
@@ -81,6 +77,7 @@ main.breach-detail {
 
 .breach-type {
   font-size: 0.9rem;
+  color: var(--grey6);
 }
 
 .priority-data-classes-list {

--- a/public/css/breach-detail.css
+++ b/public/css/breach-detail.css
@@ -3,11 +3,15 @@ main.breach-detail {
   color: var(--grey1);
 }
 
-.breach-type a {
-  color: var(--blue3);
+.breach-type {
+  color: var(--grey6);
 }
 
-.breach-type a:hover {
+.breach-domain-link {
+  margin-block-end: .5rem;
+}
+
+.breach-type:hover {
   opacity: 1;
   text-decoration: underline;
 }

--- a/views/breach-detail.hbs
+++ b/views/breach-detail.hbs
@@ -7,7 +7,10 @@
           <img class="breach-detail-logo breach-logo" alt="{{ breach.Name }} logo" src="/img/logos/{{ breach.LogoPath }}" />
         </div>
         <h2 class="headline breach-detail-headline">{{ breach.Title }}</h2>
-        <h3 class="breach-type"><a href="#what-is-this-breach">{{ category }}</a></h3>
+        {{#if breach.Domain}}
+          <a class="breach-domain-link demi text-link" href="https://www.{{ breach.Domain }}" rel="nofollow noopener noreferer" target="_blank">www.{{ breach.Domain }}</a>
+        {{/if}}
+        <a class="breach-type demi" href="#what-is-this-breach">{{ category }}</a>
       </div>
     </div>
   </main>


### PR DESCRIPTION
I am a little bit leery of linking users to some of these websites (and I wonder if this link will be perceived somehow as an endorsement or assurance of the site's authenticity/safety) but I can't think of a way of doing this without running a considerable number of checks before deciding whether or not to surface the link.