### PR TITLE
Fix shrinking breach cards in dashboard.

### DIFF
--- a/public/css/breach-cards.css
+++ b/public/css/breach-cards.css
@@ -138,10 +138,6 @@ a.latest-breach-link {
   max-width: 47%;
 }
 
-.email-card .two-up {
-  max-width: 100%;
-}
-
 .three-up {
   flex: 1 1 30%;
   min-width: 260px;
@@ -156,6 +152,7 @@ a.latest-breach-link {
   .breach-card.ec.two-up {
     flex: 1 1 100%;
     display: none;
+    max-width: 100%;
   }
 
   .email-card.active .breach-card.ec.two-up {

--- a/public/css/scan-results.css
+++ b/public/css/scan-results.css
@@ -65,6 +65,7 @@ button.alert-me:focus {
 .show-additional-breaches {
   flex-wrap: wrap;
   justify-content: space-between;
+  width: 100%;
 }
 
 .row.scan-results,


### PR DESCRIPTION
Noticed this while working on #1188. If you have an email with five breaches, the fifth breach card will appear much smaller than the other four. Related: #903 (which I think is now resolved?). 
<img width="411" alt="Screen Shot 2019-09-05 at 1 01 38 PM" src="https://user-images.githubusercontent.com/22355127/64368637-5a880b80-cfe0-11e9-95c2-b5380c62fc83.png">
