### PR TITLE
Test monthly email script, add limit

### DIFF
--- a/app-constants.js
+++ b/app-constants.js
@@ -57,7 +57,8 @@ const optionalEnvVars = [
   'EDUCATION_VIDEO_URL_RELAY',
   'EDUCATION_VIDEO_URL_VPN',
   'ADMINS',
-  'MONTHLY_CRON_ENABLED'
+  'MONTHLY_CRON_ENABLED',
+  'MONTHLY_CRON_LIMIT'
 ]
 
 const AppConstants = { }

--- a/db/DB.js
+++ b/db/DB.js
@@ -449,7 +449,7 @@ const DB = {
   async getSubscribersWithUnresolvedBreaches (limit = 0) {
     let query = this.getSubscribersWithUnresolvedBreachesQuery()
       .select('primary_email', 'primary_verification_token', 'breach_stats', 'signup_language')
-    if (limit && limit > 0) {
+    if (limit) {
       query = query.limit(limit).orderBy('created_at')
     }
     return await query

--- a/db/DB.js
+++ b/db/DB.js
@@ -443,7 +443,6 @@ const DB = {
     return knex('subscribers')
       .whereRaw('monthly_email_optout IS NOT TRUE')
       .whereRaw("greatest(created_at, monthly_email_at) < (now() - interval '30 days')")
-      // .whereJsonPath('breach_stats', '$.numBreaches.numUnresolved', '>', 0)  // Requires psql 11
       .whereRaw("(breach_stats #>> '{numBreaches, numUnresolved}')::int > 0")
   },
 

--- a/scripts/send-email-to-unresolved-breach-subscribers.js
+++ b/scripts/send-email-to-unresolved-breach-subscribers.js
@@ -2,7 +2,7 @@ const DB = require('../db/DB')
 const EmailUtils = require('../email-utils')
 const { LocaleUtils } = require('../locale-utils')
 const AppConstants = require('../app-constants')
-const { env, argv } = require('node:process')
+const { argv } = require('node:process')
 
 /* Send a monthly email to each subscriber with unresolved breaches
  *
@@ -64,7 +64,7 @@ async function init () {
 
 async function runScript (argv = []) {
   let subscribers = null
-  const limit = AppConstants.MONTHLY_CRON_LIMIT
+  const limit = parseInt(AppConstants.MONTHLY_CRON_LIMIT)
   if (argv[2]) {
     console.log('Testing job for monthly unresolved breach emails...')
     const res = await prepareTestSubscribers(argv[2])
@@ -116,7 +116,7 @@ async function teardown () {
 }
 
 async function main () {
-  if (env.NODE_ENV !== 'tests') {
+  if (AppConstants.NODE_ENV !== 'tests') {
     await init()
     try {
       await runScript(argv)

--- a/scripts/send-email-to-unresolved-breach-subscribers.js
+++ b/scripts/send-email-to-unresolved-breach-subscribers.js
@@ -62,7 +62,7 @@ async function init () {
   await DB.createConnection()
 }
 
-async function runScript (argv = []) {
+async function runScript () {
   let subscribers = null
   const limit = parseInt(AppConstants.MONTHLY_CRON_LIMIT)
   if (argv[2]) {
@@ -119,7 +119,7 @@ async function main () {
   if (AppConstants.NODE_ENV !== 'tests') {
     await init()
     try {
-      await runScript(argv)
+      await runScript()
     } finally {
       await teardown()
     }

--- a/tests/send-email-to-unresolved-breach-subscribers.test.js
+++ b/tests/send-email-to-unresolved-breach-subscribers.test.js
@@ -1,0 +1,17 @@
+const DB = require('../db/DB')
+const { TEST_SUBSCRIBERS, TEST_EMAIL_ADDRESSES } = require('../db/seeds/test_subscribers')
+const { sendUnresolvedBreachEmails } = require('../scripts/send-email-to-unresolved-breach-subscribers')
+const EmailUtils = require('../email-utils')
+
+require('./resetDB')
+
+jest.mock('../email-utils')
+
+test('sendUnresolvedBreachEmails to test subscriber', async () => {
+  const data = await sendUnresolvedBreachEmails()
+  expect(data).toEqual({"attempted": 1, "emailed": 1, "total": 1})
+  expect(EmailUtils.sendEmail).toHaveBeenCalled()
+  const subscriber = await DB.getSubscriberById(12346)
+  expect(subscriber.monthly_email_at).not.toBeNull()
+  expect(Date.now() - subscriber.monthly_email_at).toBeLessThan(100)
+})


### PR DESCRIPTION
* Move the script logic into functions so that running and initialization can be skipped in tests.
* Add a test to send an email to the test subscriber
* Add `MONTHLY_CRON_LIMIT` sets the maximum number of emails to send.
* Refactor the database functions to allow a limit and a count of total subscribers.