### PR TITLE
Fix #1182

### DIFF
--- a/controllers/oauth.js
+++ b/controllers/oauth.js
@@ -69,7 +69,7 @@ async function confirmed(req, res, next, client = FxAOAuthClient) {
     },
   });
   log.debug("fxa-confirmed-profile-data", data.body);
-  const email = JSON.parse(data.body).email;
+  const email = JSON.parse(data.body).email.toLowerCase();
 
   const existingUser = await DB.getSubscriberByEmail(email);
   req.session.user = existingUser;

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -96,7 +96,7 @@ function _checkForDuplicateEmail(sessionUser, email) {
 
 async function add(req, res) {
   const sessionUser = await _requireSessionUser(req);
-  const email = req.body.email;
+  const email = req.body.email.toLowerCase();
   if (!email || !isemail.validate(email)) {
     throw new FluentError("user-add-invalid-email");
   }
@@ -136,7 +136,8 @@ async function add(req, res) {
 }
 
 async function bundleVerifiedEmails(email, emailSha1, ifPrimary, id, verificationStatus, allBreaches) {
-  const foundBreaches = await HIBP.getBreachesForEmail(emailSha1, allBreaches, true);
+  const lowerCaseEmailSha = sha1(email.toLowerCase());
+  const foundBreaches = await HIBP.getBreachesForEmail(lowerCaseEmailSha, allBreaches, true);
 
   const emailEntry = {
     "email": email,

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -83,11 +83,11 @@ async function updateCommunicationOptions(req, res) {
 
 
 function _checkForDuplicateEmail(sessionUser, email) {
-  if (email === sessionUser.primary_email) {
+  if (email.toLowerCase() === sessionUser.primary_email.toLowerCase()) {
     throw new FluentError("user-add-duplicate-email");
   }
   for (const secondaryEmail of sessionUser.email_addresses) {
-    if (email === secondaryEmail.email) {
+    if (email.toLowerCase() === secondaryEmail.email.toLowerCase()) {
       throw new FluentError("user-add-duplicate-email");
     }
   }

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -135,7 +135,7 @@ async function add(req, res) {
   res.redirect("/user/preferences");
 }
 
-async function bundleVerifiedEmails(email, emailSha1, ifPrimary, id, verificationStatus, allBreaches) {
+async function bundleVerifiedEmails(email, ifPrimary, id, verificationStatus, allBreaches) {
   const lowerCaseEmailSha = sha1(email.toLowerCase());
   const foundBreaches = await HIBP.getBreachesForEmail(lowerCaseEmailSha, allBreaches, true);
 
@@ -154,10 +154,10 @@ async function getAllEmailsAndBreaches(user, allBreaches) {
   const monitoredEmails = await DB.getUserEmails(user.id);
   let verifiedEmails = [];
   const unverifiedEmails = [];
-  verifiedEmails.push(await bundleVerifiedEmails(user.primary_email, user.primary_sha1, true, user.id, user.primary_verified, allBreaches));
+  verifiedEmails.push(await bundleVerifiedEmails(user.primary_email, true, user.id, user.primary_verified, allBreaches));
   for (const email of monitoredEmails) {
     if (email.verified) {
-      const formattedEmail = await bundleVerifiedEmails(email.email, email.sha1, false, email.id, email.verified, allBreaches);
+      const formattedEmail = await bundleVerifiedEmails(email.email, false, email.id, email.verified, allBreaches);
       verifiedEmails.push(formattedEmail);
     } else {
       unverifiedEmails.push(email);

--- a/db/DB.js
+++ b/db/DB.js
@@ -157,7 +157,7 @@ const DB = {
         if (email) {
           const res = await knex("subscribers")
             .update({
-              primary_email: email,
+              primary_email: email.toLowerCase(),
               primary_verified: verified,
               updated_at: knex.fn.now(),
             })
@@ -171,7 +171,7 @@ const DB = {
         // Always add a verification_token value
         const verification_token = uuidv4();
         const res = await knex("subscribers")
-          .insert({ primary_sha1: sha1, primary_email: email, signup_language, primary_verification_token: verification_token, primary_verified: verified })
+          .insert({ primary_sha1: sha1, primary_email: email.toLowerCase(), signup_language, primary_verification_token: verification_token, primary_verified: verified })
           .returning("*");
         return res[0];
       });

--- a/tests/controllers/hibp.test.js
+++ b/tests/controllers/hibp.test.js
@@ -116,7 +116,7 @@ test("notify POST for subscriber with no signup_language should default to en", 
   LocaleUtils.fluentFormat = jest.fn();
   HIBPLib.subscribeHash = jest.fn();
 
-  const testEmail = "subscriberWithoutLanguage@test.com";
+  const testEmail = "subscriberwithoutlanguage@test.com";
 
   await DB.addSubscriber(testEmail);
 

--- a/tests/controllers/user.test.js
+++ b/tests/controllers/user.test.js
@@ -30,7 +30,7 @@ function expectResponseRenderedSubpagePartial(resp, partial) {
 
 
 test("user add POST with email adds unverified subscriber and sends verification email", async () => {
-  const testUserAddEmail = "addingNewEmail@test.com";
+  const testUserAddEmail = "addingnewemail@test.com";
   const testSubscriberEmail = "firefoxaccount@test.com";
   const testSubscriber = await DB.getSubscriberByEmail(testSubscriberEmail);
 
@@ -70,6 +70,38 @@ test("user add POST with email adds unverified subscriber and sends verification
   const mockCallArgs = mockCalls[0];
   expect(mockCallArgs).toContain(testUserAddEmail);
   expect(mockCallArgs).toContain("default_email");
+});
+
+
+test("user add POST with upperCaseAddress adds email_address record with lowercaseaddress", async () => {
+  const testUserAddEmail = "addingUpperCaseEmail@test.com";
+  const testSubscriberEmail = "firefoxaccount@test.com";
+  const testSubscriber = await DB.getSubscriberByEmail(testSubscriberEmail);
+
+  // Set up mocks
+  const req = httpMocks.createRequest({
+    method: "POST",
+    url: "/user/add",
+    body: { email: testUserAddEmail },
+    session: { user: testSubscriber },
+    fluentFormat: jest.fn(),
+    headers: {
+      referer: "",
+    },
+  });
+  const resp = httpMocks.createResponse();
+  EmailUtils.sendEmail.mockResolvedValue(true);
+
+  // Call code-under-test
+  await user.add(req, resp);
+
+  // Check expectations
+  expect(resp.statusCode).toEqual(302);
+  expect(testSubscriber.primary_email).toEqual(testSubscriberEmail);
+
+  const testSubscriberEmailAddressRecords = await DB.getUserEmails(testSubscriber.id);
+  const testSubscriberEmailAddresses = testSubscriberEmailAddressRecords.map(record => record.email);
+  expect(testSubscriberEmailAddresses.includes(testUserAddEmail.toLowerCase())).toBeTruthy();
 });
 
 

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -100,7 +100,7 @@ test("addSubscriber invalid argument", async () => {
 
 
 test("addSubscriber accepts email, language and returns verified subscriber", async () => {
-  const testEmail = "newFirefoxAccount@test.com";
+  const testEmail = "newfirefoxaccount@test.com";
 
   const verifiedSubscriber = await DB.addSubscriber(testEmail);
 
@@ -111,7 +111,7 @@ test("addSubscriber accepts email, language and returns verified subscriber", as
 
 
 test("addSubscriber with existing email updates updated_at", async () => {
-  const testEmail = "newFirefoxAccount@test.com";
+  const testEmail = "newfirefoxaccount@test.com";
 
   let verifiedSubscriber = await DB.addSubscriber(testEmail);
 
@@ -128,6 +128,17 @@ test("addSubscriber with existing email updates updated_at", async () => {
   expect(verifiedSubscriber.primary_verified).toBeTruthy();
   expect(verifiedSubscriber.primary_sha1).toBe(getSha1(testEmail));
   expect(verifiedSubscriber.updated_at).not.toBe(updatedAt);
+});
+
+
+test("addSubscriber accepts upperCasedAddress, and returns verified subscriber with lowercase address.", async () => {
+  const testEmail = "upperCasedAddress@test.com";
+
+  const verifiedSubscriber = await DB.addSubscriber(testEmail);
+
+  expect(verifiedSubscriber.primary_email).toBe(testEmail.toLowerCase());
+  expect(verifiedSubscriber.primary_verified).toBeTruthy();
+  expect(verifiedSubscriber.primary_sha1).toBe(getSha1(testEmail));
 });
 
 


### PR DESCRIPTION
- Lower cases new emails before adding to DB.
-  Updates `bundleVerifiedEmails` to convert existing user emails to lowercase letters before making a new sha1 hash (of the newly lowercased email) to use for scanning breaches. 

<img width="572" alt="Screen Shot 2019-09-04 at 5 58 25 PM" src="https://user-images.githubusercontent.com/22355127/64299169-c6656800-cf3d-11e9-8336-3b75ab28a6c3.png">
<img width="489" alt="Screen Shot 2019-09-04 at 5 58 31 PM" src="https://user-images.githubusercontent.com/22355127/64299203-e301a000-cf3d-11e9-9378-48cb31027308.png">