### PR TITLE
fix #1426: handle HTTPError during getProfileData

### DIFF
--- a/lib/fxa.js
+++ b/lib/fxa.js
@@ -73,10 +73,15 @@ const FXA = {
   },
 
   async getProfileData(accessToken) {
-    const data = await got(FxAOAuthUtils.profileUri,
-      { headers: { Authorization: `Bearer ${accessToken}` } }
-    );
-    return data.body;
+    try {
+      const data = await got(FxAOAuthUtils.profileUri,
+        { headers: { Authorization: `Bearer ${accessToken}` } }
+      );
+      return data.body;
+    } catch (e) {
+      log.warn("getProfileData", {stack: e.stack});
+      return e;
+    }
   },
 
   async sendMetricsFlowPing(path) {

--- a/middleware.js
+++ b/middleware.js
@@ -139,6 +139,10 @@ async function requireSessionUser(req, res, next) {
     return res.redirect(`/oauth/init?${queryParams}`);
   }
   const fxaProfileData = await FXA.getProfileData(user.fxa_access_token);
+  if (fxaProfileData.hasOwnProperty("name") && fxaProfileData.name === "HTTPError") {
+    delete req.session.user;
+    return res.redirect("/");
+  }
   await DB.updateFxAProfileData(user, fxaProfileData);
   req.session.user = user;
   req.user = user;


### PR DESCRIPTION
Steps to Test:

1. Sign in http://localhost:6060/ and go to http://localhost:6060/user/dashboard
2. In another tab, go to https://stable.dev.lcip.org/settings/clients
3. Click "Revoke" next to the most recent "blurts-server (local)"
4. On the first tab, refresh http://localhost:6060/user/dashboard

Expected results:
Should be signed out and redirected to home page

(Old result: the page would hang.)