### PR TITLE
Maintain referring site UTM values throughout Monitor.

### DIFF
--- a/public/js/fxa-analytics.js
+++ b/public/js/fxa-analytics.js
@@ -49,26 +49,33 @@ async function sendPing(el, eventAction, eventLabel = null) {
   }
 }
 
-
-function getFxaUtms(url) {
-  const bodyDataset = document.body.dataset;
+function appendFxaParams(url, storageObject) {
   getUTMNames().forEach(param => {
-    if (bodyDataset[param]) {
-      url.searchParams.append(param, encodeURIComponent(bodyDataset[param]));
+    if (storageObject[param]) {
+      url.searchParams.append(param, encodeURIComponent(storageObject[param]));
     }
   });
-  url.searchParams.append("form_type", "email");
   return url;
+}
+
+function getFxaUtms(url) {
+  if (sessionStorage) {
+    return appendFxaParams(url, sessionStorage);
+    }
+
+  return appendFxaParams(url, document.body.dataset);
 }
 
 function saveReferringPageData(utmParams) {
   const bodyDataset = document.body.dataset;
-  getUTMNames().forEach(param => {
-    if (utmParams.has(param)) {
-      const cleanParam = utmParams.get(param);
-      bodyDataset[param] = cleanParam.replace(/[&<>"',.`=:/]/g, "");
-    }
-  });
+  if (sessionStorage) {
+    getUTMNames().forEach(param => {
+      if(!sessionStorage[param]) {
+        sessionStorage[param] = utmParams.get(param);
+      }
+    });
+    return;
+  }
 }
 
 function getUTMNames() {

--- a/public/js/fxa-analytics.js
+++ b/public/js/fxa-analytics.js
@@ -61,7 +61,7 @@ function appendFxaParams(url, storageObject) {
 function getFxaUtms(url) {
   if (sessionStorage) {
     return appendFxaParams(url, sessionStorage);
-    }
+  }
 
   return appendFxaParams(url, document.body.dataset);
 }

--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -39,7 +39,7 @@ function doOauth(el) {
   ["flowId", "flowBeginTime", "entrypoint"].forEach(key => {
     url.searchParams.append(key, encodeURIComponent(el.dataset[key]));
   });
-  if (sessionStorage.length > 0) {
+  if (sessionStorage && sessionStorage.length > 0) {
     const lastScannedEmail = sessionStorage.getItem(`scanned_${sessionStorage.length}`);
     url.searchParams.append("email", lastScannedEmail);
   }


### PR DESCRIPTION
Store UTM values passed by referring sites in `sessionStorage` and pass these values to FxA.
Closes #844 