### PR TITLE
Add English encrypted-keys data class string

### DIFF
--- a/locales/en/data-classes.ftl
+++ b/locales/en/data-classes.ftl
@@ -42,6 +42,7 @@ email-addresses = Email addresses
 email-messages = Email messages
 employers = Employers
 employment-statuses = Employment statuses
+encrypted-keys = Encrypted keys
 ethnicities = Ethnicities
 family-members-names = Family members’ names
 family-plans = Family plans


### PR DESCRIPTION
Per https://github.com/mozilla/blurts-server/issues/1465#issue-545915107, specifically the last bit:

```sh
npx pdehaan/blurts-server-data-classes

Missing "encrypted-keys" data class from GateHub breach
```

&mdash; via https://monitor.firefox.com/breach-details/GateHub
