### PR TITLE
fix #1264: only send email to fxa if it exists

### DIFF
--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -41,7 +41,9 @@ function doOauth(el) {
   });
   if (sessionStorage && sessionStorage.length > 0) {
     const lastScannedEmail = sessionStorage.getItem(`scanned_${sessionStorage.length}`);
-    url.searchParams.append("email", lastScannedEmail);
+    if (lastScannedEmail) {
+      url.searchParams.append("email", lastScannedEmail);
+    }
   }
   window.location.assign(url);
 }


### PR DESCRIPTION
I'm afraid there's another logical bug here because the code just looks at `sessionStorage.length` to see indicate the email addresses that have been scanned.

But, now that we're putting `utm_*` params into `sessionStorage` too, we need to change the logic for detecting scanned email addresses in session storage to only look at items that start with `scanned_`