### PR TITLE
allow editing info via an edit=true query param

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -926,6 +926,10 @@ async function getRemovalPage(req, res) {
     partialString = "dashboards/remove-dashboard";
   }
 
+  if (req.query.edit && req.query.edit === "true") {
+    REMOVAL_CONSTANTS.REMOVE_EDIT_INFO_ENABLED = true;
+  }
+
   res.render("dashboards", {
     title: req.fluentFormat("Firefox Monitor"),
     csrfToken: req.csrfToken(),


### PR DESCRIPTION
Allows users to edit their info by inclusion of an `edit=true` param. 

We are getting requests from support and research of users who input improper information - this will allow them to easily update their own info without us needing to make SRE requests or obtain personal information from our users. 

The edit info functionality itself was preserved from the foxfooding pilot, so this PR only requires that we set the feature flag by way of the param.