### PR TITLE
Remove tabindex from `#email-add-submit`

### DIFF
--- a/views/partials/forms/add-another-email-form.hbs
+++ b/views/partials/forms/add-another-email-form.hbs
@@ -5,7 +5,7 @@
                 {{> forms/error-message }}
               </div>
               <div class="input-group-button inline">
-                <input id="email-add-submit" class="email-add-submit inline" type="submit" value="{{ getString "send-verification" }}" tabindex="1" />
+                <input id="email-add-submit" class="email-add-submit inline" type="submit" value="{{ getString "send-verification" }}"/>
                 {{> forms/loader }}
               </div>
             </form>


### PR DESCRIPTION
Removes the `tabindex` from the submit button of the `/user/dashboard` add form so that more intuitive tabbing is possible. Fixes #1151 