### PR TITLE
Update Sentry configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,10 @@ jobs:
                     "$CIRCLE_BUILD_URL" > version.json
             - run:
                 name: Build Docker image
-                command: docker build -t blurts-server .
+                command: |
+                  docker build --tag blurts-server \
+                  --build-arg SENTRY_RELEASE="$CIRCLE_TAG"
+                  .
             - run:
                 name: Deploy to Dockerhub
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,7 @@ workflows:
                         only: 
                             - main
             - heroku/deploy-via-git:
+                name: Deploy main to Heroku
                 app-name: $HEROKU_MAIN_APP_NAME
                 requires:
                     - unit-tests
@@ -166,6 +167,7 @@ workflows:
                     branches:
                         only: main
             - heroku/deploy-via-git:
+                name: Deploy l10n to Heroku
                 app-name: $HEROKU_LOCALIZATION_APP_NAME
                 requires:
                     - unit-tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,7 @@ COPY .env-dist ./.env
 
 RUN npm run build
 
+ARG SENTRY_RELEASE
+ENV SENTRY_RELEASE=$SENTRY_RELEASE
+
 CMD node server.js

--- a/controllers/home.js
+++ b/controllers/home.js
@@ -141,6 +141,13 @@ function addEmailToWaitlist (req, res) {
   return res.json('email-added')
 }
 
+function testSentry (req, res) {
+  if (!req.user || !req.user.primary_email.endsWith('@mozilla.com')) {
+    return res.redirect('/')
+  }
+  throw new Error('Successfully tested exception handling')
+}
+
 function notFound (req, res) {
   res.status(404)
   res.render('subpage', {
@@ -157,5 +164,6 @@ module.exports = {
   getBentoStrings,
   getSecurityTips,
   home,
-  notFound
+  notFound,
+  testSentry
 }

--- a/middleware.js
+++ b/middleware.js
@@ -3,7 +3,6 @@
 const { URLSearchParams } = require('url')
 
 const { negotiateLanguages, acceptedLanguages } = require('fluent-langneg')
-const Sentry = require('@sentry/node')
 
 const AppConstants = require('./app-constants')
 const DB = require('./db/DB')
@@ -111,7 +110,6 @@ function asyncMiddleware (fn) {
 
 function logErrors (err, req, res, next) {
   log.error('error', { stack: err.stack })
-  Sentry.captureException(err)
   next(err)
 }
 

--- a/routes/home.js
+++ b/routes/home.js
@@ -6,7 +6,7 @@ const csrf = require('csurf')
 
 const {
   home, getAboutPage, getAllBreaches, getBentoStrings,
-  getSecurityTips, notFound, addEmailToWaitlist
+  getSecurityTips, notFound, addEmailToWaitlist, testSentry
 } = require('../controllers/home')
 const { getIpLocation } = require('../controllers/ip-location')
 
@@ -28,6 +28,7 @@ router.get('/security-tips', getSecurityTips)
 router.get('/getBentoStrings', getBentoStrings)
 router.post('/join-waitlist', jsonParser, requireSessionUser, addEmailToWaitlist)
 router.get('/iplocation', getIpLocation)
+router.get('/test-sentry', requireSessionUser, testSentry)
 router.use(notFound)
 
 module.exports = router

--- a/server.js
+++ b/server.js
@@ -244,6 +244,7 @@ if (devOrHeroku) app.use('/email-l10n', EmailL10nRoutes)
 app.use('/breach-details', BreachRoutes)
 app.use('/', HomeRoutes)
 
+app.use(Sentry.Handlers.errorHandler())
 app.use(logErrors)
 app.use(localizeErrorMessages)
 app.use(clientErrorHandler)

--- a/server.js
+++ b/server.js
@@ -65,6 +65,12 @@ function getRedisStore () {
 }
 
 const app = express()
+app.use(
+  Sentry.Handlers.requestHandler({
+    request: ['headers', 'method', 'url'], // omit cookies, data, query_string
+    user: ['id'] // omit username, email
+  })
+)
 
 function devOrHeroku () {
   return ['dev', 'heroku'].includes(AppConstants.NODE_ENV)


### PR DESCRIPTION
This adds some additional features to blurts-server's Sentry configuration.

From the [Sentry Express guide](https://docs.sentry.io/platforms/node/guides/express/), this adds a `requestHandler` middleware to capture request information, and a `errorHandler` middleware to catch exceptions. This replaces the `captureException` call in the `logErrors` middleware, and should give more information in Sentry issues. I've disabled some features of the `requestHandler` which may contain PII, but further experience is needed to see if we need to include or exclude more.

I've added the `CIRCLE_TAG` to the Docker image as `SENTRY_RELEASE` (same as `version` at https://monitor.firefox.com/__version__). Sentry should use this, when defined, to populate the [`release` parameter](https://docs.sentry.io/platforms/node/guides/express/configuration/options/#release), and tag Sentry issues with the release number.

I've added a endpoint `/test-sentry` that throws an error if the request user has an email that ends with `@mozilla.com`. This could allow testing this PR, but also may be useful to see associated data in one of the deployments.