### PR TITLE
prevents a user from signing up for the pilot again after account deletion

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -433,7 +433,9 @@ async function postRemoveFxm(req, res) {
     await DB.removeKan(sessionUser);
   }
   //END DATA REMOVAL SPECIFIC
-
+  if (req.session?.kanary) {
+    req.session.kanary.onRemovalPilotList = false;
+  }
   await DB.removeSubscriber(sessionUser);
   await FXA.revokeOAuthTokens(sessionUser);
 
@@ -771,7 +773,7 @@ async function handleRemovalOptout(req, res) {
     });
   }
 
-  if (!req.session || !req.session.kanary) {
+  if (!req.session?.kanary) {
     const localeError = LocaleUtils.formatRemoveString(
       "remove-error-no-session"
     );
@@ -1246,6 +1248,9 @@ async function postRemovalKan(req, res) {
     });
   }
   await DB.removeKan(sessionUser);
+  if (req.session?.kanary) {
+    req.session.kanary.onRemovalPilotList = false;
+  }
   res.redirect("/user/remove-delete-confirmation");
 }
 

--- a/db/DB.js
+++ b/db/DB.js
@@ -498,6 +498,7 @@ const DB = {
         kid: null,
         removal_would_pay: null,
         removal_enrolled_time: null,
+        removal_optout: true,
       })
       .catch((e) => {
         console.error("error removing kanary id", e);

--- a/views/partials/dashboards/remove-form-confirm.hbs
+++ b/views/partials/dashboards/remove-form-confirm.hbs
@@ -75,7 +75,7 @@
       >{{getConfirmSubmitText}}</a>
       
       {{else}}
-      <p class="remove-dashboard-conirm-edit">{{getRemoveString "remove-form-change-contact-msg"}}: <a href="mailto:{{ getRemoveString "remove-about-support-email"}}">{{ getRemoveString "remove-about-support-email"}}</a></p>
+      <p>{{getRemoveString "remove-form-change-contact-msg"}}: <a href="mailto:{{ getRemoveString "remove-about-support-email"}}">{{ getRemoveString "remove-about-support-email"}}</a></p>
       {{/if}}
     {{else}}
       <a


### PR DESCRIPTION
prevents a user from signing up for the pilot again by setting their optout status to true on kanary account deletion or fxm account deletion