### PR TITLE
POST breach resolution endpoint 1413

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -145,13 +145,14 @@ function annotateFoundBreachesAsResolvedOrNot(foundBreaches, resolvedBreaches) {
 async function bundleVerifiedEmails(options) {
   const { user, email, recordId, recordVerified, allBreaches} = options;
   const lowerCaseEmailSha = sha1(email.toLowerCase());
-  const foundBreaches = await HIBP.getBreachesForEmail(lowerCaseEmailSha, allBreaches, true);
+  const foundBreaches = await HIBP.getBreachesForEmail(lowerCaseEmailSha, allBreaches, true, false);
   const resolvedBreaches = getResolvedBreachesForEmail(user, email);
   const annotatedFoundBreaches = annotateFoundBreachesAsResolvedOrNot(foundBreaches, resolvedBreaches);
+  const filteredAnnotatedFoundBreaches = HIBP.filterBreaches(annotatedFoundBreaches);
 
   const emailEntry = {
     "email": email,
-    "breaches": annotatedFoundBreaches,
+    "breaches": filteredAnnotatedFoundBreaches,
     "primary": email === user.primary_email,
     "id": recordId,
     "verified": recordVerified,

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -72,6 +72,19 @@ async function updateCommunicationOptions(req, res) {
 }
 
 
+async function resolveBreach(req, res) {
+  const sessionUser = req.user;
+  // TODO: verify that req.body.emailAddressId belongs to sessionUser
+  const updatedSubscriber = await DB.setResolvedBreach({
+    subscriber: sessionUser,
+    emailAddresses: req.body.emailAddressId,
+    recencyIndex: req.body.recencyIndex,
+  });
+  req.session.user = updatedSubscriber;
+  return res.json("Breach marked as resolved.");
+}
+
+
 function _checkForDuplicateEmail(sessionUser, email) {
   if (email === sessionUser.primary_email) {
     throw new FluentError("user-add-duplicate-email");
@@ -422,4 +435,5 @@ module.exports = {
   removeEmail,
   resendEmail,
   updateCommunicationOptions,
+  resolveBreach,
 };

--- a/db/DB.js
+++ b/db/DB.js
@@ -325,6 +325,23 @@ const DB = {
     return updatedSubscriber;
   },
 
+  async setBreachResolved(options) {
+    const {subscriber, emailAddressId, recencyIndex} = options;
+    if (emailAddressId) {
+      // TODO: SELECT email from email_addresses where ea.id
+      // TODO: if (!subscriber.breaches_resolved[email].includes(recencyIndex) {
+      //   subscriber.breaches_resolved[email].push(recencyIndex);
+      //   UPDATE subscriber SET breaches_resolved = subscriber.breaches_resolved
+      // }
+      // return updatedSubscriber;
+    }
+    // TODO: if (!subscriber.breaches_resolved[subscriber.primary_email].includes(recencyIndex) {
+    //   subscriber.breaches_resolved[subscriber.primary_email].push(recencyIndex);
+    //   UPDATE subscriber SET breaches_resolved = subscriber.breaches_resolved
+    // }
+    // return updatedSubscriber;
+  },
+
   async removeSubscriber(subscriber) {
     await knex("email_addresses").where({"subscriber_id": subscriber.id}).del();
     await knex("subscribers").where({"id": subscriber.id}).del();

--- a/hibp.js
+++ b/hibp.js
@@ -118,9 +118,14 @@ const HIBP = {
       if (sha1.toUpperCase() === sha1Prefix + breachedAccount.hashSuffix) {
         foundBreaches = allBreaches.filter(breach => breachedAccount.websites.includes(breach.Name));
         foundBreaches = this.filterBreaches(foundBreaches);
+
+        // NOTE: DO NOT CHANGE THIS SORT LOGIC
+        // We store breach resolutions by recency indices,
+        // so that our DB does not contain any part of any user's list of accounts
         foundBreaches.sort( (a,b) => {
           return new Date(b.AddedDate) - new Date(a.AddedDate);
         });
+
         break;
       }
     }

--- a/hibp.js
+++ b/hibp.js
@@ -100,7 +100,7 @@ const HIBP = {
   },
 
 
-  async getBreachesForEmail(sha1, allBreaches, includeSensitive = false) {
+  async getBreachesForEmail(sha1, allBreaches, includeSensitive = false, filterBreaches = true) {
     let foundBreaches = [];
     const sha1Prefix = sha1.slice(0, 6).toUpperCase();
     const path = `/breachedaccount/range/${sha1Prefix}`;
@@ -117,7 +117,9 @@ const HIBP = {
     for (const breachedAccount of response.body) {
       if (sha1.toUpperCase() === sha1Prefix + breachedAccount.hashSuffix) {
         foundBreaches = allBreaches.filter(breach => breachedAccount.websites.includes(breach.Name));
-        foundBreaches = this.filterBreaches(foundBreaches);
+        if (filterBreaches) {
+          foundBreaches = this.filterBreaches(foundBreaches);
+        }
 
         // NOTE: DO NOT CHANGE THIS SORT LOGIC
         // We store breach resolutions by recency indices,

--- a/routes/user.js
+++ b/routes/user.js
@@ -9,7 +9,7 @@ const { asyncMiddleware, requireSessionUser } = require("../middleware");
 const {
   add, verify, logout,
   getDashboard, getPreferences, getBreachStats,
-  removeEmail, resendEmail, updateCommunicationOptions,
+  removeEmail, resendEmail, updateCommunicationOptions, resolveBreach,
   getUnsubscribe, postUnsubscribe, getRemoveFxm, postRemoveFxm,
 } = require("../controllers/user");
 
@@ -23,6 +23,7 @@ router.get("/dashboard", csrfProtection, requireSessionUser, asyncMiddleware(get
 router.get("/preferences", csrfProtection, requireSessionUser, asyncMiddleware(getPreferences));
 router.use("/breach-stats", bearerToken());
 router.get("/breach-stats", urlEncodedParser, asyncMiddleware(getBreachStats));
+router.post("/breach-resolution", urlEncodedParser, csrfProtection, requireSessionUser, asyncMiddleware(resolveBreach));
 router.get("/logout", logout);
 router.post("/email", urlEncodedParser, csrfProtection, requireSessionUser, asyncMiddleware(add));
 router.post("/remove-email", urlEncodedParser, csrfProtection, requireSessionUser, asyncMiddleware(removeEmail));

--- a/tests/controllers/user.test.js
+++ b/tests/controllers/user.test.js
@@ -563,6 +563,10 @@ test("user breach-stats POST request with FXA response for Monitor user returns 
   });
   HIBP.getBreachesForEmail = jest.fn();
   HIBP.getBreachesForEmail.mockReturnValue([]);
+  HIBP.getResolvedBreachesForEmail = jest.fn();
+  HIBP.getResolvedBreachesForEmail.mockReturnValue([]);
+  HIBP.filterBreaches = jest.fn();
+  HIBP.filterBreaches.mockReturnValue([]);
 
   const resp = { json: jest.fn() };
 


### PR DESCRIPTION
Depends on https://github.com/mozilla/blurts-server/pull/1467 so we should merge that first. But I want a sanity check on this approach sooner than later ... @lesleyjanenorton @pdehaan ?

This should accept either of the following HTTP POST requests:
```
POST /user/breach-resolution

emailAddressId=123&recencyIndex=0
```

Will mark the logged-in subscriber's email_addresses.id's 0th breach as resolved.

```
POST /user/breach-resolution

emailAddressId=&recencyIndex=0
```

Will mark the logged-in subscriber's primary_email's 0th breach as resolved.

Could easily change this to accept a JSON body instead of form-encoded body.