### PR TITLE
Add strings for Firefox Mobile promo

### DIFF
--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -12,7 +12,6 @@
 -brand-lockwise = Firefox Lockwise
 -brand-send = Firefox Send
 -brand-fpn = Firefox Private Network
--brand-fx-mobile = Firefox Mobile
 ##
 
 terms-and-privacy = Terms & Privacy
@@ -674,5 +673,5 @@ new-breach = New
 
 promo-fx-mobile-headline = Privacy and speed on mobile
 promo-fx-mobile-body = 
-  The {-brand-name} browser is super fast, private by default, and blocks 2,000+ online trackers.
-promo-fx-mobile-cta = Get {-brand-fx-mobile}
+  The { -brand-name } browser is super fast, private by default, and blocks 2,000+ online trackers.
+promo-fx-mobile-cta = Get { -brand-name } Mobile

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -12,6 +12,7 @@
 -brand-lockwise = Firefox Lockwise
 -brand-send = Firefox Send
 -brand-fpn = Firefox Private Network
+-brand-fx-mobile = Firefox Mobile
 ##
 
 terms-and-privacy = Terms & Privacy
@@ -670,3 +671,8 @@ known-data-breaches-resolved =
 
 # A status indicator that appears in the top right corner of new breach cards
 new-breach = New
+
+promo-fx-mobile-headline = Privacy and speed on mobile
+promo-fx-mobile-body = 
+  The {-brand-name} browser is super fast, private by default, and blocks 2,000+ online trackers.
+promo-fx-mobile-cta = Get {-brand-fx-mobile}


### PR DESCRIPTION
Adds strings for a Firefox Mobile promo that will appear on `/breach-details` pages.

<img width="819" alt="Screen Shot 2020-02-21 at 1 48 36 PM" src="https://user-images.githubusercontent.com/22355127/75066713-0949d680-54b1-11ea-8540-523f6037de70.png">
