### PR TITLE
Add prompt none to relay link

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -96,7 +96,11 @@ if (removeMonitorButton) {
 }
 
 const relayLink = document.querySelector("[data-event-label='Try Firefox Relay']");
-//const relayUrl = new URL(relayLink.href);
 const user_email = document.querySelector(".nav-user-email").textContent;
-//relayUrl.searchParams.append("login_hint", user_email);
-relayLink.href = relayLink.href + encodeURIComponent("&login_hint=" + user_email);
+if (user_email) {
+  const relayUrl = new URL(relayLink.href);
+  relayUrl.pathname += "accounts/fxa/login/";
+  relayUrl.searchParams.append("process", "login");
+  relayUrl.searchParams.append("auth_params", "prompt=none&login_hint=" + user_email);
+  relayLink.href = relayUrl.href;
+}

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -94,3 +94,9 @@ if (removeMonitorButton) {
     await sendForm(formAction, {_csrf: csrfToken, primaryToken, primaryHash});
   });
 }
+
+const relayLink = document.querySelector("[data-event-label='Try Firefox Relay']");
+//const relayUrl = new URL(relayLink.href);
+const user_email = document.querySelector(".nav-user-email").textContent;
+//relayUrl.searchParams.append("login_hint", user_email);
+relayLink.href = relayLink.href + encodeURIComponent("&login_hint=" + user_email);

--- a/template-helpers/recommendations.js
+++ b/template-helpers/recommendations.js
@@ -212,7 +212,7 @@ module.exports = {
               body: "rec-email",
               cta: "rec-email-cta",
             },
-            ctaHref: "https://relay.firefox.com/",
+            ctaHref: "https://relay.firefox.com/accounts/fxa/login/?process=login&auth_params="+ encodeURIComponent("prompt=none"),
             ctaShouldOpenNewTab: true,
             ctaAnalyticsId: "Try Firefox Relay",
             recIconClassName: "rec-email",

--- a/template-helpers/recommendations.js
+++ b/template-helpers/recommendations.js
@@ -212,7 +212,7 @@ module.exports = {
               body: "rec-email",
               cta: "rec-email-cta",
             },
-            ctaHref: "https://relay.firefox.com/accounts/fxa/login/?process=login&auth_params="+ encodeURIComponent("prompt=none"),
+            ctaHref: "https://relay.firefox.com/",
             ctaShouldOpenNewTab: true,
             ctaAnalyticsId: "Try Firefox Relay",
             recIconClassName: "rec-email",


### PR DESCRIPTION
If a “trusted” FXA OAuth client knows that the browser is already signed into FXA **and** knows the signed-in email address, that trusted client can send the browser thru a "prompt-less" FXA registration & sign-up flow. It does this by sending 2 extra URL params to the FXA auth url: [`prompt=none`](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/prompt-none.md) and `login_hint=<email>`.

Because of that, 1 FXA OAuth client (e.g., monitor.firefox.com) can link a signed-in user to a 2nd FXA OAuth client (e.g., relay.firefox.com) with the signed-in user's email, and the 2nd OAuth client can:

1. Start an OAuth flow session
2. Append `prompt=none&login_hint<email>` to the FXA url
   * FXA will automatically register the user (if needed) AND sign them into the 2nd client
3. Receive the user back and automatically sign them in.

It's a kind of a single-sign-on mechanism between FXA OAuth clients.

## So ... 
This PR adds the urls params necessary to give signed-in Monitor users a prompt-less single-sign-on experience into Relay.

## To test ...

1. Run this branch on Monitor
2. Run a local instance of Relay (only our local Relay OAuth client is marked as "trusted" so far)
3. In this branch of monitor code, in `template-helpers/recommendations.js`, change the `https://relay.firefox.com` link to `http://127.0.0.1:8000`
4. Sign into http://localhost:6000
5. Go to a breach detail page (e.g., http://localhost:6060/breach-details/Apollo)
6. Click the "Try Firefox Relay" link
   * You should be automatically signed into Relay - even if the FXA that was signed into Monitor never had Relay before
7. Open a breach detail page in a signed-out session (e.g., a private browsing window)
8. Click the "Try Firefox Relay" link
   * You should be sent to the Relay home page