### PR TITLE
MNTOR-1153: Prevent users from attempting to add more emails than limit

### DIFF
--- a/src/client/css/global.css
+++ b/src/client/css/global.css
@@ -174,6 +174,12 @@ button:active,
   box-shadow: inset 0 0 64px #80808011;
 }
 
+button:disabled,
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 button.primary,
 .button.primary {
   color: white;
@@ -183,8 +189,8 @@ button.primary,
   transition: background 150ms;
 }
 
-button.primary:hover,
-.button.primary:hover {
+button.primary:hover:enabled,
+.button.primary:hover:enabled {
   background: var(--blue-60);
 }
 

--- a/src/views/partials/settings.js
+++ b/src/views/partials/settings.js
@@ -151,7 +151,10 @@ export const settings = data => {
           <p>${getMessage('settings-email-limit-info', { limit })}</p>
 
           ${createEmailList(emails, breachCounts)}
-          <button class='settings-add-email-button primary js-settings-add-email-opener'>
+          <button
+            class='settings-add-email-button primary js-settings-add-email-opener'
+            ${emails.length >= AppConstants.MAX_NUM_ADDRESSES ? 'disabled' : ''}
+          >
             ${getMessage('settings-add-email-button')}
           </button>
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1153](https://mozilla-hub.atlassian.net/browse/MNTOR-1153)

<!-- When adding a new feature: -->

# Description

Disable the “Add email” button when users reached the limit for observed emails.

# Screenshot (if applicable)

<img width="176" alt="image" src="https://user-images.githubusercontent.com/13835474/216147560-e732ef5c-0305-47bb-9694-930349d2972d.png">

# How to test

Reach the limit of allowed observed emails and try to add an email via the “Add email button” on the settings page

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
