### PR TITLE
docker run `npm start` to trigger V2 script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN npm run build
 ARG SENTRY_RELEASE
 ENV SENTRY_RELEASE=$SENTRY_RELEASE
 
-CMD node server.js
+CMD ["npm", "start"]


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1109

# Description
Updates the dockerfile to run `npm start`, which in turn should trigger the V2 sniffer script to load either legacy or refresh site.