### PR TITLE
Removed reference to Lockwise in "what to do after this breach"

### DIFF
--- a/controllers/home.js
+++ b/controllers/home.js
@@ -110,7 +110,6 @@ function getBentoStrings(req, res) {
     bentoHeadline: req.fluentFormat("fx-makes-tech"),
     bentoBottomLink: req.fluentFormat("made-by-mozilla"),
     fxDesktop: req.fluentFormat("fx-desktop"),
-    fxLockwise: req.fluentFormat("fx-lockwise"),
     fxMobile: req.fluentFormat("fx-mobile"),
     fxMonitor: req.fluentFormat("fx-monitor"),
     pocket: req.fluentFormat("pocket"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -7042,6 +7042,9 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
+      "requires": {
+        "icu4c-data": "^0.64.2"
+      },
       "dependencies": {
         "icu4c-data": {
           "version": "0.64.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7042,9 +7042,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "requires": {
-        "icu4c-data": "^0.64.2"
-      },
       "dependencies": {
         "icu4c-data": {
           "version": "0.64.2",

--- a/public/js/fx-bento.js
+++ b/public/js/fx-bento.js
@@ -42,7 +42,6 @@ async function getlocalizedBentoStrings() {
       fxDesktop: "Firefox Browser for Desktop",
       fxMobile: "Firefox Browser for Mobile",
       fxMonitor: "Firefox Monitor",
-      fxLockwise: "Firefox Lockwise",
       pocket: "Pocket",
       mozVPN: "Mozilla VPN",
     };

--- a/template-helpers/product-promos.js
+++ b/template-helpers/product-promos.js
@@ -21,13 +21,6 @@ function productPromos(locales, promoUtms, promoKey) {
       promoId: "promo-mobile",
       promoUrl: "http://mozilla.org/firefox/mobile" + promoUtms,
     },
-    "lockwise": {
-      promoHeadline: localize(locales, "promo-lockwise-headline"),
-      promoBody: localize(locales, "lockwise-promo-body"),
-      promoCta: localize(locales, "promo-lockwise-cta"),
-      promoId: "promo-lockwise",
-      promoUrl: "https://bhqf.adj.st/?adjust_t=6tteyjo&adj_deeplink=lockwise%3A%2F%2F&adj_fallback=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Ffirefox%2Flockwise" + promoUtms,
-    },
     "fpn": {
       promoHeadline: localize(locales, "fpn-promo-headline"),
       promoBody: localize(locales, "promo-fpn-body"),

--- a/template-helpers/recommendations.js
+++ b/template-helpers/recommendations.js
@@ -98,17 +98,6 @@ module.exports = {
             recIconClassName: "rec-pw-2",
             // ctaHref: "", // Will open about:logins in the future or the lockwise website.
           },
-          {
-            recommendationCopy : {
-              subhead: "rec-pw-3-subhead",
-              cta: "rec-pw-3-cta",
-              body: isUserBrowserFirefox ? "rec-pw-3-fx" : "rec-pw-3-non-fx",
-            },
-            ctaHref: "https://www.mozilla.org/firefox/lockwise/",
-            ctaShouldOpenNewTab: true,
-            ctaAnalyticsId: "Get Firefox Lockwise",
-            recIconClassName: "rec-pw-3",
-          },
         ],
       },
       "bank-account-numbers": {


### PR DESCRIPTION
Removed Firefox Lockwise from the recommendations.js file. Was being returned in the getAllPriorityDataClasses function.

fix bug #1954