### PR TITLE
Fix #1540 - The same email can be added multiple times

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -87,11 +87,12 @@ async function resolveBreach(req, res) {
 
 
 function _checkForDuplicateEmail(sessionUser, email) {
-  if (email === sessionUser.primary_email) {
+  email = email.toLowerCase();
+  if (email === sessionUser.primary_email.toLowerCase()) {
     throw new FluentError("user-add-duplicate-email");
   }
   for (const secondaryEmail of sessionUser.email_addresses) {
-    if (email === secondaryEmail.email) {
+    if (email === secondaryEmail.email.toLowerCase()) {
       throw new FluentError("user-add-duplicate-email");
     }
   }


### PR DESCRIPTION
Fixes the bug that allows the same email to be added to the same account many times as long as the letter casing is different.