### PR TITLE
Update recommendation for exposed IP addresses - DRAFT

### DIFF
--- a/public/css/feature-tip-group.css
+++ b/public/css/feature-tip-group.css
@@ -78,8 +78,9 @@
   color: #42425a;
 }
 
-.feature-tip-link {
-  display: block;
+.cta2 {
+  margin-left: 24px;
+  margin-right: 24px;
 }
 
 .breach-detail .feature-tip-group {
@@ -174,6 +175,11 @@
   .breach-detail .feature-tip-content {
     margin: auto;
     text-align: center;
+  }
+
+  .recommendation-cta {
+    display: block;
+    margin-top: 12px;
   }
 
   .breach-detail .feature-tip-content-wrapper {

--- a/template-helpers/recommendations.js
+++ b/template-helpers/recommendations.js
@@ -162,11 +162,16 @@ module.exports = {
             recommendationCopy: {
               subhead: "rec-ip-subhead",
               cta: isUserLocaleEnUs ? "rec-ip-us-cta" : "",
-              body: isUserLocaleEnUs ? "rec-ip-us" : "rec-ip-non-us",
+              cta2: isUserLocaleEnUs ? "rec-moz-vpn-cta" : "",
+              body: isUserLocaleEnUs ? "rec-moz-vpn" : "rec-ip-non-us",
             },
             ctaHref: "https://fpn.firefox.com",
             ctaShouldOpenNewTab: true,
             ctaAnalyticsId: "Try Firefox Private Network",
+            secondaryCta: isUserLocaleEnUs ? {
+              ctaHref: "https://vpn.mozilla.org",
+              ctaAnalyticsId: "Try Mozilla VPN",
+            } : "",
             recIconClassName: isUserLocaleEnUs ? "rec-ip-us" : "rec-ip-non-us",
           },
         ],

--- a/views/partials/recommendation.hbs
+++ b/views/partials/recommendation.hbs
@@ -6,5 +6,8 @@
               {{#if recommendationCopy.cta}}
                 <a class="{{ ctaClassName }} recommendation-cta feature-tip-link blue-link" href="{{addRecommendationUtmParams this}}" data-event-label="{{ ctaAnalyticsId }}" {{#if ctaShouldOpenNewTab}} target="_blank" rel="noopener noreferrer"{{/if}}>{{ recommendationCopy.cta }}</a>
               {{/if}}
+              {{#if recommendationCopy.cta2}}
+                <a class="{{ ctaClassName }} recommendation-cta cta2 feature-tip-link blue-link" href="{{addRecommendationUtmParams secondaryCta}}" data-event-label="{{ secondaryCta.analyticsId }}" {{#if ctaShouldOpenNewTab}} target="_blank" rel="noopener noreferrer"{{/if}}>{{ recommendationCopy.cta2 }}</a>
+              {{/if}}
             </div>
           </div>


### PR DESCRIPTION
This updates the recommendation templates to use the strings added in #1771 and should not deployed until on or after January 15th.

Fixes #1771 