### PR TITLE
MNTOR-1154: Fix monitore emails limit

### DIFF
--- a/src/controllers/settings.js
+++ b/src/controllers/settings.js
@@ -78,7 +78,8 @@ async function addEmail (req, res) {
     throw fluentError('user-add-invalid-email')
   }
 
-  if (sessionUser.email_addresses.length >= AppConstants.MAX_NUM_ADDRESSES) {
+  // Total max number of email addresses minus one to account for the primary email
+  if (sessionUser.email_addresses.length >= AppConstants.MAX_NUM_ADDRESSES - 1) {
     throw fluentError('user-add-too-many-emails')
   }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1154](https://mozilla-hub.atlassian.net/browse/MNTOR-1154)

<!-- When adding a new feature: -->

# Description

We need to account for the primary email.

# Screenshot (if applicable)

Not applicable.

# How to test

Add emails that should be monitored via the settings page and make sure it’s not possible to add more that four secondary ones.

# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
