### PR TITLE
check .nav-user-email exists before referencing

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -96,11 +96,14 @@ if (removeMonitorButton) {
 }
 
 const relayLink = document.querySelector("[data-event-label='Try Firefox Relay']");
-const user_email = document.querySelector(".nav-user-email").textContent;
-if (user_email) {
-  const relayUrl = new URL(relayLink.href);
-  relayUrl.pathname += "accounts/fxa/login/";
-  relayUrl.searchParams.append("process", "login");
-  relayUrl.searchParams.append("auth_params", "prompt=none&login_hint=" + user_email);
-  relayLink.href = relayUrl.href;
+const userEmailElement = document.querySelector(".nav-user-email");
+if (userEmailElement) {
+  const user_email = userEmailElement.textContent;
+  if (user_email) {
+    const relayUrl = new URL(relayLink.href);
+    relayUrl.pathname += "accounts/fxa/login/";
+    relayUrl.searchParams.append("process", "login");
+    relayUrl.searchParams.append("auth_params", "prompt=none&login_hint=" + user_email);
+    relayLink.href = relayUrl.href;
+  }
 }


### PR DESCRIPTION
When the user is signed-out, the new code in `dashboard.js` throws this error:
```
Uncaught TypeError: can't access property "textContent", document.querySelector(...) is null
```
NBD in local & heroku, because it's the last code in `dashboard.js`, so the error doesn't cause any other effects. But in stage and prod, `dashboard.js` script is bundled into the single `app.min.js` file and the error stops all the following JS from executing - yikes! Breaks a lot of functionality, including the "Sign in" button.

This changes the code so it checks the element exists before trying to access its `textContent` property.