### PR TITLE
replace node-fetch library with got

### DIFF
--- a/public/js/remove-data.js
+++ b/public/js/remove-data.js
@@ -24,7 +24,7 @@ function initRemove() {
         initRemoveStats();
         break;
       default:
-        console.log("no matching page id");
+        console.log("no page specific js required");
     }
   }
 }
@@ -362,7 +362,6 @@ function handleFormSubmit(e) {
   const $form = document.getElementById("remove-data-signup-form");
   const doValidate = $form.dataset.validate;
   if (doValidate) {
-    console.log("client side validation");
     const isValid = $form.reportValidity(); //use native html form validator
     if (!isValid) {
       return;

--- a/remove_en/remove.ftl
+++ b/remove_en/remove.ftl
@@ -467,3 +467,4 @@ remove-error-no-kid-match = The Kanary ID submitted for this user does not match
 remove-error-update = Error submitting updates to Kanary. Please try your request again.
 remove-error-kid-but-no-acct = An account is stored in our database, but does not exist in Kanary. Please contact support.
 remove-error-alpha = field allows only letters, dashes, and spaces
+remove-error-no-id = The {-brand-remove-partner} API did not return an ID


### PR DESCRIPTION
`node-fetch` was providing duplicate functionality to `got`, which is already in use elsewhere in monitor
replace all usages in user controller
add a few status messages / codes on error

fixes https://mozilla-hub.atlassian.net/browse/FPRDS-5 