### PR TITLE
fix #1685: add resolved stats to breach-stats

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -559,11 +559,17 @@ async function getBreachStats(req, res) {
   const allBreaches = req.app.locals.breaches;
   const { verifiedEmails } = await getAllEmailsAndBreaches(user, allBreaches);
   const breachStats = resultsSummary(verifiedEmails);
-  return res.json({
+  const baseStats = {
     monitoredEmails: breachStats.monitoredEmails.count,
     numBreaches: breachStats.numBreaches.count,
     passwords: breachStats.passwords.count,
-  });
+  };
+  const resolvedStats = {
+    numBreachesResolved: breachStats.numBreaches.numResolved,
+    passwordsResolved: breachStats.passwords.numResolved,
+  };
+  const returnStats = (req.query.includeResolved === "true") ? Object.assign(baseStats, resolvedStats) : baseStats;
+  return res.json(returnStats);
   }
 
 

--- a/tests/controllers/user.test.js
+++ b/tests/controllers/user.test.js
@@ -631,6 +631,7 @@ test("user breach-stats POST request with FXA response for Monitor user returns 
   const req = {
     token: "test-token",
     app: { locals: { breaches: testBreaches } },
+    query: {},
   };
   FXA.verifyOAuthToken = jest.fn();
   FXA.verifyOAuthToken.mockReturnValueOnce({
@@ -652,5 +653,38 @@ test("user breach-stats POST request with FXA response for Monitor user returns 
     monitoredEmails: expect.anything(),
     numBreaches: expect.anything(),
     passwords: expect.anything(),
+  });
+});
+
+
+test("user breach-stats POST request with includeResolved returns breach stats json with resolved", async () => {
+  const testSubscriberFxAUID = TEST_SUBSCRIBERS.firefox_account.fxa_uid;
+  const req = {
+    token: "test-token",
+    app: { locals: { breaches: testBreaches } },
+    query: {includeResolved: "true"},
+  };
+  FXA.verifyOAuthToken = jest.fn();
+  FXA.verifyOAuthToken.mockReturnValueOnce({
+      body: {
+        scope: [user.FXA_MONITOR_SCOPE],
+        user: testSubscriberFxAUID,
+      },
+  });
+  HIBP.getBreachesForEmail = jest.fn();
+  HIBP.getBreachesForEmail.mockReturnValue([]);
+
+  const resp = { json: jest.fn() };
+
+  await user.getBreachStats(req, resp);
+
+  const jsonCallArgs = resp.json.mock.calls[0];
+
+  expect(jsonCallArgs[0]).toMatchObject({
+    monitoredEmails: expect.anything(),
+    numBreaches: expect.anything(),
+    passwords: expect.anything(),
+    numBreachesResolved: expect.anything(),
+    passwordsResolved: expect.anything(),
   });
 });


### PR DESCRIPTION
Still need to figure out spot-checking instructions. It needs a Firefox configured to use stable FXA env in order to get a token that works on http://localhost:6060/user/breach-stats.

curl command would be:
```
curl 'http://localhost:6060/user/breach-stats' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:78.0) Gecko/20100101 Firefox/78.0' -H 'Accept: */*' -H 'Accept-Language: en-US,en;q=0.7,de;q=0.3' --compressed -H 'authorization: Bearer <stable auth token for the FXA user goes here!>' -H 'Connection: keep-alive' -H 'Sec-Fetch-Dest: empty' -H 'Sec-Fetch-Mode: cors' -H 'Sec-Fetch-Site: cross-site' -H 'TE: Trailers'
```