### PR TITLE
fix: Email template images

### DIFF
--- a/src/views/email-2022.js
+++ b/src/views/email-2022.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import AppConstants from '../app-constants.js'
 import { getMessage } from '../utils/fluent.js'
 
 const companyAddress = '2 Harrison St. #175, San Francisco, California 94105 USA'
@@ -13,10 +14,10 @@ const links = (data) => ({
 })
 
 const images = {
-  header: 'images/person-at-desk.webp',
-  footer: 'images/mozilla-logo-bw.webp',
-  logoDark: 'images/monitor-logo-transparent-dark-mode.webp',
-  logoLight: 'images/monitor-logo-bg-light.webp'
+  header: `${AppConstants.SERVER_URL}/images/person-at-desk.webp`,
+  footer: `${AppConstants.SERVER_URL}/images/mozilla-logo-bw.webp`,
+  logoDark: `${AppConstants.SERVER_URL}/images/monitor-logo-transparent-dark-mode.webp`,
+  logoLight: `${AppConstants.SERVER_URL}/images/monitor-logo-bg-light.webp`
 }
 
 const bodyStyle = `


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1145](https://mozilla-hub.atlassian.net/browse/MNTOR-1145)

<!-- When adding a new feature: -->

# Description

Fixes the path to the images for the email template. @toufali we might need to use PNGs for the emails instead of WebP for now since it seems like we are not able to preserve transparency (see screenshots) — or is there a quick and easy fix for that?

# Screenshot (if applicable)

| PNG | WebP |
| --- | --- |
| <img width="642" alt="image" src="https://user-images.githubusercontent.com/13835474/216066558-bd22f79d-77cc-4dcc-a943-debbdcb5a9b6.png"> | ![image](https://user-images.githubusercontent.com/13835474/216066342-2c85d081-85b6-4eb5-ba9d-e9d305e0e3f7.png) |

# How to test

Add a new email on the settings page and checkout the verification email.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
