### PR TITLE
MNTOR-1009: heroku proxy fix

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -40,6 +40,14 @@ app.use((req, res, next) => {
   next()
 })
 
+// MNTOR-1009:
+// Because of heroku's proxy settings, request / cookies are not persisted between calls
+// Setting the trust proxy to high and securing the cookie allowed the cookie to persist
+// If cookie.secure is set as true, for nodejs behind proxy, "trust proxy" needs to be set
+if (AppConstants.NODE_ENV === 'heroku') {
+  app.set('trust proxy', 1)
+}
+
 // session
 const SESSION_DURATION_HOURS = AppConstants.SESSION_DURATION_HOURS || 48
 app.use(session({


### PR DESCRIPTION
Because of heroku's proxy settings, request / cookies were not persisted between calls. Hence, after login, an error is thrown when `req.session` does not contain the state hash.

Setting the trust proxy to high and securing the cookie allowed the cookie to persist.
If cookie.secure is set as true, for nodejs behind proxy, "trust proxy" needs to be set.