### PR TITLE
fix incorrect font reference to "Inter"

### DIFF
--- a/public/scss/partials/main.scss
+++ b/public/scss/partials/main.scss
@@ -15,7 +15,7 @@ body {
   padding: 0;
   background-color: #f9f7fd;
   scroll-behavior: smooth;
-  font-family: "Inter UI", -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Open Sans', 'Helvetica Neue', sans-serif;
   font-weight: 400;
   font-size: 15px;
   overflow-y: scroll;

--- a/public/scss/partials/remove-data.scss
+++ b/public/scss/partials/remove-data.scss
@@ -34,7 +34,7 @@
   font-weight: 500;
   font-size: 18px;
   line-height: 27px;
-  font-family: "Inter UI", -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Open Sans', 'Helvetica Neue', sans-serif;
   margin: auto;
 }
 


### PR DESCRIPTION
Correctly link body font family to "Inter".  

I'm not up on original designs, but reviewers should please keep an eye out for layout shifts or strange text blocks as a result of this update.