### PR TITLE
MNTOR-1143 - limit how often users can verify email addresses to 5 minutes, with generic rate limiting for all APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5052,6 +5052,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
+      "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==",
+      "engines": {
+        "node": ">= 12.9.0"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
+      }
+    },
     "node_modules/express-session": {
       "version": "1.17.1",
       "license": "MIT",
@@ -11047,6 +11058,7 @@
       "dependencies": {
         "csrf-csrf": "^2.2.2",
         "esbuild": "^0.15.10",
+        "express-rate-limit": "^6.7.0",
         "helmet": "^6.0.0",
         "svgo": "^2.8.0",
         "uuid": "^9.0.0"
@@ -14355,6 +14367,12 @@
         }
       }
     },
+    "express-rate-limit": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
+      "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==",
+      "requires": {}
+    },
     "express-session": {
       "version": "1.17.1",
       "requires": {
@@ -16144,6 +16162,7 @@
         "c8": "^7.12.0",
         "csrf-csrf": "^2.2.2",
         "esbuild": "^0.15.10",
+        "express-rate-limit": "*",
         "helmet": "^6.0.0",
         "redis-mock": "^0.56.3",
         "svgo": "^2.8.0",

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ import helmet from 'helmet'
 import accepts from 'accepts'
 import redis from 'redis'
 import cookieParser from 'cookie-parser'
+import rateLimit from 'express-rate-limit'
 
 import AppConstants from './app-constants.js'
 import { localStorage } from './utils/local-storage.js'
@@ -122,6 +123,15 @@ app.use(express.static(staticPath))
 app.use(express.json())
 app.use(cookieParser(AppConstants.COOKIE_SECRET))
 app.use(doubleCsrfProtection)
+
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false // Disable the `X-RateLimit-*` headers
+})
+
+app.use('/api', apiLimiter)
 
 // routing
 app.use('/', indexRouter)

--- a/src/controllers/settings.js
+++ b/src/controllers/settings.js
@@ -20,6 +20,7 @@ import { sendEmail, getVerificationUrl, getUnsubscribeUrl } from '../utils/email
 
 import { getBreachesForEmail } from '../utils/hibp.js'
 import { generateToken } from '../utils/csrf.js'
+import { RateLimitError } from '../utils/error.js'
 
 import { mainLayout } from '../views/main.js'
 import { settings } from '../views/partials/settings.js'
@@ -148,27 +149,35 @@ async function resendEmail (req, res) {
 }
 
 async function sendVerificationEmail (emailId) {
-  const unverifiedEmailAddressRecord = await resetUnverifiedEmailAddress(
-    emailId
-  )
-  const recipientEmail = unverifiedEmailAddressRecord.email
-  const data = {
-    recipientEmail,
-    ctaHref: getVerificationUrl(unverifiedEmailAddressRecord),
-    utmCampaign: 'email_verify',
-    unsubscribeUrl: getUnsubscribeUrl(
-      unverifiedEmailAddressRecord,
-      'account-verification-email'
-    ),
-    heading: getMessage('email-verify-heading'),
-    subheading: getMessage('email-verify-subhead'),
-    partial: { name: 'verify' }
+  try {
+    const unverifiedEmailAddressRecord = await resetUnverifiedEmailAddress(
+      emailId
+    )
+    const recipientEmail = unverifiedEmailAddressRecord.email
+    const data = {
+      recipientEmail,
+      ctaHref: getVerificationUrl(unverifiedEmailAddressRecord),
+      utmCampaign: 'email_verify',
+      unsubscribeUrl: getUnsubscribeUrl(
+        unverifiedEmailAddressRecord,
+        'account-verification-email'
+      ),
+      heading: getMessage('email-verify-heading'),
+      subheading: getMessage('email-verify-subhead'),
+      partial: { name: 'verify' }
+    }
+    await sendEmail(
+      recipientEmail,
+      getMessage('email-subject-verify'),
+      getTemplate(data, verifyPartial(data))
+    )
+  } catch (err) {
+    if (err.message === 'error-email-validation-pending') {
+      throw new RateLimitError('Verification email recently sent, try again later')
+    } else {
+      throw err
+    }
   }
-  await sendEmail(
-    recipientEmail,
-    getMessage('email-subject-verify'),
-    getTemplate(data, verifyPartial(data))
-  )
 }
 
 async function verifyEmail (req, res) {

--- a/src/package.json
+++ b/src/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "csrf-csrf": "^2.2.2",
     "esbuild": "^0.15.10",
+    "express-rate-limit": "^6.7.0",
     "helmet": "^6.0.0",
     "svgo": "^2.8.0",
     "uuid": "^9.0.0"


### PR DESCRIPTION
This uses a postgres-only knex raw query in order to compare timestamps on the database side.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1143

<!-- When adding a new feature: -->

# Description

Limit how often users can cause verification to be sent to a particular email address to 5 minutes.

# Screenshot (if applicable)

Not applicable.

# How to test

1. Adding new secondary email addresses should immediately send a new verification email
2. Click "Resend verification email" within 5 minutes and confirm that API returns error
3. Click "Resend verification email" again after 5 minutes, should send a new verification email

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
