### PR TITLE
replace `rsync` with `cp`

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -13,8 +13,8 @@
     "dev": "nodemon app.js",
     "build": "node esbuild & npm run copy:root & npm run copy:webp & npm run build:svg",
     "build:svg": "svgo -f ./client/images/ -o ../dist/images",
-    "copy:webp": "rsync -d --include='*.webp' ./client/images/ ../dist/images/",
-    "copy:root": "rsync -d ./client/ ../dist/",
+    "copy:root": "mkdir -p ../dist/ && cp ./client/*.* ../dist/",
+    "copy:webp": "mkdir -p ../dist/images/ && cp -r ./client/images/*.webp ../dist/images/",
     "convert:webp": "sh ./utils/webp.sh",
     "test": "c8 ava"
   },


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1109


<!-- When adding a new feature: -->

# Description
GCP throws an error when using `rsync` in npm scripts.  This PR switches to using `cp` instead.

