### PR TITLE
Hide `sign in` message if the user is already signed in.

### DIFF
--- a/views/partials/subpages/confirm.hbs
+++ b/views/partials/subpages/confirm.hbs
@@ -1,3 +1,5 @@
 <span class="dashboard-email-sent bold txt-purple7 email-confirmed txt-cntr mw-550"> {{ getString "email-verified" }}</span>
 <span class="txt-purple7 email-confirmed txt-cntr mw-550 overflow-break">{{{ makeEmailAddedToSubscriptionString email }}}</span>
-<span class="txt-purple7 email-confirmed txt-cntr mw-550">{{{ makeEmailVerifiedString }}}</span>
+{{#unless req.session.user}}
+  <span class="txt-purple7 email-confirmed txt-cntr mw-550">{{{ makeEmailVerifiedString }}}</span>
+{{/unless}}


### PR DESCRIPTION
This hides the `To see and manage all emails... sign in` line when the user is already signed in. 

<img width="957" alt="Screen Shot 2020-01-22 at 10 59 25 AM" src="https://user-images.githubusercontent.com/22355127/72915925-b987bc00-3d06-11ea-8789-ed9e25d219e3.png">
