### PR TITLE
Mh/kanary 030 pmt - Payment and Enrollment Processes

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -686,6 +686,10 @@ function logout(req, res) {
 async function getRemovePage(req, res) {
   const user = req.user;
 
+  if (!checkIfEnrolledInRemovalPilot(user)) {
+    return res.redirect("/user/remove-enroll");
+  }
+
   if (checkIfRemovalPilotEnded()) {
     //if the pilot is over, redirect to the end screen
     return res.redirect("/user/remove-pilot-ended");
@@ -1275,6 +1279,10 @@ function checkIfRemovalPilotEnded() {
   } else {
     return false;
   }
+}
+
+function checkIfEnrolledInRemovalPilot(user) {
+  return user.removal_enrolled_time;
 }
 
 function checkIfRemoveDisplayMoreTime() {

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -676,6 +676,13 @@ async function getRemoveMoreTimePage(req, res) {
 
   const experimentFlags = getExperimentFlags(req, EXPERIMENTS_ENABLED);
 
+  let removeData,
+    removeAcctInfo = null; //data broker info
+  if (user.kid) {
+    removeData = await getRemoveDashData(user.kid);
+    removeAcctInfo = await getRemoveAcctInfo(user.kid);
+  }
+
   res.render("dashboards", {
     title: req.fluentFormat("Firefox Monitor"),
     csrfToken: req.csrfToken(),
@@ -686,6 +693,8 @@ async function getRemoveMoreTimePage(req, res) {
     whichPartial: "dashboards/remove-more-time",
     experimentFlags,
     utmOverrides,
+    removeData,
+    removeAcctInfo,
   });
 }
 

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -727,8 +727,6 @@ function sortRemovalData(removalData) {
 
   const sortedData = [...completeItems, ...activeItems, ...blockedItems];
 
-  console.log("sorted", sortedData);
-
   return sortedData;
 }
 

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -25,12 +25,14 @@ const FXA_MONITOR_SCOPE = "https://identity.mozilla.com/apps/monitor";
 
 async function handleEnrollFormSignup(req, res) {
   const { privacy } = req.body;
-  const isFull = true; //MH TODO: Temp - need to check this against database
-  //MH TODO: log enroll timestamp to DB
+  const isFull = false; //MH TODO: Temp - need to check this against database
+  const user = req.user;
+
   let nextPage;
   if (isFull) {
     nextPage = "/user/remove-enroll-full";
   } else {
+    const ts = await DB.setRemovalEnrollTime(user, new Date().toISOString());
     nextPage = "/user/remove-data"; //MH TODO: show success screen or just send them straight to the form?
   }
   return res.json({ nextPage: nextPage });

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -24,11 +24,9 @@ const { JS_CONSTANTS, REMOVAL_STATUS } = require("../js-constants");
 const FXA_MONITOR_SCOPE = "https://identity.mozilla.com/apps/monitor";
 
 async function handleEnrollFormSignup(req, res) {
-  //TODO: validate form data
-
   const { privacy } = req.body;
-  console.log(privacy);
   const isFull = true; //MH TODO: Temp - need to check this against database
+  //MH TODO: log enroll timestamp to DB
   let nextPage;
   if (isFull) {
     nextPage = "/user/remove-enroll-full";

--- a/db/DB.js
+++ b/db/DB.js
@@ -7,6 +7,7 @@ const { attachPaginate } = require("knex-paginate");
 
 const { FluentError } = require("../locale-utils");
 const AppConstants = require("../app-constants");
+const { JS_CONSTANTS } = require("../js-constants");
 const { FXA } = require("../lib/fxa");
 const HIBP = require("../hibp");
 const getSha1 = require("../sha1-utils");
@@ -389,6 +390,15 @@ const DB = {
     return kid;
   },
 
+  async getRemovalPilotByName(pilot_name) {
+    const res = await knex("removal_pilot")
+      .where("name", JS_CONSTANTS.REMOVAL_PILOT_GROUP)
+      .catch((e) => {
+        console.error("error retrieving pilot record", e);
+      });
+    return res[0];
+  },
+
   async setRemovalEnrollTime(user, ts) {
     await knex("subscribers")
       .where("id", user.id)
@@ -399,6 +409,15 @@ const DB = {
         console.error("error setting removal enrolled time", e);
       });
     return ts;
+  },
+
+  async incrementRemovalEnrolledUsers(user, ts) {
+    return await knex("removal_pilot")
+      .where("name", JS_CONSTANTS.REMOVAL_PILOT_GROUP)
+      .increment("enrolled_users", 1)
+      .catch((e) => {
+        console.error("error incrementing enrolled users", e);
+      });
   },
 
   async removeSubscriber(subscriber) {

--- a/db/DB.js
+++ b/db/DB.js
@@ -389,6 +389,18 @@ const DB = {
     return kid;
   },
 
+  async setRemovalEnrollTime(user, ts) {
+    await knex("subscribers")
+      .where("id", user.id)
+      .update({
+        removal_enrolled_time: ts,
+      })
+      .catch((e) => {
+        console.error("error setting removal enrolled time", e);
+      });
+    return ts;
+  },
+
   async removeSubscriber(subscriber) {
     await knex("email_addresses").where({ subscriber_id: subscriber.id }).del();
     await knex("subscribers").where({ id: subscriber.id }).del();

--- a/db/migrations/20211001120114_user_enroll_and_pay_null.js
+++ b/db/migrations/20211001120114_user_enroll_and_pay_null.js
@@ -1,0 +1,15 @@
+"use strict";
+
+exports.up = function (knex) {
+  return knex.schema.table("subscribers", (table) => {
+    table.boolean("removal_would_pay");
+    table.timestamp("removal_enrolled_time");
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table("subscribers", (table) => {
+    table.dropColumn("removal_would_pay");
+    table.dropColumn("removal_enrolled_time");
+  });
+};

--- a/db/migrations/20211001135448_removal_pilot_table.js
+++ b/db/migrations/20211001135448_removal_pilot_table.js
@@ -1,0 +1,13 @@
+"use strict";
+
+exports.up = (knex) => {
+  return knex.schema.createTable("removal_pilot", (table) => {
+    table.increments("id").primary();
+    table.string("name").unique();
+    table.integer("enrolled_users").defaultTo(0);
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTableIfExists("removal_pilot");
+};

--- a/form-utils.js
+++ b/form-utils.js
@@ -41,6 +41,14 @@ const FormUtils = {
 
     return readableDate;
   },
+  getDaysFromTimestamp(ts, numDays) {
+    const curDate = new Date(ts * 1000); //days to ms
+    return new Date(
+      curDate.getFullYear(),
+      curDate.getMonth(),
+      curDate.getDate() + numDays
+    );
+  },
 };
 
 module.exports = {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,46 +3,62 @@
 const { src, watch, series, dest } = require("gulp");
 const sass = require("gulp-sass");
 const del = require("del");
+const sourcemaps = require("gulp-sourcemaps");
 
 // directory for building SCSS, and bundles
 const buildDir = "./public/scss/libs/protocol/";
 const finalDir = "./public/css/";
 
-const compiledCssDirectories = [
-    "./public/css/*",
-    "!./public/css/legacy/**",
-];
+const compiledCssDirectories = ["./public/css/*", "!./public/css/legacy/**"];
 
 function cleanCompiledCssDirectory() {
-    return del(compiledCssDirectories);
+  return del(compiledCssDirectories);
 }
 
 function resetCssDirectories() {
-    return del(compiledCssDirectories.concat(buildDir));
+  return del(compiledCssDirectories.concat(buildDir));
 }
 
 function styles() {
-    return src("./public/scss/app.scss")
-        .pipe(sass().on("error", sass.logError))
-        .pipe(dest(finalDir));
+  return src("./public/scss/app.scss")
+    .pipe(sourcemaps.init())
+    .pipe(sass().on("error", sass.logError))
+    .pipe(sourcemaps.write("."))
+    .pipe(dest(finalDir));
 }
 
 function assetsCopyLegacy() {
-    return src(["./public/scss/partials/legacy/**/*"]).pipe(dest("./public/css/legacy/"));
+  return src(["./public/scss/partials/legacy/**/*"]).pipe(
+    dest("./public/css/legacy/")
+  );
 }
 
 function watchCss() {
-    return watch("./public/scss/**/*.scss", { ignoreInitial: false }, series(cleanCompiledCssDirectory, styles));
+  return watch(
+    "./public/scss/**/*.scss",
+    { ignoreInitial: false },
+    series(cleanCompiledCssDirectory, styles)
+  );
 }
 
 function assetsCopy() {
-    return src(["./node_modules/@mozilla-protocol/core/protocol/**/*"]).pipe(dest(buildDir));
+  return src(["./node_modules/@mozilla-protocol/core/protocol/**/*"]).pipe(
+    dest(buildDir)
+  );
 }
 
 exports.watchCss = watchCss;
 
-exports.build = series(resetCssDirectories, assetsCopy, assetsCopyLegacy, styles);
+exports.build = series(
+  resetCssDirectories,
+  assetsCopy,
+  assetsCopyLegacy,
+  styles
+);
 
 exports.default = series(
-    cleanCompiledCssDirectory, assetsCopy, styles, watchCss
+  cleanCompiledCssDirectory,
+  assetsCopy,
+  styles,
+  watchCss
 );

--- a/js-constants.js
+++ b/js-constants.js
@@ -73,6 +73,7 @@ const JS_CONSTANTS = {
     "zabasearch.com",
     "peoplebyname.com",
   ],
+  REMOVAL_PILOT_START_TIME: 1634108460, //10/13/2021 - 7:00am GMT - timestamp when the pilot started (can generate a timestamp from a calendar date at https://www.epochconverter.com/)
   REMOVAL_PILOT_MAX_USERS: 500, //max number of users allowed in this pilot group
   REMOVAL_PILOT_ENROLLMENT_END_DAY: 30, //days from pilot start to when a user can no longer enroll in their pilot group
   REMOVAL_PILOT_PMT_DAY: 45, //days from pilot start to showing the willingness to pay option

--- a/js-constants.js
+++ b/js-constants.js
@@ -73,10 +73,12 @@ const JS_CONSTANTS = {
     "zabasearch.com",
     "peoplebyname.com",
   ],
-  REMOVAL_ENROLLMENT_END_DAY: 30, //days from pilot start to when a user can no longer enroll in their pilot group
-  REMOVAL_PMT_DAY: 45, //days from pilot start to showing the willingness to pay option
-  REMOVAL_PMT_DECISION_DAY: 65, //days from pilot start to no longer displaying the pmt choice screen
-  REMOVAL_END_DAY: 90, //days from pilot start to when the pilot ends
+  REMOVAL_PILOT_MAX_USERS: 500, //max number of users allowed in this pilot group
+  REMOVAL_PILOT_ENROLLMENT_END_DAY: 30, //days from pilot start to when a user can no longer enroll in their pilot group
+  REMOVAL_PILOT_PMT_DAY: 45, //days from pilot start to showing the willingness to pay option
+  REMOVAL_PILOT_PMT_DECISION_DAY: 65, //days from pilot start to no longer displaying the pmt choice screen
+  REMOVAL_PILOT_END_DAY: 90, //days from pilot start to when the pilot ends
+  REMOVAL_PILOT_GROUP: "round_01", //name of the current pilot group
   REMOVAL_STEP: {
     AWAITING_SCAN: {
       locale_var: "remove-step-awaiting-scan",

--- a/js-constants.js
+++ b/js-constants.js
@@ -72,7 +72,10 @@ const JS_CONSTANTS = {
     "zabasearch.com",
     "peoplebyname.com",
   ],
-
+  REMOVAL_ENROLLMENT_END_DAY: 30, //days from pilot start to when a user can no longer enroll in their pilot group
+  REMOVAL_PMT_DAY: 45, //days from pilot start to showing the willingness to pay option
+  REMOVAL_PMT_DECISION_DAY: 65, //days from pilot start to no longer displaying the pmt choice screen
+  REMOVAL_END_DAY: 90, //days from pilot start to when the pilot ends
   REMOVAL_STEP: {
     FOUND: {
       //

--- a/js-constants.js
+++ b/js-constants.js
@@ -20,6 +20,7 @@ const REMOVAL_STATUS = {
 
 const JS_CONSTANTS = {
   KANARY_PRIVACY_LINK: "https://www.thekanary.com/privacy_and_security",
+  REMOVE_ROUTES: ["/user/remove-data", "/user/remove-enroll"],
   REMOVAL_SITES: [
     "anywho.com",
     "backgroundalert.com",

--- a/locale-utils.js
+++ b/locale-utils.js
@@ -33,7 +33,6 @@ class FluentError extends Error {
 
 const LocaleUtils = {
   init() {
-    console.log("init locales");
     let languageDirectories = supportedLocales.split(",");
     if (supportedLocales === "*") {
       languageDirectories = fs.readdirSync(localesDir).filter((item) => {

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -509,6 +509,7 @@ remove-enroll-submit = Join the pilot
 remove-enroll-full-title = Enrollment in the Pilot is Full
 remove-enroll-full-description = Thank you for your interest in Mozilla’s Data Removal Service powered by Kanary. 
   Unfortunately, the pilot program is at capacity
+remove-enroll-error-is_enrolled = User is already enrolled
 
 show-breaches-for-this-email = Show all breaches for this email.
 

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -480,6 +480,17 @@ remove-result-name = Name
 remove-result-address = Address
 remove-result-status = Status
 
+# remove more time page
+remove-mt-title = Get More Time
+remove-mt-intro = The 90-day pilot of our data removal service will remain at no cost to you for the duration of the pilot period. However, in order to continue for the remaining 45 days, we’d like to offer you a choice...
+remove-mt-option1-title = Option 1: Continue Service
+remove-mt-option1-description = Continue your service for the remaining 45 days of the pilot at no cost to you.
+remove-mt-option1-btn = Cntinue Service
+remove-mt-option2-title = Option 2: Discontinue Service
+remove-mt-option2-description = Discontinue your service today* and receive a $5 Amazon gift card.
+remove-mt-option2-btn = Discontinue Service
+remove-mt-option2-smalltext = *Any removals in progress will be suspended and all completed removals will remain so. No additional removals will take place. You will lose access to your exposures dashboard.
+
 show-breaches-for-this-email = Show all breaches for this email.
 
 link-change-primary = Change Primary Email Address

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -366,151 +366,6 @@ send-verification = Send Verification Link
 # email address.
 breach-summary = Breach Summary
 
-
-# dashboard tab language
-dash-tab-breach-title = Breaches
-dash-tab-remove-title = Exposures
-dash-tab-beta = Beta
-
-# removal kanary header
-dash-remove-kanary-more = Find out more
-
-# removal cta
-remove-card-title = Remove your data from websites.
-remove-card-body = We’re piloting a new service to monitor and remove your name, physical address, phone number, and email from online databases.
-remove-card-cta = Join the waitlist
-
-# removal form strings
-
-dash-remove-intro-1 = Mozilla Privacy Pack actively monitors hundreds of thousands of websites for your personal information and removes it from any website that puts you and your loved ones at risk.
-dash-remove-intro-service-link = More about the service
-dash-remove-intro-signup-title = How to start
-dash-remove-intro-signup = To start removing your exposed personal data, please provide the following information. We use this information to scan and identify exposed personal information on data broker websites. Once we  find exposed personal information, we will automatically begin the removal process. Initial results can take up to 24 hours.
-dash-remove-info-change-title = Update your info
-dash-remove-info-change = To update the info you want removed from data brokers, fill out the form below
-dash-remove-form-email-label = Select your email address
-dash-remove-form-name-label = What is your full name?
-dash-remove-form-name-first = First Name
-dash-remove-form-name-middle = Middle (Optional)
-dash-remove-form-name-last = Last Name
-dash-remove-form-loc-label = What is your current location?
-dash-remove-form-loc-city = City
-dash-remove-form-loc-state = State
-dash-remove-form-loc-country = Country
-dash-remove-form-birth-year-label = What is your birth year?
-dash-remove-form-birth-year = Enter your birth year
-dash-remove-form-privacy-label = Privacy Policy
-dash-remove-form-privacy = The Data Removal Service is offered by The Kanary. 
-dash-remove-form-privacy-link = By proceeding, you agree to their Terms of Service and Privacy Notice.
-dash-remove-submit = Start Data Removal
-dash-remove-change-submit = Submit
-dash-remove-form-required-helper = * All fields are required to properly identify your information on data broker sites
-dash-remove-form-disclaimer = By clicking “Start Data Removal” you agree to start the data removal process.
-
-# removal form confirm strings
-dash-remove-confirm-review = Review Your Information
-dash-remove-confirm-edit = Edit info
-dash-remove-confirm-label-full = Full Name
-dash-remove-confirm-email = Email Address
-dash-remove-confirm-loc = Current Location
-dash-remove-confirm-birthyear = Birth Year
-dash-remove-confirm-submit-new = Begin Data Removal
-dash-remove-confirm-submit-update = Confirm Information
-
-dash-remove-manage-info = Manage My Info
-
-# footer
-dash-remove-kanary-discalimer = Service provided by The Kanary
-dash-remove-link-risk = About Risk Level
-dash-remove-link-broker = Data Broker List
-
-
-remove-form-success-alt = Success
-remove-form-success-title = We're executing your data removal!
-remove-form-success-details = We’re checking hundreds of sites that may be putting your privacy and security at risk. Due to a high number of requests, it may take 24 hours for your report to finish.
-remove-form-success-next-title = What's next?
-remove-form-success-next-details = Check back here frequently to see the data removal requests we initiate on your behalf. As removals are verified, we'll update your dashboard to let you know the status. 
-remove-form-delete-dashboard = Go to Monitor dashboard
-remove-form-create-dashboard = Go to my dashboard
-remove-form-data-delete = Cancel Service
-
-
-remove-form-update-title = Your information has been updated!
-remove-form-update-details = We’re updating your info for our removal requests. Due to a high number of requests, it may take 24 hours for your changes to take effect.
-remove-form-delete-title = Your data removal service has been canceled.
-remove-form-delete-details = We are no longer making data removal requests on your behalf. Your Monitor Account Will Remain Active.
-
-
-
-# removal dashboard strings
-remove-status-exposures = Viewing exposures for:
-remove-status-update = Last update:
-# remove-exposure-message = is currently exposed in {$numRemoveResults} websites and has been removed from {$resolvedResults} data brokers
-
-# remove filters
-remove-filter-in-progress = In progress
-remove-filter-complete = Complete
-remove-filter-blocked = Blocked
-remove-filter-list = Filter Removal List
-remove-filter-date = Filter by Date
-
-# remove steps
-remove-step-awaiting-scan = Awaiting scan
-remove-step-found = Information found
-remove-step-awaiting-removal = Awaiting removal
-remove-step-submitted = Removal request submitted
-remove-step-awaiting-review = Awaiting review
-remove-step-removed = Removed
-remove-step-blocked = Request blocked
-
-
-# remove results
-remove-results-toggle-alt = Expand Option
-remove-risk-high = High Risk
-remove-risk-med = Medium Risk
-remove-risk-low = Low Risk
-remove-result-details-found = Info found
-remove-result-description = Description
-remove-result-link = Link
-remove-result-opt-out = Where to opt-out
-remove-pending = Generating your report. Results can take up to 48 hours. Check Back Soon!
-remove-result-updated = Updated
-remove-result-email = Email
-remove-result-phone = Phone
-remove-result-name = Name
-remove-result-address = Address
-remove-result-status = Status
-
-# remove more time page
-remove-mt-title = Get More Time
-remove-mt-intro = The 90-day pilot of our data removal service will remain at no cost to you for the duration of the pilot period. However, in order to continue for the remaining 45 days, we’d like to offer you a choice...
-remove-mt-option1-title = Option 1: Continue Service
-remove-mt-option1-description = Continue your service for the remaining 45 days of the pilot at no cost to you.
-remove-mt-option1-btn = Continue Service
-remove-mt-option2-title = Option 2: Discontinue Service
-remove-mt-option2-description = Discontinue your service today* and receive a $5 Amazon gift card.
-remove-mt-option2-btn = Discontinue Service
-remove-mt-option2-smalltext = *Any removals in progress will be suspended and all completed removals will remain so. No additional removals will take place. You will lose access to your exposures dashboard.
-
-# remove enroll page
-
-remove-enroll-title = Welcome to Firefox Monitor’s data removal pilot
-remove-enroll-description-title = Here's what you need to know
-remove-enroll-description = First, you’ll share some identifying information with us. This info allows us to find data brokers online that share it—and then get it removed. 
-  This info will only be used for the duration of the pilot, and then deleted. This pilot is separate from your main Firefox account. That means any changes you make to your account while part of this pilot program don't apply to your normal account, including changing emails, passwords, and more.
-remove-enroll-terms-title = Terms of pilot service
-remove-enroll-terms = The pilot service will be offered at no cost to you for a 90 day period.
-  The purpose of the pilot is to evaluate the service for a paid offering. As such, participating in the pilot will include additional communications and data collection about your experience. You are not required to respond to these requests for information, but we would appreciate your assistance. 
-  At the end of the 90-day pilot period, any additional service will be suspended and all account information held by Mozilla or our partner Kanary will be deleted. 
-  You may discontinue your service at any point within the 90-day pilot period.
-remove-enroll-terms-agreement = By checking this box, you agree to the terms of pilot service listed above.
-remove-enroll-submit = Join the pilot
-
-remove-enroll-full-title = Enrollment in the Pilot is Full
-remove-enroll-full-description = Thank you for your interest in Mozilla’s Data Removal Service powered by Kanary. 
-  Unfortunately, the pilot program is at capacity
-remove-enroll-error-is_enrolled = User is already enrolled
-
 show-breaches-for-this-email = Show all breaches for this email.
 
 link-change-primary = Change Primary Email Address
@@ -519,26 +374,13 @@ remove-fxm = Remove {-product-name}
 remove-fxm-blurb = Turn off {-product-name} alerts. Your {-brand-fxa} will remain active, and you may receive 
   other account-related communications.
 
-remove-kan = Cancel Data Removal Service
-remove-kan-blurb = Confirm Cancel Data Removal Service? Your Monitor Account Will Remain Active.
+show-breaches-for-this-email = Show all breaches for this email.
 
-remove-sites-list = Data Removal Site List
-remove-sites-blurb = Below are the sites we request user data to be removed from.
+link-change-primary = Change Primary Email Address
 
-# Remove risks info page
-
-remove-risk-heading = About Data Removal Risk
-remove-risk-blurb = “Risk” is assigned at the site level as a way to prioiritize actions and escalations, and is made up of 4 metrics: 
-remove-risk-criteria-1 = Does the site sell data?
-remove-risk-criteria-2 = Does the site include context beyond the personally identifiable information?
-remove-risk-criteria-3 = Does the site remove data consistently?
-remove-risk-criteria-4 = Does the site feed data to other sources?
-remove-risk-rating-high = Posts or sells location information, family information, contact information, or credentials like passwords. Site includes context about why someone would want to target a person like job, salary, political party. The site has complicated requirements and takes longer than average to remove personal information. The site feeds data to many other sources.
-remove-risk-rating-med = Posts or sells contact information like name, email, phone number. The site doesn't include additional context. The site responds to removal requests on a consistent basis. The site likely feeds data to other sources.
-remove-risk-rating-low = Posts personal information that is less likely to harm a specific person but if combined with other personal details could lead to harm. The site responds to removal requests on a consistent basis. The site likely doesn’t feed data to other sources.
-remove-risk-title-high = High
-remove-risk-title-med = Medium
-remove-risk-title-low = Low
+remove-fxm = Remove {-product-name}
+remove-fxm-blurb = Turn off {-product-name} alerts. Your {-brand-fxa} will remain active, and you may receive 
+  other account-related communications.
 
 # Button title
 manage-email-addresses = Manage Email Addresses
@@ -995,3 +837,183 @@ vpn-promo-cta = Get { -brand-mozilla-vpn }
 
 vpn-promo-headline-new = Save 50% with a full year subscription
 vpn-promo-copy-new = Protect your online data—and choose a VPN subscription plan that works for you.
+
+
+# ---DATA REMOVAL CONTENT---
+
+# Data Removal Pilot Dashboard Tabs
+dash-tab-breach-title = Breaches
+dash-tab-remove-title = Exposures
+dash-tab-beta = Beta
+
+# Data Removal Pilot Kanary Header
+dash-remove-kanary-more = Find out more
+
+# Data Removal Pilot CTA
+remove-card-title = Remove your data from websites.
+remove-card-body = We’re piloting a new service to monitor and remove your name, physical address, phone number, and email from online databases.
+remove-card-cta = Join the waitlist
+
+# Data Removal Pilot Form Strings
+dash-remove-intro-1 = Mozilla Privacy Pack actively monitors hundreds of thousands of websites for your personal information and removes it from any website that puts you and your loved ones at risk.
+dash-remove-intro-service-link = More about the service
+dash-remove-intro-signup-title = How to start
+dash-remove-intro-signup = To start removing your exposed personal data, please provide the following information. We use this information to scan and identify exposed personal information on data broker websites. Once we  find exposed personal information, we will automatically begin the removal process. Initial results can take up to 24 hours.
+dash-remove-info-change-title = Update your info
+dash-remove-info-change = To update the info you want removed from data brokers, fill out the form below
+dash-remove-form-email-label = Select your email address
+dash-remove-form-name-label = What is your full name?
+dash-remove-form-name-first = First Name
+dash-remove-form-name-middle = Middle (Optional)
+dash-remove-form-name-last = Last Name
+dash-remove-form-loc-label = What is your current location?
+dash-remove-form-loc-city = City
+dash-remove-form-loc-state = State
+dash-remove-form-loc-country = Country
+dash-remove-form-birth-year-label = What is your birth year?
+dash-remove-form-birth-year = Enter your birth year
+dash-remove-form-privacy-label = Privacy Policy
+dash-remove-form-privacy = The Data Removal Service is offered by The Kanary. 
+dash-remove-form-privacy-link = By proceeding, you agree to their Terms of Service and Privacy Notice.
+dash-remove-submit = Start Data Removal
+dash-remove-change-submit = Submit
+dash-remove-form-required-helper = * All fields are required to properly identify your information on data broker sites
+dash-remove-form-disclaimer = By clicking “Start Data Removal” you agree to start the data removal process.
+
+# Data Removal Pilot Form Confirmation Strings
+dash-remove-confirm-review = Review Your Information
+dash-remove-confirm-edit = Edit info
+dash-remove-confirm-label-full = Full Name
+dash-remove-confirm-email = Email Address
+dash-remove-confirm-loc = Current Location
+dash-remove-confirm-birthyear = Birth Year
+dash-remove-confirm-submit-new = Begin Data Removal
+dash-remove-confirm-submit-update = Confirm Information
+dash-remove-manage-info = Manage My Info
+
+# Data Removal Pilot Footer
+dash-remove-kanary-discalimer = Service provided by The Kanary
+dash-remove-link-risk = About Risk Level
+dash-remove-link-broker = Data Broker List
+
+# Data Removal Pilot Data Removal Form Completion Page
+remove-form-success-alt = Success
+remove-form-success-title = We're executing your data removal!
+remove-form-success-details = We’re checking hundreds of sites that may be putting your privacy and security at risk. Due to a high number of requests, it may take 24 hours for your report to finish.
+remove-form-success-next-title = What's next?
+remove-form-success-next-details = Check back here frequently to see the data removal requests we initiate on your behalf. As removals are verified, we'll update your dashboard to let you know the status. 
+remove-form-delete-dashboard = Go to Monitor dashboard
+remove-form-create-dashboard = Go to my dashboard
+remove-form-data-delete = Cancel Service
+
+# Data Removal Pilot Information Update Page
+remove-form-update-title = Your information has been updated!
+remove-form-update-details = We’re updating your info for our removal requests. Due to a high number of requests, it may take 24 hours for your changes to take effect.
+remove-form-delete-title = Your data removal service has been canceled.
+remove-form-delete-details = We are no longer making data removal requests on your behalf. Your Monitor Account Will Remain Active.
+
+# Data Removal Pilot Dashboard Strings
+remove-status-exposures = Viewing exposures for:
+remove-status-update = Last update:
+# remove-exposure-message = is currently exposed in {$numRemoveResults} websites and has been removed from {$resolvedResults} data brokers
+
+# Data Removal Filters 
+remove-filter-in-progress = In progress
+remove-filter-complete = Complete
+remove-filter-blocked = Blocked
+remove-filter-list = Filter Removal List
+remove-filter-date = Filter by Date
+
+# Data Removal Pilot Steps (Status)
+remove-step-awaiting-scan = Awaiting scan
+remove-step-found = Information found
+remove-step-awaiting-removal = Awaiting removal
+remove-step-submitted = Removal request submitted
+remove-step-awaiting-review = Awaiting review
+remove-step-removed = Removed
+remove-step-blocked = Request blocked
+
+
+# Data Removal Pilot Results Page
+remove-results-toggle-alt = Expand Option
+remove-risk-high = High Risk
+remove-risk-med = Medium Risk
+remove-risk-low = Low Risk
+remove-result-details-found = Info found
+remove-result-description = Description
+remove-result-link = Link
+remove-result-opt-out = Where to opt-out
+remove-pending = Generating your report. Results can take up to 48 hours. Check Back Soon!
+remove-result-updated = Updated
+remove-result-email = Email
+remove-result-phone = Phone
+remove-result-name = Name
+remove-result-address = Address
+remove-result-status = Status
+
+# Data Removal Pilot Get More Time Page
+remove-mt-title = Get More Time
+remove-mt-intro = The 90-day pilot of our data removal service will remain at no cost to you for the duration of the pilot period. However, in order to continue for the remaining 45 days, we’d like to offer you a choice...
+remove-mt-option1-title = Option 1: Continue Service
+remove-mt-option1-description = Continue your service for the remaining 45 days of the pilot at no cost to you.
+remove-mt-option1-btn = Continue Service
+remove-mt-option2-title = Option 2: Discontinue Service
+remove-mt-option2-description = Discontinue your service today* and receive a $5 Amazon gift card.
+remove-mt-option2-btn = Discontinue Service
+remove-mt-option2-smalltext = *Any removals in progress will be suspended and all completed removals will remain so. No additional removals will take place. You will lose access to your exposures dashboard.
+
+# Data Removal Pilot Enrollment Page
+remove-enroll-title = Welcome to Firefox Monitor’s data removal pilot
+remove-enroll-description-title = Here's what you need to know
+remove-enroll-description = First, you’ll share some identifying information with us. This info allows us to find data brokers online that share it—and then get it removed. 
+  This info will only be used for the duration of the pilot, and then deleted. This pilot is separate from your main Firefox account. That means any changes you make to your account while part of this pilot program don't apply to your normal account, including changing emails, passwords, and more.
+remove-enroll-terms-title = Terms of pilot service
+remove-enroll-terms = The pilot service will be offered at no cost to you for a 90 day period.
+  The purpose of the pilot is to evaluate the service for a paid offering. As such, participating in the pilot will include additional communications and data collection about your experience. You are not required to respond to these requests for information, but we would appreciate your assistance. 
+  At the end of the 90-day pilot period, any additional service will be suspended and all account information held by Mozilla or our partner Kanary will be deleted. 
+  You may discontinue your service at any point within the 90-day pilot period.
+remove-enroll-terms-agreement = By checking this box, you agree to the terms of pilot service listed above.
+remove-enroll-submit = Join the pilot
+
+# Data Removal Pilot Enrollment Full Page
+remove-enroll-full-title = Enrollment in the Pilot is Full
+remove-enroll-full-description = Thank you for your interest in Mozilla’s Data Removal Service powered by Kanary. 
+  Unfortunately, the pilot program is at capacity
+remove-enroll-error-is_enrolled = User is already enrolled
+
+# Data Removal Pilot Enrollment Ended Page
+remove-enroll-ended-title = Pilot Enrollment Deadline Expired
+remove-enroll-ended-description = Thank you for your interest in Mozilla’s Data Removal Service powered by Kanary. 
+  Unfortunately, the enrollment deadline for participating in the pilot has passed.
+
+# Data Removal Pilot Ended Page
+remove-pilot-ended-title = Data Removal Pilot Has Ended
+remove-pilot-ended-description = We are evaluating whether to continue offering the data removal service at Mozilla. 
+  In the meantime, if you wish to continue monitoring data brokers for your information, you can sign up at thekanary.com. 
+  If you participated in the pilot and chose to receive a gift card rather than continue the service, those gift cards will be distributed soon.
+
+# Data Removal Pilot Success Page
+remove-enrolled-title = Welcome to the Pilot
+remove-enrolled-description = Congratulations on successfully being enrolled in the pilot. Here's how things work:
+
+# Data Removal Pilot Cancellation Page
+remove-kan = Cancel Data Removal Service
+remove-kan-blurb = Confirm Cancel Data Removal Service? Your Monitor Account Will Remain Active.
+
+# Data Removal Pilot Sites List Page
+remove-sites-list = Data Removal Site List
+remove-sites-blurb = Below are the sites we request user data to be removed from.
+
+# Data Removal Pilot Risks Info Page
+remove-risk-heading = About Data Removal Risk
+remove-risk-blurb = “Risk” is assigned at the site level as a way to prioiritize actions and escalations, and is made up of 4 metrics: 
+remove-risk-criteria-1 = Does the site sell data?
+remove-risk-criteria-2 = Does the site include context beyond the personally identifiable information?
+remove-risk-criteria-3 = Does the site remove data consistently?
+remove-risk-criteria-4 = Does the site feed data to other sources?
+remove-risk-rating-high = Posts or sells location information, family information, contact information, or credentials like passwords. Site includes context about why someone would want to target a person like job, salary, political party. The site has complicated requirements and takes longer than average to remove personal information. The site feeds data to many other sources.
+remove-risk-rating-med = Posts or sells contact information like name, email, phone number. The site doesn't include additional context. The site responds to removal requests on a consistent basis. The site likely feeds data to other sources.
+remove-risk-rating-low = Posts personal information that is less likely to harm a specific person but if combined with other personal details could lead to harm. The site responds to removal requests on a consistent basis. The site likely doesn’t feed data to other sources.
+remove-risk-title-high = High
+remove-risk-title-med = Medium
+remove-risk-title-low = Low

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -485,11 +485,29 @@ remove-mt-title = Get More Time
 remove-mt-intro = The 90-day pilot of our data removal service will remain at no cost to you for the duration of the pilot period. However, in order to continue for the remaining 45 days, we’d like to offer you a choice...
 remove-mt-option1-title = Option 1: Continue Service
 remove-mt-option1-description = Continue your service for the remaining 45 days of the pilot at no cost to you.
-remove-mt-option1-btn = Cntinue Service
+remove-mt-option1-btn = Continue Service
 remove-mt-option2-title = Option 2: Discontinue Service
 remove-mt-option2-description = Discontinue your service today* and receive a $5 Amazon gift card.
 remove-mt-option2-btn = Discontinue Service
 remove-mt-option2-smalltext = *Any removals in progress will be suspended and all completed removals will remain so. No additional removals will take place. You will lose access to your exposures dashboard.
+
+# remove enroll page
+
+remove-enroll-title = Welcome to Firefox Monitor’s data removal pilot
+remove-enroll-description-title = Here's what you need to know
+remove-enroll-description = First, you’ll share some identifying information with us. This info allows us to find data brokers online that share it—and then get it removed. 
+  This info will only be used for the duration of the pilot, and then deleted. This pilot is separate from your main Firefox account. That means any changes you make to your account while part of this pilot program don't apply to your normal account, including changing emails, passwords, and more.
+remove-enroll-terms-title = Terms of pilot service
+remove-enroll-terms = The pilot service will be offered at no cost to you for a 90 day period.
+  The purpose of the pilot is to evaluate the service for a paid offering. As such, participating in the pilot will include additional communications and data collection about your experience. You are not required to respond to these requests for information, but we would appreciate your assistance. 
+  At the end of the 90-day pilot period, any additional service will be suspended and all account information held by Mozilla or our partner Kanary will be deleted. 
+  You may discontinue your service at any point within the 90-day pilot period.
+remove-enroll-terms-agreement = By checking this box, you agree to the terms of pilot service listed above.
+remove-enroll-submit = Join the pilot
+
+remove-enroll-full-title = Enrollment in the Pilot is Full
+remove-enroll-full-description = Thank you for your interest in Mozilla’s Data Removal Service powered by Kanary. 
+  Unfortunately, the pilot program is at capacity
 
 show-breaches-for-this-email = Show all breaches for this email.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -477,6 +477,63 @@
       "dev": true,
       "optional": true
     },
+    "@gulp-sourcemaps/identity-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-2.0.1.tgz",
+      "integrity": "sha512-Tb+nSISZku+eQ4X1lAkevcQa+jknn/OVUgZ3XCxEKIsLsqYuPoJwJOPQeaOk75X3WPftb29GWY1eqE7GLsXb1Q==",
+      "requires": {
+        "acorn": "^6.4.1",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.16",
+        "source-map": "^0.6.0",
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "through2": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
+    "@gulp-sourcemaps/map-sources": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+      "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
+      "requires": {
+        "normalize-path": "^2.0.1",
+        "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -4435,6 +4492,37 @@
         "uid-safe": "2.1.5"
       }
     },
+    "css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+      "requires": {
+        "inherits": "^2.0.4",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.6.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        }
+      }
+    },
     "css-value": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
@@ -4557,6 +4645,31 @@
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "requires": {
         "ms": "2.1.2"
+      }
+    },
+    "debug-fabulous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-1.1.0.tgz",
+      "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
+      "requires": {
+        "debug": "3.X",
+        "memoizee": "0.4.X",
+        "object-assign": "4.X"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        }
       }
     },
     "decamelize": {
@@ -5575,6 +5688,15 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "event-stream": {
       "version": "4.0.1",
@@ -7079,6 +7201,41 @@
         "vinyl-sourcemaps-apply": "^0.2.0"
       }
     },
+    "gulp-sourcemaps": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-3.0.0.tgz",
+      "integrity": "sha512-RqvUckJkuYqy4VaIH60RMal4ZtG0IbQ6PXMNkNsshEGJ9cldUPRb/YCgboYae+CLAs1HQNb4ADTKCx65HInquQ==",
+      "requires": {
+        "@gulp-sourcemaps/identity-map": "^2.0.1",
+        "@gulp-sourcemaps/map-sources": "^1.0.0",
+        "acorn": "^6.4.1",
+        "convert-source-map": "^1.0.0",
+        "css": "^3.0.0",
+        "debug-fabulous": "^1.0.0",
+        "detect-newline": "^2.0.0",
+        "graceful-fs": "^4.0.0",
+        "source-map": "^0.6.0",
+        "strip-bom-string": "^1.0.0",
+        "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
+        },
+        "detect-newline": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "gulp-util": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
@@ -8346,6 +8503,11 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
+    },
+    "is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -11045,6 +11207,14 @@
         "yallist": "^2.1.2"
       }
     },
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "requires": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
@@ -11302,6 +11472,28 @@
         "map-age-cleaner": "^0.1.1",
         "mimic-fn": "^2.0.0",
         "p-is-promise": "^2.0.0"
+      }
+    },
+    "memoizee": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.53",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
+      },
+      "dependencies": {
+        "next-tick": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+        }
       }
     },
     "memorystream": {
@@ -13284,7 +13476,6 @@
       "version": "7.0.36",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
       "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-      "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -13294,14 +13485,12 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -15571,6 +15760,11 @@
         "is-utf8": "^0.2.0"
       }
     },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -16443,6 +16637,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+    },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "got": "10.7.0",
     "gulp": "^4.0.2",
     "gulp-sass": "^3.2.1",
+    "gulp-sourcemaps": "^3.0.0",
     "helmet": "4.2.0",
     "intl-pluralrules": "1.2.1",
     "isemail": "3.2.0",

--- a/public/js/remove-data.js
+++ b/public/js/remove-data.js
@@ -13,10 +13,17 @@ function initRemove() {
       case "remove-dashboard":
         initRemoveDashboard();
         break;
+      case "remove-enroll":
+        initRemoveEnroll();
+        break;
       default:
         console.log("no matching page id");
     }
   }
+}
+
+function initRemoveEnroll() {
+  addRemoveEnrollListeners();
 }
 
 function initRemoveForm() {
@@ -25,6 +32,12 @@ function initRemoveForm() {
 
 function initRemoveDashboard() {
   addRemoveDashListeners();
+}
+
+function addRemoveEnrollListeners() {
+  document
+    .querySelector(".js-enroll-submit")
+    .addEventListener("click", onEnrollFormSubmitClick);
 }
 
 function addRemoveFormListeners() {
@@ -71,6 +84,33 @@ function onSelectChange(e) {
 function onConfirmEditClick(e) {
   e.preventDefault();
   toggleConfirmScreen(false);
+}
+
+function onEnrollFormSubmitClick(e) {
+  const $form = e.target.form;
+  const isValid = $form.reportValidity();
+  if (!isValid) {
+    console.log("not valid!");
+    return;
+  }
+  e.preventDefault();
+  fetch($form.action, {
+    method: "POST",
+    body: new URLSearchParams(new FormData($form)),
+  })
+    .then((resp) => {
+      return resp.json(); // or resp.text() or whatever the server sends
+    })
+    .then((data) => {
+      if (data.nextPage) {
+        window.location = data.nextPage; //MH TODO: probably should be doing this through the router on backend?
+      } else {
+        console.error("there was an error in the response", data);
+      }
+    })
+    .catch((error) => {
+      console.error("error with form submission", error);
+    });
 }
 
 function onRemoveFormSubmitClick(e) {

--- a/public/js/remove-data.js
+++ b/public/js/remove-data.js
@@ -104,6 +104,8 @@ function onEnrollFormSubmitClick(e) {
     .then((data) => {
       if (data.nextPage) {
         window.location = data.nextPage; //MH TODO: probably should be doing this through the router on backend?
+      } else if (data.error) {
+        alert(data.error);
       } else {
         console.error("there was an error in the response", data);
       }

--- a/public/scss/app.scss
+++ b/public/scss/app.scss
@@ -46,6 +46,7 @@
 @import "partials/remove-data.scss";
 @import "partials/remove-form-confirm.scss";
 @import "partials/remove-result.scss";
+@import "partials/remove-more-time.scss";
 @import "partials/research-recruitment.scss";
 @import "partials/scan-results.scss";
 @import "partials/security-tips.scss";

--- a/public/scss/app.scss
+++ b/public/scss/app.scss
@@ -47,6 +47,7 @@
 @import "partials/remove-form-confirm.scss";
 @import "partials/remove-result.scss";
 @import "partials/remove-more-time.scss";
+@import "partials/remove-enroll.scss";
 @import "partials/research-recruitment.scss";
 @import "partials/scan-results.scss";
 @import "partials/security-tips.scss";

--- a/public/scss/includes/_mixins.scss
+++ b/public/scss/includes/_mixins.scss
@@ -51,8 +51,14 @@
 }
 
 @mixin ff-inter {
-  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", "Open Sans",
-    "Helvetica Neue", sans-serif;
+  font-family:
+    Inter,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    "Open Sans",
+    "Helvetica Neue",
+    sans-serif;
 }
 
 @mixin ff-metropolis {
@@ -81,7 +87,9 @@
   display: flex;
   justify-content: center;
   align-items: center;
+
   @include ff-metropolis;
+
   text-align: center;
 }
 

--- a/public/scss/includes/_mixins.scss
+++ b/public/scss/includes/_mixins.scss
@@ -72,6 +72,14 @@
   }
 }
 
+@mixin remove-btn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  @include ff-metropolis;
+  text-align: center;
+}
+
 @mixin blue-link {
   &:not([class*="btn"]) {
     color: var(--blue3);

--- a/public/scss/includes/_mixins.scss
+++ b/public/scss/includes/_mixins.scss
@@ -50,6 +50,11 @@
   }
 }
 
+@mixin ff-inter {
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", "Open Sans",
+    "Helvetica Neue", sans-serif;
+}
+
 @mixin ff-metropolis {
   font-family: "Metropolis", sans-serif;
 }

--- a/public/scss/includes/_mixins.scss
+++ b/public/scss/includes/_mixins.scss
@@ -85,6 +85,15 @@
   text-align: center;
 }
 
+@mixin remove-container {
+  background-color: white;
+  padding-top: 72px;
+  padding-bottom: 72px;
+  margin-top: 72px;
+  border-radius: 8px;
+  position: relative;
+}
+
 @mixin blue-link {
   &:not([class*="btn"]) {
     color: var(--blue3);

--- a/public/scss/partials/footer.scss
+++ b/public/scss/partials/footer.scss
@@ -1,6 +1,6 @@
 footer {
   width: 100%;
-  margin: auto auto 0 auto;
+  margin: 0 auto;
   background-color: var(--inkDark);
   padding-top: 32px;
   padding-bottom: 32px;

--- a/public/scss/partials/remove-enroll.scss
+++ b/public/scss/partials/remove-enroll.scss
@@ -1,0 +1,16 @@
+.remove-enroll {
+  &-container {
+    @include remove-container;
+    p {
+      line-height: 24px;
+    }
+  }
+  &-kanary-container {
+    position: absolute;
+    top: 0;
+    right: 36px;
+  }
+  &-submit {
+    margin-top: 25px;
+  }
+}

--- a/public/scss/partials/remove-enroll.scss
+++ b/public/scss/partials/remove-enroll.scss
@@ -1,15 +1,18 @@
 .remove-enroll {
   &-container {
     @include remove-container;
+
     p {
       line-height: 24px;
     }
   }
+
   &-kanary-container {
     position: absolute;
     top: 0;
     right: 36px;
   }
+
   &-submit {
     margin-top: 25px;
   }

--- a/public/scss/partials/remove-more-time.scss
+++ b/public/scss/partials/remove-more-time.scss
@@ -1,0 +1,42 @@
+.remove-more-time {
+  &-container {
+    background-color: white;
+    padding: 72px 7%;
+    margin-top: 72px;
+    border-radius: 8px;
+  }
+  &-col {
+    width: calc(50% - 12px);
+  }
+
+  &-option-description {
+    background-color: var(--grey2);
+    padding: 20px 10px;
+    border-radius: 8px;
+  }
+  &-selections {
+    margin-top: 15px;
+  }
+  &-button {
+    height: 60px;
+    @include remove-btn;
+    border-radius: 8px;
+
+    &.continue {
+      color: white;
+      background-color: var(--blue3);
+      &:hover {
+        background-color: var(--blue4);
+      }
+    }
+    &.cancel {
+      border: 1px solid var(--alertRed);
+      background-color: transparent;
+      color: var(--alertRed);
+    }
+  }
+  &-small {
+    color: var(--grey5);
+    font-size: 12px;
+  }
+}

--- a/public/scss/partials/remove-more-time.scss
+++ b/public/scss/partials/remove-more-time.scss
@@ -8,7 +8,11 @@
   &-col {
     width: calc(50% - 12px);
   }
-
+  &-title {
+    @include ff-inter;
+    font-size: 18px;
+    font-weight: 400;
+  }
   &-option-description {
     background-color: var(--grey2);
     padding: 20px 10px;

--- a/public/scss/partials/remove-more-time.scss
+++ b/public/scss/partials/remove-more-time.scss
@@ -1,7 +1,8 @@
 .remove-more-time {
   &-container {
     background-color: white;
-    padding: 72px 7%;
+    padding-top: 72px;
+    padding-bottom: 72px;
     margin-top: 72px;
     border-radius: 8px;
   }

--- a/public/scss/partials/remove-more-time.scss
+++ b/public/scss/partials/remove-more-time.scss
@@ -2,40 +2,51 @@
   &-container {
     @include remove-container;
   }
+
   &-col {
     width: calc(50% - 12px);
   }
+
   &-title {
     @include ff-inter;
+
     font-size: 18px;
     font-weight: 400;
   }
+
   &-option-description {
     background-color: var(--grey2);
     padding: 20px 10px;
     border-radius: 8px;
   }
+
   &-selections {
     margin-top: 15px;
   }
+
   &-button {
     height: 60px;
+
     @include remove-btn;
+
     border-radius: 8px;
 
     &.continue {
       color: white;
       background-color: var(--blue3);
+
       &:hover {
         background-color: var(--blue4);
       }
     }
+
     &.cancel {
       border: 1px solid var(--alertRed);
       background-color: transparent;
       color: var(--alertRed);
     }
   }
+
   &-small {
     color: var(--grey5);
     font-size: 12px;

--- a/public/scss/partials/remove-more-time.scss
+++ b/public/scss/partials/remove-more-time.scss
@@ -1,10 +1,6 @@
 .remove-more-time {
   &-container {
-    background-color: white;
-    padding-top: 72px;
-    padding-bottom: 72px;
-    margin-top: 72px;
-    border-radius: 8px;
+    @include remove-container;
   }
   &-col {
     width: calc(50% - 12px);

--- a/routes/user.js
+++ b/routes/user.js
@@ -16,9 +16,12 @@ const {
   getRemoveUpdateConfirmationPage,
   getRemoveDeleteConfirmationPage,
   getRemoveMoreTimePage,
+  getRemoveEnrollPage,
+  getRemoveEnrollFullPage,
   getPreferences,
   getBreachStats,
   handleRemoveFormSignup,
+  handleEnrollFormSignup,
   handleRemoveAcctUpdate,
   removeEmail,
   resendEmail,
@@ -78,6 +81,27 @@ router.get(
   csrfProtection,
   requireSessionUser,
   asyncMiddleware(getRemoveMoreTimePage)
+);
+
+router.get(
+  "/remove-enroll",
+  csrfProtection,
+  requireSessionUser,
+  asyncMiddleware(getRemoveEnrollPage)
+);
+
+router.post(
+  "/remove-enroll-submit",
+  urlEncodedParser,
+  requireSessionUser,
+  asyncMiddleware(handleEnrollFormSignup)
+);
+
+router.get(
+  "/remove-enroll-full",
+  csrfProtection,
+  requireSessionUser,
+  asyncMiddleware(getRemoveEnrollFullPage)
 );
 
 router.get(

--- a/routes/user.js
+++ b/routes/user.js
@@ -11,18 +11,8 @@ const {
   verify,
   logout,
   getDashboard,
-  getRemovePage,
-  getRemoveConfirmationPage,
-  getRemoveUpdateConfirmationPage,
-  getRemoveDeleteConfirmationPage,
-  getRemoveMoreTimePage,
-  getRemoveEnrollPage,
-  getRemoveEnrollFullPage,
   getPreferences,
   getBreachStats,
-  handleRemoveFormSignup,
-  handleEnrollFormSignup,
-  handleRemoveAcctUpdate,
   removeEmail,
   resendEmail,
   updateCommunicationOptions,
@@ -30,11 +20,24 @@ const {
   postUnsubscribe,
   getRemoveFxm,
   postRemoveFxm,
+  postResolveBreach,
+  getRemovePage, //data removal pilot routes
+  getRemoveConfirmationPage,
+  getRemoveUpdateConfirmationPage,
+  getRemoveDeleteConfirmationPage,
+  getRemoveMoreTimePage,
+  getRemoveEnrollPage,
+  getRemoveEnrolledPage,
+  getRemoveEnrollFullPage,
+  getRemoveEnrollEndedPage,
+  getRemovePilotEndedPage,
+  handleRemoveFormSignup,
+  handleRemoveEnrollFormSignup,
+  handleRemoveAcctUpdate,
   getRemoveKan,
   postRemoveKan,
   getRemoveSitesList,
   getRemoveRiskLevel,
-  postResolveBreach,
 } = require("../controllers/user");
 
 const router = express.Router();
@@ -90,11 +93,18 @@ router.get(
   asyncMiddleware(getRemoveEnrollPage)
 );
 
+router.get(
+  "/remove-enrolled",
+  csrfProtection,
+  requireSessionUser,
+  asyncMiddleware(getRemoveEnrolledPage)
+);
+
 router.post(
   "/remove-enroll-submit",
   urlEncodedParser,
   requireSessionUser,
-  asyncMiddleware(handleEnrollFormSignup)
+  asyncMiddleware(handleRemoveEnrollFormSignup)
 );
 
 router.get(
@@ -102,6 +112,20 @@ router.get(
   csrfProtection,
   requireSessionUser,
   asyncMiddleware(getRemoveEnrollFullPage)
+);
+
+router.get(
+  "/remove-enroll-ended",
+  csrfProtection,
+  requireSessionUser,
+  asyncMiddleware(getRemoveEnrollEndedPage)
+);
+
+router.get(
+  "/remove-pilot-ended",
+  csrfProtection,
+  requireSessionUser,
+  asyncMiddleware(getRemovePilotEndedPage)
 );
 
 router.get(
@@ -124,7 +148,6 @@ router.post(
 router.post(
   "/remove-data-submit",
   urlEncodedParser,
-  //csrfProtection, //MH TODO: figure out how to use this
   requireSessionUser,
   asyncMiddleware(handleRemoveFormSignup)
 );
@@ -132,7 +155,6 @@ router.post(
 router.post(
   "/remove-acct-update",
   urlEncodedParser,
-  //csrfProtection, //MH TODO: figure out how to use this
   requireSessionUser,
   asyncMiddleware(handleRemoveAcctUpdate)
 );

--- a/views/partials/dashboards/breach-dash-welcome.hbs
+++ b/views/partials/dashboards/breach-dash-welcome.hbs
@@ -1,6 +1,6 @@
 <div class="dashboard-stats-and-welcome flx jst-cntr">
   <div class="mw-860 flx dashboard-stats-and-welcome-inner">
-    <div class="dashboard-welcome-container flx jst-cntr">
+    <div class="dashboard-welcome-container flx flx-cntr">
       <span class="dashboard-welcome-back">{{ welcomeMessage }}</span>
     </div>
     {{> breach-stats addClasses="user-stats"}}

--- a/views/partials/dashboards/remove-delete-confirmation.hbs
+++ b/views/partials/dashboards/remove-delete-confirmation.hbs
@@ -1,4 +1,4 @@
-<main id="remove-confirmation" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
+<main id="remove-delete-confirmation" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
   {{#getBreachStats}}
       {{> dashboards/breach-dash-welcome}}
       {{> dashboards/breach-dash-tabs activeTab="remove"}}

--- a/views/partials/dashboards/remove-enroll-ended.hbs
+++ b/views/partials/dashboards/remove-enroll-ended.hbs
@@ -1,0 +1,9 @@
+<main id="remove-enroll-ended" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
+  <div class="mw-860 flx flx-col remove-enroll-container">
+    <div class="remove-enroll-kanary-container">{{> data-removal/kanary-header}}</div>
+    <h2 class="remove-enroll-title">{{getString "remove-enroll-ended-title"}}</h2>
+    <p>{{getString "remove-enroll-ended-description"}}</p>
+  </div>
+  {{> dashboards/remove-form-kanary-footer}}
+</main>
+

--- a/views/partials/dashboards/remove-enroll-full.hbs
+++ b/views/partials/dashboards/remove-enroll-full.hbs
@@ -1,0 +1,9 @@
+<main id="remove-enroll-full" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
+  <div class="mw-860 flx flx-col remove-enroll-container">
+    <div class="remove-enroll-kanary-container">{{> data-removal/kanary-header}}</div>
+    <h2 class="remove-enroll-title">{{getString "remove-enroll-full-title"}}</h2>
+    <p>{{getString "remove-enroll-full-description"}}</p>
+  </div>
+  {{> dashboards/remove-form-kanary-footer}}
+</main>
+

--- a/views/partials/dashboards/remove-enroll.hbs
+++ b/views/partials/dashboards/remove-enroll.hbs
@@ -1,0 +1,20 @@
+<main id="remove-enroll" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
+  <div class="mw-860 flx flx-col remove-enroll-container">
+    <div class="remove-enroll-kanary-container">{{> data-removal/kanary-header}}</div>
+    <h2 class="remove-enroll-title">{{getString "remove-enroll-title"}}</h2>
+    <p>{{getString "remove-mt-intro"}}</p>
+    <h3 class="remove-enroll-heading">{{getString "remove-enroll-description-title"}}</h3>
+    <p>{{getString "remove-enroll-description"}}</p>
+    <h3 class="remove-enroll-heading">{{getString "remove-enroll-terms-title"}}</h3>
+    <p>{{getString "remove-enroll-terms"}}</p>
+    <div class="flx">
+      <form id="remove-enroll-form" action="/user/remove-enroll-submit">
+        <input required id="remove-enroll-terms-checkbox" class="input-group-checkbox" type="checkbox" name="privacy">
+        <label for="remve-enroll-terms-checkbox" class="required">{{getString "remove-enroll-terms-agreement"}}</label>
+        <input id="" class="js-enroll-submit remove-enroll-submit" type="submit" value="{{getString "remove-enroll-submit"}}"/>
+      </form>
+    </div>
+  </div>
+  {{> dashboards/remove-form-kanary-footer}}
+</main>
+

--- a/views/partials/dashboards/remove-enrolled.hbs
+++ b/views/partials/dashboards/remove-enrolled.hbs
@@ -1,4 +1,4 @@
-<main id="remove-enroll-ended" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
+<main id="remove-enrolled" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
   <div class="mw-860 flx flx-col remove-enroll-container">
     <div class="remove-enroll-kanary-container">{{> data-removal/kanary-header}}</div>
     <h2 class="remove-enroll-title">{{getString "remove-enrolled-title"}}</h2>

--- a/views/partials/dashboards/remove-enrolled.hbs
+++ b/views/partials/dashboards/remove-enrolled.hbs
@@ -1,0 +1,9 @@
+<main id="remove-enroll-ended" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
+  <div class="mw-860 flx flx-col remove-enroll-container">
+    <div class="remove-enroll-kanary-container">{{> data-removal/kanary-header}}</div>
+    <h2 class="remove-enroll-title">{{getString "remove-enrolled-title"}}</h2>
+    <p>{{getString "remove-enrolled-description"}}</p>
+  </div>
+  {{> dashboards/remove-form-kanary-footer}}
+</main>
+

--- a/views/partials/dashboards/remove-more-time.hbs
+++ b/views/partials/dashboards/remove-more-time.hbs
@@ -4,32 +4,32 @@
       {{> dashboards/breach-dash-tabs activeTab="remove"}}
   {{/getBreachStats}}
   <div class="mw-860 flx flx-col remove-more-time-container">
-    <p>Get More Time</p>
+    <h2 class="remove-more-time-title">{{getString "remove-mt-title"}}</h2>
     <div class="remove-dashboard-card">
       <div class="remove-dashboard-card-border flx">
-        <p>The 90-day pilot of our data removal service will remain at no cost to you for the duration of the pilot period. However, in order to continue for the remaining 45 days, we’d like to offer you a choice...</p>
+        <p>{{getString "remove-mt-intro"}}</p>
       </div>
     </div>
     <div class="remove-more-time-options flx space-between">
       <div class="remove-more-time-option-description remove-more-time-col">
-          <p class="bold">Option 2: Continue Service</p>
-          <p>Continue your service for the remaining 45 days of the pilot at no cost to you.</p>
+          <p class="bold">{{getString "remove-mt-option1-title"}}</p>
+          <p>{{getString "remove-mt-option1-description"}}</p>
       </div>
       <div class="remove-more-time-option-description remove-more-time-col">
-          <p class="bold">Option 1: Discontinue Service</p>
-          <p>Discontinue your service today* and receive a $5 Amazon gift card.</p>
+          <p class="bold">{{getString "remove-mt-option2-title"}}</p>
+          <p>{{getString "remove-mt-option2-description"}}</p>
       </div>
     </div>
     <div class="remove-more-time-selections flx space-between">
       <a class="remove-more-time-button remove-more-time-col continue" role="button" href="#">
-        Continue Service
+        {{getString "remove-mt-option1-btn"}}
       </a>
       <a class="remove-more-time-button remove-more-time-col cancel" role="button" href="#">
-        Discontinue Service
+        {{getString "remove-mt-option2-btn"}}
       </a>
     </div>
-    <div class="flx space-between">
-      <p class="remove-more-time-small remove-more-time-col">*Any removals in progress will be suspended and all completed removals will remain so. No additional removals will take place. You will lose access to your exposures dashboard.</p>
+    <div class="flx flx-end">
+      <p class="remove-more-time-small remove-more-time-col">{{getString "remove-mt-option2-smalltext"}}</p>
     </div>
   </div>
   {{> dashboards/remove-form-kanary-footer}}

--- a/views/partials/dashboards/remove-more-time.hbs
+++ b/views/partials/dashboards/remove-more-time.hbs
@@ -1,4 +1,4 @@
-<main id="remove-confirmation" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
+<main id="remove-more-time" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
   {{#getBreachStats}}
       {{> dashboards/breach-dash-welcome}}
   {{/getBreachStats}}

--- a/views/partials/dashboards/remove-more-time.hbs
+++ b/views/partials/dashboards/remove-more-time.hbs
@@ -3,9 +3,33 @@
       {{> dashboards/breach-dash-welcome}}
       {{> dashboards/breach-dash-tabs activeTab="remove"}}
   {{/getBreachStats}}
-  <div class="flx flx-col">
-    <div class="mw-860 flx flx-col remove-dashboard-section">
-      Hello
+  <div class="mw-860 flx flx-col remove-more-time-container">
+    <p>Get More Time</p>
+    <div class="remove-dashboard-card">
+      <div class="remove-dashboard-card-border flx">
+        <p>The 90-day pilot of our data removal service will remain at no cost to you for the duration of the pilot period. However, in order to continue for the remaining 45 days, we’d like to offer you a choice...</p>
+      </div>
+    </div>
+    <div class="remove-more-time-options flx space-between">
+      <div class="remove-more-time-option-description remove-more-time-col">
+          <p class="bold">Option 2: Continue Service</p>
+          <p>Continue your service for the remaining 45 days of the pilot at no cost to you.</p>
+      </div>
+      <div class="remove-more-time-option-description remove-more-time-col">
+          <p class="bold">Option 1: Discontinue Service</p>
+          <p>Discontinue your service today* and receive a $5 Amazon gift card.</p>
+      </div>
+    </div>
+    <div class="remove-more-time-selections flx space-between">
+      <a class="remove-more-time-button remove-more-time-col continue" role="button" href="#">
+        Continue Service
+      </a>
+      <a class="remove-more-time-button remove-more-time-col cancel" role="button" href="#">
+        Discontinue Service
+      </a>
+    </div>
+    <div class="flx space-between">
+      <p class="remove-more-time-small remove-more-time-col">*Any removals in progress will be suspended and all completed removals will remain so. No additional removals will take place. You will lose access to your exposures dashboard.</p>
     </div>
   </div>
   {{> dashboards/remove-form-kanary-footer}}

--- a/views/partials/dashboards/remove-more-time.hbs
+++ b/views/partials/dashboards/remove-more-time.hbs
@@ -1,8 +1,10 @@
 <main id="remove-confirmation" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
   {{#getBreachStats}}
       {{> dashboards/breach-dash-welcome}}
-      {{> dashboards/breach-dash-tabs activeTab="remove"}}
   {{/getBreachStats}}
+  <div class="mw-860">
+    {{> data-removal/kanary-header}}
+  </div>
   <div class="mw-860 flx flx-col remove-more-time-container">
     <h2 class="remove-more-time-title">{{getString "remove-mt-title"}}</h2>
     <div class="remove-dashboard-card">

--- a/views/partials/dashboards/remove-pilot-ended.hbs
+++ b/views/partials/dashboards/remove-pilot-ended.hbs
@@ -1,0 +1,9 @@
+<main id="remove-enroll-ended" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
+  <div class="mw-860 flx flx-col remove-enroll-container">
+    <div class="remove-enroll-kanary-container">{{> data-removal/kanary-header}}</div>
+    <h2 class="remove-enroll-title">{{getString "remove-pilot-ended-title"}}</h2>
+    <p>{{getString "remove-pilot-ended-description"}}</p>
+  </div>
+  {{> dashboards/remove-form-kanary-footer}}
+</main>
+

--- a/views/partials/dashboards/remove-pilot-ended.hbs
+++ b/views/partials/dashboards/remove-pilot-ended.hbs
@@ -1,4 +1,4 @@
-<main id="remove-enroll-ended" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
+<main id="remove-pilot-ended" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
   <div class="mw-860 flx flx-col remove-enroll-container">
     <div class="remove-enroll-kanary-container">{{> data-removal/kanary-header}}</div>
     <h2 class="remove-enroll-title">{{getString "remove-pilot-ended-title"}}</h2>

--- a/views/partials/dashboards/remove-signup-confirmation.hbs
+++ b/views/partials/dashboards/remove-signup-confirmation.hbs
@@ -1,4 +1,4 @@
-<main id="remove-confirmation" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
+<main id="remove-signup-confirmation" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
   {{#getBreachStats}}
       {{> dashboards/breach-dash-welcome}}
       {{> dashboards/breach-dash-tabs activeTab="remove"}}

--- a/views/partials/dashboards/remove-update-confirmation.hbs
+++ b/views/partials/dashboards/remove-update-confirmation.hbs
@@ -1,4 +1,4 @@
-<main id="remove-confirmation" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
+<main id="remove-update-confirmation" class="remove-page js-dashboard dashboard clear-header flx flx-col" data-page-label="User Dashboard">
   {{#getBreachStats}}
       {{> dashboards/breach-dash-welcome}}
       {{> dashboards/breach-dash-tabs activeTab="remove"}}


### PR DESCRIPTION
Lots of changes here: 

* a few DB migrations:
  * a `removal_enrolled_time` timestamp and `removal_would_pay` boolean to the `user` table
  * a `removal_pilot` table designed to house all settings for the current pilot - currently just an ID, Name, and `enrolled_users` counter which keeps track of how many people have signed up for the pilot

* a bunch of constants:
  * `REMOVE_ROUTES` which are set to be searched in order to be redirectable after login
  * `REMOVAL_PILOT_START_TIME` which is a timestamp of when we kick off the pilot, so that we can keep track of of how long after this time to end enrollment, display a payment decision, and end the pilot itself.
  * Variables for the # of days until each of the above events
* A bunch of new routes:
  * `remove-enroll` enroll page
  * `remove-enrolled` enrollment success page
  * `remove-enroll-submit` handles enrollment submission to check if there is space in the pilot
  * `remove-enroll-full` if there is no more space
  * `remove-enroll-ended` if the enrollment period has passed
  * `remove-pilot-ended` if the pilot period is over
* All of the styling and functionality for these new pages
* Checks in the controller for whether these pages can indeed be displayed or whether we should redirect the user to another phase
* Max's sourcemaps PR for scss.