### PR TITLE
Fixed #1764 - Revised entry-point IDs to be consistent

### DIFF
--- a/views/partials/forms/scan-email-form.hbs
+++ b/views/partials/forms/scan-email-form.hbs
@@ -21,21 +21,9 @@
   {{/if}}
   <div class="input-group-button">
     {{#if featuredBreach}}
-        <input class="breachesSubmitButton add-metrics-flow-values" data-form_type="other"
-          {{#if experimentFlags.treatmentBranch }}
-            {{> analytics/fxa id="fx-monitor-homepage-find-out-blue-btn-exp4v2" }}
-          {{else}}
-            {{> analytics/fxa id="fx-monitor-homepage-find-out-blue-btn" }}
-          {{/if}}
-        type="submit" value="{{ getString "find-out" }}"/>
+        <input class="breachesSubmitButton add-metrics-flow-values" data-form_type="other" {{> analytics/fxa id="fx-monitor-find-out-blue-btn" }} type="submit" value="{{ getString "find-out" }}"/>
     {{else}}
-        <input class="breachesSubmitButton add-metrics-flow-values" data-form_type="other"
-          {{#if experimentFlags.treatmentBranch }}
-            {{> analytics/fxa id="fx-monitor-homepage-check-for-breaches-blue-btn-checked-exp4v2" }}
-          {{else}}
-            {{> analytics/fxa id="fx-monitor-homepage-check-for-breaches-blue-btn" }}
-          {{/if}}
-        type="submit" value="{{ getString "check-for-breaches" }}"/>
+        <input class="breachesSubmitButton add-metrics-flow-values" data-form_type="other" {{> analytics/fxa id="fx-monitor-check-for-breaches-blue-btn" }} type="submit" value="{{ getString "check-for-breaches" }}"/>
     {{/if}}
       {{> forms/loader }}
   </div>

--- a/views/scan.hbs
+++ b/views/scan.hbs
@@ -16,13 +16,7 @@
         <h2 class="headline scan-results-headline">{{{ fluentNestedBold "scan-results-known-breaches" breachCount=foundBreaches.length }}}</h2>
         <button id="new-scan-page"
           class="open-oauth temp-marketing-btn-blue button-top"
-          {{#if experimentFlags.controlBranch }}
-            {{> analytics/fxa id="fx-monitor-scan-alert-me-blue-btn-top-exp4v2" }}
-          {{else if experimentFlags.treatmentBranch }}
-            {{> analytics/fxa id="fx-monitor-scan-alert-me-blue-btn-top-unchecked-exp4v2" }}
-          {{else}}
-            {{> analytics/fxa id="fx-monitor-scan-alert-me-blue-btn-top" }}
-          {{/if}}
+          {{> analytics/fxa id="fx-monitor-alert-me-blue-btn-top" }}
           data-event-category="Alert me about new breaches"> {{ getString "alert-about-new-breaches" }} </button>
       {{/if}}
     </div>
@@ -52,13 +46,7 @@
         between this button and the "Alert me.." button on the other version of the scan results page easier
       -->
     <button class="open-oauth temp-marketing-btn-blue "
-    {{#if experimentFlags.controlBranch }}
-      {{> analytics/fxa id="fx-monitor-scan-alert-me-blue-btn-bottom-exp4v2" }}
-    {{else if experimentFlags.treatmentBranch }}
-      {{> analytics/fxa id="fx-monitor-scan-alert-me-blue-btn-bottom-unchecked-exp4v2" }}
-    {{else}}
-      {{> analytics/fxa id="fx-monitor-scan-alert-me-blue-btn-bottom" }}
-    {{/if}}
+      {{> analytics/fxa id="fx-monitor-alert-me-blue-btn-bottom" }}
       data-event-category="Alert me about new breaches - Banner">{{ getString "alert-about-new-breaches" }}</button>
     {{> sign-up-banners/browser-not-required }}
   </div>


### PR DESCRIPTION
Fixes #1764 

This PR removes experiment-specific IDs and places the same ID on entrypoint elements, regardless of experiment branch (or exclusion).

To test, click on one of the following entry points. Check the URL that is sent to FxA to validate the entry point: 

Homepage: `fx-monitor-check-for-breaches-blue-btn`
![image](https://user-images.githubusercontent.com/2692333/86046659-397f2400-ba13-11ea-8638-1310c89de010.png)



Homepage (featured): `fx-monitor-find-out-blue-btn`
![image](https://user-images.githubusercontent.com/2692333/86046662-3be17e00-ba13-11ea-9c36-d341a10fa8dc.png)


Breach Scan Results (Top): `fx-monitor-alert-me-blue-btn-top`
<img width="745" alt="image" src="https://user-images.githubusercontent.com/2692333/86046690-4865d680-ba13-11ea-9c47-07f81826bbe2.png">


Breach Scan Results (Bottom): `fx-monitor-alert-me-blue-btn-bottom`
<img width="633" alt="image" src="https://user-images.githubusercontent.com/2692333/86046694-4a2f9a00-ba13-11ea-9b5e-040ab84532ad.png">