### PR TITLE
adds the review screen as the default view on the removal form

### DIFF
--- a/remove_en/remove.ftl
+++ b/remove_en/remove.ftl
@@ -88,6 +88,7 @@ remove-dash-form-disclaimer = By clicking “Start Data Removal” you agree to 
 remove-dash-confirm-review = Review Your Information
 remove-dash-confirm-edit = Edit Info
 remove-dash-confirm-cancel = Cancel
+remove-dash-confirm-back = Back
 remove-dash-confirm-label-full = Full Name
 remove-dash-confirm-email = Email Address
 remove-dash-confirm-loc = Current Location

--- a/views/partials/dashboards/remove-form-confirm.hbs
+++ b/views/partials/dashboards/remove-form-confirm.hbs
@@ -1,15 +1,17 @@
 <div class="remove-dashboard-confirm">
   <div class="flx space-between remove-dashboard-confirm-review-container">
-    <h3 class="remove-dashboard-confirm-review-title">{{getRemoveString
-        "remove-dash-confirm-review"
-      }}</h3>
-    <div class="flx remove-dashboard-confirm-review-btns">
+    <div class="flx cntr">
       {{#if this.acctInfo}}
         <a
           href="/user/remove-data"
           class="remove-dashboard-confirm-cancel btn-grey btn-small"
-        >{{getRemoveString "remove-dash-confirm-cancel"}}</a>
+        >{{getRemoveString "remove-dash-confirm-back"}}</a>
       {{/if}}
+      <h3 class="remove-dashboard-confirm-review-title">{{getRemoveString
+        "remove-dash-confirm-review"
+      }}</h3>
+    </div>
+    <div class="flx remove-dashboard-confirm-review-btns">
       <a href="#" class="js-confirm-edit-btn btn-blue btn-small">{{getRemoveString
           "remove-dash-confirm-edit"
         }}</a>
@@ -21,25 +23,36 @@
         <span class="remove-dashboard-confirm-item-label">{{getRemoveString
             "remove-dash-confirm-label-full"
           }}</span>
-        <span class="remove-dashboard-confirm-item-entry"></span>
+        <span class="remove-dashboard-confirm-item-entry">
+          {{#if this.acctInfo.names.0.first_name}}{{this.acctInfo.names.0.first_name}}{{/if}}
+          {{#if this.acctInfo.names.0.middle_name}}{{this.acctInfo.names.0.middle_name}}{{/if}}
+          {{#if this.acctInfo.names.0.last_name}}{{this.acctInfo.names.0.last_name}}{{/if}}
+        </span>
       </li>
       <li class="remove-dashboard-confirm-item" data-id="account">
         <span class="remove-dashboard-confirm-item-label">{{getRemoveString
             "remove-dash-confirm-email"
           }}</span>
-        <span class="remove-dashboard-confirm-item-entry"></span>
+        <span class="remove-dashboard-confirm-item-entry">
+          {{#if this.acctInfo.emails.0.email}}{{this.acctInfo.emails.0.email}}{{/if}}
+        </span>
       </li>
       <li class="remove-dashboard-confirm-item" data-id="location">
         <span class="remove-dashboard-confirm-item-label">{{getRemoveString
             "remove-dash-confirm-loc"
           }}</span>
-        <span class="remove-dashboard-confirm-item-entry"></span>
+        <span class="remove-dashboard-confirm-item-entry">
+          {{#if this.acctInfo.addresses.0.city}}{{this.acctInfo.addresses.0.city}}{{/if}}, 
+          {{#if this.acctInfo.addresses.0.state}}{{this.acctInfo.addresses.0.state}}{{/if}}
+        </span>
       </li>
       <li class="remove-dashboard-confirm-item" data-id="birthyear">
         <span class="remove-dashboard-confirm-item-label">{{getRemoveString
             "remove-dash-confirm-birthyear"
           }}</span>
-        <span class="remove-dashboard-confirm-item-entry"></span>
+        <span class="remove-dashboard-confirm-item-entry">
+          {{#if this.acctInfo.birth_year}}{{this.acctInfo.birth_year}}{{/if}}
+        </span>
       </li>
     </ul>
   </div>

--- a/views/partials/dashboards/remove-form-confirm.hbs
+++ b/views/partials/dashboards/remove-form-confirm.hbs
@@ -42,7 +42,7 @@
             "remove-dash-confirm-loc"
           }}</span>
         <span class="remove-dashboard-confirm-item-entry">
-          {{#if this.acctInfo.addresses.0.city}}{{this.acctInfo.addresses.0.city}}{{/if}}, 
+          {{#if this.acctInfo.addresses.0.city}}{{this.acctInfo.addresses.0.city}}, {{/if}}
           {{#if this.acctInfo.addresses.0.state}}{{this.acctInfo.addresses.0.state}}{{/if}}
         </span>
       </li>

--- a/views/partials/dashboards/remove-form.hbs
+++ b/views/partials/dashboards/remove-form.hbs
@@ -1,6 +1,6 @@
 <main id="remove-form" class="js-dashboard remove-page dashboard clear-header flx flx-col" data-page-label="User Dashboard">
 {{#getRemoveFormData}}
-<div class="flx flx-col remove-dashboard-container js-remove-dashboard-container"
+<div class="flx flx-col remove-dashboard-container js-remove-dashboard-container" {{#if this.acctInfo}}data-confirm="true"{{/if}}
   {{!-- MH TODO: US Only for now
     {{#if this.acctInfo.addresses.0.country}}data-country="{{this.acctInfo.addresses.0.country}}"{{/if}} 
   --}}
@@ -144,7 +144,7 @@
         </div>
         {{/if}}
       </div>
-      {{> dashboards/remove-form-confirm}}
+      {{> dashboards/remove-form-confirm acctInfo=acctInfo}}
       </form>
     </section>
   </div>


### PR DESCRIPTION
 ...when someone already has an account, otherwise shows the form

prepopulates the review screen with account info if available
changes the back button from cancel and moves its location

figma design for back button (out of margin, no alt text, icon, larger than other items in row), would cause some responsive issues as well as accessibility hurdles, keeping it simple for now.