### PR TITLE
use template and dynamic email for zero-state

### DIFF
--- a/src/client/css/fonts.css
+++ b/src/client/css/fonts.css
@@ -200,26 +200,6 @@ https://discourse.mozilla.org/t/metropolis-font-repo-missing/69415
 @font-face {
   font-family: Metropolis;
   font-style: normal;
-  font-weight: 500;
-  font-display: optional;
-  src:
-    local('Metropolis-Medium'),
-    url('../fonts/Metropolis-Medium.woff2') format('woff2');
-}
-
-@font-face {
-  font-family: Metropolis;
-  font-style: normal;
-  font-weight: 600;
-  font-display: optional;
-  src:
-    local('Metropolis-SemiBold'),
-    url('../fonts/Metropolis-SemiBold.woff2') format('woff2');
-}
-
-@font-face {
-  font-family: Metropolis;
-  font-style: normal;
   font-weight: 700;
   font-display: optional;
   src:

--- a/src/client/css/global.css
+++ b/src/client/css/global.css
@@ -24,6 +24,7 @@ body {
 h1 {
   font: var(--h1-font);
   margin: var(--padding-md) 0;
+  line-height: 1.2;
 }
 
 h2 {
@@ -52,6 +53,11 @@ a,
   line-height: inherit;
   text-decoration: underline;
   text-underline-position: under;
+}
+
+b,
+strong {
+  font-weight: 600;
 }
 
 hr {

--- a/src/client/css/partials/breaches.css
+++ b/src/client/css/partials/breaches.css
@@ -257,25 +257,8 @@
   animation: fade-in 0.5s ease-out;
 }
 
-.breaches-table .no-unresolved-breaches-message > .no-breaches-message,
-.breaches-table .no-unresolved-breaches-message > .all-breaches-resolved-message {
-  display: none;
-}
-
-/* Show the "No breaches found!" message when the breaches table has no resolved
- * nor unresolved breaches: */
-.breaches-table[data-nr-unresolved='0'][data-nr-resolved='0'] .no-unresolved-breaches-message .no-breaches-message {
+.zero-state {
   display: flex;
-}
-
-/* Show the "All breaches resolved!" message when the breaches table has no
- * unresolved but more than 0 resolved breaches: */
-.breaches-filter:not([data-selected='resolved']) + .breaches-table[data-nr-unresolved='0']:not([data-nr-resolved='0']) .no-unresolved-breaches-message .all-breaches-resolved-message {
-  display: flex;
-}
-
-.no-breaches-message,
-.all-breaches-resolved-message {
   flex-direction: column;
   align-items: center;
   gap: var(--padding-sm);
@@ -283,19 +266,21 @@
   text-align: center;
 }
 
-.no-breaches-message h2,
-.all-breaches-resolved-message h2 {
+.zero-state h2 {
   font-weight: 600;
 }
 
-.no-breaches-message p,
-.all-breaches-resolved-message p {
+.zero-state p {
   font: var(--h3-font);
   font-weight: 500;
   max-width: 800px;
 }
 
-.no-breaches-message p b,
-.all-breaches-resolved-message p b {
+.zero-state p b {
   font-weight: 700;
+}
+
+.zero-state .add-email-cta > span:first-of-type {
+  display: block;
+  padding-bottom: var(--padding-md);
 }

--- a/src/client/css/partials/breaches.css
+++ b/src/client/css/partials/breaches.css
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .breaches-header {
-  width: fit-content;
+  width: min(720px, 100%);
   max-width: 100%;
   margin: auto;
   padding: var(--padding-md);
@@ -14,8 +14,6 @@
 
 .breaches-header > h1 {
   font: var(--h3-font);
-  margin: var(--padding-md);
-  line-height: 1.2;
 }
 
 .breaches-header > figure {
@@ -261,23 +259,16 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--padding-sm);
-  padding: var(--padding-xl) var(--padding-md);
+  padding: var(--padding-lg);
   text-align: center;
 }
 
 .zero-state h2 {
-  font-weight: 600;
+  font: var(--h3-font);
 }
 
 .zero-state p {
-  font: var(--h3-font);
-  font-weight: 500;
-  max-width: 800px;
-}
-
-.zero-state p b {
-  font-weight: 700;
+  max-width: var(--max-width-p);
 }
 
 .zero-state .add-email-cta > span:first-of-type {

--- a/src/client/css/partials/breaches.css
+++ b/src/client/css/partials/breaches.css
@@ -48,12 +48,9 @@
   grid-template-columns: 1fr 1fr;
   width: min(640px, 100%);
   margin: 0 auto;
+  padding: var(--padding-lg);
   border: none;
   font-size: 0.75rem;
-}
-
-.breaches-filter[hidden] {
-  display: none;
 }
 
 .breaches-filter output {
@@ -73,10 +70,15 @@
   cursor: pointer;
 }
 
-.breaches-filter input[type='radio']:checked + label {
+.breaches-filter:disabled label {
+  cursor: default;
+}
+
+.breaches-filter:not(:disabled) input[type='radio']:checked + label {
   color: var(--purple-90);
   border-color: currentcolor;
   transition: border-color 0.3s ease-out;
+  cursor: default;
 }
 
 .breaches-table {
@@ -261,6 +263,7 @@
   align-items: center;
   padding: var(--padding-lg);
   text-align: center;
+  animation: fade-in 0.5s ease-out;
 }
 
 .zero-state h2 {

--- a/src/client/css/partials/landing.css
+++ b/src/client/css/partials/landing.css
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+[data-partial='landing'] h3 {
+  font: var(--h4-font);
+}
+
 .hero {
   display: flex;
   flex-wrap: wrap-reverse;

--- a/src/client/css/partials/settings.css
+++ b/src/client/css/partials/settings.css
@@ -11,6 +11,7 @@
 }
 
 .settings-section-title {
+  font: var(--h4-font);
   margin: var(--padding-sm) 0 var(--padding-md) 0;
 }
 

--- a/src/client/css/variables.css
+++ b/src/client/css/variables.css
@@ -5,6 +5,7 @@
 :root {
   --multiplier: 1;
   --max-width: 1200px;
+  --max-width-p: 800px;
   --min-width: 320px;
   --mobile-breakpoint: 480px;
   --border-radius: 4px;
@@ -17,8 +18,8 @@
   --gap: calc(32px * var(--multiplier));
   --h1-font: 700 2.5rem/1 metropolis, sans-serif;
   --h2-font: 700 1.75rem/1 metropolis, sans-serif;
-  --h3-font: 700 1.125rem/1 metropolis, sans-serif;
-  --h4-font: 700 1rem/1 metropolis, sans-serif;
+  --h3-font: 700 1.25rem/1 metropolis, sans-serif;
+  --h4-font: 700 1.125rem/1 metropolis, sans-serif;
   --gray-5: #f9f9fa;
   --gray-10: #e7e7e7;
   --gray-20: #cececf;

--- a/src/client/js/partials/breaches.js
+++ b/src/client/js/partials/breaches.js
@@ -110,7 +110,7 @@ function renderZeroState () {
   let temp
 
   breachesTable.querySelector('.zero-state')?.remove()
-  statusFilter.toggleAttribute('hidden', state.resolvedCount === 0 && state.unresolvedCount === 0)
+  statusFilter.toggleAttribute('disabled', state.resolvedCount === 0 && state.unresolvedCount === 0)
 
   switch (true) {
     case state.resolvedCount === 0 && state.unresolvedCount === 0:

--- a/src/client/js/partials/breaches.js
+++ b/src/client/js/partials/breaches.js
@@ -30,8 +30,8 @@ function init () {
   resolvedCountOutput = statusFilter.querySelector("label[for='breaches-resolved'] output")
   unresolvedCountOutput = statusFilter.querySelector("label[for='breaches-unresolved'] output")
 
-  state.emailCount = Number(breachesPartial.querySelector('.email-stats').dataset.count)
-  state.emailTotal = Number(breachesPartial.querySelector('.email-stats').dataset.total)
+  state.emailCount = parseInt(breachesPartial.querySelector('.email-stats').dataset.count)
+  state.emailTotal = parseInt(breachesPartial.querySelector('.email-stats').dataset.total)
   state.selectedEmail = emailSelect.value // triggers render
 
   emailSelect.addEventListener('change', handleEvent)

--- a/src/views/partials/breaches.js
+++ b/src/views/partials/breaches.js
@@ -97,12 +97,12 @@ export const breaches = data => `
     </figure>
   </header>
 </section>
-<section class='breaches-filter'>
+<fieldset class='breaches-filter'>
   <input id='breaches-unresolved' type='radio' name='breaches-status' value='unresolved' autocomplete='off' checked>
   <label for='breaches-unresolved'><output>&nbsp;</output>${getMessage('filter-label-unresolved')}</label>
   <input id='breaches-resolved' type='radio' name='breaches-status' value='resolved' autocomplete='off'>
   <label for='breaches-resolved'><output>&nbsp;</output>${getMessage('filter-label-resolved')}</label>
-</section>
+</fieldset>
 <section class='breaches-table' data-token=${data.csrfToken}>
   <header>
     <span>${getMessage('column-company')}</span>

--- a/src/views/partials/breaches.js
+++ b/src/views/partials/breaches.js
@@ -76,26 +76,6 @@ function createResolveSteps (breach) {
   return resolveStepsHTML.join('')
 }
 
-/**
- * @param {*} data
- * @param {'none' | 'all-resolved'} status
- * @returns string
- */
-function createAddEmailButton (data, status) {
-  if (data.emailCount >= AppConstants.MAX_NUM_ADDRESSES) {
-    return ''
-  }
-
-  return `
-    <p>
-      ${getMessage(`breaches-${status}-cta-blurb`)}
-    </p>
-    <button class="primary" data-dialog='add-email'>
-      ${getMessage(`breaches-${status}-cta-button`)}
-    </button>
-  `
-}
-
 export const breaches = data => `
 <section>
   <header class='breaches-header'>
@@ -108,7 +88,7 @@ export const breaches = data => `
         <label>Unresolved</label>
       </figcaption>
     </figure>
-    <figure class='email-stats'>
+    <figure class='email-stats' data-count=${data.emailCount} data-total=${AppConstants.MAX_NUM_ADDRESSES}>
       <img src='/images/icon-email.svg' width='55' height='30'>
       <figcaption>
         <strong>${getMessage('emails-monitored', { count: data.emailCount, total: AppConstants.MAX_NUM_ADDRESSES })}</strong>
@@ -138,35 +118,27 @@ export const breaches = data => `
     <span>${getMessage('column-detected')}</span>
   </header>
   ${createBreachRows(data.breachesData)}
-  <div class="no-unresolved-breaches-message">
-    <div class="no-breaches-message">
+  <template class='no-breaches'>
+    <div class="zero-state no-breaches-message">
       <img src='/images/breaches-none.svg' alt='' width="136" height="102" />
-      <h2>
-        ${getMessage('breaches-none-headline')}
-      </h2>
-      <p>
-        ${
-          data.breachesData.verifiedEmails.map(account => {
-            return `<span data-email="${account.email}" ${account.primary ? '' : 'hidden'}>${getMessage('breaches-none-copy', { email: `<b>${account.email}</b>` })}</span>`
-          }).join('')
-        }
+      <h2>${getMessage('breaches-none-headline')}</h2>
+      <p>${getMessage('breaches-none-copy', { email: '<b class="current-email"></b>' })}</p>
+      <p class='add-email-cta'>
+        <span>${getMessage('breaches-none-cta-blurb')}</span>
+        <button class="primary" data-dialog='add-email'>${getMessage('breaches-none-cta-button')}</button>
       </p>
-      ${createAddEmailButton(data, 'none')}
     </div>
-    <div class="all-breaches-resolved-message">
+  </template>
+  <template class='all-breaches-resolved'>
+    <div class="zero-state all-breaches-resolved-message">
       <img src='/images/breaches-all-resolved.svg' alt='' width="136" height="102" />
-      <h2>
-        ${getMessage('breaches-all-resolved-headline')}
-      </h2>
-      <p>
-        ${
-          data.breachesData.verifiedEmails.map(account => {
-            return `<span data-email="${account.email}" ${account.primary ? '' : 'hidden'}>${getMessage('breaches-all-resolved-copy', { email: `<b>${account.email}</b>` })}</span>`
-          }).join('')
-        }
+      <h2>${getMessage('breaches-all-resolved-headline')}</h2>
+      <p>${getMessage('breaches-all-resolved-copy', { email: '<b class="current-email"></b>' })}</p>
+      <p class='add-email-cta'>
+        <span>${getMessage('breaches-all-resolved-cta-blurb')}</span>
+        <button class="primary" data-dialog='add-email'>${getMessage('breaches-all-resolved-cta-button')}</button>
       </p>
-      ${createAddEmailButton(data, 'all-resolved')}
     </div>
-  </div>
+  </template>
 </section>
 `


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1086
Figma: https://www.figma.com/file/gvyyqS9egsGjsH0LUDqT1m/Breach-Resolution-Flow-Design?node-id=654%3A16313&t=I1S7G3TnYG1IGh0z-4


<!-- When adding a new feature: -->

# Description
Refactor Breaches page zero-states to use a single template with dynamic email updated with state.  

Per @Vinnl [comment](https://github.com/mozilla/blurts-server/pull/2821#discussion_r1101504633), creating a separate zero state for each condition under each email account is not ideal.  This refactor attempts to simplify it by using `selectedEmail` stored in state to inject into a single zero-state, created as needed.


# Screenshot (if applicable)

Not applicable.

# How to test

1. Open the breaches page for an email address with zero breaches - it should show the "No breaches found" message and hide the "Unresolved / Resolved" tabs.
2. Open the breaches page for an email address with more than zero unresolved breaches - it should just list those breaches.
3. Open the breaches page for an email address with more than zero resolved, and no unresolved breaches - it should show the "All breaches resolved" under the "Unresolved" tab, and list all breaches under the "Resolved" tab.
4. 1 and 3 above should show an "Add email address" button if the user has not reached their email address quota. Once they do, it should be hidden.

