### PR TITLE
Merge/mk 025 no manage info

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -931,6 +931,8 @@ async function getRemovalPage(req, res) {
     whichPartial: partialString,
     experimentFlags,
     utmOverrides,
+    //DATA REMOVAL SPECIFIC
+    allowEditRemovalInfo: REMOVAL_CONSTANTS.REMOVE_EDIT_INFO_ENABLED,
     doClientsideValidation: REMOVAL_CONSTANTS.REMOVE_CLIENT_VALIDATION_ENABLED,
   });
 }

--- a/removal-constants.js
+++ b/removal-constants.js
@@ -25,6 +25,7 @@ const REMOVAL_CONSTANTS = {
   REMOVE_WILLINGNESS_TO_PAY_ENABLED: false, //show the willingness to pay screen
   REMOVE_CHECK_ENROLLMENT_ENDED_ENABLED: false, //allows us to enforce a fixed amount of time from the pilot start (set with REMOVAL_PILOT_ENROLLMENT_END_DAY) for users to enroll when true
   REMOVE_CLIENT_VALIDATION_ENABLED: true, //allows us to run removal form validity check client side before server side validation
+  REMOVE_EDIT_INFO_ENABLED: false, //when true, users can edit their info without the need to contact support
   REMOVE_EMAIL_DOMAIN_LIST: [
     "mozilla.com",
     "getpocket.com",

--- a/remove_en/remove.ftl
+++ b/remove_en/remove.ftl
@@ -82,6 +82,7 @@ remove-dash-change-submit = Review Information
 remove-dash-form-required-helper = * All fields are required to properly identify your exposed information
 remove-dash-form-disclaimer = By clicking “Start Data Removal” you agree to start the data removal process.
 remove-optout = Opt-Out
+remove-form-change-contact-msg = If you need to change your personal information due to an error, please contact support
 
 
 # Data Removal Form Confirmation Strings

--- a/template-helpers/dashboard.js
+++ b/template-helpers/dashboard.js
@@ -211,6 +211,7 @@ function getRemoveFormData(args) {
   const acctInfo = args.data.root.removeAcctInfo;
   const csrfToken = args.data.root.csrfToken;
   const doClientsideValidation = args.data.root.doClientsideValidation;
+  const allowEditRemovalInfo = args.data.root.allowEditRemovalInfo;
 
   // move emails with 0 breaches to the bottom of the page
   verifiedEmails.sort((a, b) => {
@@ -240,6 +241,7 @@ function getRemoveFormData(args) {
     acctInfo: acctInfo,
     jsConstants: REMOVAL_CONSTANTS,
     doClientsideValidation: doClientsideValidation,
+    allowEditRemovalInfo: allowEditRemovalInfo,
   };
 
   return args.fn(emailCards);

--- a/views/partials/dashboards/remove-form-confirm.hbs
+++ b/views/partials/dashboards/remove-form-confirm.hbs
@@ -12,9 +12,17 @@
           class="remove-dashboard-confirm-cancel btn-grey btn-small"
         >{{getRemoveString "remove-dash-confirm-back"}}</a>
       {{/if}}
-      <a href="#" class="js-confirm-edit-btn btn-blue btn-small">{{getRemoveString
+      {{#if this.acctInfo}}
+        {{#if this.allowEditRemovalInfo}}
+        <a href="#" class="js-confirm-edit-btn btn-blue btn-small">{{getRemoveString
+            "remove-dash-confirm-edit"
+          }}</a>
+        {{/if}}
+      {{else}}
+        <a href="#" class="js-confirm-edit-btn btn-blue btn-small">{{getRemoveString
           "remove-dash-confirm-edit"
         }}</a>
+      {{/if}}
     </div>
   </div>
   <div class="remove-dashboard-confirm-container">
@@ -58,11 +66,24 @@
   </div>
   <div class="remove-dashboard-form-error --general"></div>
   <div class="flx">
-    <a
-      href="#"
-      class="js-remove-confirm remove-dashboard-confirm-submit jst-cntr flx btn-blue-primary"
-      role="button"
-    >{{getConfirmSubmitText}}</a>
+    {{#if this.acctInfo}}
+      {{#if this.allowEditRemovalInfo}}
+      <a
+        href="#"
+        class="js-remove-confirm remove-dashboard-confirm-submit jst-cntr flx btn-blue-primary"
+        role="button"
+      >{{getConfirmSubmitText}}</a>
+      
+      {{else}}
+      <p class="remove-dashboard-conirm-edit">{{getRemoveString "remove-form-change-contact-msg"}}: <a href="mailto:{{ getRemoveString "remove-about-support-email"}}">{{ getRemoveString "remove-about-support-email"}}</a></p>
+      {{/if}}
+    {{else}}
+      <a
+        href="#"
+        class="js-remove-confirm remove-dashboard-confirm-submit jst-cntr flx btn-blue-primary"
+        role="button"
+      >{{getConfirmSubmitText}}</a>
+    {{/if}}
   </div>
   {{#if this.acctInfo}}
   <div class="remove-dashboard-delete-container flx jst-cntr">


### PR DESCRIPTION
adds a removal constant that toggles the ability to edit one's info.
implements a check on the info page for this constant:

- if the ability to edit is disabled users should be allowed to edit their info on initial form entry, but not on subsequent entries - in which case they will see an email address they should contact to change their info
- if the ability to edit is enabled, users should be able to edit their info regardless of whether it is their initial entry or a subsequent edit, and should no longer see the contact email address message.

If the user is editing their info, regardless of whether the ability to edit is enabled or disabled, the user should be able to go back via the "back" button on the manage info screen.