### PR TITLE
Fix the flickering active-link underline

### DIFF
--- a/public/css/header.css
+++ b/public/css/header.css
@@ -95,7 +95,6 @@ nav {
   font-weight: 700;
 }
 
-.active-link span::after,
 .nav-link span::after {
   height: 2px;
   background: var(--monitorGradient);

--- a/public/css/header.css
+++ b/public/css/header.css
@@ -86,17 +86,17 @@ nav {
   font-size: 16px;
 }
 
+.nav-link span {
+  position: relative;
+  pointer-events: none; /* Prevents conflicts with GA events that should fire off the wrapping <a> tag. */
+}
+
 .active-link {
   font-weight: 700;
-  display: block;
 }
 
-.active-link-underline {
-  position: relative;
-  pointer-events: none; /* Make sure span attributes aren't used for GA ping */
-}
-
-.active-link-underline::after {
+.active-link span::after,
+.nav-link span::after {
   height: 2px;
   background: var(--monitorGradient);
   opacity: 0;
@@ -111,20 +111,12 @@ nav {
   transition: all 0.2s ease;
 }
 
-.active-link::after {
+.active-link span::after,
+.active-link-underline span::after {
   right: 0;
   width: 100%;
-  opacity: 1;
-  animation: activeLinkUnderline ease 0.25s;
-  -webkit-animation: activeLinkUnderline ease 0.25s;
-  -moz-animation: activeLinkUnderline ease 0.25s;
-  transition: all 0.1s ease-in-out;
-}
-
-.nav-link:hover .active-link-underline::after {
-  width: 100%;
-  opacity: 1;
-  transition: all 0.2s ease;
+  opacity: 1 !important;
+  transition: all 0.1s ease;
 }
 
 .drop-down-menu,
@@ -313,7 +305,8 @@ img.avatar,
   }
 
   .desktop-menu .nav-link,
-  .active-link::after {
+  .active-link span::after,
+  .active-link-underline span::after {
     display: none;
   }
 
@@ -458,16 +451,5 @@ img.avatar,
   100% {
     opacity: 1;
     transform: translateY(8px);
-  }
-}
-
-@keyframes activeLinkUnderline {
-  0% {
-    opacity: 0;
-    width: 100%;
-  }
-
-  100% {
-    opacity: 1;
   }
 }

--- a/public/css/header.css
+++ b/public/css/header.css
@@ -105,6 +105,7 @@ nav {
   position: absolute;
   bottom: -8px;
   left: 0;
+  right: 0;
   width: 0;
   margin: auto;
   border-radius: 5px;
@@ -113,7 +114,6 @@ nav {
 
 .active-link span::after,
 .active-link-underline span::after {
-  right: 0;
   width: 100%;
   opacity: 1 !important;
   transition: all 0.1s ease;

--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -205,20 +205,23 @@ function toggleHeaderStates(header, win) {
   }
 }
 
-function styleActiveLink(locationHref) {
-  let queryString = `.nav-link[href='${locationHref}']`;
-  const activeLink = document.querySelector(queryString);
-  if (activeLink) {
-    return activeLink.firstChild.classList.add("active-link");
-  }
-
-  if (locationHref.indexOf("/dashboard") !== -1) {
-    queryString = queryString.replace("user/dashboard", "");
-    return document.querySelector(queryString).firstChild.classList.add("active-link");
-  }
-  if (locationHref.indexOf("/security-tips") !== -1) {
-    return document.querySelector(".nav-link[href*='/security-tips']").firstChild.classList.add("active-link");
-  }
+function addMainNavListeners() {
+  const inactiveNavLinks = document.querySelectorAll(".nav-link:not(.active-link)");
+  inactiveNavLinks.forEach(link => {
+    /* Remove the .active-link-underline class from any link
+       that isn't the current ".active-link" which occasionally
+       happens when the user navigates to a page using browser
+       backwards/forwards buttons. */
+    if (link.classList.contains("active-link-underline")) {
+      link.classList.remove("active-link-underline");
+    }
+    link.addEventListener("mouseenter", () => {
+      link.classList.add("active-link-underline");
+    });
+    link.addEventListener("mouseleave", () => {
+      link.classList.remove("active-link-underline");
+    });
+  });
 }
 
 function addBentoObserver(){
@@ -242,11 +245,7 @@ function addBentoObserver(){
   const header = document.getElementById("header");
   const topNavigation = document.querySelector("#navigation-wrapper");
   win.addEventListener("pageshow", function() {
-    const previousActiveLink = document.querySelector(".active-link");
-    if (previousActiveLink) {
-      previousActiveLink.classList.remove("active-link");
-    }
-    styleActiveLink(win.location.href);
+    addMainNavListeners();
     toggleMobileFeatures(topNavigation);
     toggleArticles();
     toggleHeaderStates(header, win);

--- a/template-helpers/header.js
+++ b/template-helpers/header.js
@@ -12,6 +12,7 @@ function getSignedInAs(args) {
 }
 
 function navLinks(args) {
+  const hostUrl = args.data.root.req.url;
   const serverUrl = args.data.root.constants.SERVER_URL;
   const locales = args.data.root.req.supportedLocales;
   const links = [
@@ -19,16 +20,19 @@ function navLinks(args) {
       title: "Home",
       stringId: "home",
       href: `${serverUrl}/`,
+      activeLink: (hostUrl === "/" || hostUrl === "/dashboard"),
     },
     {
       title: "Breaches",
       stringId: "breaches",
       href: `${serverUrl}/breaches`,
+      activeLink: (hostUrl === "/breaches"),
     },
     {
       title: "Security Tips",
       stringId: "security-tips",
       href: `${serverUrl}/security-tips`,
+      activeLink: (hostUrl === "/security-tips"),
     },
   ];
 

--- a/views/partials/header/nav-links.hbs
+++ b/views/partials/header/nav-links.hbs
@@ -1,3 +1,3 @@
 {{#each (navLinks)}}
-  <a class="nav-link" {{> analytics/internal-link eventLabel=this.title }} href="{{ this.href }}"><span class="active-link-underline">{{ this.stringId }}</span></a>
+  <a class="nav-link {{#if activeLink}} active-link {{/if}}" {{> analytics/internal-link eventLabel=this.title }} href="{{ this.href }}"><span>{{ this.stringId }}</span></a>
 {{/each}}


### PR DESCRIPTION
Fixes #1415

- Sets the `.active-link` class from the template instead of `monitor.js`.
- Adds mouseenter/mouseleave event listeners to the other header links to handle showing and hiding the gradient underline.