### PR TITLE
Disable show=true parameter ability on stage / prod

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -696,21 +696,20 @@ function logout(req, res) {
 async function getRemovalEnrollPage(req, res) {
   const user = req.user;
 
-  if (
-    checkIfRemovalEnrollmentEnded(user) &&
-    !FormUtils.canShowViaParams(req.query?.show)
-  ) {
+  const canShowViaParams = FormUtils.canShowViaParams(req.query?.show);
+
+  if (checkIfRemovalEnrollmentEnded(user) && !canShowViaParams) {
     //If the pilot enrollment period is not active
     return res.redirect("/user/remove-enroll-ended");
   }
 
   const isEnrolledInPilot = checkIfEnrolledInRemovalPilot(user);
-  if (isEnrolledInPilot && !FormUtils.canShowViaParams(req.query?.show)) {
+  if (isEnrolledInPilot && !canShowViaParams) {
     //if the user has already enrolled in the pilot, just send them to the remove data page
     return res.redirect("/user/remove-data");
   }
 
-  if ((await checkIfRemovalPilotFull(user)) && !FormUtils.canShowViaParams(req.query?.show)) {
+  if ((await checkIfRemovalPilotFull(user)) && !canShowViaParams) {
     //If we have already hit the enrollment limit:
     return res.redirect("/user/remove-enroll-full");
   }
@@ -750,7 +749,10 @@ async function getRemovalEnrolledPage(req, res) {
 
   const experimentFlags = getExperimentFlags(req, EXPERIMENTS_ENABLED);
 
-  if (!checkIfEnrolledInRemovalPilot(user) && !FormUtils.canShowViaParams(req.query?.show)) {
+  if (
+    !checkIfEnrolledInRemovalPilot(user) &&
+    !FormUtils.canShowViaParams(req.query?.show)
+  ) {
     return res.redirect("/user/remove-enroll");
   }
 
@@ -794,7 +796,10 @@ async function getRemovalEnrollFullPage(req, res) {
 
   const experimentFlags = getExperimentFlags(req, EXPERIMENTS_ENABLED);
 
-  if (!(await checkIfRemovalPilotFull(user)) && !FormUtils.canShowViaParams(req.query?.show)) {
+  if (
+    !(await checkIfRemovalPilotFull(user)) &&
+    !FormUtils.canShowViaParams(req.query?.show)
+  ) {
     return res.redirect("/user/remove-enroll");
   }
 
@@ -815,7 +820,10 @@ async function getRemovalEnrollEndedPage(req, res) {
 
   const experimentFlags = getExperimentFlags(req, EXPERIMENTS_ENABLED);
 
-  if (!checkIfRemovalEnrollmentEnded(user) && !FormUtils.canShowViaParams(req.query?.show)) {
+  if (
+    !checkIfRemovalEnrollmentEnded(user) &&
+    !FormUtils.canShowViaParams(req.query?.show)
+  ) {
     return res.redirect("/user/remove-enroll");
   }
 
@@ -940,11 +948,13 @@ async function getRemovalPage(req, res) {
 async function getRemovalConfirmationPage(req, res) {
   const user = req.user;
 
-  if (!user.kid && !checkIfEnrolledInRemovalPilot(user) && !FormUtils.canShowViaParams(req.query?.show)) {
+  const canShowViaParams = FormUtils.canShowViaParams(req.query?.show);
+
+  if (!user.kid && !checkIfEnrolledInRemovalPilot(user) && !canShowViaParams) {
     return res.redirect("/user/remove-enroll");
   }
 
-  if (!user.kid && checkIfEnrolledInRemovalPilot(user) && !FormUtils.canShowViaParams(req.query?.show)) {
+  if (!user.kid && checkIfEnrolledInRemovalPilot(user) && !canShowViaParams) {
     return res.redirect("/user/remove-data");
   }
 
@@ -996,11 +1006,13 @@ async function getRemovalConfirmationPage(req, res) {
 async function getRemovalUpdateConfirmationPage(req, res) {
   const user = req.user;
 
-  if (!user.kid && !FormUtils.canShowViaParams(req.query?.show)) {
+  canShowViaParams = FormUtils.canShowViaParams(req.query?.show);
+
+  if (!user.kid && !canShowViaParams) {
     return res.redirect("/user/remove-enroll");
   }
 
-  if (user.kid && !FormUtils.canShowViaParams(req.query?.show)) {
+  if (user.kid && !canShowViaParams) {
     return res.redirect("/user/remove-data");
   }
 

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -696,18 +696,21 @@ function logout(req, res) {
 async function getRemovalEnrollPage(req, res) {
   const user = req.user;
 
-  if (checkIfRemovalEnrollmentEnded(user) && !req.query.show) {
+  if (
+    checkIfRemovalEnrollmentEnded(user) &&
+    !FormUtils.canShowViaParams(req.query?.show)
+  ) {
     //If the pilot enrollment period is not active
     return res.redirect("/user/remove-enroll-ended");
   }
 
   const isEnrolledInPilot = checkIfEnrolledInRemovalPilot(user);
-  if (isEnrolledInPilot && !req.query.show) {
+  if (isEnrolledInPilot && !FormUtils.canShowViaParams(req.query?.show)) {
     //if the user has already enrolled in the pilot, just send them to the remove data page
     return res.redirect("/user/remove-data");
   }
 
-  if ((await checkIfRemovalPilotFull(user)) && !req.query.show) {
+  if ((await checkIfRemovalPilotFull(user)) && !FormUtils.canShowViaParams(req.query?.show)) {
     //If we have already hit the enrollment limit:
     return res.redirect("/user/remove-enroll-full");
   }
@@ -747,7 +750,7 @@ async function getRemovalEnrolledPage(req, res) {
 
   const experimentFlags = getExperimentFlags(req, EXPERIMENTS_ENABLED);
 
-  if (!checkIfEnrolledInRemovalPilot(user) && !req.query.show) {
+  if (!checkIfEnrolledInRemovalPilot(user) && !FormUtils.canShowViaParams(req.query?.show)) {
     return res.redirect("/user/remove-enroll");
   }
 
@@ -791,7 +794,7 @@ async function getRemovalEnrollFullPage(req, res) {
 
   const experimentFlags = getExperimentFlags(req, EXPERIMENTS_ENABLED);
 
-  if (!(await checkIfRemovalPilotFull(user)) && !req.query.show) {
+  if (!(await checkIfRemovalPilotFull(user)) && !FormUtils.canShowViaParams(req.query?.show)) {
     return res.redirect("/user/remove-enroll");
   }
 
@@ -812,7 +815,7 @@ async function getRemovalEnrollEndedPage(req, res) {
 
   const experimentFlags = getExperimentFlags(req, EXPERIMENTS_ENABLED);
 
-  if (!checkIfRemovalEnrollmentEnded(user) && !req.query.show) {
+  if (!checkIfRemovalEnrollmentEnded(user) && !FormUtils.canShowViaParams(req.query?.show)) {
     return res.redirect("/user/remove-enroll");
   }
 
@@ -830,11 +833,11 @@ async function getRemovalEnrollEndedPage(req, res) {
 async function getRemovalPage(req, res) {
   const user = req.user;
 
-  if (!checkIfEnrolledInRemovalPilot(user) && !req.query.show) {
+  if (!checkIfEnrolledInRemovalPilot(user) && !FormUtils.canShowViaParams(req.query?.show)) {
     return res.redirect("/user/remove-enroll");
   }
 
-  if (checkIfRemovalPilotEnded(user) && !req.query.show) {
+  if (checkIfRemovalPilotEnded(user) && !FormUtils.canShowViaParams(req.query?.show)) {
     //if the pilot is over, redirect to the end screen
     return res.redirect("/user/remove-pilot-ended");
   }
@@ -936,11 +939,11 @@ async function getRemovalPage(req, res) {
 async function getRemovalConfirmationPage(req, res) {
   const user = req.user;
 
-  if (!user.kid && !checkIfEnrolledInRemovalPilot(user) && !req.query.show) {
+  if (!user.kid && !checkIfEnrolledInRemovalPilot(user) && !FormUtils.canShowViaParams(req.query?.show)) {
     return res.redirect("/user/remove-enroll");
   }
 
-  if (!user.kid && checkIfEnrolledInRemovalPilot(user) && !req.query.show) {
+  if (!user.kid && checkIfEnrolledInRemovalPilot(user) && !FormUtils.canShowViaParams(req.query?.show)) {
     return res.redirect("/user/remove-data");
   }
 
@@ -992,11 +995,11 @@ async function getRemovalConfirmationPage(req, res) {
 async function getRemovalUpdateConfirmationPage(req, res) {
   const user = req.user;
 
-  if (!user.kid && !req.query.show) {
+  if (!user.kid && !FormUtils.canShowViaParams(req.query?.show)) {
     return res.redirect("/user/remove-enroll");
   }
 
-  if (user.kid && !req.query.show) {
+  if (user.kid && !FormUtils.canShowViaParams(req.query?.show)) {
     return res.redirect("/user/remove-data");
   }
 
@@ -1039,7 +1042,7 @@ async function getRemovalUpdateConfirmationPage(req, res) {
 async function getRemovalDeleteConfirmationPage(req, res) {
   const user = req.user;
 
-  if (user.kid && !req.query.show) {
+  if (user.kid && !FormUtils.canShowViaParams(req.query?.show)) {
     return res.redirect("/user/remove-data");
   }
 
@@ -1080,7 +1083,7 @@ async function getRemovalPilotEndedPage(req, res) {
 
   const experimentFlags = getExperimentFlags(req, EXPERIMENTS_ENABLED);
 
-  if (!checkIfRemovalPilotEnded(user) && !req.query.show) {
+  if (!checkIfRemovalPilotEnded(user) && !FormUtils.canShowViaParams(req.query?.show)) {
     return res.redirect("/user/remove-data");
   }
 

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -833,13 +833,14 @@ async function getRemovalEnrollEndedPage(req, res) {
 async function getRemovalPage(req, res) {
   const user = req.user;
 
-  if (!checkIfEnrolledInRemovalPilot(user) && !FormUtils.canShowViaParams(req.query?.show)) {
-    return res.redirect("/user/remove-enroll");
-  }
-
-  if (checkIfRemovalPilotEnded(user) && !FormUtils.canShowViaParams(req.query?.show)) {
-    //if the pilot is over, redirect to the end screen
-    return res.redirect("/user/remove-pilot-ended");
+  if (!FormUtils.canShowViaParams(req.query?.show)) {
+    if (!checkIfEnrolledInRemovalPilot(user)) {
+      return res.redirect("/user/remove-enroll");
+    }
+    if (checkIfRemovalPilotEnded(user)) {
+      // if the pilot is over, redirect to the end screen
+      return res.redirect("/user/remove-pilot-ended");
+    }
   }
 
   let show_form;

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1006,7 +1006,7 @@ async function getRemovalConfirmationPage(req, res) {
 async function getRemovalUpdateConfirmationPage(req, res) {
   const user = req.user;
 
-  canShowViaParams = FormUtils.canShowViaParams(req.query?.show);
+  const canShowViaParams = FormUtils.canShowViaParams(req.query?.show);
 
   if (!user.kid && !canShowViaParams) {
     return res.redirect("/user/remove-enroll");

--- a/form-utils.js
+++ b/form-utils.js
@@ -95,11 +95,7 @@ const FormUtils = {
     return parseFloat(mode);
   },
   canShowViaParams(doShow) {
-    if (["dev", "heroku"].includes(AppConstants.NODE_ENV) && doShow) {
-      return true;
-    } else {
-      return false;
-    }
+    return ["dev", "heroku"].includes(AppConstants.NODE_ENV) && doShow;
   },
 };
 

--- a/form-utils.js
+++ b/form-utils.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const Countrily = require("countrily");
+const AppConstants = require("./app-constants");
 
 let countryCodes;
 let usStates;
@@ -92,6 +93,13 @@ const FormUtils = {
       current[1] >= previous[1] ? current : previous
     )[0];
     return parseFloat(mode);
+  },
+  canShowViaParams(doShow) {
+    if (["dev", "heroku"].includes(AppConstants.NODE_ENV) && doShow) {
+      return true;
+    } else {
+      return false;
+    }
   },
 };
 

--- a/views/partials/top-level/remove-faq.hbs
+++ b/views/partials/top-level/remove-faq.hbs
@@ -109,7 +109,7 @@
             </div>
             <div class="remove-faq__details-container">
               <p>We scan for sites that collect and sell your personal data like
-                names, addresses, and phone numbers. While the list changes frequently, you can <a href="https://www.thekanary.com/faq" rel="noopener noreferrer" target="_blank">visit Kanary's FAQ page</a> to see the most common sites.</p>
+                names, addresses, and phone numbers. While the list changes frequently, you can <a href="https://www.thekanary.com/faq#heading1" rel="noopener noreferrer" target="_blank">visit Kanary's FAQ page</a> to see the most common sites.</p>
             </div>
           </li>
           <li class="remove-faq__list-item drop-shadow flx flx-col">


### PR DESCRIPTION
modify the `show=true` parameter check  so that it can only be allowed if the `NODE_EV` parameter is for `dev` or `heroku`