### PR TITLE
split relay test helpers and display logic

### DIFF
--- a/template-helpers/dashboard.js
+++ b/template-helpers/dashboard.js
@@ -4,16 +4,12 @@ const { LocaleUtils } = require("./../locale-utils");
 const { makeBreachCards } = require("./breaches");
 const { hasUserSignedUpForRelay } = require("./../controllers/utils");
 
-function showRelayCallout(args) {
-  const enLocaleIsSupported = args.data.root.req.headers["accept-language"].includes("en");
-  const userIsOnRelayWaitList = hasUserSignedUpForRelay(args.data.root.req.user);
-  const userIsOnDashboard = args.data.root.whichPartial = "dashboards/breaches-dash";
+function enLocaleIsSupported(args) {
+  return args.data.root.req.headers["accept-language"].includes("en");
+}
 
-  if ((userIsOnDashboard && !enLocaleIsSupported) || userIsOnRelayWaitList) {
-    return false;
-  }
-
-  return true;
+function userIsOnRelayWaitList(args) {
+  return hasUserSignedUpForRelay(args.data.root.req.user);
 }
 
 function getBreachesDashboard(args) {
@@ -191,5 +187,6 @@ module.exports = {
   getLastAddedEmailStrings,
   makeEmailVerifiedString,
   makeEmailAddedToSubscriptionString,
-  showRelayCallout,
+  enLocaleIsSupported,
+  userIsOnRelayWaitList,
 };

--- a/views/partials/dashboards/breaches-dash.hbs
+++ b/views/partials/dashboards/breaches-dash.hbs
@@ -40,7 +40,8 @@
       {{#eachFromTo this.verifiedEmails 0 1 }}
         {{> email-card }}
       {{/eachFromTo}}
-      {{#if (showRelayCallout)}}
+      {{#if (enLocaleIsSupported) }}
+        {{#unless (userIsOnRelayWaitList) }}
         <div class="private-relay-dashboard-card">
           <a href="/protect-my-email" class="private-relay-dashboard-card-border flx private-relay-cta" data-analytics-label="join-the-waitlist-link" data-user-is-signed-up={{ ./../userHasSignedUpForRelay }}>
             <div class="private-relay-dashboard-card-content flx">
@@ -52,6 +53,7 @@
             </div>
           </a>
         </div>
+        {{/unless}}
       {{/if}}
       {{#eachFromTo this.verifiedEmails 1 this.verifiedEmails.length }}
         {{> email-card }}

--- a/views/private-relay.hbs
+++ b/views/private-relay.hbs
@@ -25,7 +25,7 @@
 
   </div>
   <div class="row relay-sign-up-wrapper">
-    <div class="relay-sign-up txt-cntr {{#unless (showRelayCallout)}} email-sent {{/unless}}">
+    <div class="relay-sign-up txt-cntr {{#if (userIsOnRelayWaitList)}} email-sent {{/if}}">
       <div class="relay-sign-up-content flx flx-col jst-cntr">
         <h2 class="relay-sign-up-headline">Join the waitlist for updates</h2>
           <img alt="{{ req.session.user.primary_email }}" class="relay-avatar" src="{{ req.session.user.fxa_profile_json.avatar }}"/>


### PR DESCRIPTION
Fixes last little bug in relay test logic ...

1. Change your Firefox to only accept `de` - no `en`
2. Go straight to http://localhost:6060/protect-my-email

Expected results:
Should show “Join the waitlist for updates”

Actual results:
It says “You’re on the list!” even though the user hasn’t signed up for the list.

This happens because the logic for `enLocalesIsSupported` and `hasUserSignedUpForRelay` where combined into the single `showRelayCallout` function, but the logic to display the blocks needed to be a little bit different on each page where it was used.

This PR to split those back out and use them separately on each page.