### PR TITLE
Add missing data-classes strings from recent SuperVPNGeckoVPN breach

### DIFF
--- a/locales/en/data-classes.ftl
+++ b/locales/en/data-classes.ftl
@@ -33,6 +33,7 @@ dates-of-birth = Dates of birth
 deceased-date = Deceased date
 deceased-statuses = Deceased statuses
 device-information = Device information
+device-serial-numbers = Device serial numbers
 device-usage-tracking-data = Device usage tracking data
 drinking-habits = Drinking habits
 drug-habits = Drug habits
@@ -66,6 +67,7 @@ ip-addresses = IP addresses
 job-applications = Job applications
 job-titles = Job titles
 living-costs = Living costs
+login-histories = Login histories
 mac-addresses = MAC addresses
 marital-statuses = Marital statuses
 # Mnemonic phrases are a group of words used to access the content of cryptocurrency wallets.


### PR DESCRIPTION
Ref: https://monitor.firefox.com/breach-details/SuperVPNGeckoVPN

![Firefox_Monitor](https://user-images.githubusercontent.com/557895/109578257-b46d7280-7aab-11eb-84b8-61b8c3900110.png)


Via:

```sh
npx pdehaan/blurts-server-data-classes

Missing "device-serial-numbers" data class from SuperVPNGeckoVPN breach
Missing "login-histories" data class from SuperVPNGeckoVPN breach
```