### PR TITLE
stylelint fixes

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,18 +1,14 @@
 {
-  "extends": [
-    "stylelint-config-standard"
-  ],
-  "plugins": [
-    "stylelint-scss"
-  ],
-  "ignoreFiles": [
-    "public/scss/includes/fonts/**",
-    "public/scss/libs/**"
-  ],
+  "extends": ["stylelint-config-standard", "stylelint-config-prettier"],
+  "plugins": ["stylelint-scss"],
+  "ignoreFiles": ["public/scss/includes/fonts/**", "public/scss/libs/**"],
   "rules": {
     "no-descending-specificity": null,
     "selector-type-no-unknown": null,
     "at-rule-no-unknown": null,
     "scss/at-rule-no-unknown": true,
+    "rule-empty-line-before": null,
+    "comment-empty-line-before": null,
+    "declaration-empty-line-before": null
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14446,6 +14446,12 @@
         }
       }
     },
+    "stylelint-config-prettier": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz",
+      "integrity": "sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==",
+      "dev": true
+    },
     "stylelint-config-recommended": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "onchange": "6.1.1",
     "redis-mock": "0.52.0",
     "stylelint": "^13.13.1",
+    "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-standard": "^22.0.0",
     "stylelint-scss": "^3.19.0",
     "wdio-docker-service": "2.4.0",

--- a/public/scss/partials/data-removal/remove-data.scss
+++ b/public/scss/partials/data-removal/remove-data.scss
@@ -773,23 +773,29 @@
     margin-top: 72px;
     margin-bottom: 72px;
   }
+
   &-title {
     font-size: 24px;
     font-weight: 600;
   }
+
   &-list {
     margin-top: 20px;
   }
+
   &-time-list {
     margin-top: 20px;
   }
+
   &-item,
   &-time-item {
     margin-top: 10px;
+
     &:first-child {
       margin-top: 0;
     }
   }
+
   &-time-item {
     white-space: nowrap;
   }
@@ -806,10 +812,9 @@
     background-color: var(--purple);
     color: white;
   }
+
   &-link {
     color: white;
     text-decoration: underline;
-  }
-  &-content {
   }
 }

--- a/public/scss/partials/data-removal/remove-faq.scss
+++ b/public/scss/partials/data-removal/remove-faq.scss
@@ -123,10 +123,12 @@
       display: flex;
     }
   }
+
   &__risk-list {
     li {
       display: block;
       margin-top: 10px;
+
       &:first-child {
         margin-top: 0;
       }


### PR DESCRIPTION
disable the `line-before` rules of stylelint due to css compilation removing those things

add the stylelint prettier package so stylelint does not collide with prettier