### PR TITLE
Updates the call to action link in breach alerts sent to Pre-FxA subscribers. 

### DIFF
--- a/controllers/hibp.js
+++ b/controllers/hibp.js
@@ -81,12 +81,13 @@ async function notify (req, res) {
   log.info("notification", { length: recipients.length, breachAlertName: breachAlert.Name });
 
   const utmID = "breach-alert";
-  const ctaHref = EmailUtils.getViewMyDashboardHref(utmID);
   const notifiedRecipients = [];
 
   for (const recipient of recipients) {
     log.info("notify", {recipient});
     const { recipientEmail, breachedEmail, signupLanguage, preFxaSubscriber } = getAddressesAndLanguageForEmail(recipient);
+    const campaignId = (preFxaSubscriber) ? "preFXA-see-all-breaches" : "see-all-breaches";
+    const ctaHref = EmailUtils.getEmailCtaHref(utmId, campaignId, preFxaSubscriber);
 
     const requestedLanguage = signupLanguage ? acceptedLanguages(signupLanguage) : "";
     const supportedLocales = negotiateLanguages(

--- a/controllers/hibp.js
+++ b/controllers/hibp.js
@@ -87,7 +87,7 @@ async function notify (req, res) {
     log.info("notify", {recipient});
     const { recipientEmail, breachedEmail, signupLanguage, preFxaSubscriber } = getAddressesAndLanguageForEmail(recipient);
     const campaignId = (preFxaSubscriber) ? "preFXA-see-all-breaches" : "see-all-breaches";
-    const ctaHref = EmailUtils.getEmailCtaHref(utmID, campaignId, preFxaSubscriber);
+    const ctaHref = EmailUtils.getEmailCtaHref(utmID, campaignId);
 
     const requestedLanguage = signupLanguage ? acceptedLanguages(signupLanguage) : "";
     const supportedLocales = negotiateLanguages(

--- a/controllers/hibp.js
+++ b/controllers/hibp.js
@@ -87,7 +87,7 @@ async function notify (req, res) {
     log.info("notify", {recipient});
     const { recipientEmail, breachedEmail, signupLanguage, preFxaSubscriber } = getAddressesAndLanguageForEmail(recipient);
     const campaignId = (preFxaSubscriber) ? "preFXA-see-all-breaches" : "see-all-breaches";
-    const ctaHref = EmailUtils.getEmailCtaHref(utmId, campaignId, preFxaSubscriber);
+    const ctaHref = EmailUtils.getEmailCtaHref(utmID, campaignId, preFxaSubscriber);
 
     const requestedLanguage = signupLanguage ? acceptedLanguages(signupLanguage) : "";
     const supportedLocales = negotiateLanguages(

--- a/controllers/oauth.js
+++ b/controllers/oauth.js
@@ -109,7 +109,7 @@ async function confirmed(req, res, next, client = FxAOAuthClient) {
         recipientEmail: email,
         date: req.fluentFormat(new Date()),
         unsafeBreachesForEmail: unsafeBreachesForEmail,
-        ctaHref: EmailUtils.getViewMyDashboardHref(utmID),
+        ctaHref: EmailUtils.getEmailCtaHref(utmID, "view-my-dashboard"),
         unsubscribeUrl: EmailUtils.getUnsubscribeUrl(verifiedSubscriber, utmID),
         whichPartial: "email_partials/report",
       }

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -232,7 +232,7 @@ async function _verify(req) {
       recipientEmail: verifiedEmailHash.email,
       supportedLocales: req.supportedLocales,
       unsafeBreachesForEmail: unsafeBreachesForEmail,
-      ctaHref: EmailUtils.getViewMyDashboardHref(utmID),
+      ctaHref: EmailUtils.getEmailCtaHref(utmID, "view-my-dashboard"),
       unsubscribeUrl: EmailUtils.getUnsubscribeUrl(verifiedEmailHash, utmID),
       whichPartial: "email_partials/report",
     }

--- a/email-utils.js
+++ b/email-utils.js
@@ -99,10 +99,9 @@ const EmailUtils = {
     return req.fluentFormat("email-subject-found-breaches");
   },
 
-  getViewMyDashboardHref(emailType) {
-    let url = new URL(AppConstants.SERVER_URL);
-    url = this.appendUtmParams(url, "view-my-dashboard", emailType);
-    return url;
+  getEmailCtaHref(emailType, campaign) {
+    const url = new URL(AppConstants.SERVER_URL);
+    return this.appendUtmParams(url, campaign, emailType);
   },
 
   getVerificationUrl(subscriber) {


### PR DESCRIPTION

- Changes the href of the call to the action link from the user dashboard to SERVER_URL
- Changes the UTM values attached to the call to action link so that these clicks can be categorized separately.

Should fix #1278. I wasn't able to recreate the redirect to /breaches, but it does look like we were attempting to send pre-fxa subscribers to a signed in user dashboard. @groovecoder any thoughts on what could cause a redirect from the user dashboard to /breaches?