### PR TITLE
Fix #2194 - Remove VPN Pricing Update Copy (EN-only) 

### DIFF
--- a/locale-utils.js
+++ b/locale-utils.js
@@ -78,6 +78,29 @@ const LocaleUtils = {
     }
     return id;
   },
+
+  fluentFormatWithFallback (supportedLocales, id, fallbackId, args=null, errors=null) {
+    if (!fallbackId) {
+      log.error("fluentFormatWithFallback: No fallbackId");
+      return false;
+    }
+
+    for (const locale of supportedLocales) {
+      const bundle = fluentBundles[locale];
+      if (bundle.hasMessage(id)) {
+        const message = bundle.getMessage(id);
+        return bundle.format(message, args);
+      }
+
+      // If first message id doesn't have translation, use fallback id
+      if (fallbackId && bundle.hasMessage(fallbackId)) {
+        const message = bundle.getMessage(fallbackId);
+        return bundle.format(message, args);
+      }
+    }
+    return id;
+  },
+
 };
 
 module.exports = {

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -795,3 +795,6 @@ steps-to-resolve-headline = Steps to resolve this breach
 vpn-promo-headline = Now’s the time to boost your safety online.
 vpn-promo-copy = { -brand-Mozilla }’s Virtual Private Network helps shield your internet connection from hackers and spies. 
 vpn-promo-cta = Get { -brand-mozilla-vpn }
+
+vpn-promo-headline-new = Save 50% with a full year subscription
+vpn-promo-copy-new = Protect your online data—and choose a VPN subscription plan that works for you.

--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -530,7 +530,7 @@ function vpnBannerLogic() {
     return;
   }
 
-  // Only show banner if users first language is some English-locale variant
+  // Only show banner if users first language is English, Germand or French variant
   if (["en", "de", "fr"].some(lang=>preferredLanguages[0].includes(lang))) {
     vpnBannerLogic();
   }

--- a/public/js/monitor.js
+++ b/public/js/monitor.js
@@ -413,30 +413,13 @@ function addWaitlistObservers() {
   }
 }
 
-function vpnBannerLogic(options) {
+function vpnBannerLogic() {
 
   // Check if element exists at all
   const vpnPromoBanner = document.getElementById("vpnPromoBanner");
 
   if (!vpnPromoBanner) {
     return;
-  }
-
-  if (options && options.isEnglish) {
-    const vpnPromoCopy = document.querySelector(".vpn-promo-copy");
-    vpnPromoCopy.innerHTML = "";
-    const vpnPromoCopyStrongTag = document.createElement("strong");
-    const vpnPromoCopySpanTag = document.createElement("span");
-    const vpnPromoCopySmallTag = document.createElement("small");
-    vpnPromoCopyStrongTag.textContent = "Introductory offer ends soon: $4.99/month for Mozilla VPN";
-    vpnPromoCopySpanTag.textContent = "Now's the time to protect your device against hackers and prying eyes.";
-    vpnPromoCopySmallTag.textContent = "Offer only available in the United States, United Kingdom, Canada, New Zealand, Malaysia, and Singapore";
-    vpnPromoCopy.appendChild(vpnPromoCopyStrongTag);
-    vpnPromoCopy.appendChild(vpnPromoCopySpanTag);
-    vpnPromoCopy.appendChild(vpnPromoCopySmallTag);
-
-    const vpnPromoButton = document.querySelector(".vpn-promo-cta");
-    vpnPromoButton.href = "https://www.mozilla.org/products/vpn/?utm_source=monitor&utm_medium=monitor&utm_campaign=intro-pricing";
   }
 
   // Check for dismissal cookie
@@ -548,12 +531,8 @@ function vpnBannerLogic(options) {
   }
 
   // Only show banner if users first language is some English-locale variant
-  if (["de", "fr"].some(lang=>preferredLanguages[0].includes(lang))) {
+  if (["en", "de", "fr"].some(lang=>preferredLanguages[0].includes(lang))) {
     vpnBannerLogic();
-  }
-
-  if (["en"].some(lang=>preferredLanguages[0].includes(lang))) {
-    vpnBannerLogic({isEnglish: true});
   }
 
   if (document.getElementById("fxaCheckbox")) {

--- a/template-helpers/hbs-helpers.js
+++ b/template-helpers/hbs-helpers.js
@@ -134,6 +134,10 @@ function getString (id, args) {
   return LocaleUtils.fluentFormat(supportedLocales, id, args.hash);
 }
 
+function getStringWithFallback (id, fallbackId, args) {
+  const supportedLocales = getSupportedLocales(args);
+  return LocaleUtils.fluentFormatWithFallback(supportedLocales, id, fallbackId, args.hash);
+}
 
 function getStrings(stringArr, locales) {
   stringArr.forEach(string => {
@@ -281,6 +285,7 @@ module.exports = {
   microsurveyBanner,
   englishInAcceptLanguages,
   getString,
+  getStringWithFallback,
   getStrings,
   fluentFxa,
   getStringID,

--- a/views/partials/vpn-promo.hbs
+++ b/views/partials/vpn-promo.hbs
@@ -2,8 +2,8 @@
 	<div class="vpn-promo-banner-wrapper">
 		<img alt="Mozilla VPN" class="vpn-promo-logo" src="/img/svg/logos/mozilla-vpn.svg"/>
 		<div class="vpn-promo-copy">
-			<strong>{{ getString "vpn-promo-headline" }}</strong>
-			<span>{{ getString "vpn-promo-copy" }}</span>
+			<strong>{{ getStringWithFallback "vpn-promo-headline-new" "vpn-promo-headline" }}</strong>
+			<span>{{ getStringWithFallback "vpn-promo-copy-new" "vpn-promo-copy" }}</span>
 		</div>
 		<a class="vpn-promo-cta" href="https://www.mozilla.org/products/vpn/?utm_source=monitor&utm_medium=monitor&utm_campaign=mozillavpn-monitor-top-banner">{{ getString "vpn-promo-cta" }}</a>
 		<button id="vpnPromoCloseButton" type="button" name="button" data-event-category="vpn-promo-close"><img src="/img/svg/x-close-black.svg"/></button>


### PR DESCRIPTION
### ⚠️  **NOTE: DO NOT MERGE/DEPLOY UNTIL TUESDAY, JULY 13TH** ⚠️

This PR removes the current English pricing promo from the VPN banner. Reverted back to original localized strings.

Preview: 
![image](https://user-images.githubusercontent.com/2692333/125368636-50539880-e340-11eb-9352-435394c3b897.png)
## Testing

### VPN Banner is Visible

- Set browser language to any EN/FR/DE variant. 
- Clear any previous cookies for `localhost` (in case you dismissed the banner previously) 
- Go to homepage
- **Expected:** See VPN banner at top of the page with the following text: 
  - Headline: _Now’s the time to boost your safety online._
  - Body copy: _Mozilla’s Virtual Private Network helps shield your internet connection from hackers and spies._ 

### VPN Banner is hidden

- Set browser language to any other language that is **NOT** an EN/FR/DE variant. 
- Clear any previous cookies for `localhost` (in case you dismissed the banner previously) 
- Go to homepage
- **Expected:** No VPN banner is visible. 

