### PR TITLE
revert to doc.pathname and doc.search for GA

### DIFF
--- a/public/js/analytics_tracking_protection.js
+++ b/public/js/analytics_tracking_protection.js
@@ -53,7 +53,7 @@ if(typeof(ga) !== "undefined") {
 
   // Strip token and hash values from pings sent to GA
   const loc = document.location;
-  let pageValue = loc.href;
+  let pageValue = loc.pathname + loc.search;
   if (loc.search && (loc.search.includes("token=") || loc.search.includes("hash="))) {
     pageValue = loc.href.replace(/token=\w+&?/, "").replace(/hash=\w+&?/, "");
   }


### PR DESCRIPTION
https://github.com/mozilla/blurts-server/pull/1275/files was an over-fix. Didn't need to use `document.location.href` for the GA `location` and `page` values. Only needed to move the `ga("set" ...)` calls out of the `loc.search` check.