### PR TITLE
Merge/mk 029 pilot groups logic

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1336,11 +1336,17 @@ function checkIfRemovalEnrollmentEnded(user) {
   }
   const pilotGroup = getPilotGroup(user);
 
+  const today = new Date();
+  const enrollmentStartDate = FormUtils.convertTimestampToDate(
+    pilotGroup.start_time
+  );
   const enrollmentEndDate = FormUtils.getDaysFromTimestamp(
     pilotGroup.start_time,
     REMOVAL_CONSTANTS.REMOVAL_PILOT_ENROLLMENT_END_DAY
   );
-  return new Date() > enrollmentEndDate;
+
+  return today < enrollmentStartDate || today > enrollmentEndDate;
+
 }
 
 async function checkIfOnRemovalPilotList(user) {

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1289,28 +1289,28 @@ function getPilotGroup(user) {
 
     //sort the array by the closest future end date
     if (aDiff > 0 && bDiff < 0) {
-      //console.log("a end is in the future, b end is in past, assign to a");
+      //a end is in the future, b end is in past, assign to a
       return -1;
     } else if (aDiff < 0 && bDiff > 0) {
-      //console.log("a end is in the past, b end is in future, move to b");
+      //a end is in the past, b end is in future, move to b
       return 1;
     } else if (aDiff > 0 && bDiff > 0 && aDiff < bDiff) {
-      //console.log("both are in the future, but a is less far off, assign to a");
+      //both are in the future, but a is less far off, assign to a
       return -1;
     } else if (aDiff > 0 && bDiff > 0 && aDiff > bDiff) {
-      //console.log("both are in the future, but b is less far off, assign to b");
+      //both are in the future, but b is less far off, assign to b
       return 1;
     } else if (aDiff < 0 && bDiff < 0 && aDiff < bDiff) {
-      //console.log("both are in the past, but b is less far off, assign to b");
+      //both are in the past, but b is less far off, assign to b
       return 1;
     } else if (aDiff < 0 && bDiff < 0 && aDiff > bDiff) {
-      //console.log("both are in the past, but a is less far off, assign to a");
+      //both are in the past, but a is less far off, assign to a
       return -1;
     } else {
       return 0;
     }
   });
-  console.log("user is in group", removalPilots[0].name);
+  //console.log("user is in group", removalPilots[0].name);
   return removalPilots[0];
 }
 

--- a/form-utils.js
+++ b/form-utils.js
@@ -39,6 +39,9 @@ const FormUtils = {
   convertDateToTimestamp(curDate) {
     return parseInt((new Date(curDate).getTime() / 1000).toFixed(0));
   },
+  convertTimestampToDate(ts) {
+    return new Date(parseInt(ts) * 1000);
+  },
   calculateDaysBetweenTimestamps(startTime, endTime) {
     const timeDifference = endTime.getTime() - startTime.getTime();
     return timeDifference / (1000 * 3600 * 24); //ms to seconds, seconds to minutes, minutes to hours, hours to days

--- a/removal-constants.js
+++ b/removal-constants.js
@@ -53,28 +53,15 @@ const REMOVAL_CONSTANTS = {
     {
       id: 1,
       name: "group_01",
-      start_time: 1638393405, //test - 1/13/22
-      max_users: 500,
+      start_time: 1641967200, //wed, jan 12
+      max_users: 300,
     },
     {
       id: 2,
       name: "group_02",
-      start_time: 1641676605, //test - 1/14/22
-      max_users: 500, //max users represents the sum of all users from this and the preceding pilot groups (thus 700 in this cohort and 1000 total from both) - so that we can compare against a single DB value of max users
+      start_time: 1644601719, //fri, feb 11
+      max_users: 1000, //max users represents the sum of all users from this and the preceding pilot groups (thus 700 in this cohort and 1000 total from both) - so that we can compare against a single DB value of max users
     },
-    //MH - leave these - they are the actual values for the pilot
-    // {
-    //   id: 1,
-    //   name: "group_01",
-    //   start_time: 1641967200, //wed, jan 12
-    //   max_users: 300,
-    // },
-    // {
-    //   id: 2,
-    //   name: "group_02",
-    //   start_time: 1644601719, //fri, feb 11
-    //   max_users: 1000, //max users represents the sum of all users from this and the preceding pilot groups (thus 700 in this cohort and 1000 total from both) - so that we can compare against a single DB value of max users
-    // },
   ],
   REMOVAL_PILOT_ENROLLMENT_END_DAY: 7, //days from pilot start to when a user can no longer enroll in their pilot group
   REMOVAL_PILOT_END_DAY: 90, //days from pilot start to when the pilot ends

--- a/removal-constants.js
+++ b/removal-constants.js
@@ -53,13 +53,13 @@ const REMOVAL_CONSTANTS = {
     {
       id: 1,
       name: "group_01",
-      start_time: 1642060800, //test - 1/13/22
+      start_time: 1638393405, //test - 1/13/22
       max_users: 500,
     },
     {
       id: 2,
       name: "group_02",
-      start_time: 1642147200, //test - 1/14/22
+      start_time: 1641676605, //test - 1/14/22
       max_users: 500, //max users represents the sum of all users from this and the preceding pilot groups (thus 700 in this cohort and 1000 total from both) - so that we can compare against a single DB value of max users
     },
     //MH - leave these - they are the actual values for the pilot

--- a/removal-constants.js
+++ b/removal-constants.js
@@ -23,7 +23,7 @@ const REMOVAL_CONSTANTS = {
   REMOVE_CHECK_WAITLIST_ENABLED: true, //enable the waitlist check
   REMOVE_CHECK_EMAIL_DOMAIN_ENABLED: false, //enable a check of the user's email domain to be within the REMOVE_EMAIL_DOMAIN_LIST array
   REMOVE_WILLINGNESS_TO_PAY_ENABLED: false, //show the willingness to pay screen
-  REMOVE_CHECK_ENROLLMENT_ENDED_ENABLED: false, //allows us to enforce a fixed amount of time from the pilot start (set with REMOVAL_PILOT_ENROLLMENT_END_DAY) for users to enroll when true
+  REMOVE_CHECK_ENROLLMENT_ENDED_ENABLED: true, //allows us to enforce a fixed amount of time from the pilot start (set with REMOVAL_PILOT_ENROLLMENT_END_DAY) for users to enroll when true
   REMOVE_CLIENT_VALIDATION_ENABLED: true, //allows us to run removal form validity check client side before server side validation
   REMOVE_EDIT_INFO_ENABLED: false, //when true, users can edit their info without the need to contact support
   REMOVE_EMAIL_DOMAIN_LIST: [
@@ -47,18 +47,37 @@ const REMOVAL_CONSTANTS = {
     "/remove-pilot-ended",
   ], //used to underline the exposures menu tab on any route in this array
   REMOVE_ROUTES: ["/user/remove-data", "/user/remove-enroll"],
+  REMOVAL_PILOT_GROUP: "round_01", //the `name` used to retrieve the proper record from the `removal_pilot` database tablename of the current pilot group in the removal_pilot_database
   REMOVAL_PILOTS: [
     //can use https://www.epochconverter.com/ for a timestamp
     {
       id: 1,
       name: "group_01",
-      start_time: 1641967200, //wed, jan 12
-      max_users: 50, //total max users in pilot across all groups at this point in time
+      start_time: 1642060800, //test - 1/13/22
+      max_users: 500,
     },
+    {
+      id: 2,
+      name: "group_02",
+      start_time: 1642147200, //test - 1/14/22
+      max_users: 500, //max users represents the sum of all users from this and the preceding pilot groups (thus 700 in this cohort and 1000 total from both) - so that we can compare against a single DB value of max users
+    },
+    //MH - leave these - they are the actual values for the pilot
+    // {
+    //   id: 1,
+    //   name: "group_01",
+    //   start_time: 1641967200, //wed, jan 12
+    //   max_users: 300,
+    // },
+    // {
+    //   id: 2,
+    //   name: "group_02",
+    //   start_time: 1644601719, //fri, feb 11
+    //   max_users: 1000, //max users represents the sum of all users from this and the preceding pilot groups (thus 700 in this cohort and 1000 total from both) - so that we can compare against a single DB value of max users
+    // },
   ],
-  REMOVAL_PILOT_ENROLLMENT_END_DAY: 14, //days from pilot start to when a user can no longer enroll in their pilot group
-  REMOVAL_PILOT_END_DAY: 51, //days from pilot start to when the pilot ends
-  REMOVAL_PILOT_GROUP: "round_01", //the `name` used to retrieve the proper record from the `removal_pilot` database tablename of the current pilot group in the removal_pilot_database
+  REMOVAL_PILOT_ENROLLMENT_END_DAY: 7, //days from pilot start to when a user can no longer enroll in their pilot group
+  REMOVAL_PILOT_END_DAY: 90, //days from pilot start to when the pilot ends
   REMOVAL_STEP: {
     AWAITING_SCAN: {
       locale_var: "remove-step-awaiting-scan",


### PR DESCRIPTION
Fix pilot group logic to assign user to appropriate pilot group and ensure that they receive the appropriate of 3 outcomes:

The Enrollment Page
The Pilot Closed Page
The Pilot Full Page

The logic should be:


CAPACITY AVAILABLE:

Enrollment ended for a, but not for b = user assigned to b, sees enrollment page
Enrollment ended for both groups = user receives "closed" page
Enrollment open for both groups = user assigned to a, sees enrollment page
Enrollment ended for a, and hasn't started for b, user sees closed page


CAPACITY FULL:
Enrollment hasn't ended for a group, b hasn't started, a is full but b is not = user assigned a, should see full message
Both groups have started, a is past enrollment, b is not but is full = user should see full message
Both groups past enrollment, both groups are full, user sees enrollment ended screen

