### PR TITLE
MNTOR-249: Improve test coverage of EmailUtils

### DIFF
--- a/email-utils.js
+++ b/email-utils.js
@@ -109,8 +109,8 @@ const EmailUtils = {
   getUnsubscribeUrl (subscriber, emailType) {
     // TODO: email unsubscribe is broken for most emails
     let url = new URL(`${AppConstants.SERVER_URL}/user/unsubscribe`)
-    const token = (subscriber.hasOwnProperty('verification_token')) ? subscriber.verification_token : subscriber.primary_verification_token
-    const hash = (subscriber.hasOwnProperty('sha1')) ? subscriber.sha1 : subscriber.primary_sha1
+    const token = (Object.prototype.hasOwnProperty.call(subscriber, 'verification_token')) ? subscriber.verification_token : subscriber.primary_verification_token
+    const hash = (Object.prototype.hasOwnProperty.call(subscriber, 'sha1')) ? subscriber.sha1 : subscriber.primary_sha1
     url.searchParams.append('token', encodeURIComponent(token))
     url.searchParams.append('hash', encodeURIComponent(hash))
     url = this.appendUtmParams(url, 'unsubscribe', emailType)

--- a/email-utils.js
+++ b/email-utils.js
@@ -99,6 +99,7 @@ const EmailUtils = {
   },
 
   getVerificationUrl (subscriber) {
+    if (!subscriber.verification_token) throw new Error('subscriber has no verification_token')
     let url = new URL(`${AppConstants.SERVER_URL}/user/verify`)
     url = this.appendUtmParams(url, 'verified-subscribers', 'account-verification-email')
     url.searchParams.append('token', encodeURIComponent(subscriber.verification_token))
@@ -118,6 +119,7 @@ const EmailUtils = {
 
   getMonthlyUnsubscribeUrl (subscriber, campaign, content) {
     // TODO: create new subscriptions section in settings to manage all emails and avoid one-off routes like this
+    if (!subscriber.primary_verification_token) throw new Error('subscriber has no primary verification_token')
     let url = new URL('user/unsubscribe-monthly/', AppConstants.SERVER_URL)
 
     url = this.appendUtmParams(url, campaign, content)

--- a/tests/email.test.js
+++ b/tests/email.test.js
@@ -142,6 +142,12 @@ test('EmailUtils.getVerificationUrl returns a URL', () => {
     ])
 })
 
+test('EmailUtils.getVerificationUrl throws when subscriber has no token', () => {
+  const fakeSubscriber = {"verification_token": null}
+  const expected = 'subscriber has no verification_token'
+  expect(() => EmailUtils.getVerificationUrl(fakeSubscriber)).toThrow(expected)
+})
+
 test('EmailUtils.getUnsubscribeUrl works with subscriber record', () => {
   const subscriberRecord = TEST_SUBSCRIBERS.firefox_account
 
@@ -174,4 +180,10 @@ test('EmailUtils.getMonthlyUnsubscribeUrl returns unsubscribe URL', () => {
       ['utm_medium', 'email'],
       ['utm_source', 'fx-monitor'],
     ])
+})
+
+test('EmailUtils.getMonthlyUnsubscribeUrl throws when subscriber has no token', () => {
+  const fakeSubscriber = {'primary_verification_token': null}
+  const expected = 'subscriber has no primary verification_token'
+  expect(() => EmailUtils.getMonthlyUnsubscribeUrl(fakeSubscriber, 'campaign', 'content')).toThrow(expected)
 })

--- a/tests/email.test.js
+++ b/tests/email.test.js
@@ -7,14 +7,12 @@ const { TEST_SUBSCRIBERS, TEST_EMAIL_ADDRESSES } = require('../db/seeds/test_sub
 
 jest.mock('nodemailer')
 
-test('EmailUtils.init with empty host doesnt invoke nodemailer', () => {
+test('EmailUtils.init with empty host uses jsonTransport', () => {
   nodemailer.createTransport = jest.fn()
 
   EmailUtils.init('')
 
-  const mockCreateTransport = nodemailer.createTransport.mock
-  expect(mockCreateTransport.calls.length).toBe(1)
-  expect(mockCreateTransport.calls[0][0]).toEqual({ jsonTransport: true })
+  expect(nodemailer.createTransport).toHaveBeenCalledWith({ jsonTransport: true })
 })
 
 test.skip('EmailUtils.init with user, pass, host, port invokes nodemailer.createTransport', () => {


### PR DESCRIPTION
For MNTOR-249, add tests to improve coverage of `EmailUtils` from `email-utils.js`. Line coverage is 100%, branch coverage is 95% (but may improve with tool updates).

There are some small changes to `EmailUtils`:

* `EmailUtils.getVerificationUrl(subscriber)` raises an error if `subscriber.verification_token` is unset, since the URL will be invalid.
* `EmailUtils.getMonthlyUnsubscribeUrl(subscriber, campaign, content)` raises an error if `subscriber.primary_verification_token` is unset, since the URL will be invalid.
* Use `Object.prototype.hasOwnProperty` to avoid `eslint` warning [no-prototype-builtins](https://eslint.org/docs/latest/rules/no-prototype-builtins)