### PR TITLE
remove pilot ending banner

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -1338,17 +1338,6 @@ function getPilotGroup(user) {
   return removalPilots[0];
 }
 
-function checkIfRemovalPilotEnding(user) {
-  const pilotGroup = getPilotGroup(user);
-
-  const pilotEndingDate = FormUtils.getDaysFromTimestamp(
-    pilotGroup.start_time,
-    REMOVAL_CONSTANTS.REMOVAL_PILOT_ENDING_DAY
-  );
-
-  return new Date() > pilotEndingDate;
-}
-
 function checkIfRemovalPilotEnded(user) {
   const pilotGroup = getPilotGroup(user);
 
@@ -2037,5 +2026,4 @@ module.exports = {
   handleRemovalAdminOptin,
   getRemovalAdminCounts,
   setRemovalAdminEnrollmentCount,
-  checkIfRemovalPilotEnding,
 };

--- a/template-helpers/hbs-helpers.js
+++ b/template-helpers/hbs-helpers.js
@@ -5,7 +5,6 @@ const { LocaleUtils } = require("./../locale-utils");
 const mozlog = require("./../log");
 
 const log = mozlog("template-helpers/hbs-helpers");
-const { checkIfRemovalPilotEnding } = require("./../controllers/user");
 
 function getSupportedLocales(args) {
   if (args.data) {
@@ -372,27 +371,6 @@ function checkIfInRemovalPilot(args) {
   return false;
 }
 
-function isRemovalPilotEnding(args) {
-  //used to determine if we show UI elements notifying the user that the pilot is ending
-
-  if (args.data.root.req.query?.showEnding === "true") {
-    //if we force visibility via param
-    return true;
-  }
-  const user = args.data.root.req.session?.user;
-  if (!user) {
-    return false;
-  }
-  const isInRemovalPilot = checkIfInRemovalPilot(args);
-  if (!isInRemovalPilot) {
-    return false;
-  }
-
-  //if they are in the pilot, check today's date against the ending date from the constants file
-  const isPilotEnding = checkIfRemovalPilotEnding(user); //check
-  return isPilotEnding;
-}
-
 //END DATA REMOVAL SPECIFIC
 
 module.exports = {
@@ -425,5 +403,4 @@ module.exports = {
   incrementedIndex,
   getRemoveString,
   checkIfInRemovalPilot,
-  isRemovalPilotEnding,
 };

--- a/views/partials/header/header.hbs
+++ b/views/partials/header/header.hbs
@@ -28,7 +28,4 @@
           </nav>
         </section>
       </div>
-      {{#if (isRemovalPilotEnding)}}
-        {{> data-removal/removal-ending-banner}}
-      {{/if}}
     </header>


### PR DESCRIPTION
 to resolve issue with adding additional emails.

Requiring the `user` controller within `hbs-helpers` was causing some sort of load order issue, in which `const EmailUtils = require("../email-utils");` within the `user` controller was resolving as `undefined`. I'm not quite sure why that was happening, but for now, this pull request removes that banner altogether, as well as the code in the helper which was requiring the user controller.

We will need to come up with a method of showing a "pilot ending" banner sometime before April, but for now, pushing this PR to prevent further user issues with adding additional emails.