### PR TITLE
Audit usage of sha1, .toLowerCase() and .toUpperCase() - WIP

### DIFF
--- a/controllers/home.js
+++ b/controllers/home.js
@@ -1,11 +1,14 @@
 "use strict";
 
 const AppConstants = require("../app-constants");
-const { scanResult } = require("../scan-results");
 const { generatePageToken } = require("./utils");
 
 
 async function home(req, res) {
+
+  if (req.session.user) {
+    return res.redirect("/user/dashboard");
+  }
 
   const formTokens = {
     pageToken: AppConstants.PAGE_TOKEN_TIMER > 0 ? generatePageToken(req) : "",
@@ -15,10 +18,6 @@ async function home(req, res) {
   let featuredBreach = null;
   let scanFeaturedBreach = false;
 
-  if (req.session.user && !req.query.breach) {
-    return res.redirect("/user/dashboard");
-  }
-
   if (req.query.breach) {
     const reqBreachName = req.query.breach.toLowerCase();
     featuredBreach = req.app.locals.breaches.find(breach => breach.Name.toLowerCase() === reqBreachName);
@@ -27,11 +26,6 @@ async function home(req, res) {
       return notFound(req, res);
     }
 
-    const scanRes = await scanResult(req);
-
-    if (scanRes.doorhangerScan) {
-      return res.render("scan", Object.assign(scanRes, formTokens));
-    }
     scanFeaturedBreach = true;
 
     return res.render("monitor", {

--- a/controllers/scan.js
+++ b/controllers/scan.js
@@ -44,6 +44,11 @@ function _validatePageToken(pageToken, req) {
 
 
 async function post (req, res) {
+
+  if (req.session.user) {
+    return res.redirect("/user/dashboard");
+  }
+
   const emailHash = req.body.emailHash;
   const encryptedPageToken = req.body.pageToken;
   let validPageToken = false;
@@ -65,16 +70,13 @@ async function post (req, res) {
     return res.redirect("/");
   }
 
-  const scanRes = await scanResult(req);
+  const scanRes = await scanResult(req, emailHash);
 
   const formTokens = {
     pageToken: encryptedPageToken,
     csrfToken: req.csrfToken(),
   };
 
-  if (req.session.user && scanRes.selfScan && !req.body.featuredBreach) {
-    return res.redirect("/user/dashboard");
-  }
   res.render("scan", Object.assign(scanRes, formTokens));
 }
 

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -126,8 +126,8 @@ async function add(req, res) {
 }
 
 async function bundleVerifiedEmails(email, ifPrimary, id, verificationStatus, allBreaches) {
-  const lowerCaseEmailSha = sha1(email.toLowerCase());
-  const foundBreaches = await HIBP.getBreachesForEmail(lowerCaseEmailSha, allBreaches, true);
+  const emailHash = sha1(email);
+  const foundBreaches = await HIBP.getBreachesForEmail(emailHash, allBreaches, true);
 
   const emailEntry = {
     "email": email,
@@ -198,7 +198,7 @@ async function _verify(req) {
   const verifiedEmailHash = await DB.verifyEmailHash(req.query.token);
   let unsafeBreachesForEmail = [];
   unsafeBreachesForEmail = await HIBP.getBreachesForEmail(
-    sha1(verifiedEmailHash.email.toLowerCase()),
+    sha1(verifiedEmailHash.email),
     req.app.locals.breaches,
     true,
   );

--- a/db/DB.js
+++ b/db/DB.js
@@ -23,6 +23,14 @@ const log = mozlog("DB");
 
 
 const DB = {
+
+  // Hashes are stored in the db using lowercase letters
+  getLowerCaseHash(email) {
+    email = getSha1(email);
+    return email.toLowerCase();
+  },
+
+
   async getSubscriberByToken(token) {
     const res = await knex("subscribers")
       .where("primary_verification_token", "=", token);
@@ -117,7 +125,7 @@ const DB = {
     const res = await knex("email_addresses").insert({
       subscriber_id: user.id,
       email: email,
-      sha1: getSha1(email),
+      sha1: this.getLowerCaseHash(email),
       verification_token: uuidv4(),
       verified: false,
     }).returning("*");
@@ -160,6 +168,7 @@ const DB = {
     }
   },
 
+
   // Used internally.
   async _addEmailHash(sha1, email, signup_language, verified = false) {
     try {
@@ -169,7 +178,7 @@ const DB = {
           const res = await knex("subscribers")
             .update({
               primary_email: email,
-              primary_sha1: getSha1(email.toLowerCase()),
+              primary_sha1: this.getLowerCaseHash(email),
               primary_verified: verified,
               updated_at: knex.fn.now(),
             })
@@ -183,7 +192,7 @@ const DB = {
         // Always add a verification_token value
         const verification_token = uuidv4();
         const res = await knex("subscribers")
-          .insert({ primary_sha1: getSha1(email.toLowerCase()), primary_email: email, signup_language, primary_verification_token: verification_token, primary_verified: verified })
+          .insert({ primary_sha1: this.getLowerCaseHash(email), primary_email: email, signup_language, primary_verification_token: verification_token, primary_verified: verified })
           .returning("*");
         return res[0];
       });
@@ -206,7 +215,7 @@ const DB = {
    * @returns {object} subscriber knex object added to DB
    */
   async addSubscriber(email, signupLanguage, fxaAccessToken=null, fxaRefreshToken=null, fxaProfileData=null) {
-    const emailHash = await this._addEmailHash(getSha1(email), email, signupLanguage, true);
+    const emailHash = await this._addEmailHash(this.getLowerCaseHash(email), email, signupLanguage, true);
     const verified = await this._verifySubscriber(emailHash);
     const verifiedSubscriber = Array.isArray(verified) ? verified[0] : null;
     if (fxaRefreshToken || fxaProfileData) {

--- a/hibp.js
+++ b/hibp.js
@@ -100,10 +100,15 @@ const HIBP = {
   },
 
 
-  async getBreachesForEmail(sha1, allBreaches, includeSensitive = false) {
+  getHashPrefix(emailHash) {
+    return emailHash.slice(0, 6);
+  },
+
+
+  async getBreachesForEmail(sha1EmailHash, allBreaches, includeSensitive = false) {
     let foundBreaches = [];
-    const sha1Prefix = sha1.slice(0, 6).toUpperCase();
-    const path = `/breachedaccount/range/${sha1Prefix}`;
+    const emailHashPrefix = this.getHashPrefix(sha1EmailHash);
+    const path = `/breachedaccount/range/${emailHashPrefix}`;
 
     const response = await this.kAnonReq(path);
     if (!response) {
@@ -115,10 +120,10 @@ const HIBP = {
     //   {"hashSuffix":<suffix>,"websites":[<breach1Name>,...]},
     // ]
     for (const breachedAccount of response.body) {
-      if (sha1.toUpperCase() === sha1Prefix + breachedAccount.hashSuffix) {
+      if (sha1EmailHash === emailHashPrefix + breachedAccount.hashSuffix) {
         foundBreaches = allBreaches.filter(breach => breachedAccount.websites.includes(breach.Name));
         foundBreaches = this.filterBreaches(foundBreaches);
-        foundBreaches.sort( (a,b) => {
+        foundBreaches.sort((a,b) => {
           return new Date(b.AddedDate) - new Date(a.AddedDate);
         });
         break;
@@ -167,8 +172,8 @@ const HIBP = {
   },
 
 
-  async subscribeHash(sha1) {
-    const sha1Prefix = sha1.slice(0, 6).toUpperCase();
+  async subscribeHash(sha1EmailHash) {
+    const sha1Prefix = this.getHashPrefix(sha1EmailHash);
     const path = "/range/subscribe";
     const options = {
       method: "POST",

--- a/public/js/scan-email.js
+++ b/public/js/scan-email.js
@@ -4,9 +4,12 @@
 /* global libpolycrypt */
 /* global sendPing */
 
-async function sha1(message) {
-  message = message.toLowerCase();
-  const msgBuffer = new TextEncoder("utf-8").encode(message);
+async function sha1(emailAddress) {
+
+  // Email addresses must be lowercased before
+  // hashing to return correct results from HIBP
+  emailAddress = emailAddress.toLowerCase();
+  const msgBuffer = new TextEncoder("utf-8").encode(emailAddress);
   let hashBuffer;
   if (/edge/i.test(navigator.userAgent)) {
     hashBuffer = libpolycrypt.sha1(msgBuffer);
@@ -15,6 +18,8 @@ async function sha1(message) {
   }
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   const hashHex = hashArray.map(b => ("00" + b.toString(16)).slice(-2)).join("");
+
+  // Hashes must be uppercased to return correct results from HIBP
   return hashHex.toUpperCase();
 }
 

--- a/scan-results.js
+++ b/scan-results.js
@@ -1,102 +1,41 @@
 "use strict";
 
-const { URL } = require("url");
-
 const HIBP = require("./hibp");
-const sha1 = require("./sha1-utils");
 
 
-const scanResult = async(req, selfScan=false) => {
-
+const scanResult = async(req, scannedEmail) => {
   const allBreaches = req.app.locals.breaches;
-  let scannedEmail = null;
-
+  const foundBreaches = await HIBP.getBreachesForEmail(scannedEmail, allBreaches);
   const title = req.fluentFormat("scan-title");
-  let foundBreaches = [];
-  let specificBreach = null;
-  let doorhangerScan = false;
-  let userCompromised = false;
-  let signedInUser = null;
-  let fullReport = false;
-  let userDash = false;
-  let scannedEmailId = null;
 
-
-  if (req.session.user) {
-    signedInUser = req.session.user;
-  }
-
-
-  // Checks if the user scanning their own verified email.
-  if (req.body && req.body.emailHash) {
-    scannedEmail = req.body.emailHash;
-
-    if (req.body.scannedEmailId) {
-      scannedEmailId = req.body.scannedEmailId;
-    }
-
-    if (signedInUser) {
-      for (const emailAddress of signedInUser.email_addresses) {
-        if (!selfScan && sha1(emailAddress.email) === req.body.emailHash) {
-          selfScan = true;
-          break;
-        }
-      }
-    }
-  }
-
-  const url = new URL(req.url, req.app.locals.SERVER_URL);
   const thisBreach = (breach) => {
     return (element) => element.Name.toLowerCase() === breach.toLowerCase();
   };
 
-  // Checks for a signedInUser arriving from doorhanger.
-  if (signedInUser && url.searchParams.has("utm_source") && url.searchParams.get("utm_source") === "firefox") {
-    doorhangerScan = true, selfScan = true;
-    specificBreach = allBreaches.find(thisBreach(req.query.breach));
+  const  scannedEmailId = (req.body.scannedEmailId !== "undefined") ?
+    req.body.scannedEmailId :
+    null;
+
+  const specificBreach = (req.body && req.body.featuredBreach) ?
+    allBreaches.find(thisBreach(req.body.featuredBreach)) :
+    null;
+
+  const specificBreachIndex = (
+    specificBreach &&
+    foundBreaches.findIndex(breach => breach.Name === specificBreach.Name)
+  );
+
+  const userCompromised = (specificBreach && specificBreachIndex !== -1);
+  if (userCompromised) {
+    foundBreaches.splice(specificBreachIndex, 1);
+    foundBreaches.unshift(specificBreach);
   }
-
-  fullReport = url.pathname === "/full_report";
-
-  userDash = url.pathname === "/user_dashboard";
-
-  if (selfScan) {
-    scannedEmail = sha1(signedInUser.primary_email);
-  }
-
-  if (scannedEmail) {
-    // Gets sensitive breaches only if selfScan === true
-    foundBreaches = await HIBP.getBreachesForEmail(scannedEmail, allBreaches, selfScan);
-  }
-
-  // Checks if scan originated from a breach detail/"featured breach" page.
-  if (req.body && req.body.featuredBreach) {
-    specificBreach = allBreaches.find(thisBreach(req.body.featuredBreach));
-  }
-
-  if (doorhangerScan || specificBreach) {
-    const specificBreachIndex = foundBreaches.findIndex(breach => breach.Name === specificBreach.Name);
-
-    // Checks foundBreaches for specificBreach and if found,
-    // brings specificBreach to front of foundBreaches list.
-    if (specificBreachIndex !== -1) {
-      userCompromised = true;
-      foundBreaches.splice(specificBreachIndex, 1);
-      foundBreaches.unshift(specificBreach);
-    }
-  }
-
 
   return {
     title,
     foundBreaches,
     specificBreach,
-    doorhangerScan,
     userCompromised,
-    signedInUser,
-    selfScan,
-    fullReport,
-    userDash,
     scannedEmailId,
   };
 };

--- a/scan-results.js
+++ b/scan-results.js
@@ -3,9 +3,10 @@
 const HIBP = require("./hibp");
 
 
-const scanResult = async(req, scannedEmail) => {
+const scanResult = async(req, scannedEmailHash) => {
   const allBreaches = req.app.locals.breaches;
-  const foundBreaches = await HIBP.getBreachesForEmail(scannedEmail, allBreaches);
+
+  const foundBreaches = await HIBP.getBreachesForEmail(scannedEmailHash, allBreaches);
   const title = req.fluentFormat("scan-title");
 
   const thisBreach = (breach) => {

--- a/scripts/lowercase-all-records.js
+++ b/scripts/lowercase-all-records.js
@@ -10,10 +10,9 @@ const getSha1 = require("../sha1-utils");
 
 
 async function subscribeLowercaseHashToHIBP(emailAddress) {
-  const lowerCasedEmail = emailAddress.toLowerCase();
-  const lowerCasedSha1 = getSha1(lowerCasedEmail);
-  await HIBP.subscribeHash(lowerCasedSha1);
-  return lowerCasedSha1;
+  const emailHash = getSha1(emailAddress);
+  await HIBP.subscribeHash(emailHash);
+  return emailHash;
 }
 
 
@@ -23,10 +22,10 @@ async function subscribeLowercaseHashToHIBP(emailAddress) {
   const subsWithUpperCount = subRecordsWithUpperChars.length;
   console.log(`found ${subsWithUpperCount} subscribers records with primary_email != lower(primary_email). fixing ...`);
   for (const subRecord of subRecordsWithUpperChars) {
-    const lowerCasedSha1 = await subscribeLowercaseHashToHIBP(subRecord.primary_email);
+    const emailHash = await subscribeLowercaseHashToHIBP(subRecord.primary_email);
     await knex("subscribers")
       .update({
-        primary_sha1: lowerCasedSha1,
+        primary_sha1: emailHash.toLowerCase(),
       })
       .where("id", subRecord.id);
     console.log(`fixed subscribers record ID: ${subRecord.id}`);
@@ -37,10 +36,10 @@ async function subscribeLowercaseHashToHIBP(emailAddress) {
   const emailsWithUpperCount = emailRecordsWithUpperChars.length;
   console.log(`found ${emailsWithUpperCount} email_addresses records with email != lower(email)`);
   for (const emailRecord of emailRecordsWithUpperChars) {
-    const lowerCasedSha1 = await subscribeLowercaseHashToHIBP(emailRecord.email);
+    const emailHash = await subscribeLowercaseHashToHIBP(emailRecord.email);
     await knex("email_addresses")
       .update({
-        sha1: lowerCasedSha1,
+        sha1: emailHash.toLowerCase(),
       })
       .where("id", emailRecord.id);
     console.log(`fixed email_addresses record ID: ${emailRecord.id}`);

--- a/sha1-utils.js
+++ b/sha1-utils.js
@@ -2,8 +2,15 @@
 
 const crypto = require("crypto");
 
-function getSha1(email) {
-  return crypto.createHash("sha1").update(email).digest("hex");
+function getSha1Hash(email) {
+  // Email addresses must be lowercased before
+  // hashing to return correct results from HIBP
+  const lowerCaseEmail = email.toLowerCase();
+  const sha1EmailHash = crypto.createHash("sha1").update(lowerCaseEmail).digest("hex");
+
+  // Hashes must be uppercased to return correct results from HIBP
+  return sha1EmailHash.toUpperCase();
 }
 
-module.exports = getSha1;
+
+module.exports = getSha1Hash;

--- a/tests/controllers/home.test.js
+++ b/tests/controllers/home.test.js
@@ -2,7 +2,6 @@
 
 const AppConstants = require("../../app-constants");
 const home = require("../../controllers/home");
-const { scanResult } = require("../../scan-results");
 
 let mockRequest = { fluentFormat: jest.fn(), csrfToken: jest.fn() };
 
@@ -41,10 +40,7 @@ test("home GET with breach renders monitor with breach", async() => {
 
   const mockResponse = { render: jest.fn(), redirect: jest.fn() };
   home.home(mockRequest, mockResponse);
-  const scanRes = await scanResult(mockRequest);
 
-  expect(scanRes.doorhangerScan).toBe(false);
-  expect(scanRes.selfScan).toBe(false);
   const mockRenderCallArgs = mockResponse.render.mock.calls[0];
   expect(mockRenderCallArgs[0]).toBe("monitor");
   expect(mockRenderCallArgs[1].featuredBreach).toEqual(testBreach);


### PR DESCRIPTION
This attempts to bring come consistency to the way we hash emails for scanning and storing. It's WIP but I'm pushing it up early so that we can start discussing.


A few findings/confirmations from the ongoing sha1 deep dive:
#### In order to return correct scan results from HIBP:
- An email should be lowercased before hashing
- The hash itself should be numbers and uppercase letters only

#### The confusing gotcha:
- Hashes are stored in our database in _lowercase_ letters
- When HIBP callbacks hit our `/notify` endpoint, we first have to lowercase everything in order to match the hash coming from HIBP to what is stored in our DB.

Maybe we can consider converting our existing hashes to uppercase letters to match HIBP (this, I believe, is the path of greatest sanity). I think w may need to rerun `lowercase-all-records.js` on production because we may have stored hashes for emails that were not first converted to lowercase letters (which caused the false negative emails, did not affect dashboard since those breach results are retrieved differently, and I'm concerned could result in us not correctly sending breach alerts to some affected individuals). 

