### PR TITLE
Dependency updates, September 22, 2022

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "knex": "^2.2.0",
         "knex-paginate": "3.0.1",
         "mozlog": "3.0.2",
-        "nodemailer": "^6.6.5",
+        "nodemailer": "^6.7.8",
         "nodemailer-express-handlebars": "5.0.0",
         "pg": "^8.7.1",
         "redis": "3.1.1",
@@ -6896,9 +6896,9 @@
       "dev": true
     },
     "node_modules/nodemailer": {
-      "version": "6.7.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.7.5.tgz",
-      "integrity": "sha512-6VtMpwhsrixq1HDYSBBHvW0GwiWawE75dS3oal48VqRhUvKJNnKnJo2RI/bCVQubj1vgrgscMNW4DHaD6xtMCg==",
+      "version": "6.7.8",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.7.8.tgz",
+      "integrity": "sha512-2zaTFGqZixVmTxpJRCFC+Vk5eGRd/fYtvIR+dl5u9QXLTQWGIf48x/JXvo58g9sa0bU6To04XUv554Paykum3g==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -14879,9 +14879,9 @@
       "dev": true
     },
     "nodemailer": {
-      "version": "6.7.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.7.5.tgz",
-      "integrity": "sha512-6VtMpwhsrixq1HDYSBBHvW0GwiWawE75dS3oal48VqRhUvKJNnKnJo2RI/bCVQubj1vgrgscMNW4DHaD6xtMCg=="
+      "version": "6.7.8",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.7.8.tgz",
+      "integrity": "sha512-2zaTFGqZixVmTxpJRCFC+Vk5eGRd/fYtvIR+dl5u9QXLTQWGIf48x/JXvo58g9sa0bU6To04XUv554Paykum3g=="
     },
     "nodemailer-express-handlebars": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "nodemailer-express-handlebars": "5.0.0",
         "pg": "^8.7.1",
         "redis": "3.1.1",
-        "sns-validator": "0.3.4",
+        "sns-validator": "0.3.5",
         "uuid": "3.4.0"
       },
       "devDependencies": {
@@ -8547,9 +8547,9 @@
       }
     },
     "node_modules/sns-validator": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/sns-validator/-/sns-validator-0.3.4.tgz",
-      "integrity": "sha512-v2pDbfPW4qeUKssV9GbgbDf7XC3b9CG+0JTSATGYWKAo/2F7d0PBQJnSY5fpdryJyoquBkER647+7f/d+HR46A=="
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/sns-validator/-/sns-validator-0.3.5.tgz",
+      "integrity": "sha512-lapYNmezLsltnt2fcQyhmYnC41mYZ7EjU7f2oR/hrhpbD/LemryclRpApwxO84gOyDIQ7MWe/h4HvkdunFzSKg=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -16078,9 +16078,9 @@
       }
     },
     "sns-validator": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/sns-validator/-/sns-validator-0.3.4.tgz",
-      "integrity": "sha512-v2pDbfPW4qeUKssV9GbgbDf7XC3b9CG+0JTSATGYWKAo/2F7d0PBQJnSY5fpdryJyoquBkER647+7f/d+HR46A=="
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/sns-validator/-/sns-validator-0.3.5.tgz",
+      "integrity": "sha512-lapYNmezLsltnt2fcQyhmYnC41mYZ7EjU7f2oR/hrhpbD/LemryclRpApwxO84gOyDIQ7MWe/h4HvkdunFzSKg=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "connect-redis": "6.1.3",
         "cookie-parser": "^1.4.6",
         "csurf": "1.11.0",
-        "dotenv": "8.2.0",
+        "dotenv": "16.0.2",
         "esbuild": "^0.14.39",
         "express": "4.17.1",
         "express-bearer-token": "2.4.0",
@@ -2845,11 +2845,11 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
+      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -11944,9 +11944,9 @@
       }
     },
     "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
+      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sentry/node": "7.12.0",
         "body-parser": "1.19.0",
         "client-oauth2": "4.3.3",
-        "connect-redis": "5.0.0",
+        "connect-redis": "6.1.3",
         "cookie-parser": "^1.4.6",
         "csurf": "1.11.0",
         "dotenv": "8.2.0",
@@ -2388,11 +2388,11 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/connect-redis": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-5.0.0.tgz",
-      "integrity": "sha512-R4nTW5uXeG5s6zr/q4abmtcdloglZrL/A3cpa0JU0RLFJU4mTR553HUY8OZ0ngeySkGDclwQ5xmCcjjKkxdOSg==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-6.1.3.tgz",
+      "integrity": "sha512-aaNluLlAn/3JPxRwdzw7lhvEoU6Enb+d83xnokUNhC9dktqBoawKWL+WuxinxvBLTz6q9vReTnUDnUslaz74aw==",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=12"
       }
     },
     "node_modules/content-disposition": {
@@ -11587,9 +11587,9 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "connect-redis": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-5.0.0.tgz",
-      "integrity": "sha512-R4nTW5uXeG5s6zr/q4abmtcdloglZrL/A3cpa0JU0RLFJU4mTR553HUY8OZ0ngeySkGDclwQ5xmCcjjKkxdOSg=="
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-6.1.3.tgz",
+      "integrity": "sha512-aaNluLlAn/3JPxRwdzw7lhvEoU6Enb+d83xnokUNhC9dktqBoawKWL+WuxinxvBLTz6q9vReTnUDnUslaz74aw=="
     },
     "content-disposition": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@sentry/node": "7.12.0",
     "body-parser": "1.19.0",
     "client-oauth2": "4.3.3",
-    "connect-redis": "5.0.0",
+    "connect-redis": "6.1.3",
     "cookie-parser": "^1.4.6",
     "csurf": "1.11.0",
     "dotenv": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "knex": "^2.2.0",
     "knex-paginate": "3.0.1",
     "mozlog": "3.0.2",
-    "nodemailer": "^6.6.5",
+    "nodemailer": "^6.7.8",
     "nodemailer-express-handlebars": "5.0.0",
     "pg": "^8.7.1",
     "redis": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "nodemailer-express-handlebars": "5.0.0",
     "pg": "^8.7.1",
     "redis": "3.1.1",
-    "sns-validator": "0.3.4",
+    "sns-validator": "0.3.5",
     "uuid": "3.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "connect-redis": "6.1.3",
     "cookie-parser": "^1.4.6",
     "csurf": "1.11.0",
-    "dotenv": "8.2.0",
+    "dotenv": "16.0.2",
     "esbuild": "^0.14.39",
     "express": "4.17.1",
     "express-bearer-token": "2.4.0",


### PR DESCRIPTION
Update dependencies. This covers:

* Bump dotenv from 8.2.0 to 16.0.2 (from PR #2643)
* Bump sns-validator from 0.3.4 to 0.3.5 (from PR #2642)
* Bump nodemailer from 6.7.5 to 6.7.8 (from PR #2641)
* Bump connect-redis from 5.0.0 to 6.1.3 (from PR #2640)
