### PR TITLE
Update Mozilla link

### DIFF
--- a/public/js/fx-bento.js
+++ b/public/js/fx-bento.js
@@ -88,7 +88,7 @@ class FirefoxApps extends HTMLElement {
 
     this._messageBottomLink = createAndAppendEl(this._bentoContent, "a", "fx-bento-bottom-link fx-bento-link");
     this._messageBottomLink.textContent = this._localizedBentoStrings.bentoBottomLink;
-    this._messageBottomLink.href = "https://www.mozilla.com/";
+    this._messageBottomLink.href = "https://www.mozilla.org/";
 
     this._bentoContent.querySelectorAll("a").forEach( (anchorEl, idx) => {
       anchorEl.dataset.bentoLinkOrder = idx;


### PR DESCRIPTION
This link should take users to the Mozilla homepage, instead of redirecting to the Firefox landing page on Mozilla.org.