### PR TITLE
update .env-dist and README to use FXA stage

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -40,12 +40,12 @@ BASKET_NEWSLETTER=mozilla-and-you
 # Firefox Accounts OAuth
 # leave FXA_ENABLED empty to disable FXA
 FXA_ENABLED=
-FXA_SETTINGS_URL="https://stable.dev.lcip.org/settings"
+FXA_SETTINGS_URL="https://accounts.stage.mozaws.net/settings"
 OAUTH_CLIENT_ID=edd29a80019d61a1
-OAUTH_CLIENT_SECRET=a80feaad77c847275d39ac989ee12a873ef6b54cbc184128f86f2afecdf003b5
-OAUTH_AUTHORIZATION_URI="https://oauth-stable.dev.lcip.org/v1/authorization"
-OAUTH_PROFILE_URI="https://stable.dev.lcip.org/profile/v1/profile"
-OAUTH_TOKEN_URI="https://oauth-stable.dev.lcip.org/v1/token"
+OAUTH_CLIENT_SECRET=get-this-from-groovecoder-or-fxmonitor-engineering
+OAUTH_AUTHORIZATION_URI="https://oauth.stage.mozaws.net/v1/authorization"
+OAUTH_PROFILE_URI="https://profile.stage.mozaws.net/v1/profile"
+OAUTH_TOKEN_URI="https://oauth.stage.mozaws.net/v1/token"
 
 # HIBP API for breach data
 # How many seconds to wait before refreshing upstream breach data from HIBP

--- a/README.md
+++ b/README.md
@@ -100,20 +100,8 @@ Subscribe with a Firefox Account is controlled via the `FXA_ENABLED`
 environment variable. (See `.env-dist`)
 
 The repo comes with a development FxA oauth app pre-configured in `.env`, which
-should work fine running the app on http://localhost:6060
-
-To use a different Firefox Accounts oauth relying party,
-you'll need to [create an FxA Oauth Client](https://oauth-stable.dev.lcip.org/console/clients) and then set some `OAUTH` config values.
-
-You can set and source these via the `.env` file:
-
-```sh
-OAUTH_CLIENT_ID=<your-fxa-oauth-client-id>
-OAUTH_CLIENT_SECRET=<your-fxa-oauth-client-secret>
-OAUTH_AUTHORIZATION_URI="https://oauth-stable.dev.lcip.org/v1/authorization"
-OAUTH_PROFILE_URI="https://stable.dev.lcip.org/profile/v1/profile"
-OAUTH_TOKEN_URI="https://oauth-stable.dev.lcip.org/v1/token"
-```
+should work fine running the app on http://localhost:6060. You'll need to get
+the `OAUTH_CLIENT_SECRET` value from someone in #fxmonitor-engineering.
 
 ## Testing
 


### PR DESCRIPTION
To develop and test Monitor integration with SubPlat, it needs to use the FXA stage environment.