### PR TITLE
fix Mozilla footer link

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -46,6 +46,13 @@ app.use(
   })
 )
 
+// fallback to default 'no-referrer' only when 'strict-origin-when-cross-origin' not available
+app.use(
+  helmet.referrerPolicy({
+    policy: ['no-referrer', 'strict-origin-when-cross-origin']
+  })
+)
+
 app.use((req, res, next) => {
   if (!req.headers.accept.startsWith('text/html')) return next() // only update for html req
   const accept = accepts(req)

--- a/src/client/css/global.css
+++ b/src/client/css/global.css
@@ -116,9 +116,10 @@ footer {
 footer > :first-child {
   flex-grow: 999;
   flex-basis: fit-content;
+  display: flex;
 }
 
-footer > menu {
+footer > :last-child {
   flex-basis: fit-content;
   flex-grow: 1;
 }

--- a/src/client/css/landing.css
+++ b/src/client/css/landing.css
@@ -162,3 +162,7 @@
   z-index: -1;
   background: linear-gradient(74deg, #e53fb0 15%, #a260f7 121%);
 }
+
+.mobile .see-if-data-breach .button {
+  display: block;
+}

--- a/src/views/layouts/main.js
+++ b/src/views/layouts/main.js
@@ -48,13 +48,15 @@ export const mainLayout = data => `
       ${data.partial(data)}
     </main>
     <footer>
-      <a href='https://www.mozilla.org' target='_blank'>
-        <img src='/images/moz-logo-1color-white-rgb-01.svg' width='100' loading='lazy' alt='${getMessage('mozilla')}'>
-      </a>
+      <div>
+        <a href='https://www.mozilla.org' target='_blank'>
+          <img src='/images/moz-logo-1color-white-rgb-01.svg' width='100' loading='lazy' alt='${getMessage('mozilla')}'>
+        </a>
+      </div>
       <menu>
         <li><a href='https://support.mozilla.org/kb/firefox-monitor-faq' target='_blank'>FAQ</a></li>
         <li><a href='https://www.mozilla.org/privacy/firefox-monitor' target='_blank'>${getMessage('terms-and-privacy')}</a></li>
-        <li><a href='https://github.com/mozilla/blurts-server' target='_blank' rel='noreferrer'>${getMessage('github')}</a></li>
+        <li><a href='https://github.com/mozilla/blurts-server' target='_blank'>${getMessage('github')}</a></li>
       </menu>
     </footer>
   </body>


### PR DESCRIPTION
Fixes Mozilla logo link hit-area extends full width of footer.  Also makes minor style improvements and uses safe but less-strict default for referrer-policy.