### PR TITLE
Deploy from CircleCI to Heroku

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ executors:
 orbs:
     node: circleci/node@5.0.2
     python: circleci/python@1.4.0
+    heroku: circleci/heroku@1.2.6
 
 jobs:
     lint-js:
@@ -154,3 +155,17 @@ workflows:
                     branches:
                         only: 
                             - main
+            - heroku/deploy-via-git:
+                app-name: $HEROKU_MAIN_APP_NAME
+                requires:
+                    - unit-tests
+                filters:
+                    branches:
+                        only: main
+            - heroku/deploy-via-git:
+                app-name: $HEROKU_LOCALIZATION_APP_NAME
+                requires:
+                    - unit-tests
+                filters:
+                    branches:
+                        only: localization


### PR DESCRIPTION
This is similar to https://github.com/mozilla/fx-private-relay/pull/2355, except I'm using the [deploy-from-git job](https://circleci.com/developer/orbs/orb/circleci/heroku#jobs-deploy-via-git) rather than the command, and there are two jobs, one for `main` and one for `localization`. I've added the environment variables to make these jobs work.

The [CircleCI heroku orb](https://circleci.com/developer/orbs/orb/circleci/heroku) does not support review apps. It looks possible using the [REST API](https://devcenter.heroku.com/articles/platform-api-reference#review-app), but not easy. The website still recommends the GitHub integration for reviews, and I don't think we're ready to enable that integration yet.