### PR TITLE
remove hash email check on any non-enrollment routes

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1491,19 +1491,6 @@ async function handleRemovalFormSignup(req, res) {
     });
   }
 
-  if (REMOVAL_CONSTANTS.REMOVE_CHECK_WAITLIST_ENABLED) {
-    const hashMatch = await checkEmailHash(account);
-
-    if (!hashMatch) {
-      const localeError = LocaleUtils.formatRemoveString(
-        "remove-error-no-waitlist-match"
-      );
-      return res.status(400).json({
-        error: localeError,
-      });
-    }
-  }
-
   const validationResults = validateRemovalForm(req.body);
 
   if (validationResults.error) {
@@ -1718,7 +1705,7 @@ async function handleRemovalAcctUpdate(req, res) {
     });
   }
 
-  const emailDomainMatch = await checkEmailDomainMatch(account);
+  const emailDomainMatch = await checkEmailDomainMatch(account); //runs if email check enabled in remove-constants
 
   if (!emailDomainMatch) {
     console.error(
@@ -1730,19 +1717,6 @@ async function handleRemovalAcctUpdate(req, res) {
     return res.status(404).json({
       error: localeError,
     });
-  }
-
-  if (REMOVAL_CONSTANTS.REMOVE_CHECK_WAITLIST_ENABLED) {
-    const hashMatch = await checkEmailHash(account);
-
-    if (!hashMatch) {
-      const localeError = LocaleUtils.formatRemoveString(
-        "remove-error-no-waitlist-match"
-      );
-      return res.status(400).json({
-        error: localeError,
-      });
-    }
   }
 
   const removeAcctInfo = await getRemoveAcctInfo(user.kid);

--- a/remove_en/remove.ftl
+++ b/remove_en/remove.ftl
@@ -214,7 +214,7 @@ remove-enroll-terms = The pilot service will be offered at no cost to you for a 
  removal account information held by { -brand-Mozilla } or our partner { -remove-brand-partner } will be deleted.
  You may discontinue the { remove-process-name } service at any point within the 90 day pilot period.
 remove-enroll-link-faq = { -product-name } { remove-pilot-title } FAQ
-remove-enroll-link-tos = { -product-name } { remove-pilot-title } Terms of Service and Privacy Notice
+remove-enroll-link-tos = { remove-pilot-title } Terms of Service and Privacy Notice
 remove-enroll-terms-agreement = By continuing, I agree to the Terms of Service and Privacy Notice.
 remove-enroll-submit = Join the pilot
 

--- a/routes/user.js
+++ b/routes/user.js
@@ -170,7 +170,6 @@ router.get(
   "/remove-data",
   csrfProtection,
   requireSessionUser,
-  asyncMiddleware(requireRemovalUser),
   asyncMiddleware(getRemovalPage)
 );
 
@@ -178,7 +177,6 @@ router.get(
   "/remove-signup-confirmation",
   csrfProtection,
   requireSessionUser,
-  asyncMiddleware(requireRemovalUser),
   asyncMiddleware(getRemovalConfirmationPage)
 );
 
@@ -186,7 +184,6 @@ router.get(
   "/remove-update-confirmation",
   csrfProtection,
   requireSessionUser,
-  asyncMiddleware(requireRemovalUser),
   asyncMiddleware(getRemovalUpdateConfirmationPage)
 );
 
@@ -194,7 +191,6 @@ router.get(
   "/remove-delete-confirmation",
   csrfProtection,
   requireSessionUser,
-  asyncMiddleware(requireRemovalUser),
   asyncMiddleware(getRemovalDeleteConfirmationPage)
 );
 
@@ -228,7 +224,6 @@ router.post(
   csrfProtection,
   urlEncodedParser,
   requireSessionUser,
-  asyncMiddleware(requireRemovalUser),
   asyncMiddleware(handleRemovalAcctUpdate)
 );
 
@@ -244,7 +239,6 @@ router.post(
   jsonParser,
   csrfProtection,
   requireSessionUser,
-  asyncMiddleware(requireRemovalUser),
   asyncMiddleware(postRemovalKan)
 );
 


### PR DESCRIPTION
, as, at this point, the user could add verified email addresses that do not appear on the waitlist.