### PR TITLE
Fix strange alignment of breach cards on /breaches

### DIFF
--- a/public/css/all-breaches.css
+++ b/public/css/all-breaches.css
@@ -202,7 +202,7 @@ input#fuzzy-find-input {
   padding: var(--padding);
   flex-direction: row;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-start;
 }
 
 @media screen and (max-width: 1000px) {


### PR DESCRIPTION
Et voila!
<img width="1298" alt="Screen Shot 2019-10-21 at 4 37 26 PM" src="https://user-images.githubusercontent.com/22355127/67245356-63faf500-f421-11e9-9ce7-669635399d4e.png">

Fixes #1290 