### PR TITLE
idea: only add gulp & scss to intermediate build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+FROM node:10-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+COPY gulpfile.js ./
+COPY public ./public/
+RUN npm install
+RUN npm run build:all
+
 FROM node:10-alpine
 
 RUN addgroup -g 10001 app && \
@@ -9,6 +17,7 @@ WORKDIR /app
 
 USER app
 
+COPY --from=builder --chown=app /app/public ./public
 COPY package.json package.json
 COPY package-lock.json package-lock.json
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "url": "https://github.com/mozilla/blurts-server/issues"
   },
   "dependencies": {
-    "@mozilla-protocol/core": "^14.0.3",
     "@sentry/node": "5.27.2",
     "arg": "4.1.3",
     "babel-minify": "0.5.1",
@@ -19,7 +18,6 @@
     "connect-redis": "5.0.0",
     "cpr": "3.0.1",
     "csurf": "1.11.0",
-    "del": "^6.0.0",
     "dotenv": "8.2.0",
     "express": "4.17.1",
     "express-bearer-token": "2.4.0",
@@ -30,8 +28,6 @@
     "full-icu": "1.3.1",
     "git-rev-sync": "1.12.0",
     "got": "10.7.0",
-    "gulp": "^4.0.2",
-    "gulp-sass": "^3.2.1",
     "helmet": "4.2.0",
     "intl-pluralrules": "1.2.1",
     "isemail": "3.2.0",
@@ -48,6 +44,7 @@
     "uuid": "3.4.0"
   },
   "devDependencies": {
+    "@mozilla-protocol/core": "^14.0.3",
     "@wdio/cli": "5.23.0",
     "@wdio/dot-reporter": "5.22.4",
     "@wdio/firefox-profile-service": "5.21.0",
@@ -59,9 +56,12 @@
     "chai": "4.2.0",
     "clean-css-cli": "4.3.0",
     "coveralls": "3.1.0",
+    "del": "^6.0.0",
     "eslint": "7.12.1",
     "eslint-plugin-node": "6.0.1",
     "faucet": "0.0.1",
+    "gulp": "^4.0.2",
+    "gulp-sass": "^3.2.1",
     "htmllint-cli": "0.0.7",
     "jest": "26.4.2",
     "jest-tap-reporter": "1.9.0",


### PR DESCRIPTION
Just an idea ... can we use the same technique we use in Relay, where we:

1. Move all the gulp & SCSS dependencies to `devDependencies`
2. Add an intermediate docker `builder` image just for building the statics
3. Copy the build statics into the final app image
4. Only install the production-necessary node modules in the final app image