### PR TITLE
fix #2228 - dev server restart loop during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "lint:css": "stylelint --fix public/scss/ public/css/app.css",
     "lint:audit": "npm-audit-ci-wrapper -t 'high'",
     "get-hashsets": "node scripts/get-hashsets",
-    "server": "NODE_ICU_DATA=./node_modules/full-icu nodemon server.js",
+    "server": "NODE_ICU_DATA=./node_modules/full-icu nodemon server.js --ignore public/",
     "start": "run-p build:all watch:all server",
     "test:db:migrate": "NODE_ENV=tests knex migrate:latest --knexfile db/knexfile.js --env tests",
     "test:tests": "NODE_ENV=tests HIBP_THROTTLE_DELAY=1000 HIBP_THROTTLE_MAX_TRIES=3 jest --runInBand --coverage tests/",


### PR DESCRIPTION
Nodemon should not care about files in `public/`.  By ignoring all the files built in that folder, we avoid the many server restarts triggered by Nodemon's watch.