### PR TITLE
switches from using the kanary_partner_api module to using fetch

### DIFF
--- a/routes/user.js
+++ b/routes/user.js
@@ -17,7 +17,6 @@ const {
   getPreferences,
   getBreachStats,
   handleRemoveFormSignup,
-  handleRemoveFormGet,
   removeEmail,
   resendEmail,
   updateCommunicationOptions,
@@ -80,10 +79,9 @@ router.post(
 router.post(
   "/remove-data-submit",
   urlEncodedParser,
-  //csrfProtection,
+  //csrfProtection, //MH TODO: figure out how to use this
   requireSessionUser,
   asyncMiddleware(handleRemoveFormSignup)
-  //asyncMiddleware(handleRemoveFormGet)
 );
 
 router.post(


### PR DESCRIPTION
trying to resolve heroku issues, as npm-link is used to run a local version of kanary's swaggerhub generated npm module (the npm module is unpublished). Using fetch removes this dependency.