### PR TITLE
Fix CircleCI "deploy/Build Docker Image" step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
                 name: Build Docker image
                 command: |
                   docker build --tag blurts-server \
-                  --build-arg SENTRY_RELEASE="$CIRCLE_TAG"
+                  --build-arg SENTRY_RELEASE="$CIRCLE_TAG" \
                   .
             - run:
                 name: Deploy to Dockerhub


### PR DESCRIPTION
Add a missing continuation slash from changing the command from a single to a multi-line command. This was broken in PR #2612.