### PR TITLE
Fix phsyical typo in priority breaches

### DIFF
--- a/template-helpers/breach-detail.js
+++ b/template-helpers/breach-detail.js
@@ -100,7 +100,7 @@ const priorityDataClasses = {
     weight: 89,
     pathToGlyph: "svg/glyphs/pins",
   },
-  "phsyical-addresses": {
+  "physical-addresses": {
     weight: 88,
     pathToGlyph: "svg/glyphs/physical-addresses",
   },


### PR DESCRIPTION
Fixes #1408 

And here's a list of all the current breaches w/ physical-addresses:

```js
{
  'physical-addresses': [
    'VerificationsIO',
    'RiverCityMedia',
    'Exactis',
    'B2BUSABusinesses',
    'Evite',
    'ModernBusinessSolutions',
    'DataAndLeads',
    'NetProspex',
    'SCDailyPhoneSpamList',
    'AshleyMadison',
    'SpecialKSpamList',
    'Ticketfly',
    'VNG',
    'CafePress',
    'Wanelo',
    'Adapt',
    'DataEnrichment',
    'Experian',
    'CashCrate',
    'StockX',
    'EatStreet',
    'ElasticsearchSalesLeads',
    'Yatra',
    'VTech',
    'MoneyBookers',
    'JobStreet',
    'Neteller',
    'SaverSpy',
    'ClixSense',
    'Patreon',
    'MasterDeeds',
    'gPotato',
    'VTightGel',
    'KnownCircle',
    'SterKinekor',
    'Eroticy',
    'WhiteRoom',
    'MyFHA',
    'Stratfor',
    'Dominos',
    'Comcast',
    'MortalOnline',
    'PaddyPower',
    'OpenCSGO',
    'BulgarianNationalRevenueAgency',
    'HTHStudios',
    'VINs',
    'HealthNowNetworks',
    'RealEstateMogul',
    'NapsGear',
    'FoxyBingo',
    'GoldSilver',
    'COMELEC',
    'WienerBuchereien',
    'VictoryPhones',
    'WHMCS',
    'FreshMenu',
    'BlueSnapRegpack',
    'QatarNationalBank',
    'TheFlyOnTheWall',
    'eThekwiniMunicipality',
    'AerServ',
    'Vodafone',
    'Spirol',
    'Appartoo',
    'Hemmakvall',
    'Lanwar',
    'Flashback',
    'MuslimDirectory',
    'Sony',
    'BigMoneyJobs'
  ]
}
```