### PR TITLE
When unsubscribing a user by token, delete emails

### DIFF
--- a/db/DB.js
+++ b/db/DB.js
@@ -365,6 +365,12 @@ const DB = {
     if (!subscriber) {
       return false
     }
+
+    // Delete subscriber's emails
+    // TODO issue 2744: Replace this code with a DB migration to add cascading deletion
+    await knex('email_addresses').where({ subscriber_id: subscriber.id }).del()
+
+    // Delete the subscriber
     await knex('subscribers')
       .where({
         primary_verification_token: subscriber.primary_verification_token,

--- a/tests/controllers/user.test.js
+++ b/tests/controllers/user.test.js
@@ -427,6 +427,24 @@ test('user unsubscribe POST request with valid session and emailId for email_add
   expect(emailAddress).toBeUndefined()
 })
 
+test('user unsubscribe POST request with valid session and emailId for primary subscriber token removes from DB (issue 2744)', async () => {
+  const validToken = TEST_SUBSCRIBERS.firefox_account.primary_verification_token
+  const validHash = TEST_SUBSCRIBERS.firefox_account.primary_sha1
+
+  // Set up mocks
+  const req = { fluentFormat: jest.fn(), body: { token: validToken, emailHash: validHash }, session: { user: TEST_SUBSCRIBERS.firefox_account, destroy: jest.fn() } }
+  const resp = httpMocks.createResponse()
+
+  // Call code-under-test
+  await user.postUnsubscribe(req, resp)
+
+  expect(resp.statusCode).toEqual(302)
+  expect(resp._getRedirectUrl()).toEqual('/')
+  expect(req.session.destroy).toHaveBeenCalledTimes(1)
+  const subscriber = await DB.getSubscriberById(TEST_SUBSCRIBERS.firefox_account.id)
+  expect(subscriber).toBeUndefined()
+})
+
 test('user removeEmail POST request with valid session but wrong emailId for email_address throws error and doesnt remove email', async () => {
   const testEmailAddress = TEST_EMAIL_ADDRESSES.all_emails_to_primary
   const testEmailId = testEmailAddress.id


### PR DESCRIPTION
This is a hotfix for v15.3.1, currently in production, to address issue #2744.

Add a test to remove a subscription via the primary verification token and hash. Fix `removeSubscriberByToken` by first deleting the user's emails, to avoid violating the primary key constraint.

This could be better handled by a cascading delete, but that fix should be applied to the main branch.