### PR TITLE
Fixed #1669 - Set default dataset to use SERVER_URL.hostname

### DIFF
--- a/public/js/fxa-analytics.js
+++ b/public/js/fxa-analytics.js
@@ -46,7 +46,7 @@ function appendFxaParams(url, storageObject) {
 
 function getFxaUtms(url) {
   if (sessionStorage) {
-    return appendFxaParams(url, sessionStorage);
+    url = appendFxaParams(url, sessionStorage);
   }
 
   return appendFxaParams(url, document.body.dataset);

--- a/views/partials/analytics/default_dataset.hbs
+++ b/views/partials/analytics/default_dataset.hbs
@@ -2,11 +2,7 @@ data-server-url="{{ SERVER_URL }}"
 data-logos-origin="{{ LOGOS_ORIGIN }}"
 data-fxa-enabled="fxa-enabled"
 data-fxa-address={{ getFxaUrl }}
-{{#if req.session.experimentBranch}}
-  data-utm_source="{{ UTM_SOURCE }}"
-{{else}}
-  data-utm_source="{{ SERVER_URL }}"
-{{/if}}
+data-utm_source="{{ UTM_SOURCE }}"
 
 {{#if req.session.user}}
   data-signed-in-user="true"


### PR DESCRIPTION
## To verify: 

Start the OAUth process and examine the URL. Check the `utm_source` param. It should be the `.hostname` of whatever dev site URL you're testing on. 

Example: On dev master: `utm_source=fx-breach-alerts.herokuapp.com`