### PR TITLE
set custom dimension for signed-in user state

### DIFF
--- a/public/js/fxa-analytics.js
+++ b/public/js/fxa-analytics.js
@@ -31,10 +31,6 @@ async function sendPing(el, eventAction, eventLabel = null) {
       eventLabel = `${getLocation()}`;
     }
     const eventCategory = `[v2] ${el.dataset.eventCategory}`;
-    if (eventCategory.includes("Scan")) {
-      // Append user status to eventLabel for scan form events.
-      eventLabel = `${eventLabel} [Signed in user: ${document.body.dataset.signedInUser}]`;
-    }
     return ga("send", "event", eventCategory, eventAction, eventLabel);
   }
 }
@@ -119,6 +115,7 @@ function sendRecommendationPings(ctaSelector) {
     ga("create", "UA-77033033-16");
     ga("set", "anonymizeIp", true);
     ga("set", "transport", "beacon");
+    ga("set", "dimension6", `${document.body.dataset.signedInUser}`);
 
     ga("send", "pageview", {
       hitCallback: function() {


### PR DESCRIPTION
I'm not sure which scope level these should be? I set them to `hit` level in GA, but if we think they should be session, user, or period we can change it.