### PR TITLE
revert `npm start` now points to Refresh site

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,10 +78,8 @@
     "url": "git+https://github.com/mozilla/blurts-server.git"
   },
   "scripts": {
-    "start": "npm start -w src",
-    "start:legacy": "npm run build && node server.js",
-    "dev": "cd src && nodemon app.js",
-    "dev:legacy": "nodemon server.js",
+    "start": "node is-v2.js && npm start -w src || npm run build && node server.js",
+    "dev": "node is-v2.js && (cd src && nodemon app.js || exit 0) || nodemon server.js",
     "build": "node esbuild.js",
     "db:migrate": "knex migrate:latest --knexfile db/knexfile.js",
     "db:rollback": "knex migrate:rollback --knexfile db/knexfile.js",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-MNTOR-1109
Figma: 


<!-- When adding a new feature: -->

# Description
Reverts test of calling `npm start` directly, since the issue was determined to be caused by dockerflow heartbeats.

# How to test
- `npm start` should load the legacy site when .env var `MONITOR_V2=false` or undefined
- `npm start` should load the Refresh site when .env var `MONITOR_V2=true`

