### PR TITLE
MNTOR-978: user.breach_resolution can be null

### DIFF
--- a/src/utils/breaches.js
+++ b/src/utils/breaches.js
@@ -66,7 +66,7 @@ async function bundleVerifiedEmails (options) {
     ? user.breach_resolution[email] ? user.breach_resolution[email] : {}
     : []
 
-  const { useBreachId } = user.breach_resolution
+  const useBreachId = user.breach_resolution?.useBreachId
 
   for (const breach of foundBreachesWithRecency) {
     // if breach resolution json has `useBreachId` boolean, that means the migration has taken place


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-978
Figma: n/a


<!-- When adding a new feature: -->

# Description
Quick fix for an error present in Heroku testing. When user.breach_resolution is `null`, the destructure fails

# Screenshot (if applicable)

<img width="807" alt="Screenshot 2023-01-30 at 8 46 54 AM" src="https://user-images.githubusercontent.com/42494162/215540686-0312fb06-109b-4ecd-a0ee-fcc5356b85a1.png">

# How to test
- Login with an account that has null `breach_resolution` column
- Make sure the app doesn't error out


# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
