### PR TITLE
Fix #2207 - Strict-mode waitlist signup GA fix

### DIFF
--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -398,10 +398,13 @@ function addWaitlistObservers() {
       observer.observe(relayCta);
       relayCta.addEventListener("click", (e) => {
         if (relayCta.href) {
-          e.preventDefault();
-          ga("send", "event", "Waitlist Test", "Engage", relayCta.dataset.analyticsLabel, {
-          "hitCallback": window.location.href = relayCta.href,
-          });
+          if (typeof(ga) !== "undefined") {
+            // Recheck if the user is on strict-mode and only block the click default action if GA is available
+            e.preventDefault();
+            ga("send", "event", "Waitlist Test", "Engage", relayCta.dataset.analyticsLabel, {
+            "hitCallback": window.location.href = relayCta.href,
+            });
+          }
           return;
         }
         ga("send", "event", "Waitlist Test", "Engage", relayCta.dataset.analyticsLabel);


### PR DESCRIPTION
Add additional logic to re-check if GA is available before tracking click to join the waitlist

To test: 

- Set your browser mode to Strict ETP 
- Go to Monitor Dashboard (Log into FxA Stage) - https://monitor-v2.herokuapp.com 
- Click on "Join Waitlist" CTA at the bottom of the page
- **Expected:** Should navigate to `/remove-my-data` page without issue. 