### PR TITLE
remove style nonce for CSP inline style rule

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1879,7 +1879,6 @@ async function getRemovalStatsUser(req, res) {
     title: req.fluentFormat("Firefox Monitor"),
     csrfToken: req.csrfToken(),
     stats: userStats,
-    styleNonce: res.locals.styleNonce,
     whichPartial: "dashboards/remove-all-stats",
   });
 }

--- a/server.js
+++ b/server.js
@@ -40,7 +40,6 @@ const EmailUtils = require("./email-utils");
 const HBSHelpers = require("./template-helpers/");
 const HIBP = require("./hibp");
 const IpLocationService = require("./ip-location-service");
-const uuidv4 = require("uuid/v4");
 
 const { getHashedWaitlist } = require("./removal-waitlist");
 
@@ -152,7 +151,7 @@ const SCRIPT_SOURCES = [
   "'self'",
   "https://www.google-analytics.com/analytics.js",
 ];
-const STYLE_SOURCES = ["https://code.cdn.mozilla.net/fonts/"];
+const STYLE_SOURCES = ["'self'", "https://code.cdn.mozilla.net/fonts/"];
 const FRAME_ANCESTORS = ["'none'"];
 
 app.locals.ENABLE_PONTOON_JS = false;
@@ -189,12 +188,6 @@ if (AppConstants.FXA_ENABLED) {
   });
 }
 
-app.use((req, res, next) => {
-  // nonce should be base64 encoded
-  res.locals.styleNonce = Buffer.from(uuidv4()).toString("base64");
-  next();
-});
-
 app.use(
   helmet.contentSecurityPolicy({
     directives: {
@@ -215,10 +208,7 @@ app.use(
       imgSrc: imgSrc,
       objectSrc: ["'none'"],
       scriptSrc: SCRIPT_SOURCES,
-      styleSrc: [
-        ...STYLE_SOURCES,
-        "'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' 'sha256-We76yQ6BbUqy3OL7pB4AiChSOtAH/BdDsZ0Z+MzXvD0='", //MH TODO: this SHA may change, in which case this needs to be updated to avoid console / CSP errors
-      ],
+      styleSrc: STYLE_SOURCES,
       reportUri: "/__cspreport__",
     },
   })

--- a/views/layouts/default.hbs
+++ b/views/layouts/default.hbs
@@ -2,7 +2,6 @@
 <html lang="{{ getFirstItem (getSupportedLocales) }}">
   <head>
     <meta charset="utf-8" />
-    <meta property="csp-nonce" content="{{ styleNonce }}" />
     {{> imports }}
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="{{getString "og-site-description"}}" />


### PR DESCRIPTION
CSP does not allow inline styles.  The style nonce code was added to safely bypass this, as well resolve related client errors.  Since we are not using inline styles, and I cannot replicate errors, this PR removes the associated code.

Removing the code removes the ability to bypass CSP for inline styles, and as well allows syncing between `main` and `main-kanary` to proceed without conflict.