### PR TITLE
handle dynamic user IDs

### DIFF
--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -407,6 +407,7 @@ remove-result-details-found = Info found
 remove-result-description = Description
 remove-result-link = Link
 remove-result-opt-out = Where to opt-out
+remove-complete = No Data Currently to Remove
 
 show-breaches-for-this-email = Show all breaches for this email.
 

--- a/public/js/remove-data.js
+++ b/public/js/remove-data.js
@@ -8,13 +8,7 @@ function initRemove() {
     switch ($removePage.id) {
       //MH - TODO: remove need for conditional and do this before we route. Talk to P&S about how best to handle this.
       case "remove-form":
-        //const removeFormSubmitted = localStorage.getItem("remove-form-submitted") === "true";
-        const kanaryID = parseInt(localStorage.getItem("kanary-id"));
-        if (kanaryID) {
-          window.location = "/user/remove-dashboard"; //MH TODO: - this check should be happening at the router level before hitting this page so redirect is not needed
-        } else {
-          initRemoveForm();
-        }
+        initRemoveForm();
         break;
       case "remove-dashboard":
         initRemoveDashboard();
@@ -30,8 +24,6 @@ function initRemoveForm() {
 }
 
 function initRemoveDashboard() {
-  //localStorage.setItem("remove-form-submitted", false); //MH - TODO: temp - clear localStorage so form is shown next time we hit the remove tab default route.
-  localStorage.setItem("kanary-id", false); //MH - TODO: temp - clear localStorage so form is shown next time we hit the remove tab default route.
   addRemoveDashListeners();
 }
 
@@ -66,9 +58,7 @@ function handleFormSubmit(e) {
     })
     .then((body) => {
       if (body.id) {
-        // localStorage.setItem("remove-form-submitted", true);
-        localStorage.setItem("kanary-id", body.id); //MH - temp, set local storage to handle showing remove dashboard after form submission.
-        window.location = "/user/remove-signup-confirmation";
+        window.location = "/user/remove-signup-confirmation"; //MH TODO: probably should be doing this through the router on backend?
       } else {
         console.error("no member id received", body);
       }

--- a/routes/user.js
+++ b/routes/user.js
@@ -11,9 +11,8 @@ const {
   verify,
   logout,
   getDashboard,
-  getRemoveFormPage,
+  getRemovePage,
   getRemoveConfirmationPage,
-  getRemoveDashPage,
   getPreferences,
   getBreachStats,
   handleRemoveFormSignup,
@@ -39,10 +38,10 @@ router.get(
   asyncMiddleware(getDashboard)
 );
 router.get(
-  "/remove-form",
+  "/remove-data",
   csrfProtection,
   requireSessionUser,
-  asyncMiddleware(getRemoveFormPage)
+  asyncMiddleware(getRemovePage)
 );
 
 router.get(
@@ -50,13 +49,6 @@ router.get(
   csrfProtection,
   requireSessionUser,
   asyncMiddleware(getRemoveConfirmationPage)
-);
-
-router.get(
-  "/remove-dashboard",
-  csrfProtection,
-  requireSessionUser,
-  asyncMiddleware(getRemoveDashPage)
 );
 
 router.get(

--- a/template-helpers/dashboard.js
+++ b/template-helpers/dashboard.js
@@ -86,7 +86,6 @@ function getRemoveFormData(args) {
   const verifiedEmails = args.data.root.verifiedEmails;
   //const locales = args.data.root.req.supportedLocales;
 
-  //MH TODO: include only necessary logic here
   // move emails with 0 breaches to the bottom of the page
   verifiedEmails.sort((a, b) => {
     if (
@@ -108,12 +107,10 @@ function getRemoveFormData(args) {
 }
 
 function getRemoveDashData(args) {
-  //console.log("removeDashArgs", args);
   const verifiedEmails = args.data.root.verifiedEmails;
   const locales = args.data.root.req.supportedLocales;
   const removeResults = args.data.root.removeData;
 
-  //MH TODO: include only necessary logic here
   // move emails with 0 breaches to the bottom of the page
   verifiedEmails.sort((a, b) => {
     if (
@@ -125,7 +122,7 @@ function getRemoveDashData(args) {
     return 0;
   });
 
-  //MH - temp construct FPO dynamic update date
+  //MH TODO: temp construct FPO dynamic update date
   const curDate = new Date();
   const options = {
     month: "short",
@@ -137,9 +134,11 @@ function getRemoveDashData(args) {
 
   const upDate = curDate.toLocaleDateString(locales, options);
 
-  removeResults.forEach((result) => {
-    result.info = verifiedEmails[0].email; //MH - temp - this info doesn't seem to be available
-  });
+  if (removeResults && removeResults.length) {
+    removeResults.forEach((result) => {
+      result.info = verifiedEmails[0].email; //MH - temp - this info doesn't seem to be available
+    });
+  }
 
   const emailCards = {
     verifiedEmails: verifiedEmails,

--- a/views/partials/dashboards/breach-dash-tabs.hbs
+++ b/views/partials/dashboards/breach-dash-tabs.hbs
@@ -5,7 +5,7 @@
         <a href="/user/dashboard" class="dash-tabs-link">{{ getString "dash-tab-breach-title" }}</a>
         </li>
       <li class="dash-tabs-item dash-tabs-item--remove {{#ifCompare activeTab "===" "remove"}}active{{/ifCompare}}">
-        <a href="/user/remove-form" class="dash-tabs-link">{{ getString "dash-tab-remove-title" }}
+        <a href="/user/remove-data" class="dash-tabs-link">{{ getString "dash-tab-remove-title" }}
           <span class="dash-tabs-beta hidden-mobile">{{ getString "dash-tab-beta" }}</span>
         </a>
       </li>

--- a/views/partials/dashboards/remove-dashboard.hbs
+++ b/views/partials/dashboards/remove-dashboard.hbs
@@ -65,9 +65,13 @@
     </div>
     <div class="remove-dash-results-container">
         <ul class="remove-dash-results-list">
-          {{#each this.removeResults}}
-            {{> removal/removal-result }}
-          {{/each}}
+          {{#if this.removeResults}}
+            {{#each this.removeResults}}
+              {{> removal/removal-result }}
+            {{/each}}
+          {{else}}
+            {{> removal/removal-complete }}
+          {{/if}}
         </ul>
       </div>
   </div>

--- a/views/partials/removal/removal-complete.hbs
+++ b/views/partials/removal/removal-complete.hbs
@@ -1,0 +1,21 @@
+<li
+  class="remove-dash-results-list-item drop-shadow flx flx-col"
+  data-status="completed"
+>
+  <div class="remove-dash-results-summary-container flx space-between">
+    <div class="remove-dash-results-site-container flx flx-cntr">
+
+      <img
+        src="/img/svg/remove-filter-key-completed-icon.svg"
+        alt="{{getString "remove-filter-completed"}}"
+        class="remove-dash-results-list-icon"
+      />
+
+      <div class="remove-dash-results-site-name-container flx flx-col">
+        <span class="remove-dash-results-site-name">{{getString
+            "remove-complete"
+          }}</span>
+      </div>
+    </div>
+  </div>
+</li>

--- a/views/partials/removal/removal-result.hbs
+++ b/views/partials/removal/removal-result.hbs
@@ -11,7 +11,7 @@
           class="remove-dash-results-list-icon"
         />
       {{/ifCompare}}
-      {{#ifCompare this.status "===" "completed"}}
+      {{#ifCompare this.status "===" "REMOVAL_VERIFIED"}}
         <img
           src="/img/svg/remove-filter-key-completed-icon.svg"
           alt="{{getString "remove-filter-completed"}}"


### PR DESCRIPTION
store kanary id in session object vs browser local storage
handle empty reports results set
route remove-form and remove-dashboard routes to a single remove-data route which conditionally renders the appropriate partial
allow ability to pass a hardcoded user ID via a url param, e.g. `/user/remove-data/?kid=2875`