### PR TITLE
Accepts emails on internationalized domain names

### DIFF
--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -25,14 +25,6 @@ function toggleEl(e) {
   });
 }
 
-
-function isValidEmail(val) {
-  // https://stackoverflow.com/a/46181
-  const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-  return re.test(String(val).toLowerCase());
-}
-
-
 function doOauth(el) {
   let url = new URL("/oauth/init", document.body.dataset.serverUrl);
   url = getFxaUtms(url);
@@ -87,7 +79,7 @@ function handleFormSubmits(formEvent) {
     email = thisForm.email.value.trim();
     thisForm.email.value = email;
   }
-  if (thisForm.email && !isValidEmail(email)) {
+  if (thisForm.email) {
     sendPing(thisForm, "Failure");
     thisForm.classList.add("invalid");
     return;


### PR DESCRIPTION
Since the service sends an email to verify the email address and the form already has input type `email`, using an out of date regex copy pasted from a stackoverflow answer which doesn't account for RFC822 and RFC2822 to verify email is not necessary.