### PR TITLE
Fixed #1552 - Verify Email Link UTM Params

### DIFF
--- a/email-utils.js
+++ b/email-utils.js
@@ -107,8 +107,8 @@ const EmailUtils = {
 
   getVerificationUrl(subscriber) {
     let url = new URL(`${AppConstants.SERVER_URL}/user/verify`);
-    url.searchParams.append("token", encodeURIComponent(subscriber.verification_token));
     url = this.appendUtmParams(url, "verified-subscribers", "account-verification-email");
+    url.searchParams.append("token", encodeURIComponent(subscriber.verification_token));
     return url;
   },
 


### PR DESCRIPTION
Reordered token param to be at the **end** of the verification URL.