### PR TITLE
Update the URL for the VPN

### DIFF
--- a/template-helpers/product-promos.js
+++ b/template-helpers/product-promos.js
@@ -33,7 +33,7 @@ function productPromos(locales, promoUtms, promoKey) {
       promoBody: localize(locales, "promo-fpn-body"),
       promoCta: localize(locales, "promo-fpn-cta"),
       promoId: "promo-fpn",
-      promoUrl: "https://fpn.firefox.com" + promoUtms,
+      promoUrl: "https://vpn.mozilla.org" + promoUtms,
     },
     "fx-ecosystem": {
       promoHeadline: localize(locales, "ecosystem-promo-headline"),

--- a/template-helpers/recommendations.js
+++ b/template-helpers/recommendations.js
@@ -164,7 +164,7 @@ module.exports = {
               cta: isUserLocaleEnUs ? "rec-ip-us-cta" : "",
               body: isUserLocaleEnUs ? "rec-ip-us" : "rec-ip-non-us",
             },
-            ctaHref: "https://fpn.firefox.com",
+            ctaHref: "https://vpn.mozilla.org",
             ctaShouldOpenNewTab: true,
             ctaAnalyticsId: "Try Firefox Private Network",
             recIconClassName: isUserLocaleEnUs ? "rec-ip-us" : "rec-ip-non-us",


### PR DESCRIPTION
The VPN moved to vpn.mozilla.org. We miss the traffic.