### PR TITLE
Add `breach-overview-title` to app.ftl.

### DIFF
--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -470,6 +470,10 @@ additional-information-including = Additional information, including:
 # Title
 email-addresses-title = Email Addresses
 
+# This is a section headline on the breach detail page that appears above
+# a short summary about the breach.
+breach-overview-title = Overview
+
 # This is a standardized breach overview blurb that appears on all breach detail pages.
 # $breachTitle is the name of the breached company or website.
 # $breachDate and $addedDate are calendar dates.


### PR DESCRIPTION
Adds `breach-overview-title` to the FTL file and, once localized, will be added to breach detail pages above the paragraph that summarizes breach information.