### PR TITLE
check removal admins env for match to access pilot mgmt interface

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -18,7 +18,7 @@ DISABLE_DOCKERFLOW=
 # Kanary API
 KANARY_TOKEN="get-this-from-fx-monitor-engineering"
 KANARY_ENDPOINT="get-this-from-fx-monitor-engineering"
-
+REMOVAL_ADMINS=
 
 # Database server
 DATABASE_URL=postgres://postgres@localhost:5432/blurts

--- a/app-constants.js
+++ b/app-constants.js
@@ -8,6 +8,7 @@ require("dotenv").config({ path: path.join(__dirname, ".env") });
 const requiredEnvVars = [
   "KANARY_ENDPOINT",
   "KANARY_TOKEN",
+  "REMOVAL_ADMINS",
   "NODE_ENV",
   "SERVER_URL",
   "PORT",

--- a/middleware.js
+++ b/middleware.js
@@ -301,7 +301,9 @@ async function requireNoOptOut(req, res, next) {
 async function requireMozAdmin(req, res, next) {
   const user = req.user;
 
-  if (!user?.primary_email.endsWith("@mozilla.com")) {
+  const adminArray = AppConstants.REMOVAL_ADMINS.toString().split(",");
+
+  if (!adminArray.includes(user.primary_email)) {
     console.error("You are not authorized to access this page");
     return res.status(401).json({
       error: "You are not authorized to access this page",
@@ -309,6 +311,7 @@ async function requireMozAdmin(req, res, next) {
   }
   next();
   return;
+
 }
 
 module.exports = {


### PR DESCRIPTION
Adds a new `REMOVAL_ADMINS` env and checks against this comma separated email list to allow access to the pilot mgmt interface in the `requireMozAdmin` middleware - replacing a previous implementation which allowed any `mozilla.com` fxa user to access.