### PR TITLE
Add ability to opt out of pilot

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -424,7 +424,7 @@ async function postRemoveFxm(req, res) {
   //DATA REMOVAL SPECIFIC
   if (sessionUser.kid) {
     const deleteResponse = await removeKanaryAcct(sessionUser.kid);
-    if (!deleteResponse.id) {
+    if (!deleteResponse?.id) {
       const localeError = LocaleUtils.formatRemoveString("remove-error-no-id");
       return res.status(400).json({
         error: localeError,
@@ -1289,7 +1289,7 @@ async function getRemovalKan(req, res) {
 async function postRemovalKan(req, res) {
   const sessionUser = req.user;
   const deleteResponse = await removeKanaryAcct(sessionUser.kid);
-  if (!deleteResponse || !deleteResponse.id) {
+  if (!deleteResponse?.id) {
     const localeError = LocaleUtils.formatRemoveString("remove-error-no-id");
     return res.status(400).json({
       error: localeError,

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -772,7 +772,9 @@ async function handleRemovalOptout(req, res) {
   }
 
   if (!req.session || !req.session.kanary) {
-    const localeError = LocaleUtils.formatRemoveString("remove-error-optout");
+    const localeError = LocaleUtils.formatRemoveString(
+      "remove-error-no-session"
+    );
     return res.status(400).json({
       error: localeError,
     });
@@ -1287,7 +1289,7 @@ async function getRemovalKan(req, res) {
 async function postRemovalKan(req, res) {
   const sessionUser = req.user;
   const deleteResponse = await removeKanaryAcct(sessionUser.kid);
-  if (!deleteResponse.id) {
+  if (!deleteResponse || !deleteResponse.id) {
     const localeError = LocaleUtils.formatRemoveString("remove-error-no-id");
     return res.status(400).json({
       error: localeError,

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1297,19 +1297,6 @@ async function postRemovalKan(req, res) {
   res.redirect("/user/remove-delete-confirmation");
 }
 
-async function postRemovalKan(req, res) {
-  const sessionUser = req.user;
-  const deleteResponse = await removeKanaryAcct(sessionUser.kid);
-  if (!deleteResponse.id) {
-    const localeError = LocaleUtils.formatRemoveString("remove-error-no-id");
-    return res.status(400).json({
-      error: localeError,
-    });
-  }
-  await DB.removeKan(sessionUser);
-  res.redirect("/user/remove-delete-confirmation");
-}
-
 async function checkIfRemovalPilotFull(user) {
   const curPilot = await DB.getRemovalPilotByName(
     REMOVAL_CONSTANTS.REMOVAL_PILOT_GROUP

--- a/db/DB.js
+++ b/db/DB.js
@@ -504,6 +504,27 @@ const DB = {
       });
   },
 
+  async removalOptout(subscriber) {
+    const res = await knex("subscribers")
+      .where({ id: subscriber.id })
+      .update({
+        removal_optout: true,
+      })
+      .catch((e) => {
+        console.error("error updating optout status in db", e);
+      });
+    return res;
+  },
+
+  async getRemovalOptoutStatus(user) {
+    const res = await knex
+      .select("removal_optout")
+      .from("subscribers")
+      .where("id", user.id)
+      .pluck("removal_optout"); //return only the values in an array not the object
+    return res[0];
+  },
+
   async getRemoveParticipants() {
     const res = await knex
       .select("kid")

--- a/db/migrations/20220104095854_add-unenroll-col-to-subscribers.js
+++ b/db/migrations/20220104095854_add-unenroll-col-to-subscribers.js
@@ -1,0 +1,13 @@
+"use strict";
+
+exports.up = function (knex) {
+  return knex.schema.table("subscribers", (table) => {
+    table.boolean("removal_optout").defaultTo(false);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table("subscribers", (table) => {
+    table.dropColumn("removal_optout");
+  });
+};

--- a/middleware.js
+++ b/middleware.js
@@ -268,6 +268,22 @@ async function requireRemovalUser(req, res, next) {
   }
 }
 
+async function requireNoOptOut(req, res, next) {
+  if (req.user) {
+    const isOptedOut = await DB.getRemovalOptoutStatus(req.user);
+    if (isOptedOut) {
+      console.log("user opted out, redirecting...");
+      return res.redirect("/");
+    } else {
+      next();
+      return;
+    }
+  } else {
+    console.log("no user found, redirecting...");
+    return res.redirect("/");
+  }
+}
+
 module.exports = {
   addRequestToResponse,
   pickLanguage,
@@ -280,4 +296,5 @@ module.exports = {
   requireSessionUser,
   getShareUTMs,
   requireRemovalUser,
+  requireNoOptOut,
 };

--- a/public/js/remove-data.js
+++ b/public/js/remove-data.js
@@ -112,6 +112,12 @@ function addRemoveFormListeners() {
   document.querySelectorAll(".js-form-select").forEach((selector) => {
     selector.addEventListener("change", onSelectChange);
   });
+
+  //user should only see the opt out button the first time they sign up, not when editing info, hence the check
+  const $optOutBtn = document.querySelector(".js-remove-optout");
+  if ($optOutBtn) {
+    $optOutBtn.addEventListener("click", onRemoveFormOptoutClick);
+  }
 }
 
 function onSelectChange(e) {
@@ -311,6 +317,10 @@ function onRemoveFormSubmitClick(e) {
 
   populateConfirmData(formData);
   toggleConfirmScreen(true);
+}
+
+function onRemoveFormOptoutClick(e) {
+  e.preventDefault();
 }
 
 function toggleConfirmScreen(doShow) {

--- a/public/scss/includes/_mixins.scss
+++ b/public/scss/includes/_mixins.scss
@@ -97,6 +97,18 @@
   }
 }
 
+@mixin dark-grey-button {
+  @include button;
+
+  background-color: var(--grey6);
+  color: white;
+
+  &:hover,
+  &:focus {
+    background-color: var(--grey7);
+  }
+}
+
 @mixin red-button {
   @include button;
 

--- a/public/scss/partials/data-removal/remove-data.scss
+++ b/public/scss/partials/data-removal/remove-data.scss
@@ -728,6 +728,10 @@
     font-size: 13px;
   }
 
+  &-optout-btn {
+    margin-top: 30px;
+  }
+
   &-kanary-container {
     margin-top: 120px;
     margin-bottom: 50px;

--- a/public/scss/partials/main.scss
+++ b/public/scss/partials/main.scss
@@ -256,12 +256,24 @@ button.btn-ghost {
   min-width: 200px;
 }
 
+.btn-link {
+  border: 0;
+  @include ff-inter;
+  @include default-link;
+  font-size: 15px;
+  font-weight: normal;
+}
+
 .btn-blue {
   @include blue-button;
 }
 
 .btn-grey {
   @include grey-button;
+}
+
+.btn-grey-dark {
+  @include dark-grey-button;
 }
 
 .btn-red-primary {

--- a/remove_en/remove.ftl
+++ b/remove_en/remove.ftl
@@ -81,7 +81,7 @@ remove-dash-submit = Start Data Removal
 remove-dash-change-submit = Review Information
 remove-dash-form-required-helper = * All fields are required to properly identify your exposed information
 remove-dash-form-disclaimer = By clicking “Start Data Removal” you agree to start the data removal process.
-remove-optout = Opt Out
+remove-optout = Opt-Out
 
 
 # Data Removal Form Confirmation Strings
@@ -169,7 +169,7 @@ remove-result-details-found = Info found
 remove-result-description = What is this website?
 remove-result-link = Links to exposed info
 remove-result-link-title = Record Link
-remove-result-opt-out = Manual removal instructions
+remove-result-manual = Manual removal instructions
 remove-pending-title = Starting your { remove-process-name }. Check back in 24-48 hours for results.
 remove-pending = We're scanning for sites that expose your personal information. It may take 24 hours for your report to finish.
 remove-result-updated = Updated

--- a/remove_en/remove.ftl
+++ b/remove_en/remove.ftl
@@ -81,6 +81,7 @@ remove-dash-submit = Start Data Removal
 remove-dash-change-submit = Review Information
 remove-dash-form-required-helper = * All fields are required to properly identify your exposed information
 remove-dash-form-disclaimer = By clicking “Start Data Removal” you agree to start the data removal process.
+remove-optout = Opt Out
 
 
 # Data Removal Form Confirmation Strings
@@ -311,7 +312,7 @@ remove-modal-close-accessible = Close this dialog window
 remove-modal-more-info = Learn More
 remove-modal-more-info-found = Learn more about info found
 remove-modal-more-info-links = Learn more about links to exposed info
-remove-modal-more-optout = Learn more about manual removal
+remove-modal-more-manual = Learn more about manual removal
 remove-modal-more-risk = Learn more about risk
 remove-modal-more-status = Learn more about risk
 remove-expand = Expand Section
@@ -361,11 +362,16 @@ remove-modal-link-text = The following links are the web addresses where your in
 
 remove-modal-risk-title = What is Risk Level?
 
-# Data Removal Opt Out Modal
+# Data Removal Manual Modal
 
-remove-modal-optout-title = Manual Removal Instructions
-remove-modal-optout-text = If your request is blocked, or if for any reason you wish to attempt to manually remove your information,
+remove-modal-manual-title = Manual Removal Instructions
+remove-modal-manual-text = If your request is blocked, or if for any reason you wish to attempt to manually remove your information,
  you can use the contact email or website provided for this result to do so.
+
+ # Data Removal Optout Modal
+
+remove-modal-optout-title = Confirm Opt-Out of Data Removal Pilot
+remove-modal-optout-text = Once you submit your opt-out request, this action cannot be undone. 
 
 # Data Removal About Page
 
@@ -494,3 +500,5 @@ remove-error-update = Error submitting updates to Kanary. Please try your reques
 remove-error-kid-but-no-acct = An account is stored in our database, but does not exist in Kanary. Please contact support.
 remove-error-alpha = field allows only letters, dashes, and spaces
 remove-error-no-id = The {-brand-remove-partner} API did not return an ID
+remove-error-optout = There was an error opting out of the { remove-pilot-title }
+remove-error-no-session = No { -remove-brand-partner } session variable found

--- a/routes/user.js
+++ b/routes/user.js
@@ -32,6 +32,7 @@ const {
   getRemovalDeleteConfirmationPage,
   getRemovalMoreTimePage,
   getRemovalEnrollPage,
+  handleRemovalOptout,
   getRemovalEnrolledPage,
   getRemovalEnrollFullPage,
   getRemovalEnrollEndedPage,
@@ -148,6 +149,14 @@ router.post(
   requireSessionUser,
   asyncMiddleware(requireRemovalUser),
   asyncMiddleware(handleRemovalEnrollFormSignup)
+);
+
+router.get(
+  "/remove-optout-confirm",
+  csrfProtection,
+  urlEncodedParser,
+  requireSessionUser,
+  asyncMiddleware(handleRemovalOptout)
 );
 
 router.get(

--- a/routes/user.js
+++ b/routes/user.js
@@ -9,6 +9,7 @@ const {
   asyncMiddleware,
   requireSessionUser,
   requireRemovalUser,
+  requireNoOptOut,
 } = require("../middleware");
 const {
   add,
@@ -179,6 +180,7 @@ router.get(
   "/remove-data",
   csrfProtection,
   requireSessionUser,
+  asyncMiddleware(requireNoOptOut),
   asyncMiddleware(getRemovalPage)
 );
 
@@ -200,6 +202,7 @@ router.get(
   "/remove-delete-confirmation",
   csrfProtection,
   requireSessionUser,
+  asyncMiddleware(requireNoOptOut),
   asyncMiddleware(getRemovalDeleteConfirmationPage)
 );
 
@@ -241,6 +244,7 @@ router.get(
   urlEncodedParser,
   csrfProtection,
   requireSessionUser,
+  asyncMiddleware(requireRemovalUser),
   asyncMiddleware(getRemovalKan)
 );
 router.post(

--- a/views/partials/dashboards/remove-dashboard.hbs
+++ b/views/partials/dashboards/remove-dashboard.hbs
@@ -43,5 +43,5 @@
 {{> data-removal/modal-remove-info-found}}
 {{> data-removal/modal-remove-link}}
 {{> data-removal/modal-remove-risk}}
-{{> data-removal/modal-remove-optout}}
+{{> data-removal/modal-remove-manual}}
 {{> data-removal/modal-leaving-monitor}}

--- a/views/partials/dashboards/remove-enroll.hbs
+++ b/views/partials/dashboards/remove-enroll.hbs
@@ -31,6 +31,7 @@
         <button
           class="js-remove-optout remove-dashboard-optout-btn btn-small btn-grey-dark"
           data-micromodal-trigger="modal-remove-optout"
+          type="button"
         >{{getRemoveString "remove-optout"}}</button>
     </div>
     <div class="remove-dashboard-form-error --general --enroll"></div>

--- a/views/partials/dashboards/remove-enroll.hbs
+++ b/views/partials/dashboards/remove-enroll.hbs
@@ -27,9 +27,15 @@
         <input id="" class="js-enroll-submit remove-enroll-submit" type="submit" value="{{getRemoveString "remove-enroll-submit"}}"/>
       </form>
     </div>
+    <div class="flx jst-cntr">
+        <button
+          class="js-remove-optout remove-dashboard-optout-btn btn-small btn-grey-dark"
+          data-micromodal-trigger="modal-remove-optout"
+        >{{getRemoveString "remove-optout"}}</button>
+    </div>
     <div class="remove-dashboard-form-error --general --enroll"></div>
     {{/unless}}
   </div>
   {{> dashboards/remove-form-kanary-footer}}
 </main>
-
+{{> data-removal/modal-remove-optout}}

--- a/views/partials/dashboards/remove-form.hbs
+++ b/views/partials/dashboards/remove-form.hbs
@@ -142,6 +142,7 @@
             <button
               class="js-remove-optout remove-dashboard-optout-btn btn-small btn-grey-dark"
               data-micromodal-trigger="modal-remove-optout"
+              type="button"
             >{{getRemoveString "remove-optout"}}</button>
           </div>
           {{/unless}}

--- a/views/partials/dashboards/remove-form.hbs
+++ b/views/partials/dashboards/remove-form.hbs
@@ -129,14 +129,22 @@
             </div>
             
           </div>
+          <div class="flx flx-col flx-cntr">
+            <p class="alert txt-cntr remove-dashboard-form-rqd bold">{{ getRemoveString "remove-dash-form-required-helper"}}</p>
+          </div>
           <div class="input-group-button inline">
             <input id="remove-dashboard-data-submit" class="js-remove-submit input-group-submit remove-dashboard-data-submit inline" type="submit" 
               value="{{ getRemoveString "remove-dash-change-submit" }}"/>
             {{> forms/loader }}
           </div>
-          <div class="flx flx-col flx-cntr">
-            <p class="alert txt-cntr remove-dashboard-form-rqd bold">{{ getRemoveString "remove-dash-form-required-helper"}}</p>
+          {{#unless this.acctInfo}}
+          <div class="flx jst-cntr">
+            <button
+              class="js-remove-optout remove-dashboard-optout-btn btn-small btn-grey-dark"
+              data-micromodal-trigger="modal-remove-optout"
+            >{{getRemoveString "remove-optout"}}</button>
           </div>
+          {{/unless}}
       </div>
       {{> dashboards/remove-form-confirm acctInfo=acctInfo}}
       </form>
@@ -165,3 +173,4 @@
 
 {{> data-removal/modal-info-needed}}
 {{> data-removal/modal-birth-year}}
+{{> data-removal/modal-remove-optout}}

--- a/views/partials/data-removal/modal-birth-year.hbs
+++ b/views/partials/data-removal/modal-birth-year.hbs
@@ -14,7 +14,9 @@
           class="modal__close"
           aria-label="Close modal"
           data-micromodal-close
-        ></button>
+        >
+          <span class="sr-only">{{getRemoveString "remove-modal-close"}}</span>
+        </button>
       </div>
       <div class="modal__content" id="modal-2-content">
         <p>

--- a/views/partials/data-removal/modal-info-needed.hbs
+++ b/views/partials/data-removal/modal-info-needed.hbs
@@ -14,7 +14,9 @@
           class="modal__close"
           aria-label="Close modal"
           data-micromodal-close
-        ></button>
+        >
+          <span class="sr-only">{{getRemoveString "remove-modal-close"}}</span>
+        </button>
       </div>
       <div class="modal__content" id="modal-1-content">
         <p>

--- a/views/partials/data-removal/modal-leaving-monitor.hbs
+++ b/views/partials/data-removal/modal-leaving-monitor.hbs
@@ -14,7 +14,9 @@
           class="modal__close"
           aria-label="Close modal"
           data-micromodal-close
-        ></button>
+        >
+          <span class="sr-only">{{getRemoveString "remove-modal-close"}}</span>
+        </button>
       </div>
       <div class="modal__content" id="modal-leaving-content">
         <p>

--- a/views/partials/data-removal/modal-remove-info-found.hbs
+++ b/views/partials/data-removal/modal-remove-info-found.hbs
@@ -18,7 +18,9 @@
           class="modal__close"
           aria-label="Close modal"
           data-micromodal-close
-        ></button>
+        >
+          <span class="sr-only">{{getRemoveString "remove-modal-close"}}</span>
+        </button>
       </div>
       <div class="modal__content" id="modal-1-content">
         <p>

--- a/views/partials/data-removal/modal-remove-link.hbs
+++ b/views/partials/data-removal/modal-remove-link.hbs
@@ -14,7 +14,9 @@
           class="modal__close"
           aria-label="Close modal"
           data-micromodal-close
-        ></button>
+        >
+          <span class="sr-only">{{getRemoveString "remove-modal-close"}}</span>
+        </button>
       </div>
       <div class="modal__content" id="modal-1-content">
         <p>

--- a/views/partials/data-removal/modal-remove-manual.hbs
+++ b/views/partials/data-removal/modal-remove-manual.hbs
@@ -1,14 +1,14 @@
-<div class="modal micromodal-slide" id="modal-remove-status" aria-hidden="true">
+<div class="modal micromodal-slide" id="modal-remove-manual" aria-hidden="true">
   <div class="modal__overlay flx jst-cntr" tabindex="-1" data-micromodal-close>
     <div
       class="modal__container"
       role="dialog"
       aria-modal="true"
-      aria-labelledby="modal-status-title"
+      aria-labelledby="modal-manual-title"
     >
       <div class="flx space-between cntr modal__header">
-        <h2 class="modal__title" id="modal-status-title">
-          {{getRemoveString "remove-modal-status-title"}}
+        <h2 class="modal__title" id="modal-manual-title">
+          {{getRemoveString "remove-modal-manual-title"}}
         </h2>
         <button
           class="modal__close"
@@ -19,18 +19,18 @@
         </button>
       </div>
       <div class="modal__content" id="modal-1-content">
-        <div class="modal__status-container">
-          {{{getRemoveString "remove-modal-status-text"}}}
-        </div>
+        <p>
+          {{getRemoveString "remove-modal-manual-text"}}
+        </p>
       </div>
       <div class="modal__footer flx space-between">
-        <a href="/remove-faq#status">{{getRemoveString "remove-modal-more-status"}}</a>
+        <a href="/remove-faq">{{getRemoveString "remove-modal-more-manual"}}</a>
         <a
           class="modal__close-footer"
           href="#"
           role="button"
           data-micromodal-close
-          aria-label="{{getRemoveString "remove-modal-close-accessible"}}"
+          aria-label="{{getRemoveString 'remove-modal-close-accessible'}}"
         >{{getRemoveString "remove-modal-close"}}</a>
       </div>
     </div>

--- a/views/partials/data-removal/modal-remove-optout.hbs
+++ b/views/partials/data-removal/modal-remove-optout.hbs
@@ -14,22 +14,30 @@
           class="modal__close"
           aria-label="Close modal"
           data-micromodal-close
-        ></button>
+        ><span class="sr-only">{{getRemoveString "remove-modal-close"}}</span></button>
       </div>
-      <div class="modal__content" id="modal-1-content">
+      <div class="modal__content" id="modal-optout-content">
         <p>
           {{getRemoveString "remove-modal-optout-text"}}
         </p>
       </div>
       <div class="modal__footer flx space-between">
-        <a href="/remove-faq">{{getRemoveString "remove-modal-more-optout"}}</a>
         <a
-          class="modal__close-footer"
+          class=""
           href="#"
           role="button"
           data-micromodal-close
-          aria-label="{{getRemoveString "remove-modal-close-accessible"}}"
-        >{{getRemoveString "remove-modal-close"}}</a>
+          aria-label="{{getRemoveString "remove-modal-cancel"}}"
+        >{{getRemoveString "remove-modal-cancel"}}</a>
+        <div class="remove-modal-optout-container">
+          <form action="/user/remove-optout-confirm">
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+            <button
+              class="remove-modal-optout-confirm btn-link"
+              type="submit"
+            >{{getRemoveString "remove-modal-continue"}}</button>
+          </form>
+        </div>
       </div>
     </div>
   </div>

--- a/views/partials/data-removal/modal-remove-risk.hbs
+++ b/views/partials/data-removal/modal-remove-risk.hbs
@@ -14,7 +14,9 @@
           class="modal__close"
           aria-label="Close modal"
           data-micromodal-close
-        ></button>
+        >
+          <span class="sr-only">{{getRemoveString "remove-modal-close"}}</span>
+        </button>
       </div>
       <div class="modal__content" id="modal-1-content">
         <p>{{getRemoveString "remove-about-risk-content"}}</p>

--- a/views/partials/removal/removal-result.hbs
+++ b/views/partials/removal/removal-result.hbs
@@ -119,7 +119,7 @@
         <li class="remove-dash-results-details-item flx flx-col align-start">
           <p class="remove-dash-results-detail-title flx jst-cntr">
             {{getRemoveString "remove-result-opt-out"}}
-            {{> removal/removal-question-trigger modal="modal-remove-optout" alt="About Manual Removal"}}
+            {{> removal/removal-question-trigger modal="modal-remove-manual" alt="About Manual Removal"}}
           </p>
           <p class="remove-dash-results-detail">
             <a

--- a/views/partials/removal/removal-result.hbs
+++ b/views/partials/removal/removal-result.hbs
@@ -118,8 +118,8 @@
       {{#ifCompare this.current_step "===" "BLOCKED"}}
         <li class="remove-dash-results-details-item flx flx-col align-start">
           <p class="remove-dash-results-detail-title flx jst-cntr">
-            {{getRemoveString "remove-result-opt-out"}}
-            {{> removal/removal-question-trigger modal="modal-remove-manual" alt="About Manual Removal"}}
+            {{getRemoveString "remove-result-manual"}}
+            {{> removal/removal-question-trigger modal="modal-remove-manual" alt=(getRemoveString "remove-result-manual")}}
           </p>
           <p class="remove-dash-results-detail">
             <a


### PR DESCRIPTION
*Note*: contains DB migrations which must be run in order to test, an…d upon merge / deployment to server

rename previous opt-out modal to manual modal, as it treats manual removal instructions for broker results
create new opt out modal that allows user to opt out of the removal pilot, thus hiding any part of the removal pilot experience from further view
implement this opt out modal trigger both on the enroll screen as well as in the initial data removal signup form (but only when signing up for the first time, not editing info).
handle setting the session variable which allows users to see the removal pilot navigation to false on optout
create a database migration which adds a removal_optout column to the subscribers table - this column will be checked as part of the `checkIfOnRemovalPilotList` function - if the user is on the list but has opted out, the check returns false. This allows us to prevent having to write to the pilot list and re-hash whenever someone opts out.
add an accessibility sr-only button label for all top right modal close buttons.