### PR TITLE
always force clean deploy for heroku

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,8 +208,7 @@ jobs:
                   command: |
                       set -x
                       heroku_url="https://heroku:${HEROKU_API_KEY}@git.heroku.com/<< parameters.app-name >>.git"
-                      git push -f $heroku_url $CIRCLE_BRANCH:main ||
-                      echo "*** git push failed, but it is allowed to fail. ***"
+                      git push -f $heroku_url $CIRCLE_BRANCH:main
 
 workflows:
     lint-and-test:


### PR DESCRIPTION
when main is merged, always force deploy to heroku, overwriting current heroku main