### PR TITLE
Remove Lockwise from Bento

### DIFF
--- a/public/css/fx-bento.css
+++ b/public/css/fx-bento.css
@@ -160,11 +160,6 @@ a.fx-bento-app-link {
   content: "";
 }
 
-.fx-bento-app-link-span.fx-lockwise::before {
-  background-position-x: -54px;
-  width: calc(var(--appIconHeight) + 1px);
-}
-
 .fx-bento-app-link-span.pocket::before {
   background-position-x: -18px;
 }
@@ -367,11 +362,6 @@ body.hide-bento firefox-apps > button {
   .fx-bento-app-link-span.fx-mobile::before {
     background-position-x: -157px;
     margin-left: 1px;
-  }
-
-  .fx-bento-app-link-span.fx-lockwise::before {
-    background-position-x: -79px;
-    width: calc(var(--appIconHeight) + 2px);
   }
 }
 

--- a/public/js/fx-bento.js
+++ b/public/js/fx-bento.js
@@ -8,7 +8,6 @@ function getFxAppLinkInfo(localizedBentoStrings, referringSiteURL) {
     [localizedBentoStrings.pocket, "https://app.adjust.com/hr2n0yz?engagement_type=fallback_click&fallback=https%3A%2F%2Fgetpocket.com%2Ffirefox_learnmore%3Fsrc%3Dff_bento&fallback_lp=https%3A%2F%2Fapps.apple.com%2Fapp%2Fpocket-save-read-grow%2Fid309601447", "pocket"],
     [localizedBentoStrings.fxDesktop, `https://www.mozilla.org/firefox/new/?utm_source=${referringSiteURL}&utm_medium=referral&utm_campaign=bento&utm_content=desktop`, "fx-desktop"],
     [localizedBentoStrings.fxMobile, `http://mozilla.org/firefox/mobile?utm_source=${referringSiteURL}&utm_medium=referral&utm_campaign=bento&utm_content=desktop`, "fx-mobile"],
-    [localizedBentoStrings.fxLockwise, "https://bhqf.adj.st/?adjust_t=6tteyjo&adj_deeplink=lockwise%3A%2F%2F&adj_fallback=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Ffirefox%2Flockwise", "fx-lockwise"],
   ];
 }
 


### PR DESCRIPTION
This removes Lockwise from the Bento. We need to continue sending the string until Better Web has a chance to deploy these changes.