### PR TITLE
Fix #2011 - Add logic to not overwrite already set URL params

### DIFF
--- a/public/js/fxa-analytics.js
+++ b/public/js/fxa-analytics.js
@@ -37,7 +37,10 @@ async function sendPing(el, eventAction, eventLabel = null, options = null) {
 
 function appendFxaParams(url, storageObject) {
   getUTMNames().forEach(param => {
-    if (storageObject[param]) {
+    if (storageObject[param] && !url.searchParams.get(param)) {
+      // Bug #2011 - This logic only allows params to be set/passed
+      // on to FxA isn't that param isn't already set.
+      // (Example: Overwriting a utm_source)
       url.searchParams.append(param, encodeURIComponent(storageObject[param]));
     }
   });

--- a/public/js/fxa-analytics.js
+++ b/public/js/fxa-analytics.js
@@ -39,7 +39,7 @@ function appendFxaParams(url, storageObject) {
   getUTMNames().forEach(param => {
     if (storageObject[param] && !url.searchParams.get(param)) {
       // Bug #2011 - This logic only allows params to be set/passed
-      // on to FxA isn't that param isn't already set.
+      // on to FxA if that param isn't already set.
       // (Example: Overwriting a utm_source)
       url.searchParams.append(param, encodeURIComponent(storageObject[param]));
     }


### PR DESCRIPTION
## Testing Steps

- Start the URL with an entry point and utm_source alreay set: 
  - Go to `localhost:6060/?entrypoint=protection_report_monitor&utm_source=about-protections`
- Complete the form on the homepage with the checkbox checked (to login/create a new FxA account) 
- On the Accounts page, check the URL. It should have only one `utm_source` entry. (From this example, it should be set to `about-protections`)
