### PR TITLE
Audit Sha1() usage

### DIFF
--- a/controllers/oauth.js
+++ b/controllers/oauth.js
@@ -65,7 +65,7 @@ async function confirmed(req, res, next, client = FxAOAuthClient) {
     let unsafeBreachesForEmail = [];
 
     unsafeBreachesForEmail = await HIBP.getBreachesForEmail(
-      sha1(email),
+      sha1.getSha1ForHIBP(email),
       req.app.locals.breaches,
       true,
     );

--- a/controllers/scan.js
+++ b/controllers/scan.js
@@ -61,7 +61,7 @@ async function post (req, res) {
     }
   }
 
-  if (!emailHash || emailHash === sha1("")) {
+  if (!emailHash || emailHash === sha1.getSha1ForHIBP("")) {
     return res.redirect("/");
   }
 

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -126,8 +126,8 @@ async function add(req, res) {
 }
 
 async function bundleVerifiedEmails(email, ifPrimary, id, verificationStatus, allBreaches) {
-  const lowerCaseEmailSha = sha1(email.toLowerCase());
-  const foundBreaches = await HIBP.getBreachesForEmail(lowerCaseEmailSha, allBreaches, true);
+  const emailHash = sha1.getSha1ForHIBP(email);
+  const foundBreaches = await HIBP.getBreachesForEmail(emailHash, allBreaches, true);
 
   const emailEntry = {
     "email": email,
@@ -198,7 +198,7 @@ async function _verify(req) {
   const verifiedEmailHash = await DB.verifyEmailHash(req.query.token);
   let unsafeBreachesForEmail = [];
   unsafeBreachesForEmail = await HIBP.getBreachesForEmail(
-    sha1(verifiedEmailHash.email.toLowerCase()),
+    sha1.getSha1ForHIBP(verifiedEmailHash.email),
     req.app.locals.breaches,
     true,
   );

--- a/db/DB.js
+++ b/db/DB.js
@@ -117,7 +117,7 @@ const DB = {
     const res = await knex("email_addresses").insert({
       subscriber_id: user.id,
       email: email,
-      sha1: getSha1(email),
+      sha1: getSha1.getLowerCaseSha1(email),
       verification_token: uuidv4(),
       verified: false,
     }).returning("*");
@@ -169,7 +169,7 @@ const DB = {
           const res = await knex("subscribers")
             .update({
               primary_email: email,
-              primary_sha1: getSha1(email.toLowerCase()),
+              primary_sha1: getSha1.getLowerCaseSha1(email),
               primary_verified: verified,
               updated_at: knex.fn.now(),
             })
@@ -183,7 +183,7 @@ const DB = {
         // Always add a verification_token value
         const verification_token = uuidv4();
         const res = await knex("subscribers")
-          .insert({ primary_sha1: getSha1(email.toLowerCase()), primary_email: email, signup_language, primary_verification_token: verification_token, primary_verified: verified })
+          .insert({ primary_sha1: getSha1.getLowerCaseSha1(email), primary_email: email, signup_language, primary_verification_token: verification_token, primary_verified: verified })
           .returning("*");
         return res[0];
       });
@@ -206,7 +206,7 @@ const DB = {
    * @returns {object} subscriber knex object added to DB
    */
   async addSubscriber(email, signupLanguage, fxaAccessToken=null, fxaRefreshToken=null, fxaProfileData=null) {
-    const emailHash = await this._addEmailHash(getSha1(email), email, signupLanguage, true);
+    const emailHash = await this._addEmailHash(getSha1.getLowerCaseSha1(email), email, signupLanguage, true);
     const verified = await this._verifySubscriber(emailHash);
     const verifiedSubscriber = Array.isArray(verified) ? verified[0] : null;
     if (fxaRefreshToken || fxaProfileData) {

--- a/db/seeds/test_subscribers.js
+++ b/db/seeds/test_subscribers.js
@@ -6,7 +6,7 @@ const getSha1 = require("../../sha1-utils");
 exports.TEST_SUBSCRIBERS = {
   firefox_account: {
     id: 12345,
-    primary_sha1: getSha1("firefoxaccount@test.com"),
+    primary_sha1: getSha1.getLowerCaseSha1("firefoxaccount@test.com"),
     primary_email: "firefoxaccount@test.com",
     primary_verification_token: "0e2cb147-2041-4e5b-8ca9-494e773b2cf1",
     primary_verified: true,
@@ -18,7 +18,7 @@ exports.TEST_SUBSCRIBERS = {
   },
   all_emails_to_primary: {
     id: 67890,
-    primary_sha1: getSha1("all_emails_to_primary@test.com"),
+    primary_sha1: getSha1.getLowerCaseSha1("all_emails_to_primary@test.com"),
     primary_email: "all_emails_to_primary@test.com",
     primary_verification_token: "0e2cb147-2041-4e5b-8ca9-494e773b2ca7",
     primary_verified: true,
@@ -27,13 +27,13 @@ exports.TEST_SUBSCRIBERS = {
     all_emails_to_primary: true,
   },
   unverified_email: {
-    primary_sha1: getSha1("unverifiedemail@test.com"),
+    primary_sha1: getSha1.getLowerCaseSha1("unverifiedemail@test.com"),
     primary_email: "unverifiedemail@test.com",
     primary_verification_token: "0e2cb147-2041-4e5b-8ca9-494e773b2cf0",
     primary_verified: false,
   },
   verified_email: {
-    primary_sha1: getSha1("verifiedemail@test.com"),
+    primary_sha1: getSha1.getLowerCaseSha1("verifiedemail@test.com"),
     primary_email: "verifiedemail@test.com",
     primary_verification_token: "54010800-6c3c-4186-971a-76dc92874941",
     primary_verified: true,
@@ -45,7 +45,7 @@ exports.TEST_EMAIL_ADDRESSES = {
   firefox_account: {
     id: 11111,
     subscriber_id: 12345,
-    sha1: getSha1("firefoxaccount-secondary@test.com"),
+    sha1: getSha1.getLowerCaseSha1("firefoxaccount-secondary@test.com"),
     email: "firefoxaccount-secondary@test.com",
     verification_token: "0e2cb147-2041-4e5b-8ca9-494e773b2cf2",
     verified: true,
@@ -53,7 +53,7 @@ exports.TEST_EMAIL_ADDRESSES = {
   unverified_email_on_firefox_account: {
     id: 98765,
     subscriber_id: 12345,
-    sha1: getSha1("firefoxaccount-tertiary@test.com"),
+    sha1: getSha1.getLowerCaseSha1("firefoxaccount-tertiary@test.com"),
     email: "firefoxaccount-tertiary@test.com",
     verification_token: "0e2cb147-2041-4e5b-8ca9-494e773b2cf3",
     verified: false,
@@ -61,7 +61,7 @@ exports.TEST_EMAIL_ADDRESSES = {
   all_emails_to_primary: {
     id: 99999,
     subscriber_id: 67890,
-    sha1: getSha1("secondary_sending_to_primary@test.com"),
+    sha1: getSha1.getLowerCaseSha1("secondary_sending_to_primary@test.com"),
     email: "secondary_sending_to_primary@test.com",
     verification_token: "0e2cb147-2041-4e5b-8ca9-494e773b2cf4",
     verified: true,

--- a/hibp.js
+++ b/hibp.js
@@ -102,7 +102,7 @@ const HIBP = {
 
   async getBreachesForEmail(sha1, allBreaches, includeSensitive = false) {
     let foundBreaches = [];
-    const sha1Prefix = sha1.slice(0, 6).toUpperCase();
+    const sha1Prefix = sha1.slice(0, 6);
     const path = `/breachedaccount/range/${sha1Prefix}`;
 
     const response = await this.kAnonReq(path);
@@ -115,7 +115,7 @@ const HIBP = {
     //   {"hashSuffix":<suffix>,"websites":[<breach1Name>,...]},
     // ]
     for (const breachedAccount of response.body) {
-      if (sha1.toUpperCase() === sha1Prefix + breachedAccount.hashSuffix) {
+      if (sha1 === sha1Prefix + breachedAccount.hashSuffix) {
         foundBreaches = allBreaches.filter(breach => breachedAccount.websites.includes(breach.Name));
         foundBreaches = this.filterBreaches(foundBreaches);
         foundBreaches.sort( (a,b) => {
@@ -168,6 +168,7 @@ const HIBP = {
 
 
   async subscribeHash(sha1) {
+    // Hashes sent to HIBP should be uppercased
     const sha1Prefix = sha1.slice(0, 6).toUpperCase();
     const path = "/range/subscribe";
     const options = {

--- a/public/js/scan-email.js
+++ b/public/js/scan-email.js
@@ -4,9 +4,11 @@
 /* global libpolycrypt */
 /* global sendPing */
 
-async function sha1(message) {
-  message = message.toLowerCase();
-  const msgBuffer = new TextEncoder("utf-8").encode(message);
+async function getSha1ForHIBP(scannedEmailAddress) {
+  // Email addresses should be converted to lowercase letters
+  // before hashing
+  scannedEmailAddress = scannedEmailAddress.toLowerCase();
+  const msgBuffer = new TextEncoder("utf-8").encode(scannedEmailAddress);
   let hashBuffer;
   if (/edge/i.test(navigator.userAgent)) {
     hashBuffer = libpolycrypt.sha1(msgBuffer);
@@ -15,6 +17,9 @@ async function sha1(message) {
   }
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   const hashHex = hashArray.map(b => ("00" + b.toString(16)).slice(-2)).join("");
+
+  // Hashes should be converted to uppercase letters
+  // before sending to server and HIBP
   return hashHex.toUpperCase();
 }
 
@@ -26,7 +31,7 @@ async function hashEmailAndSend(emailFormSubmitEvent) {
 
   // show loader and hash email
   emailForm.classList.add("loading-data");
-  emailForm.querySelector("input[name=emailHash]").value = await sha1(userEmail);
+  emailForm.querySelector("input[name=emailHash]").value = await getSha1ForHIBP(userEmail);
 
   // set unhashed email in client's sessionStorage and send key to server
   // so we can pluck these out later in scan-results and not lose them on back clicks

--- a/scan-results.js
+++ b/scan-results.js
@@ -37,7 +37,7 @@ const scanResult = async(req, selfScan=false) => {
 
     if (signedInUser) {
       for (const emailAddress of signedInUser.email_addresses) {
-        if (!selfScan && sha1(emailAddress.email) === req.body.emailHash) {
+        if (!selfScan && sha1.getSha1ForHIBP(emailAddress.email) === req.body.emailHash) {
           selfScan = true;
           break;
         }
@@ -61,7 +61,7 @@ const scanResult = async(req, selfScan=false) => {
   userDash = url.pathname === "/user_dashboard";
 
   if (selfScan) {
-    scannedEmail = sha1(signedInUser.primary_email);
+    scannedEmail = sha1.getSha1ForHIBP(signedInUser.primary_email);
   }
 
   if (scannedEmail) {

--- a/scripts/lowercase-all-records.js
+++ b/scripts/lowercase-all-records.js
@@ -10,8 +10,7 @@ const getSha1 = require("../sha1-utils");
 
 
 async function subscribeLowercaseHashToHIBP(emailAddress) {
-  const lowerCasedEmail = emailAddress.toLowerCase();
-  const lowerCasedSha1 = getSha1(lowerCasedEmail);
+  const lowerCasedSha1 = getSha1.getSha1ForHIBP(emailAddress);
   await HIBP.subscribeHash(lowerCasedSha1);
   return lowerCasedSha1;
 }

--- a/scripts/make-sha1-hashes.js
+++ b/scripts/make-sha1-hashes.js
@@ -9,7 +9,7 @@ console.log(PROMPT);
 
 stdin.addListener("data", data => {
   const trimmedString = data.toString().trim();
-  const sha1 = getSha1(trimmedString);
+  const sha1 = getSha1.getSha1ForHIBP(trimmedString);
   console.log(`You entered: [${trimmedString}], sha1 hash of lowercase: ${sha1}`);
   console.log(PROMPT);
 });

--- a/scripts/send-breach-notification.js
+++ b/scripts/send-breach-notification.js
@@ -29,9 +29,9 @@ LocaleUtils.loadLanguagesIntoApp(app);
   };
   rl.question("What email address? ", (answer) => {
     emailAddress = answer;
-    const hash = sha1(emailAddress);
-    const hashPrefix = hash.slice(0, 6).toUpperCase();
-    const hashSuffix = hash.slice(6).toUpperCase();
+    const hash = sha1.getSha1ForHIBP(emailAddress);
+    const hashPrefix = hash.slice(0, 6);
+    const hashSuffix = hash.slice(6);
     rl.question("What breach name? ", async (answer) => {
       breachName = answer;
       const req = {

--- a/scripts/subscribe-lowercase-hashes.js
+++ b/scripts/subscribe-lowercase-hashes.js
@@ -11,8 +11,7 @@ const getSha1 = require("../sha1-utils");
 
 
 async function subscribeLowercaseHashToHIBP(emailAddress) {
-  const lowerCasedEmail = emailAddress.toLowerCase();
-  const lowerCasedSha1 = getSha1(lowerCasedEmail);
+  const lowerCasedSha1 = getSha1.getSha1ForHIBP(emailAddress);
   await HIBP.subscribeHash(lowerCasedSha1);
   return lowerCasedSha1;
 }

--- a/sha1-utils.js
+++ b/sha1-utils.js
@@ -2,8 +2,23 @@
 
 const crypto = require("crypto");
 
-function getSha1(email) {
-  return crypto.createHash("sha1").update(email).digest("hex");
+// Email addresses must be lowercased before hashing
+// Hashes sent to HIBP should be uppercased
+function getSha1ForHIBP (email) {
+  const formattedEmail = email.toLowerCase();
+  const emailHash = crypto.createHash("sha1").update(formattedEmail).digest("hex");
+  return emailHash.toUpperCase();
 }
 
-module.exports = getSha1;
+// Email addresses must be lowercased before hashing
+// Hashes that are stored in our DB should be lowercased
+// The "crypto" hash library returns hashes with lowercase letters by default
+function getLowerCaseSha1(email) {
+  const formattedEmail = email.toLowerCase();
+  return crypto.createHash("sha1").update(formattedEmail).digest("hex");
+}
+
+module.exports = {
+  getSha1ForHIBP,
+  getLowerCaseSha1,
+};

--- a/tests/controllers/hibp.test.js
+++ b/tests/controllers/hibp.test.js
@@ -14,9 +14,9 @@ require("../resetDB");
 
 test("notify POST without token should throw error", async() => {
   const testEmail = "victim@spoofattack.com";
-  const testHash = sha1(testEmail);
-  const testPrefix = testHash.slice(0, 6).toUpperCase();
-  const testSuffix = testHash.slice(6).toUpperCase();
+  const testHash = sha1.getSha1ForHIBP(testEmail);
+  const testPrefix = testHash.slice(0, 6);
+  const testSuffix = testHash.slice(6);
 
   const mockRequest = { body: { hashPrefix: testPrefix, hashSuffixes: [testSuffix], breachName: "SomeSensitiveBreach" } };
   const mockResponse = { status: jest.fn(), json: jest.fn() };
@@ -27,10 +27,9 @@ test("notify POST without token should throw error", async() => {
 
 test("notify POST with invalid token should throw error", async() => {
   const testEmail = "victim@spoofattack.com";
-  const testHash = sha1(testEmail);
-  const testPrefix = testHash.slice(0, 6).toUpperCase();
-  const testSuffix = testHash.slice(6).toUpperCase();
-
+  const testHash = sha1.getSha1ForHIBP(testEmail);
+  const testPrefix = testHash.slice(0, 6);
+  const testSuffix = testHash.slice(6);
   const mockRequest = { token: "token-that-doesnt-match-AppConstants", body: { hashPrefix: testPrefix, hashSuffixes: [testSuffix], breachName: "SomeSensitiveBreach" } };
   const mockResponse = { status: jest.fn(), json: jest.fn() };
 
@@ -47,9 +46,9 @@ async function checkNotifyCallsEverythingItShould(breachedEmail, recipientEmail)
   LocaleUtils.fluentFormat = jest.fn();
   HIBPLib.getBreachesForEmail = jest.fn();
 
-  const testHash = sha1(breachedEmail);
-  const testPrefix = testHash.slice(0, 6).toUpperCase();
-  const testSuffix = testHash.slice(6).toUpperCase();
+  const testHash = sha1.getSha1ForHIBP(breachedEmail);
+  const testPrefix = testHash.slice(0, 6);
+  const testSuffix = testHash.slice(6);
   const mockRequest = { token: AppConstants.HIBP_NOTIFY_TOKEN, body: { hashPrefix: testPrefix, hashSuffixes: [testSuffix], breachName: "Test" }, app: { locals: { breaches: testBreaches, AVAILABLE_LANGUAGES: ["en"] } } };
   const mockResponse = { status: jest.fn(), json: jest.fn() };
 
@@ -98,9 +97,9 @@ test("notify POST with unknown breach should throw error", async () => {
   jest.mock("../../hibp");
   HIBPLib.loadBreachesIntoApp = jest.fn();
   const testEmail = "test@example.com";
-  const testHash = sha1(testEmail);
-  const testPrefix = testHash.slice(0, 6).toUpperCase();
-  const testSuffix = testHash.slice(6).toUpperCase();
+  const testHash = sha1.getSha1ForHIBP(testEmail);
+  const testPrefix = testHash.slice(0, 6);
+  const testSuffix = testHash.slice(6);
 
   const mockRequest = { token: AppConstants.HIBP_NOTIFY_TOKEN, body: { hashPrefix: testPrefix, hashSuffixes: [testSuffix], breachName: "Test" }, app: { locals: { breaches: [] } } };
   const mockResponse = { status: jest.fn(), json: jest.fn() };
@@ -120,9 +119,9 @@ test("notify POST for subscriber with no signup_language should default to en", 
 
   await DB.addSubscriber(testEmail);
 
-  const testHash = sha1(testEmail);
-  const testPrefix = testHash.slice(0, 6).toUpperCase();
-  const testSuffix = testHash.slice(6).toUpperCase();
+  const testHash = sha1.getSha1ForHIBP(testEmail);
+  const testPrefix = testHash.slice(0, 6);
+  const testSuffix = testHash.slice(6);
 
   const mockRequest = { token: AppConstants.HIBP_NOTIFY_TOKEN, body: { hashPrefix: testPrefix, hashSuffixes: [testSuffix], breachName: "Test" }, app: { locals: { breaches: testBreaches } } };
   const mockResponse = { status: jest.fn(), json: jest.fn() };

--- a/tests/controllers/oauth.test.js
+++ b/tests/controllers/oauth.test.js
@@ -64,7 +64,7 @@ test("confirmed request checks session cookie, calls FXA for token and email, ad
   expect(mockGotCallArgs[0]).toMatch(AppConstants.OAUTH_PROFILE_URI);
   expect(mockGotCallArgs[1].headers.Authorization).toMatch("testToken");
 
-  const subscribers = await DB.getSubscribersByHashes([getSha1(testFxAEmail)]);
+  const subscribers = await DB.getSubscribersByHashes([getSha1.getLowerCaseSha1(testFxAEmail)]);
   expect(subscribers[0].primary_verified).toBeTruthy();
   expect(subscribers[0].primary_email).toBe(testFxAEmail);
   expect(subscribers[0].signup_language).toBe(userAddLanguages);

--- a/tests/controllers/scan.test.js
+++ b/tests/controllers/scan.test.js
@@ -26,7 +26,7 @@ test("scan POST with empty email hash redirects to home", () => {
 
 
 test("scan POST with hash of empty string redirects to home", () => {
-  mockRequest.body = { emailHash: sha1("") };
+  mockRequest.body = { emailHash: sha1.getSha1ForHIBP("") };
 
   shouldRedirectHome(scan.post, mockRequest);
 });
@@ -36,7 +36,7 @@ test("scan POST with hash should render scan with foundBreaches", async () => {
   const testEmail = "test@example.com";
   const testFoundBreaches = [];
 
-  mockRequest.body = { emailHash: sha1(testEmail) };
+  mockRequest.body = { emailHash: sha1.getSha1ForHIBP(testEmail) };
   mockRequest.app = { locals: { breaches: testBreaches } };
   mockRequest.session = { user: null };
 

--- a/tests/controllers/ses.test.js
+++ b/tests/controllers/ses.test.js
@@ -26,7 +26,7 @@ const createRequestBody = function(notificationType) {
 test("ses notification with Permanent bounce unsubscribes recipient subscriber", async () => {
   // TODO: restore tests for ["General", "NoEmail", "Suppressed"] sub types
   const testEmail = "bounce@simulator.amazonses.com";
-  const testHashes = [getSha1(testEmail)];
+  const testHashes = [getSha1.getLowerCaseSha1(testEmail)];
 
   await DB.addSubscriber(testEmail);
   let subscribers = await DB.getSubscribersByHashes(testHashes);
@@ -51,7 +51,7 @@ test("ses notification with Complaint unsubscribes recipient subscriber", async 
   const testEmail = "complaint@simulator.amazonses.com";
 
   await DB.addSubscriber(testEmail);
-  let subscribers = await DB.getSubscribersByHashes([getSha1(testEmail)]);
+  let subscribers = await DB.getSubscribersByHashes([getSha1.getLowerCaseSha1(testEmail)]);
   expect(subscribers.length).toEqual(1);
 
   const req = httpMocks.createRequest({
@@ -64,7 +64,7 @@ test("ses notification with Complaint unsubscribes recipient subscriber", async 
   await ses.notification(req, resp);
   expect(resp.statusCode).toEqual(200);
 
-  subscribers = await DB.getSubscribersByHashes([getSha1(testEmail)]);
+  subscribers = await DB.getSubscribersByHashes([getSha1.getLowerCaseSha1(testEmail)]);
   expect(subscribers.length).toEqual(0);
 });
 
@@ -95,7 +95,7 @@ test("ses notification with invalid signature responds with error and doesn't ch
   const testEmail = "complaint@simulator.amazonses.com";
 
   await DB.addSubscriber(testEmail);
-  let subscribers = await DB.getSubscribersByHashes([getSha1(testEmail)]);
+  let subscribers = await DB.getSubscribersByHashes([getSha1.getLowerCaseSha1(testEmail)]);
   expect(subscribers.length).toEqual(1);
 
   const req = httpMocks.createRequest({
@@ -108,7 +108,7 @@ test("ses notification with invalid signature responds with error and doesn't ch
   await expect(ses.notification(req, resp)).rejects.toMatch("invalid");
   expect(resp.statusCode).toEqual(401);
 
-  subscribers = await DB.getSubscribersByHashes([getSha1(testEmail)]);
+  subscribers = await DB.getSubscribersByHashes([getSha1.getLowerCaseSha1(testEmail)]);
   expect(subscribers.length).toEqual(1);
 });
 
@@ -122,7 +122,7 @@ test("sns notification for FxA account deletes monitor subscriber record", async
   const testFxaProfileData = JSON.stringify({uid: testFxaUID});
   await DB.addSubscriber(testEmail, testSignupLanguage, testFxaAccessToken, testFxaRefreshToken, testFxaProfileData);
 
-  let subscribers = await DB.getSubscribersByHashes([getSha1(testEmail)]);
+  let subscribers = await DB.getSubscribersByHashes([getSha1.getLowerCaseSha1(testEmail)]);
   expect(subscribers.length).toEqual(1);
 
   const req = httpMocks.createRequest({
@@ -134,6 +134,6 @@ test("sns notification for FxA account deletes monitor subscriber record", async
   await ses.notification(req, resp);
   expect(resp.statusCode).toEqual(200);
 
-  subscribers = await DB.getSubscribersByHashes([getSha1(testEmail)]);
+  subscribers = await DB.getSubscribersByHashes([getSha1.getLowerCaseSha1(testEmail)]);
   expect(subscribers.length).toEqual(0);
 });

--- a/tests/controllers/user.test.js
+++ b/tests/controllers/user.test.js
@@ -106,7 +106,7 @@ test("user add POST with upperCaseAddress adds email_address record with lowerca
   const testSubscriberEmailAddresses = testSubscriberEmailAddressRecords.map(record => record.email);
   expect(testSubscriberEmailAddresses.includes(testUserAddEmail)).toBeTruthy();
   const testSubscriberEmailAddressHashes = testSubscriberEmailAddressRecords.map(record => record.sha1);
-  expect(testSubscriberEmailAddressHashes.includes(getSha1(testUserAddEmail))).toBeTruthy();
+  expect(testSubscriberEmailAddressHashes.includes(getSha1.getLowerCaseSha1(testUserAddEmail))).toBeTruthy();
 });
 
 
@@ -304,7 +304,7 @@ test("user verify request with invalid token returns error", async () => {
 test("user unsubscribe GET request with valid token and hash for primary/subscriber record returns 302 to preferences", async () => {
   // from db/seeds/test_subscribers.js
   const subscriberToken = TEST_SUBSCRIBERS.firefox_account.primary_verification_token;
-  const subscriberHash = getSha1(TEST_SUBSCRIBERS.firefox_account.primary_email);
+  const subscriberHash = getSha1.getLowerCaseSha1(TEST_SUBSCRIBERS.firefox_account.primary_email);
 
   // Set up mocks
   const req = { fluentFormat: jest.fn(), query: { token: subscriberToken, hash: subscriberHash } };
@@ -321,7 +321,7 @@ test("user unsubscribe GET request with valid token and hash for primary/subscri
 test("user unsubscribe GET request with valid token and hash for a secondary email_addresses record renders unsubscribe", async () => {
   // from db/seeds/test_subscribers.js
   const subscriberToken = TEST_EMAIL_ADDRESSES.firefox_account.verification_token;
-  const subscriberHash = getSha1(TEST_EMAIL_ADDRESSES.firefox_account.email);
+  const subscriberHash = getSha1.getLowerCaseSha1(TEST_EMAIL_ADDRESSES.firefox_account.email);
 
   // Set up mocks
   const req = { fluentFormat: jest.fn(), query: { token: subscriberToken, hash: subscriberHash } };
@@ -338,7 +338,7 @@ test("user unsubscribe GET request with valid token and hash for a secondary ema
 test("user unsubscribe GET request with valid token and hash for an old pre-FxA subscriber record renders unsubscribe", async () => {
   // from db/seeds/test_subscribers.js
   const subscriberToken = TEST_SUBSCRIBERS.verified_email.primary_verification_token;
-  const subscriberHash = getSha1(TEST_SUBSCRIBERS.firefox_account.primary_email);
+  const subscriberHash = getSha1.getLowerCaseSha1(TEST_SUBSCRIBERS.firefox_account.primary_email);
 
   // Set up mocks
   const req = { fluentFormat: jest.fn(), query: { token: subscriberToken, hash: subscriberHash } };

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -31,7 +31,7 @@ test("getSubscribersByHashes accepts hashes and only returns verified subscriber
     "firefoxaccount@test.com",
     "unverifiedemail@test.com",
     "verifiedemail@test.com",
-  ].map(email => getSha1(email));
+  ].map(email => getSha1.getLowerCaseSha1(email));
   const subscribers = await DB.getSubscribersByHashes(testHashes);
   for (const subscriber of subscribers) {
     expect(subscriber.primary_verified).toBeTruthy();
@@ -43,7 +43,7 @@ test("getEmailAddressesByHashes accepts hashes and only returns verified email_a
   const testHashes = [
     "firefoxaccount-secondary@test.com",
     "firefoxaccount-tertiary@test.com",
-  ].map(email => getSha1(email));
+  ].map(email => getSha1.getLowerCaseSha1(email));
   const emailAddresses = await DB.getEmailAddressesByHashes(testHashes);
   for (const emailAddress of emailAddresses) {
     expect(emailAddress.verified).toBeTruthy();
@@ -72,7 +72,7 @@ test("addSubscriberUnverifiedEmailHash accepts user and email and returns unveri
   const subscriber = await DB.getSubscriberByEmail("firefoxaccount@test.com");
 
   const unverifiedEmailAddress = await DB.addSubscriberUnverifiedEmailHash(subscriber, testEmail);
-  expect(unverifiedEmailAddress.sha1).toBe(getSha1(testEmail));
+  expect(unverifiedEmailAddress.sha1).toBe(getSha1.getLowerCaseSha1(testEmail));
   expect(uuidRE.test(unverifiedEmailAddress.verification_token)).toBeTruthy();
   expect(unverifiedEmailAddress.verified).toBeFalsy();
 });
@@ -87,7 +87,7 @@ test("verifyEmailHash accepts token and returns verified subscriber", async () =
 
   HIBP.subscribeHash.mockResolvedValue(true);
   const verifiedEmailAddress = await DB.verifyEmailHash(unverifiedEmailAddress.verification_token);
-  expect(verifiedEmailAddress.sha1).toBe(getSha1(testEmail));
+  expect(verifiedEmailAddress.sha1).toBe(getSha1.getLowerCaseSha1(testEmail));
   expect(verifiedEmailAddress.verified).toBeTruthy();
 });
 
@@ -106,7 +106,7 @@ test("addSubscriber accepts email, language and returns verified subscriber", as
 
   expect(verifiedSubscriber.primary_email).toBe(testEmail);
   expect(verifiedSubscriber.primary_verified).toBeTruthy();
-  expect(verifiedSubscriber.primary_sha1).toBe(getSha1(testEmail));
+  expect(verifiedSubscriber.primary_sha1).toBe(getSha1.getLowerCaseSha1(testEmail));
 });
 
 
@@ -117,7 +117,7 @@ test("addSubscriber with existing email updates updated_at", async () => {
 
   expect(verifiedSubscriber.primary_email).toBe(testEmail);
   expect(verifiedSubscriber.primary_verified).toBeTruthy();
-  expect(verifiedSubscriber.primary_sha1).toBe(getSha1(testEmail));
+  expect(verifiedSubscriber.primary_sha1).toBe(getSha1.getLowerCaseSha1(testEmail));
   const updatedAt = verifiedSubscriber.updated_at;
 
   await sleep(1000);
@@ -126,7 +126,7 @@ test("addSubscriber with existing email updates updated_at", async () => {
 
   expect(verifiedSubscriber.primary_email).toBe(testEmail);
   expect(verifiedSubscriber.primary_verified).toBeTruthy();
-  expect(verifiedSubscriber.primary_sha1).toBe(getSha1(testEmail));
+  expect(verifiedSubscriber.primary_sha1).toBe(getSha1.getLowerCaseSha1(testEmail));
   expect(verifiedSubscriber.updated_at).not.toBe(updatedAt);
 });
 
@@ -137,7 +137,7 @@ test("addSubscriber accepts upperCasedAddress, and returns verified subscriber w
   const verifiedSubscriber = await DB.addSubscriber(testEmail);
 
   expect(verifiedSubscriber.primary_email).toBe(testEmail);
-  expect(verifiedSubscriber.primary_sha1).toBe(getSha1(testEmail.toLowerCase()));
+  expect(verifiedSubscriber.primary_sha1).toBe(getSha1.getLowerCaseSha1(testEmail));
 });
 
 
@@ -181,11 +181,11 @@ test("removeEmail accepts email and removes from subscribers table", async () =>
   const testEmail = "removingfirefoxaccount@test.com";
 
   const verifiedSubscriber = await DB.addSubscriber(testEmail);
-  const subscribers = await DB.getSubscribersByHashes([getSha1(testEmail)]);
+  const subscribers = await DB.getSubscribersByHashes([getSha1.getLowerCaseSha1(testEmail)]);
   expect(subscribers.length).toEqual(1);
 
   await DB.removeEmail(verifiedSubscriber.primary_email);
-  const noMoreSubscribers = await DB.getSubscribersByHashes([getSha1(testEmail)]);
+  const noMoreSubscribers = await DB.getSubscribersByHashes([getSha1.getLowerCaseSha1(testEmail)]);
   expect(noMoreSubscribers.length).toEqual(0);
 });
 

--- a/tests/hibp.test.js
+++ b/tests/hibp.test.js
@@ -69,7 +69,7 @@ test("getBreachesForEmail HIBP responses with status of 429 cause throttled retr
   got.mockClear();
   got.mockRejectedValue( { statusCode: 429 });
 
-  await expect(hibp.getBreachesForEmail(getSha1("unverifiedemail@test.com"), testBreaches)).rejects.toThrow("error-hibp-throttled");
+  await expect(hibp.getBreachesForEmail(getSha1.getSha1ForHIBP("unverifiedemail@test.com"), testBreaches)).rejects.toThrow("error-hibp-throttled");
 
   const gotCalls = got.mock.calls;
   expect(gotCalls.length).toEqual(Number(AppConstants.HIBP_THROTTLE_MAX_TRIES));

--- a/tests/sha1.test.js
+++ b/tests/sha1.test.js
@@ -14,5 +14,5 @@ function isHexString(hashDigest) {
 
 
 test("getSha1 returns hex digest", () => {
-  expect(isHexString(getSha1("test@test.com"))).toBeTruthy();
+  expect(isHexString(getSha1.getSha1ForHIBP("test@test.com"))).toBeTruthy();
 });


### PR DESCRIPTION
Replaces our single `sha1()` function with `getSha1ForHIBP()` and `getLowerCasedSha1()` which should return hashes correctly formatted for the purpose. This will hopefully help us cut down on the .toUpperCase()/.toLowerCase()/.toBasketCase() shenanigans. 

`getSha1ForHIBP(emailAddress)` 
- converts emailAddress to lowercase letters before hashing
- converts the hash to uppercase letters.
- should be used anytime we're creating a hash for scanning HIBP

`getLowerCaseSha1(emailAddress)` 
- converts emailAddress to lowercase letters before hashing
- leaves the hash in lowercase letters to be stored in our DB.
- should be used anytime a hash is being created for storing in our DB, or for finding something in our DB. 


TODO:
It would be great to add some related tests and a readme documenting the Laws of Monitor Casing. 