### PR TITLE
Growth Experiment #6 - Homepage FxA Checkbox (Worldwide) 

### DIFF
--- a/controllers/home.js
+++ b/controllers/home.js
@@ -6,6 +6,7 @@ const HIBP = require("../hibp");
 const { scanResult } = require("../scan-results");
 const {
   generatePageToken,
+  getExperimentBranch,
   getExperimentFlags,
   getUTMContents,
 } = require("./utils");
@@ -42,6 +43,15 @@ async function home(req, res) {
   // Note - If utmOverrides get set, they are unenrolled from the experiment
   const utmOverrides = getUTMContents(req);
   const experimentFlags = getExperimentFlags(req, EXPERIMENTS_ENABLED);
+
+  // Growth Experiment
+  if (EXPERIMENTS_ENABLED) {
+    getExperimentBranch(req, false, ["de", "fr"], {
+      "va": 25,
+      "vb": 25,
+    });
+  }
+
 
   if (req.params && req.params.breach) {
     req.query.breach = req.params.breach;

--- a/controllers/home.js
+++ b/controllers/home.js
@@ -44,11 +44,18 @@ async function home(req, res) {
   const utmOverrides = getUTMContents(req);
   const experimentFlags = getExperimentFlags(req, EXPERIMENTS_ENABLED);
 
+  // These languages were pulled from https://pontoon.mozilla.org/projects/firefox-monitor-website. Each language has the string "get-email-alerts" from app.ftl translated and had at least 75% of all the strings translated.
+  // Things to note:
+  // - This test applies to every where BUT Tier 1 languages (EN, DE, and FR).
+  // - This includes variations of each languages, so all Spanish version (Spain, Mexico, etc)
+  //   are included by including "ES"
+  const experimentLanguages = ["cak", "cs", "cy", "es", "fi", "fy", "gn", "hu", "ia", "id", "it", "kab", "nb", "nl", "nn", "pt", "ro", "ru", "sk", "sl", "sq", "sv", "tr", "uk", "vi", "zh"];
+
   // Growth Experiment
   if (EXPERIMENTS_ENABLED) {
-    getExperimentBranch(req, false, ["de", "fr"], {
-      "va": 25,
-      "vb": 25,
+    getExperimentBranch(req, false, experimentLanguages, {
+      "va": 50,
+      "vb": 50,
     });
   }
 

--- a/controllers/oauth.js
+++ b/controllers/oauth.js
@@ -14,6 +14,13 @@ const sha1 = require("../sha1-utils");
 
 const log = mozlog("controllers.oauth");
 
+// Growth Experiment
+const utmArray = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"];
+
+function getUTMNames() {
+  return utmArray;
+}
+
 function init(req, res, next, client = FxAOAuthClient) {
   // Set a random state string in a cookie so that we can verify
   // the user when they're redirected back to us after auth.
@@ -28,6 +35,10 @@ function init(req, res, next, client = FxAOAuthClient) {
   url.searchParams.append("action", "email");
 
   for (const param of fxaParams.searchParams.keys()) {
+    // Growth Experiment
+    if (utmArray.includes(param)) {
+      req.session.utmContents[param] = fxaParams.searchParams.get(param);
+    }
     url.searchParams.append(param, fxaParams.searchParams.get(param));
   }
 
@@ -56,6 +67,15 @@ async function confirmed(req, res, next, client = FxAOAuthClient) {
   req.session.user = existingUser;
 
   const returnURL = new URL("/user/dashboard", AppConstants.SERVER_URL);
+
+  // Growth Experiment
+  if (req.session.utmContents) {
+    getUTMNames().forEach(param => {
+      if (req.session.utmContents[param]) {
+        returnURL.searchParams.append(param, req.session.utmContents[param]);
+      }
+    });
+  }
 
   // Check if user is signing up or signing in,
   // then add new users to db and send email.

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -231,6 +231,7 @@ async function getDashboard(req, res) {
   const { verifiedEmails, unverifiedEmails } = await getAllEmailsAndBreaches(user, allBreaches);
   const utmOverrides = getUTMContents(req);
 
+  // Growth Experiment
   const experimentFlags = getExperimentFlags(req, EXPERIMENTS_ENABLED);
 
   let lastAddedEmail = null;
@@ -563,6 +564,18 @@ async function getBreachStats(req, res) {
 
 
 function logout(req, res) {
+  // Growth Experiment
+  if (EXPERIMENTS_ENABLED && req.session.experimentFlags) {
+    // Persist experimentBranch across session reset
+    const sessionExperimentFlags = req.session.experimentFlags;
+    req.session.reset();
+    req.session.experimentFlags = sessionExperimentFlags;
+
+    // Return
+    res.redirect("/");
+    return;
+  }
+
   req.session.reset();
   res.redirect("/");
 }

--- a/public/js/fxa-analytics.js
+++ b/public/js/fxa-analytics.js
@@ -155,6 +155,19 @@ function setGAListeners(){
       });
     });
 
+    // Growth Experiment
+    if (document.body.dataset.experiment) {
+      document.querySelectorAll(".ga-growth-ping").forEach((el) => {
+        el.addEventListener("click", async(e) => {
+          // Overwrite current event category for active OAuth buttons
+          if (el.dataset.eventCategory !== "fxa-oauth") {
+            el.dataset.eventCategory = "fxa-oauth";
+          }
+          await sendPing(el, "Click", el.dataset.eventLabel, {transport: "beacon"});
+        });
+      });
+    }
+
   }
 
   window.sessionStorage.setItem("gaInit", true);
@@ -200,6 +213,17 @@ function setGAListeners(){
     ga("create", "UA-77033033-16");
     ga("set", "anonymizeIp", true);
     ga("set", "dimension6", `${document.body.dataset.signedInUser}`);
+
+    // Growth Experiment
+    if (document.body.dataset.experiment) {
+      // If an experiment is active, set the "Growth Experiment Version"
+      // Custom Dimension to whichever branch is active.
+      ga("set", "dimension7", `${document.body.dataset.experiment}`);
+      ga("set", "dimension8", `${document.body.dataset.experiment}`);
+      ga("set", "dimension9", `${document.body.dataset.utm_campaign}`);
+      ga("set", "campaignName", `${document.body.dataset.utm_campaign}`);
+      ga("set", "campaignKeyword", `${document.body.dataset.utm_term}`);
+    }
 
     ga("send", "pageview", {
       hitCallback: function() {

--- a/scan-results.js
+++ b/scan-results.js
@@ -5,6 +5,7 @@ const { URL } = require("url");
 const HIBP = require("./hibp");
 const sha1 = require("./sha1-utils");
 
+// Growth Experiment
 const AppConstants = require("./app-constants");
 const EXPERIMENTS_ENABLED = (AppConstants.EXPERIMENT_ACTIVE === "1");
 const { getExperimentFlags } = require("./controllers/utils");
@@ -14,6 +15,7 @@ const scanResult = async(req, selfScan=false) => {
   const allBreaches = req.app.locals.breaches;
   let scannedEmail = null;
 
+  // Growth Experiment
   const experimentFlags = getExperimentFlags(req, EXPERIMENTS_ENABLED);
 
   const title = req.fluentFormat("scan-title");

--- a/views/layouts/default.hbs
+++ b/views/layouts/default.hbs
@@ -21,8 +21,7 @@
     <link rel="icon" href="/img/favicons/favicon-128.png" sizes="128x128" />
     <link rel="icon" href="/img/favicons/favicon-256.png" sizes="256x256" />
   </head>
-  <body {{> analytics/default_dataset }} data-bento-app-id="fx-monitor"
-    {{#if utmOverrides.campaignName }} {{> analytics/share }} {{/if}} >
+  <body {{> analytics/default_dataset }} data-bento-app-id="fx-monitor" {{#if utmOverrides.campaignName }} {{> analytics/share }} {{/if}} {{#if experimentFlags.experimentBranch }} {{> analytics/experiment }} {{/if}} >
     {{> header/header }}
       {{{ body }}}
     {{> footer }}

--- a/views/partials/analytics/experiment.hbs
+++ b/views/partials/analytics/experiment.hbs
@@ -1,0 +1,3 @@
+data-utm_term={{experimentFlags.experimentBranch}}
+data-experiment={{experimentFlags.experimentBranch}}
+data-utm_campaign="growthuserflow6"


### PR DESCRIPTION
### Steps to test: 
- Control: https://monitor-v2.herokuapp.com/?experimentBranch=va 
- Treatment: https://monitor-v2.herokuapp.com/?experimentBranch=vb

Verify you are enrolled in the experiment by looking at the `data-experiment` attribute on `<body>` tag. 

**Treatment:**
- Go to website (with any of the listed languages set as the language)
- Click the checkbox
- It should open FxA flow.
- When you land on the /user-dashboard after completing the flow, it should still have the same meta data as mentioned above. 


#### Notes: 
- The user MUST have either German or French variant as the primary/top language. Any other deviation will be excluded from the experiment. If the first language is NOT English, then they should not get the checkbox. If English (any variant), 
-  These languages were selected from [Pontoon[(https://pontoon.mozilla.org/projects/firefox-monitor-website). Each selected language has the string ["get-email-alerts" from app.ftl](https://github.com/mozilla/blurts-server/blob/master/locales/en/app.ftl#L284) translated and has at least 75% of all the strings translated. _(As of Aug 14, 2020)_
- This test applies to every where BUT Tier 1 languages (EN, DE, and FR). If in one of those locales, the default state is now to HAVE a checkbox. (Once #1869 is merged) 
- Each language entry includes variations of that language, so all Spanish versions (Spain, Mexico, etc) are included by including only "ES"
- From the top 20 languages, this test covers all of them except for Polish (14) and Japanese (15)