### PR TITLE
Upgrade handlebars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "stylelint-config-standard": "^26.0.0"
       },
       "engines": {
-        "node": "16.x",
+        "node": "16.15.x",
         "npm": "8.x"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "knex-paginate": "1.2.2",
         "mozlog": "3.0.2",
         "nodemailer": "^6.6.5",
-        "nodemailer-express-handlebars": "^4.0.0",
+        "nodemailer-express-handlebars": "5.0.0",
         "pg": "^8.7.1",
         "redis": "3.1.1",
         "sns-validator": "0.3.4",
@@ -8091,24 +8091,11 @@
       }
     },
     "node_modules/nodemailer-express-handlebars": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nodemailer-express-handlebars/-/nodemailer-express-handlebars-4.0.0.tgz",
-      "integrity": "sha512-oUYl2D1AkFNwRe7RXt8iNTtmQGmI4Bt4PXRkE9lX891FHNNUB3I5yRDGL1WQPOujYIHH79uAvD3QzsBStG4SFA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nodemailer-express-handlebars/-/nodemailer-express-handlebars-5.0.0.tgz",
+      "integrity": "sha512-DMeoCr8kSyLjzXZR+wclDidPDcgy68mIiuSlDZeeDP4IQLJmRzXrlTv+3C2r+uYUnajN5vxqB8pTBdju6aH/yA==",
       "dependencies": {
-        "express-handlebars": "^4.0.0"
-      }
-    },
-    "node_modules/nodemailer-express-handlebars/node_modules/express-handlebars": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-4.0.6.tgz",
-      "integrity": "sha512-SWwmp4ERN/hPySdRnQYiNcJP/LHAeTz1qq0MXQ2ztZiMC6sKw1WathtVWWY+AUPkjV6eDmQXqybJQwnUsoI9vw==",
-      "dependencies": {
-        "glob": "^7.1.6",
-        "graceful-fs": "^4.2.4",
-        "handlebars": "^4.7.6"
-      },
-      "engines": {
-        "node": ">=0.10"
+        "express-handlebars": "^6.0.0"
       }
     },
     "node_modules/nodemon": {
@@ -18110,23 +18097,11 @@
       "integrity": "sha512-6VtMpwhsrixq1HDYSBBHvW0GwiWawE75dS3oal48VqRhUvKJNnKnJo2RI/bCVQubj1vgrgscMNW4DHaD6xtMCg=="
     },
     "nodemailer-express-handlebars": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nodemailer-express-handlebars/-/nodemailer-express-handlebars-4.0.0.tgz",
-      "integrity": "sha512-oUYl2D1AkFNwRe7RXt8iNTtmQGmI4Bt4PXRkE9lX891FHNNUB3I5yRDGL1WQPOujYIHH79uAvD3QzsBStG4SFA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nodemailer-express-handlebars/-/nodemailer-express-handlebars-5.0.0.tgz",
+      "integrity": "sha512-DMeoCr8kSyLjzXZR+wclDidPDcgy68mIiuSlDZeeDP4IQLJmRzXrlTv+3C2r+uYUnajN5vxqB8pTBdju6aH/yA==",
       "requires": {
-        "express-handlebars": "^4.0.0"
-      },
-      "dependencies": {
-        "express-handlebars": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-4.0.6.tgz",
-          "integrity": "sha512-SWwmp4ERN/hPySdRnQYiNcJP/LHAeTz1qq0MXQ2ztZiMC6sKw1WathtVWWY+AUPkjV6eDmQXqybJQwnUsoI9vw==",
-          "requires": {
-            "glob": "^7.1.6",
-            "graceful-fs": "^4.2.4",
-            "handlebars": "^4.7.6"
-          }
-        }
+        "express-handlebars": "^6.0.0"
       }
     },
     "nodemon": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "esbuild": "^0.14.39",
         "express": "4.17.1",
         "express-bearer-token": "2.4.0",
-        "express-handlebars": "5.3.1",
+        "express-handlebars": "6.0.6",
         "express-session": "1.17.1",
         "fluent": "0.12.0",
         "fluent-langneg": "0.2.0",
@@ -4515,16 +4515,53 @@
       }
     },
     "node_modules/express-handlebars": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-5.3.1.tgz",
-      "integrity": "sha512-mHpf3PAYysgo6M2yl/r0p5ui/gHwVa7vLBgA3ht8HlNxRGcwXSAGOwKAtAEVdHs4j7FDb5ZGsAJoA8nFaogbGw==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-6.0.6.tgz",
+      "integrity": "sha512-E4QHYCh+9fyfdBEb8uKJ8p6HD4qq/sUSHBq83lRNlLJp2TQKEg2nFJYbVdC+M3QzaV19dODe43lgjQWVaIpbyQ==",
       "dependencies": {
-        "glob": "^7.1.6",
-        "graceful-fs": "^4.2.6",
+        "glob": "^8.0.2",
+        "graceful-fs": "^4.2.10",
         "handlebars": "^4.7.7"
       },
       "engines": {
-        "node": ">=v10.24.1"
+        "node": ">=v12.22.9"
+      }
+    },
+    "node_modules/express-handlebars/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/express-handlebars/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/express-handlebars/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/express-session": {
@@ -15382,13 +15419,43 @@
       }
     },
     "express-handlebars": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-5.3.1.tgz",
-      "integrity": "sha512-mHpf3PAYysgo6M2yl/r0p5ui/gHwVa7vLBgA3ht8HlNxRGcwXSAGOwKAtAEVdHs4j7FDb5ZGsAJoA8nFaogbGw==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-6.0.6.tgz",
+      "integrity": "sha512-E4QHYCh+9fyfdBEb8uKJ8p6HD4qq/sUSHBq83lRNlLJp2TQKEg2nFJYbVdC+M3QzaV19dODe43lgjQWVaIpbyQ==",
       "requires": {
-        "glob": "^7.1.6",
-        "graceful-fs": "^4.2.6",
+        "glob": "^8.0.2",
+        "graceful-fs": "^4.2.10",
         "handlebars": "^4.7.7"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "express-session": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "esbuild": "^0.14.39",
     "express": "4.17.1",
     "express-bearer-token": "2.4.0",
-    "express-handlebars": "5.3.1",
+    "express-handlebars": "6.0.6",
     "express-session": "1.17.1",
     "fluent": "0.12.0",
     "fluent-langneg": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "knex-paginate": "1.2.2",
     "mozlog": "3.0.2",
     "nodemailer": "^6.6.5",
-    "nodemailer-express-handlebars": "^4.0.0",
+    "nodemailer-express-handlebars": "5.0.0",
     "pg": "^8.7.1",
     "redis": "3.1.1",
     "sns-validator": "0.3.4",


### PR DESCRIPTION
Upgrade:

* `express-handlebars` from 5.3.1 to 6.0.6. It is mostly dependency updates, and 6.x requires node 12
* `nodemailer-express-handlebars` from 4.0.0 to 5.0.0. The major change is requiring `express-handlebars` 6.0.6

There's no feature or security content here, and no changes needed to our code. `express-handlebars` added this to their README:

> **Danger 🔥**
> 
> Never put objects on the `req` object straight in as the data, this can allow hackers to run XSS attacks. Always make sure you are destructuring the values on objects like `req.query` and `req.params`. See https://blog.shoebpatel.com/2021/01/23/The-Secret-Parameter-LFR-and-Potential-RCE-in-NodeJS-Apps/ for more details.

The closest we get to that behaviour is the email test page index, and we validate that the query parameters are a known set of strings.
