### PR TITLE
Add quotes around data-fxa-address data attribute in body tag

### DIFF
--- a/views/partials/analytics/default_dataset.hbs
+++ b/views/partials/analytics/default_dataset.hbs
@@ -1,7 +1,7 @@
 data-server-url="{{ SERVER_URL }}"
 data-logos-origin="{{ LOGOS_ORIGIN }}"
 data-fxa-enabled="fxa-enabled"
-data-fxa-address={{ getFxaUrl }}
+data-fxa-address="{{ getFxaUrl }}"
 data-utm_source="{{ UTM_SOURCE }}"
 
 {{#if req.session.user}}


### PR DESCRIPTION
Currently the `data-fxa-address` attribute isn't wrapped in quotes, and it was throwing some confusing warning in a tool I was trying to build:

```diff
<body data-server-url="https://monitor.firefox.com"
    data-logos-origin="https://monitor.cdn.mozilla.net"
    data-fxa-enabled="fxa-enabled"
-   data-fxa-address=https://accounts.firefox.com/settings
+   data-fxa-address="https://accounts.firefox.com/settings"
    data-utm_source="monitor.firefox.com"
    data-signed-in-user="false"
    data-bento-app-id="fx-monitor"
>
```

```sh
[error] https-monitor-firefox-com-breaches.raw.html: SyntaxError: Unexpected closing tag "body". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags (76:7)
[error]   74 |
[error]   75 |
[error] > 76 |       </body>
[error]      |       ^^^^^^^
[error]   77 | </html>
```