### PR TITLE
MNTOR-854: Add tests for `getSubscribersWithUnresolvedBreaches`, fix query for psql 9.6

### DIFF
--- a/db/DB.js
+++ b/db/DB.js
@@ -445,7 +445,6 @@ const DB = {
       .whereRaw('monthly_email_optout IS NOT TRUE')
       .whereRaw("greatest(created_at, monthly_email_at) < (now() - interval '30 days')")
       // .whereJsonPath('breach_stats', '$.numBreaches.numUnresolved', '>', 0)  // Requires psql 11
-      .whereNotNull('breach_stats')
       .whereRaw("(breach_stats #>> '{numBreaches, numUnresolved}')::int > 0")
 
     return res

--- a/db/DB.js
+++ b/db/DB.js
@@ -444,7 +444,9 @@ const DB = {
       .select('primary_email', 'primary_verification_token', 'breach_stats', 'signup_language')
       .whereRaw('monthly_email_optout IS NOT TRUE')
       .whereRaw("greatest(created_at, monthly_email_at) < (now() - interval '30 days')")
-      .whereJsonPath('breach_stats', '$.numBreaches.numUnresolved', '>', 0)
+      // .whereJsonPath('breach_stats', '$.numBreaches.numUnresolved', '>', 0)  // Requires psql 11
+      .whereNotNull('breach_stats')
+      .whereRaw("(breach_stats #>> '{numBreaches, numUnresolved}')::int > 0")
 
     return res
   },

--- a/db/seeds/test_subscribers.js
+++ b/db/seeds/test_subscribers.js
@@ -38,6 +38,37 @@ exports.TEST_SUBSCRIBERS = {
     primary_verification_token: '54010800-6c3c-4186-971a-76dc92874941',
     primary_verified: true,
     signup_language: 'en-US;q=0.7,en;q=0.3'
+  },
+  has_breaches: {
+    id: 12346,
+    created_at: '2022-06-07 14:29:00.000-05',
+    primary_sha1: getSha1('has-breaches@example.com'),
+    primary_email: 'has-breaches@example.com',
+    primary_verification_token: 'c165711a-69d1-42f1-9850-ce74754f36de',
+    primary_verified: true,
+    fxa_access_token: '5a4792b89434153f1a6262fbd6a4510c00834ff842585fc4f4d972da158f0fc0',
+    fxa_refresh_token: '5a4792b89434153f1a6262fbd6a4510c00834ff842585fc4f4d972da158f0fc1',
+    fxa_uid: 12346,
+    fxa_profile_json: {},
+    breaches_last_shown: '2022-07-08 14:19:00.000-05',
+    breaches_resolved: { 'has-breaches@example.com': [1] },
+    breach_stats: {
+      passwords: {
+        count: 1,
+        numResolved: 0
+      },
+      numBreaches: {
+        count: 2,
+        numResolved: 1,
+        numUnresolved: 1
+      },
+      monitoredEmails: {
+        count: 1
+      }
+    },
+    monthly_email_at: '2022-08-07 14:22:00.000-05',
+    monthly_email_optout: false,
+    signup_language: 'fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7,*;q=0.5'
   }
 }
 
@@ -64,6 +95,14 @@ exports.TEST_EMAIL_ADDRESSES = {
     sha1: getSha1('secondary_sending_to_primary@test.com'),
     email: 'secondary_sending_to_primary@test.com',
     verification_token: '0e2cb147-2041-4e5b-8ca9-494e773b2cf4',
+    verified: true
+  },
+  has_breaches: {
+    id: 11112,
+    subscriber_id: 12346,
+    sha1: getSha1('has-breaches@example.com'),
+    email: 'has-breaches@example.com',
+    verification_token: 'c165711a-69d1-42f1-9850-ce74754f36df',
     verified: true
   }
 }

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -206,3 +206,16 @@ test('getPreFxaSubscribersPage returns subscribers without an FxA ID', async () 
   const expectedPagination = {"currentPage": 1, "from": 0, "lastPage": 1, "perPage": 10, "to": 3, "total": 3}
   expect(subscribersPageResult.pagination).toEqual(expectedPagination)
 })
+
+test('getSubscribersWithUnresolvedBreaches returns subscribers', async () => {
+  const subscribersResult = await DB.getSubscribersWithUnresolvedBreaches();
+  expect(subscribersResult.length).toEqual(1)
+  expect(subscribersResult[0].primary_email).toEqual('has-breaches@example.com')
+  expect(subscribersResult[0].breach_stats.monitoredEmails).toEqual({"count": 1})
+})
+
+test('getSubscribersWithUnresolvedBreaches with null breach_stats returns', async () => {
+  await DB.updateBreachStats(12346, null)
+  const subscribersResult = await DB.getSubscribersWithUnresolvedBreaches();
+  expect(subscribersResult.length).toEqual(0)
+})


### PR DESCRIPTION
Add a test subscriber and email `has_breaches`, with two tests for `getSubscribersWithUnresolvedBreaches`:

* The one subscriber is returned by `getSubscribersWithUnresolvedBreaches`
* No subscribers are returned when the `breach_stats` value is `null`

Update `getSubscribersWithUnresolvedBreaches` so that it works on PostgreSQL 9.6 and later.