### PR TITLE
Fix breach card wiggling on hover.

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -529,15 +529,13 @@ ul li {
 }
 
 .drop-shadow {
-  transform: scale(1);
   box-shadow: 0 0 1px 1px #607d8b08, 1px 1px 10px #4341571a;
-  transition: box-shadow 0.15s ease-in-out, transform 0.15s ease-in-out;
+  transition: all 0.15s ease-in-out;
 }
 
 .drop-shadow:hover {
-  transform: scale(1.01);
-  box-shadow: 1px 1px 10px #4341573a;
-  transition: box-shadow 0.15s ease-in-out, transform 0.15s ease-in-out;
+  box-shadow: 0 0 1px 1px #607d8b12, 1px 1px 12px #4341574d;
+  transition: all 0.15s ease-in-out;
 }
 
 .source-info {

--- a/public/css/breach-cards.css
+++ b/public/css/breach-cards.css
@@ -1,23 +1,13 @@
 .breach-card {
   --logoDmns: 24px;
   --logoMargin: 20px;
-  --breachInfoPadding: calc(var(--logoMargin) * 2 + var(--logoDmns));
 
   padding: 1.5rem  3.25rem 1.5rem 1.5rem;
   border-radius: 8px;
   display: flex;
-  flex-direction: row;
-  overflow: hidden;
   margin: 0.5rem;
-  transform: scale(1);
   color: var(--ink);
   background-color: rgba(255, 255, 255, 1);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  transition: all 0.15s ease-in-out;
-}
-
-a.breach-card:hover {
-  opacity: 1;
 }
 
 .breach-key {
@@ -35,15 +25,6 @@ a.breach-card:hover {
 .breach-key,
 .breach-value {
   line-height: 1.5;
-}
-
-/* .more-about-this-breach {
-  font-size: 14px;
-} */
-
-.breach-card:hover {
-  transform: scale(1.01);
-  transition: all 0.15s ease-in-out;
 }
 
 .breach-title {


### PR DESCRIPTION
Use `box-shadow` to simulate a slight scaling effect instead of `transform: scale()`, which was causing a noticeable wiggle in some browsers.

Fixes #1419 , #1287 