### PR TITLE
CSS visual fixes

### DIFF
--- a/public/scss/app.scss
+++ b/public/scss/app.scss
@@ -14,6 +14,7 @@
 
 // Previous Styles
 @import "partials/all-breaches.scss";
+@import "partials/main.scss";
 @import "partials/articles.scss";
 @import "partials/breach-cards.scss";
 @import "partials/breach-detail.scss";
@@ -27,7 +28,6 @@
 @import "partials/fx-bento.scss";
 @import "partials/header.scss";
 @import "partials/latest-breach.scss";
-@import "partials/main.scss";
 @import "partials/monitor.scss";
 @import "partials/product-promos.scss";
 @import "partials/remove-data.scss";

--- a/public/scss/partials/email-card.scss
+++ b/public/scss/partials/email-card.scss
@@ -392,9 +392,9 @@ input.remove-email-submit {
   }
 
   .toggle-resolved-breaches,
-  .ec.breach-card, /* Hide breach cards until the email-card is toggled down */
-  .active .show-additional-breaches.hide .ec.breach-card, /* Hides any breaches gated behind "Show Remaining Breaches" button when there are more than 4 to an email. */
-  .active .show-remaining-breaches.hide, /* Hide "Show Remaining Breaches"" button after it has been clicked */
+  .ec.breach-card, // Hide breach cards until the email-card is toggled down */
+  .active .show-additional-breaches.hide .ec.breach-card, // Hides any breaches gated behind "Show Remaining Breaches" button when there are more than 4 to an email. */
+  .active .show-remaining-breaches.hide, // Hide "Show Remaining Breaches"" button after it has been clicked */
   .e-address::after,
   .show-remaining-breaches {
     display: none;

--- a/public/scss/partials/latest-breach.scss
+++ b/public/scss/partials/latest-breach.scss
@@ -24,7 +24,6 @@
   max-height: 48px;
   max-width: 48px;
   width: 48px;
-  margin-left: 20px;
 }
 
 .latest-breach .breach-title {


### PR DESCRIPTION
I ran an audit from the compiled CSS from [v13.4.8](https://github.com/mozilla/blurts-server/releases/tag/v13.4.8) against the compiled CSS. I made a few adjustments and now when comparing the dev site version prod, it's much much closer. 

- Reordered when the main SCSS file (previously app.css) gets compiled. (Previously, it was the second file to be concat'd, so I moved it back to that position) 

Notes:
- The new CSS includes additional font weights. (Ex: The main navigation had a font-weight of `600`. Previously, bc of which font weights were available, it defaulted to `700`. Now that `600` is present, the weight changed. 

STR: 
- Open both https://monitor.firefox.com/ and https://monitor-v2.herokuapp.com/
- **Expected:** Both sites should look visually the same 