### PR TITLE
CircleCI: Add tests for PostgreSQL versions 9.6.24 and 13.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,25 @@ executors:
         machine:
             image: ubuntu-2004:202107-02
 
+    node_with_postgres:
+        parameters:
+            postgres_version:
+                description: "Which cimg/postgres tag to use"
+                type: string
+        docker:
+            - image: cimg/node:16.15
+              auth:
+                username: $DOCKER_USER
+                password: $DOCKER_PASS
+            - image: cimg/postgres:<< parameters.postgres_version >>
+              environment:
+                  POSTGRES_USER: postgres
+                  POSTGRES_PASSWORD: 93e389316eaf4ea2be4010d526cc1468
+                  POSTGRES_DB: test-circle
+              auth:
+                  username: $DOCKER_USER
+                  password: $DOCKER_PASS
+
 orbs:
     node: circleci/node@5.0.2
     python: circleci/python@1.4.0
@@ -51,7 +70,7 @@ jobs:
             DATABASE_URL: postgresql://postgres:test-pass@localhost/blurts
         steps:
             - checkout
-            - run: 
+            - run:
                 name: Install Postgres
                 # Installing Postgres on a host machine. 
                 # Originally attempted to use a container, but communication between container-within-a-container is not well supported currently
@@ -80,6 +99,41 @@ jobs:
                     -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN \
                     -e COVERALLS_GIT_BRANCH=$CIRCLE_BRANCH \
                     blurts-server npm test
+
+    unit-tests-psql:
+        parameters:
+            postgres_version:
+                description: "Which cimg/postgres tag to use"
+                type: string
+        executor:
+            name: node_with_postgres
+            postgres_version: << parameters.postgres_version >>
+        steps:
+            - checkout
+            - node/install-packages
+            - run: sudo apt-get update
+            - run: sudo apt-get install postgresql-client
+            - run:
+                name: install dockerize
+                command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+                environment:
+                    DOCKERIZE_VERSION: v0.6.1
+            - run:
+                name: Wait for db
+                command: dockerize -wait tcp://localhost:5432 -timeout 1m
+            - run:
+                name: Use default .env
+                command: cp .env-dist .env
+            - run:
+                name: Test Code
+                command: |
+                    NODE_ENV=tests \
+                    DATABASE_URL=postgresql://postgres:93e389316eaf4ea2be4010d526cc1468@localhost/circle \
+                    HIBP_KANON_API_TOKEN=$HIBP_KANON_API_TOKEN \
+                    COVERALLS_SERVICE_NAME=circleci \
+                    COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN \
+                    COVERALLS_GIT_BRANCH=$CIRCLE_BRANCH \
+                    npm test
 
     deploy:
         docker:
@@ -164,6 +218,18 @@ workflows:
             - lint-css
             - lint-l10n
             - unit-tests:
+                filters:
+                    tags:
+                        only: /.*/
+            - unit-tests-psql:
+                name: "unit-tests on psql 9.6"
+                postgres_version: "9.6.24"
+                filters:
+                    tags:
+                        only: /.*/
+            - unit-tests-psql:
+                name: "unit-tests on psql 13.7"
+                postgres_version: "13.7"
                 filters:
                     tags:
                         only: /.*/


### PR DESCRIPTION
Run unit tests against specific PostgreSQL versions, using current CircleCI instructions for a PostgreSQL service container.