### PR TITLE
Fix #2107 - Update exposed IP address recommendation text

### DIFF
--- a/locales/en/recommendations.ftl
+++ b/locales/en/recommendations.ftl
@@ -80,10 +80,9 @@ rec-ip-non-us =
 
 # Recommendation subhead
 rec-moz-vpn-cta = Try { -brand-mozilla-vpn }
-rec-moz-vpn =
-  Your Internet Protocol address (IP address) can reveal your location and internet service provider. A service like
-  { -brand-fpn } hides your IP address and location for { -brand-name } and a service like { -brand-mozilla-vpn } hides your
-  IP address and location for your entire device.
+rec-moz-vpn-update =
+  Your Internet Protocol address (IP address) can reveal your location and internet service provider. A service 
+  like { -brand-mozilla-vpn } hides your IP address and location for your entire device.
 
 rec-hist-pw-subhead = Avoid reusing passwords
 # Link title

--- a/template-helpers/recommendations.js
+++ b/template-helpers/recommendations.js
@@ -151,7 +151,7 @@ module.exports = {
             recommendationCopy: {
               subhead: "rec-ip-subhead",
               cta: isUserLocaleEnUs ? "rec-moz-vpn-cta" : "",
-              body: isUserLocaleEnUs ? "rec-moz-vpn" : "rec-ip-non-us",
+              body: isUserLocaleEnUs ? "rec-moz-vpn-update" : "rec-ip-non-us",
             },
             ctaHref: "https://vpn.mozilla.org?utm_source=monitor.firefox.com&utm_medium=referral&utm_campaign=monitor-recommendations",
             ctaShouldOpenNewTab: true,


### PR DESCRIPTION
Update string language for IP address recommendation. 

To review: 
- Visit any breach detail page with an IP address data class
- Expected: Under the "What to do for this breach" section, on the "Use a service that masks your IP address" bullet: The text should read:  _"Your Internet Protocol address (IP address) can reveal your location and internet service provider. A service like Mozilla VPN hides your IP address and location for your entire device."_

Screenshot:
![image](https://user-images.githubusercontent.com/2692333/119725154-37952f00-be35-11eb-87dc-9206e1aa2b01.png)
