### PR TITLE
Update @sentry/node from v5.27.2 to v7.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@maxmind/geoip2-node": "^3.1.0",
-        "@sentry/node": "5.27.2",
+        "@sentry/node": "7.12.0",
         "body-parser": "1.19.0",
         "client-oauth2": "4.3.3",
         "connect-redis": "5.0.0",
@@ -1253,98 +1253,68 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.27.2.tgz",
-      "integrity": "sha512-FMX0Aignhi9Rk4tZkjwSXCsFFQc8FIOgUTvfIKCdayLhKxfbY0H37b0fFNzaQ9v15SFzIZJ9uzw4PTmjzEh6Uw==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.12.0.tgz",
+      "integrity": "sha512-ERkeB/XdThvdSVZH4XysMPyWRG653HDq0AkJh8SgapExCZbwgj1lutCIpT1LIbZ8lUhRx5P+ua9OR2qj+vo5RA==",
       "dependencies": {
-        "@sentry/hub": "5.27.2",
-        "@sentry/minimal": "5.27.2",
-        "@sentry/types": "5.27.2",
-        "@sentry/utils": "5.27.2",
+        "@sentry/hub": "7.12.0",
+        "@sentry/types": "7.12.0",
+        "@sentry/utils": "7.12.0",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.27.2.tgz",
-      "integrity": "sha512-KCAWF5oDXd/Pjzbcmfj53F5ZzOX53Rzi23a2mWyUXMdPXoXIiMrIcdC/DqrqKV787LvOJcSFaTychJCH3t15/A==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.12.0.tgz",
+      "integrity": "sha512-UgpC9WiHQAfcoEIIgeIopp3jeabllK6beLl5vA4ei6ay2TDMjA4NqUpzGq/GWVG0ewnblvHkqmjwAls2AEMtWg==",
       "dependencies": {
-        "@sentry/types": "5.27.2",
-        "@sentry/utils": "5.27.2",
+        "@sentry/types": "7.12.0",
+        "@sentry/utils": "7.12.0",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.27.2.tgz",
-      "integrity": "sha512-n9SssI30rpS1tw6hH0ylxVlONdmZCqiPy60fotxUzql6mCo/nW7tcADsW15fvQlUQ160VaGf3iMj+hpHkRBerw==",
-      "dependencies": {
-        "@sentry/hub": "5.27.2",
-        "@sentry/types": "5.27.2",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.27.2.tgz",
-      "integrity": "sha512-JHY+EYjq3iqVnTPIow7KzKX+lIqJXZGVT0xHdPrhaVcfBtUUBYTpjO7SSCkINPt6dPKVRq0QDzIfevd5nybR7A==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.12.0.tgz",
+      "integrity": "sha512-N3Ja/lHb8rf0pFwgsRKW7yUB2p0lOVGIEwCl/7w1XxqOinBMT6L1W/OcLNOHjBKxMfk6LRhaqHe+vpZr4FbIPw==",
       "dependencies": {
-        "@sentry/core": "5.27.2",
-        "@sentry/hub": "5.27.2",
-        "@sentry/tracing": "5.27.2",
-        "@sentry/types": "5.27.2",
-        "@sentry/utils": "5.27.2",
+        "@sentry/core": "7.12.0",
+        "@sentry/hub": "7.12.0",
+        "@sentry/types": "7.12.0",
+        "@sentry/utils": "7.12.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/tracing": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.27.2.tgz",
-      "integrity": "sha512-5Lptd32VtKBzIzTmFqcKgcetTMRraMvjPFTX8kFVX4aGDaUGOx0cCZeAURNoHDfHfjCazYK8yV6BkJfi6YJNww==",
-      "dependencies": {
-        "@sentry/hub": "5.27.2",
-        "@sentry/minimal": "5.27.2",
-        "@sentry/types": "5.27.2",
-        "@sentry/utils": "5.27.2",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.2.tgz",
-      "integrity": "sha512-oszEOlWJuySvGc2HJ2KLTgtYwRFnHWDu8YIZ99UhmO2PcGQ5HlZJpV2oC8n3x0g1YSSlAaThjKbliJEAT7fmPg==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.12.0.tgz",
+      "integrity": "sha512-ldcuRzEx2ccZvaJjTSemWj+7TiWCV5A/vV7fEtZeoETFI+SiVbmqI5whdH7ZVVfhRNFf25Ib+TfTeaM9PM7A1A==",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.27.2.tgz",
-      "integrity": "sha512-ZrdRgcFapi1NACbtvnPLOIXKjBPVTlhGzmXNCVao0uRBBRNJa5i2Mjp/U/Xy/fT0K1MGJQ+F9YZjZPnAMsDNbw==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.12.0.tgz",
+      "integrity": "sha512-GVB8E0V3RJHQClvi0gsRRJvDXP5c7M5ByYAvspJDczOOxNF8LTjTYVkBXAUdR9kcs+nya1q1YVsKvde2WGORTA==",
       "dependencies": {
-        "@sentry/types": "5.27.2",
+        "@sentry/types": "7.12.0",
         "tslib": "^1.9.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@servie/events": {
@@ -10737,76 +10707,52 @@
       }
     },
     "@sentry/core": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.27.2.tgz",
-      "integrity": "sha512-FMX0Aignhi9Rk4tZkjwSXCsFFQc8FIOgUTvfIKCdayLhKxfbY0H37b0fFNzaQ9v15SFzIZJ9uzw4PTmjzEh6Uw==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.12.0.tgz",
+      "integrity": "sha512-ERkeB/XdThvdSVZH4XysMPyWRG653HDq0AkJh8SgapExCZbwgj1lutCIpT1LIbZ8lUhRx5P+ua9OR2qj+vo5RA==",
       "requires": {
-        "@sentry/hub": "5.27.2",
-        "@sentry/minimal": "5.27.2",
-        "@sentry/types": "5.27.2",
-        "@sentry/utils": "5.27.2",
+        "@sentry/hub": "7.12.0",
+        "@sentry/types": "7.12.0",
+        "@sentry/utils": "7.12.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.27.2.tgz",
-      "integrity": "sha512-KCAWF5oDXd/Pjzbcmfj53F5ZzOX53Rzi23a2mWyUXMdPXoXIiMrIcdC/DqrqKV787LvOJcSFaTychJCH3t15/A==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.12.0.tgz",
+      "integrity": "sha512-UgpC9WiHQAfcoEIIgeIopp3jeabllK6beLl5vA4ei6ay2TDMjA4NqUpzGq/GWVG0ewnblvHkqmjwAls2AEMtWg==",
       "requires": {
-        "@sentry/types": "5.27.2",
-        "@sentry/utils": "5.27.2",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/minimal": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.27.2.tgz",
-      "integrity": "sha512-n9SssI30rpS1tw6hH0ylxVlONdmZCqiPy60fotxUzql6mCo/nW7tcADsW15fvQlUQ160VaGf3iMj+hpHkRBerw==",
-      "requires": {
-        "@sentry/hub": "5.27.2",
-        "@sentry/types": "5.27.2",
+        "@sentry/types": "7.12.0",
+        "@sentry/utils": "7.12.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.27.2.tgz",
-      "integrity": "sha512-JHY+EYjq3iqVnTPIow7KzKX+lIqJXZGVT0xHdPrhaVcfBtUUBYTpjO7SSCkINPt6dPKVRq0QDzIfevd5nybR7A==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.12.0.tgz",
+      "integrity": "sha512-N3Ja/lHb8rf0pFwgsRKW7yUB2p0lOVGIEwCl/7w1XxqOinBMT6L1W/OcLNOHjBKxMfk6LRhaqHe+vpZr4FbIPw==",
       "requires": {
-        "@sentry/core": "5.27.2",
-        "@sentry/hub": "5.27.2",
-        "@sentry/tracing": "5.27.2",
-        "@sentry/types": "5.27.2",
-        "@sentry/utils": "5.27.2",
+        "@sentry/core": "7.12.0",
+        "@sentry/hub": "7.12.0",
+        "@sentry/types": "7.12.0",
+        "@sentry/utils": "7.12.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
       }
     },
-    "@sentry/tracing": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.27.2.tgz",
-      "integrity": "sha512-5Lptd32VtKBzIzTmFqcKgcetTMRraMvjPFTX8kFVX4aGDaUGOx0cCZeAURNoHDfHfjCazYK8yV6BkJfi6YJNww==",
-      "requires": {
-        "@sentry/hub": "5.27.2",
-        "@sentry/minimal": "5.27.2",
-        "@sentry/types": "5.27.2",
-        "@sentry/utils": "5.27.2",
-        "tslib": "^1.9.3"
-      }
-    },
     "@sentry/types": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.2.tgz",
-      "integrity": "sha512-oszEOlWJuySvGc2HJ2KLTgtYwRFnHWDu8YIZ99UhmO2PcGQ5HlZJpV2oC8n3x0g1YSSlAaThjKbliJEAT7fmPg=="
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.12.0.tgz",
+      "integrity": "sha512-ldcuRzEx2ccZvaJjTSemWj+7TiWCV5A/vV7fEtZeoETFI+SiVbmqI5whdH7ZVVfhRNFf25Ib+TfTeaM9PM7A1A=="
     },
     "@sentry/utils": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.27.2.tgz",
-      "integrity": "sha512-ZrdRgcFapi1NACbtvnPLOIXKjBPVTlhGzmXNCVao0uRBBRNJa5i2Mjp/U/Xy/fT0K1MGJQ+F9YZjZPnAMsDNbw==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.12.0.tgz",
+      "integrity": "sha512-GVB8E0V3RJHQClvi0gsRRJvDXP5c7M5ByYAvspJDczOOxNF8LTjTYVkBXAUdR9kcs+nya1q1YVsKvde2WGORTA==",
       "requires": {
-        "@sentry/types": "5.27.2",
+        "@sentry/types": "7.12.0",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@maxmind/geoip2-node": "^3.1.0",
-    "@sentry/node": "5.27.2",
+    "@sentry/node": "7.12.0",
     "body-parser": "1.19.0",
     "client-oauth2": "4.3.3",
     "connect-redis": "5.0.0",


### PR DESCRIPTION
Some highlights from the [Changelog](https://github.com/getsentry/sentry-javascript/blob/master/CHANGELOG.md) and [migration guide](https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md), which do not affect our code:

* 6.0.0 - Start supporting Release Health
* 6.17.0 - Remove DSN class
* 6.18.0 - Deprecate frameContextLines
* 7.0.0 - Split @sentry/tracing into own package, distribute ES5, drop Node.js v6