### PR TITLE
Some attempts to better address the errors happening on stage

### DIFF
--- a/controllers/oauth.js
+++ b/controllers/oauth.js
@@ -65,9 +65,12 @@ async function confirmed(req, res, next, client = FxAOAuthClient) {
   //DATA REMOVAL SPECIFIC
   const post_auth_redirect = req.session.post_auth_redirect;
   let returnURL;
-
-  if (existingUser && (await checkIfOnRemovalPilotList(existingUser))) {
+  const isOnRemovalPilotList = await checkIfOnRemovalPilotList(existingUser);
+  if (isOnRemovalPilotList) {
     req.session.kanary = { onRemovalPilotList: true };
+  }
+
+  if (existingUser && isOnRemovalPilotList) {
     //if they are an existing user and on the pilot list, use pilot redirect
     if (post_auth_redirect) {
       returnURL = new URL(post_auth_redirect, AppConstants.SERVER_URL);

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1444,15 +1444,16 @@ async function handleRemovalFormSignup(req, res) {
 
   if (user.kid) {
     console.error(
-      "user should have been directed to the handleRemovalAcctUpdate function if they have a kid"
+      "user should not be able to submit the form again if they already have a Kanary ID"
     );
-    const localeError = LocaleUtils.formatRemoveString(
-      "remove-error-account-exists"
-    );
+    // const localeError = LocaleUtils.formatRemoveString(
+    //   "remove-error-account-exists"
+    // );
 
-    return res.status(400).json({
-      error: localeError,
-    });
+    // return res.status(400).json({
+    //   error: localeError,
+    // });
+    return res.redirect("/user/remove-data");
   }
 
   const {

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1446,13 +1446,7 @@ async function handleRemovalFormSignup(req, res) {
     console.error(
       "user should not be able to submit the form again if they already have a Kanary ID"
     );
-    // const localeError = LocaleUtils.formatRemoveString(
-    //   "remove-error-account-exists"
-    // );
 
-    // return res.status(400).json({
-    //   error: localeError,
-    // });
     return res.redirect("/user/remove-data");
   }
 

--- a/db/DB.js
+++ b/db/DB.js
@@ -498,7 +498,7 @@ const DB = {
         kid: null,
         removal_would_pay: null,
         removal_enrolled_time: null,
-        removal_optout: true,
+        removal_optout: false, //MH TODO: reenable after debugging stage
       })
       .catch((e) => {
         console.error("error removing kanary id", e);

--- a/form-utils.js
+++ b/form-utils.js
@@ -98,7 +98,7 @@ const FormUtils = {
     return parseFloat(mode);
   },
   canShowViaParams(doShow) {
-    return ["dev", "heroku"].includes(AppConstants.NODE_ENV) && doShow;
+    return ["dev", "heroku", "stage"].includes(AppConstants.NODE_ENV) && doShow;
   },
 };
 


### PR DESCRIPTION
• Regardless of whether user is an existing user, if they're on the pilot list set their session.onRemovalPilotList to true.
• if a user has a kanary ID, redirect them to the dashboard instead of just throwing an error.
• allow the `show=true params` to be used on stage for better debugging.