### PR TITLE
When deleting a subscriber, also delete emails

### DIFF
--- a/db/migrations/20230102203608_delete-emails-with-subscriber.js
+++ b/db/migrations/20230102203608_delete-emails-with-subscriber.js
@@ -1,0 +1,32 @@
+// Issue 2744: Delete email_addresses when the subscriber is deleted
+// email_addresses.subscriber_id added in 20190328111900_add_email_addresses_table.js
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('email_addresses', (table) => {
+    // Drop existing constraint
+    table.dropForeign(['subscriber_id'])
+    // Re-create with ON UPDATE / ON DELETE clauses
+    table.foreign('subscriber_id')
+      .references('subscribers.id')
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE')
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('email_addresses', (table) => {
+    // Drop existing constraint
+    table.dropForeign(['subscriber_id'])
+    // Re-create without ON UPDATE / ON DELETE clauses
+    table.foreign('subscriber_id')
+      .references('subscribers.id')
+  })
+}

--- a/tests/controllers/user.test.js
+++ b/tests/controllers/user.test.js
@@ -427,6 +427,24 @@ test('user unsubscribe POST request with valid session and emailId for email_add
   expect(emailAddress).toBeUndefined()
 })
 
+test('user unsubscribe POST request with valid session and emailId for primary subscriber token removes from DB (issue 2744)', async () => {
+  const validToken = TEST_SUBSCRIBERS.firefox_account.primary_verification_token
+  const validHash = TEST_SUBSCRIBERS.firefox_account.primary_sha1
+
+  // Set up mocks
+  const req = { fluentFormat: jest.fn(), body: { token: validToken, emailHash: validHash }, session: { user: TEST_SUBSCRIBERS.firefox_account, destroy: jest.fn() } }
+  const resp = httpMocks.createResponse()
+
+  // Call code-under-test
+  await user.postUnsubscribe(req, resp)
+
+  expect(resp.statusCode).toEqual(302)
+  expect(resp._getRedirectUrl()).toEqual('/')
+  expect(req.session.destroy).toHaveBeenCalledTimes(1)
+  const subscriber = await DB.getSubscriberById(TEST_SUBSCRIBERS.firefox_account.id)
+  expect(subscriber).toBeUndefined()
+})
+
 test('user removeEmail POST request with valid session but wrong emailId for email_address throws error and doesnt remove email', async () => {
   const testEmailAddress = TEST_EMAIL_ADDRESSES.all_emails_to_primary
   const testEmailId = testEmailAddress.id


### PR DESCRIPTION
Add a migration that adds `ON DELETE` and `ON UPDATE` clauses to the foreign key constraint, so that deleting a subscriber also deletes their emails.

Add a test to remove a subscription via the primary verification token and hash. This test fails without the migration.

This is an alternate to the hotfix in PR #2745, which deleted the emails manually, but couldn't use a migration.