### PR TITLE
Add GA event to "Change your password" pathways on Breach Details page

### DIFF
--- a/public/js/fxa-analytics.js
+++ b/public/js/fxa-analytics.js
@@ -124,6 +124,16 @@ function getUTMNames() {
         removeUtmsFromUrl();
       },
     });
+
+    document.querySelectorAll("send-ga-ping").forEach((el) => {
+      el.addEventListener("click", async(e) => {
+        const eventCategory = e.target.dataset.eventCategory;
+        const eventAction = e.target.dataset.eventAction;
+        const eventLabel = e.target.dataset.eventLabel;
+        ga("send", "event", eventCategory, eventAction, eventLabel);
+      });
+    });
+
   } else {
     removeUtmsFromUrl();
   }

--- a/public/js/fxa-analytics.js
+++ b/public/js/fxa-analytics.js
@@ -125,7 +125,7 @@ function getUTMNames() {
       },
     });
 
-    document.querySelectorAll("send-ga-ping").forEach((el) => {
+    document.querySelectorAll(".send-ga-ping").forEach((el) => {
       el.addEventListener("click", async(e) => {
         const eventCategory = e.target.dataset.eventCategory;
         const eventAction = e.target.dataset.eventAction;

--- a/views/breach-detail.hbs
+++ b/views/breach-detail.hbs
@@ -8,7 +8,7 @@
         </div>
         <h2 class="headline breach-detail-headline">{{ breach.Title }}</h2>
         {{#if breach.Domain}}
-          <a class="blue-link" href="https://www.{{ breach.Domain }}" rel="nofollow noopener noreferrer" target="_blank">www.{{ breach.Domain }}</a>
+          <a class="blue-link send-ga-ping" href="https://www.{{ breach.Domain }}" rel="nofollow noopener noreferrer" data-event-label="{{ breach.Domain }}" data-event-action="Engage" data-event-category="Breach Detail: Website URL Link" target="_blank">www.{{ breach.Domain }}</a>
         {{/if}}
         <a class="breach-type demi" href="#what-is-this-breach">{{ category }}</a>
       </div>

--- a/views/partials/feature-tip-group.hbs
+++ b/views/partials/feature-tip-group.hbs
@@ -4,7 +4,7 @@
               <h3 class="feature-title">{{ title }}</h3>
               <h4 class="feature-subhead">{{ subtitle }}</h4>
               {{#if linkTitle }}
-                <a class="feature-tip-link blue-link {{#if changePWBtn }} btn-small btn-violet-secondary btn-transparent {{/if}} " href="{{ href }}">{{ linkTitle }}</a>
+                <a class="feature-tip-link blue-link {{#if changePWBtn }} send-ga-ping btn-small btn-violet-secondary btn-transparent {{/if}}" href="{{ href }}" {{#if changePWBtn }} data-event-label="{{ href }}" data-event-action="Engage" data-event-category="Breach Detail: Change Password Button"{{/if}} >{{ linkTitle }}</a>
               {{/if}}
             </div>
           </div>


### PR DESCRIPTION
Fixes #1301

This PR added a function that can add dynamic GA events on elements that have a class of `send-ga-ping`. Once clicked, it looks for three specific data-attributes on that element to fire a GA event. 

