### PR TITLE
MNTOR-1037: Migrate sign-up email template

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -100,6 +100,7 @@ async function confirmed (req, res, next, client = FxAOAuthClient) {
       fxaProfileData
     )
 
+    // Get breaches for email the user signed-up with
     const allBreaches = req.app.locals.breaches
     const unsafeBreachesForEmail = await getBreachesForEmail(
       email.sha1,
@@ -108,17 +109,19 @@ async function confirmed (req, res, next, client = FxAOAuthClient) {
       false
     )
 
+    // Send report email
     const utmCampaignId = 'report'
-    const reportSubject = unsafeBreachesForEmail?.length
+    const heading = unsafeBreachesForEmail?.length
       ? getMessage('email-subject-found-breaches')
       : getMessage('email-subject-no-breaches')
 
     const data = {
       breachedEmail: email,
       ctaHref: getEmailCtaHref(utmCampaignId, 'dashboard-cta'),
-      heading: reportSubject,
+      heading,
       recipientEmail: email,
       subscriberId: verifiedSubscriber,
+      unsafeBreachesForEmail,
       unsubscribeUrl: getUnsubscribeUrl(email, 'account-verification-email'),
       utmCampaign: utmCampaignId
     }

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -105,8 +105,7 @@ async function confirmed (req, res, next, client = FxAOAuthClient) {
     const unsafeBreachesForEmail = await getBreachesForEmail(
       email.sha1,
       allBreaches,
-      true,
-      false
+      true
     )
 
     // Send report email

--- a/src/controllers/email-preview.js
+++ b/src/controllers/email-preview.js
@@ -146,8 +146,7 @@ async function sendTestEmail (req, res) {
       )
       await sendEmail(
         recipient,
-        // TODO: Localize string
-        'Sign-up report email subject',
+        getMessage('email-subject-found-breaches'),
         emailTemplate
       )
       break

--- a/src/controllers/email-preview.js
+++ b/src/controllers/email-preview.js
@@ -9,6 +9,7 @@ import { mainLayout } from '../views/main.js'
 import { emailPreview } from '../views/partials/email-preview.js'
 import { getTemplate, getPreviewTemplate } from '../views/email-2022.js'
 import { breachAlertEmailPartial } from '../views/partials/email-breach-alert.js'
+import { signupReportEmailPartial } from '../views/partials/email-signup-report.js'
 import { verifyPartial } from '../views/partials/email-verify.js'
 import {
   monthlyUnresolvedEmailPartial
@@ -50,6 +51,13 @@ function emailsPage (req, res) {
       template: getPreviewTemplate(
         getMonthlyDummyData(EMAIL_TEST_RECIPIENT),
         monthlyUnresolvedEmailPartial
+      )
+    },
+    [EmailTemplateType.SignupReport]: {
+      label: 'Signup report',
+      template: getPreviewTemplate(
+        getMonthlyDummyData(EMAIL_TEST_RECIPIENT),
+        signupReportEmailPartial
       )
     }
   }
@@ -125,6 +133,20 @@ async function sendTestEmail (req, res) {
       await sendEmail(
         recipient,
         getMessage('email-unresolved-heading'),
+        emailTemplate
+      )
+      break
+    }
+    case EmailTemplateType.SignupReport: {
+      // Send test sign-up report email
+      const emailTemplate = getTemplate(
+        getMonthlyDummyData(EMAIL_TEST_RECIPIENT),
+        signupReportEmailPartial
+      )
+      await sendEmail(
+        recipient,
+        // TODO: Localize string
+        'Sign-up report email subject',
         emailTemplate
       )
       break

--- a/src/controllers/email-preview.js
+++ b/src/controllers/email-preview.js
@@ -22,6 +22,7 @@ import {
   getNotifictionDummyData,
   getVerificationDummyData,
   getMonthlyDummyData,
+  getSignupReportDummyData,
   sendEmail
 } from '../utils/email.js'
 
@@ -56,7 +57,7 @@ function emailsPage (req, res) {
     [EmailTemplateType.SignupReport]: {
       label: 'Signup report',
       template: getPreviewTemplate(
-        getMonthlyDummyData(EMAIL_TEST_RECIPIENT),
+        getSignupReportDummyData(EMAIL_TEST_RECIPIENT),
         signupReportEmailPartial
       )
     }
@@ -140,7 +141,7 @@ async function sendTestEmail (req, res) {
     case EmailTemplateType.SignupReport: {
       // Send test sign-up report email
       const emailTemplate = getTemplate(
-        getMonthlyDummyData(EMAIL_TEST_RECIPIENT),
+        getSignupReportDummyData(EMAIL_TEST_RECIPIENT),
         signupReportEmailPartial
       )
       await sendEmail(

--- a/src/controllers/hibp.js
+++ b/src/controllers/hibp.js
@@ -148,7 +148,7 @@ async function notify (req, res) {
 
       if (!notifiedRecipients.includes(breachedEmail)) {
         const data = {
-          breachAlert,
+          breachData: breachAlert,
           breachedEmail,
           ctaHref: getEmailCtaHref(utmCampaignId, 'dashboard-cta'),
           heading: getMessage('email-spotted-new-breach'),

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -11,6 +11,8 @@ import { getMessage } from '../utils/fluent.js'
 
 const log = mozlog('email-utils')
 
+const { SERVER_URL } = AppConstants
+
 // The SMTP transport object. This is initialized to a nodemailer transport
 // object while reading SMTP credentials, or to a dummy function in debug mode.
 let gTransporter
@@ -87,13 +89,13 @@ function appendUtmParams (url, campaign, content) {
 
 function getEmailCtaHref (emailType, content, subscriberId = null) {
   const subscriberParamPath = (subscriberId) ? `/?subscriber_id=${subscriberId}` : '/'
-  const url = new URL(subscriberParamPath, AppConstants.SERVER_URL)
+  const url = new URL(subscriberParamPath, SERVER_URL)
   return appendUtmParams(url, emailType, content)
 }
 
 function getVerificationUrl (subscriber) {
   if (!subscriber.verification_token) throw new Error('subscriber has no verification_token')
-  let url = new URL(`${AppConstants.SERVER_URL}/api/v1/user/verify-email`)
+  let url = new URL(`${SERVER_URL}/api/v1/user/verify-email`)
   url = appendUtmParams(url, 'verified-subscribers', 'account-verification-email')
   url.searchParams.append('token', encodeURIComponent(subscriber.verification_token))
   return url
@@ -101,7 +103,7 @@ function getVerificationUrl (subscriber) {
 
 function getUnsubscribeUrl (subscriber, emailType) {
   // TODO: email unsubscribe is broken for most emails
-  let url = new URL(`${AppConstants.SERVER_URL}/user/unsubscribe`)
+  let url = new URL(`${SERVER_URL}/user/unsubscribe`)
   const token = (Object.prototype.hasOwnProperty.call(subscriber, 'verification_token')) ? subscriber.verification_token : subscriber.primary_verification_token
   const hash = (Object.prototype.hasOwnProperty.call(subscriber, 'sha1')) ? subscriber.sha1 : subscriber.primary_sha1
   url.searchParams.append('token', encodeURIComponent(token))
@@ -113,7 +115,7 @@ function getUnsubscribeUrl (subscriber, emailType) {
 function getMonthlyUnsubscribeUrl (subscriber, campaign, content) {
   // TODO: create new subscriptions section in settings to manage all emails and avoid one-off routes like this
   if (!subscriber.primary_verification_token) throw new Error('subscriber has no primary verification_token')
-  let url = new URL('user/unsubscribe-monthly/', AppConstants.SERVER_URL)
+  let url = new URL('user/unsubscribe-monthly/', SERVER_URL)
 
   url = appendUtmParams(url, campaign, content)
   url.searchParams.append('token', encodeURIComponent(subscriber.primary_verification_token))
@@ -153,12 +155,12 @@ const getNotifictionDummyData = (recipient) => ({
     IsMalware: false
   },
   breachedEmail: recipient,
-  ctaHref: '',
+  ctaHref: SERVER_URL,
   heading: getMessage('email-spotted-new-breach'),
   recipientEmail: recipient,
   subscriberId: 123,
   supportedLocales: ['en'],
-  unsubscribeUrl: '',
+  unsubscribeUrl: SERVER_URL,
   utmCampaign: ''
 })
 
@@ -170,9 +172,9 @@ const getNotifictionDummyData = (recipient) => ({
  */
 const getVerificationDummyData = (recipient) => ({
   recipientEmail: recipient,
-  ctaHref: '',
+  ctaHref: SERVER_URL,
   utmCampaign: 'email_verify',
-  unsubscribeUrl: '',
+  unsubscribeUrl: SERVER_URL,
   heading: getMessage('email-verify-heading'),
   subheading: getMessage('email-verify-subhead')
 })
@@ -185,9 +187,9 @@ const getVerificationDummyData = (recipient) => ({
  */
 const getMonthlyDummyData = (recipient) => ({
   recipientEmail: recipient,
-  ctaHref: '',
+  ctaHref: SERVER_URL,
   utmCampaign: '',
-  unsubscribeUrl: '',
+  unsubscribeUrl: SERVER_URL,
   heading: getMessage('email-unresolved-heading'),
   subheading: getMessage('email-unresolved-subhead'),
   breachedEmail: 'breached@email.com',
@@ -232,7 +234,7 @@ const getSignupReportDummyData = (recipient) => {
 
   return {
     breachedEmail: recipient,
-    ctaHref: '',
+    ctaHref: SERVER_URL,
     heading: unsafeBreachesForEmail.length
       ? getMessage('email-subject-found-breaches')
       : getMessage('email-subject-no-breaches'),
@@ -240,7 +242,7 @@ const getSignupReportDummyData = (recipient) => {
     recipientEmail: recipient,
     subscriberId: 123,
     unsafeBreachesForEmail,
-    unsubscribeUrl: '',
+    unsubscribeUrl: SERVER_URL,
     utmCampaign: ''
   }
 }

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -18,7 +18,8 @@ let gTransporter
 const EmailTemplateType = {
   Notification: 'notification',
   Verification: 'verification',
-  Monthly: 'monthly'
+  Monthly: 'monthly',
+  SignupReport: 'signup-report'
 }
 
 async function initEmail (smtpUrl = AppConstants.SMTP_URL) {

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -128,7 +128,7 @@ function getMonthlyUnsubscribeUrl (subscriber, campaign, content) {
  * @returns {object} Breach dummy data
  */
 const getNotifictionDummyData = (recipient) => ({
-  breachAlert: {
+  breachData: {
     Id: 1,
     Name: 'Adobe',
     Title: 'Adobe',
@@ -201,15 +201,60 @@ const getMonthlyDummyData = (recipient) => ({
   }
 })
 
+/**
+ * Dummy data for populating the signup report email
+ *
+ * @param {string} recipient
+ * @returns {object} Signup report email dummy data
+ */
+
+const getSignupReportDummyData = (recipient) => {
+  const unsafeBreachesForEmail = [
+    getNotifictionDummyData(recipient)
+  ]
+  const breachesCount = unsafeBreachesForEmail.length
+  const numPasswordsExposed = 1
+
+  const emailBreachStats = [
+    {
+      statNumber: breachesCount,
+      statTitle: getMessage('known-data-breaches-exposed', {
+        breaches: breachesCount
+      })
+    },
+    {
+      statNumber: numPasswordsExposed,
+      statTitle: getMessage('passwords-exposed', {
+        passwords: numPasswordsExposed
+      })
+    }
+  ]
+
+  return {
+    breachedEmail: recipient,
+    ctaHref: '',
+    heading: unsafeBreachesForEmail.length
+      ? getMessage('email-subject-found-breaches')
+      : getMessage('email-subject-no-breaches'),
+    emailBreachStats,
+    recipientEmail: recipient,
+    subscriberId: 123,
+    unsafeBreachesForEmail,
+    unsubscribeUrl: '',
+    utmCampaign: ''
+  }
+}
+
 export {
   EmailTemplateType,
-  initEmail,
-  sendEmail,
   getEmailCtaHref,
   getMonthlyDummyData,
-  getVerificationUrl,
-  getUnsubscribeUrl,
   getMonthlyUnsubscribeUrl,
   getNotifictionDummyData,
-  getVerificationDummyData
+  getSignupReportDummyData,
+  getUnsubscribeUrl,
+  getVerificationDummyData,
+  getVerificationUrl,
+  initEmail,
+  sendEmail
 }

--- a/src/views/partials/email-breach-alert.js
+++ b/src/views/partials/email-breach-alert.js
@@ -2,58 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { breachCardPartial } from './email-breach-card.js'
 import { getMessage } from '../../utils/fluent.js'
-import { formatDate } from '../../utils/format-date.js'
 
 const breachAlertContainerStyle = `
   background: #f9f9fa;
   color: black;
   padding: 36px 0 24px;
-`
-
-const breachAlertTableStyle = `
-  margin: auto
-`
-
-const breachAlertCardsContainerStyle = `
-  background: white;
-  border-radius: 6px;
-  border-spacing: 0;
-  border: 1px solid #eeeeee;
-  box-shadow: 0 0 6px #dddddd;
-  display: inline-table;
-  margin: 12px;
-  min-width: 240px;
-  width: 30%;
-`
-
-const breachAlertCardsTitleStyle = `
-  background: #eeeeee;
-  border-top-left-radius: 6px;
-  border-top-right-radius: 6px;
-  padding: 12px;
-`
-
-const breachAlertCardsTitleImageStyle = `
-  vertical-align: bottom;
-`
-
-const breachAlertLabelStyle = `
-  color: #5e5e72;
-  font-family: sans-serif;
-  font-size: 13px;
-  font-weight: 300;
-  margin: 0px;
-  padding-bottom: 4px;
-`
-
-const breachAlertValueStyle = `
-  color: #20123a;
-  font-family: sans-serif;
-  font-size: 15px;
-  font-weight: 600;
-  margin: 0px;
-  padding-bottom: 15px;
 `
 
 const breachAlertCtaStyle = `
@@ -67,8 +22,7 @@ const breachAlertCtaStyle = `
 `
 
 const breachAlertEmailPartial = data => {
-  const { breachAlert, breachedEmail, ctaHref, supportedLocales } = data
-  const { LogoPath, AddedDate, DataClasses, Title } = breachAlert
+  const { breachedEmail, ctaHref } = data
 
   return `
     <tr>
@@ -78,48 +32,7 @@ const breachAlertEmailPartial = data => {
             'email-address': `<strong>${breachedEmail}</strong>`
           })}
         </p>
-        <table style='${breachAlertTableStyle}'>
-          <tr>
-            <td>
-              <table style='${breachAlertCardsContainerStyle}'>
-                <tr>
-                  <td style='${breachAlertCardsTitleStyle}'>
-                    <img
-                      height='25'
-                      src='${LogoPath}'
-                      style='${breachAlertCardsTitleImageStyle}'
-                      width='25'
-                    >
-                    ${Title}
-                  </td>
-                </tr>
-                <tr>
-                  <td style='padding: 24px;'>
-                    <p style='${breachAlertLabelStyle}'>
-                      ${getMessage('breach-added-label')}
-                    </p>
-                    <p style='${breachAlertValueStyle}'>
-                      ${formatDate(AddedDate, supportedLocales)}
-                    </p>
-
-                    ${DataClasses?.length > 0
-                      ? `
-                          <p style='${breachAlertLabelStyle}'>
-                            ${getMessage('compromised-data')}
-                          </p>
-                          <span style='${breachAlertValueStyle}'>
-                            ${DataClasses.map(classKey => getMessage(classKey))
-                              .join(', ')
-                              .trim()}
-                          </span>
-                        `
-                      : ''}
-                  </td>
-                </tr>
-              </table>
-            </td>
-          </tr>
-        </table>
+        ${breachCardPartial(data)}
         <a
           href='${ctaHref}'
           style='${breachAlertCtaStyle}'

--- a/src/views/partials/email-breach-card.js
+++ b/src/views/partials/email-breach-card.js
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getMessage } from '../../utils/fluent.js'
+import { formatDate } from '../../utils/format-date.js'
+
+const breachAlertTableStyle = `
+  margin: auto
+`
+
+const breachAlertCardsContainerStyle = `
+  background: white;
+  border-radius: 6px;
+  border-spacing: 0;
+  border: 1px solid #eeeeee;
+  box-shadow: 0 0 6px #dddddd;
+  display: inline-table;
+  margin: 12px;
+  min-width: 240px;
+  width: 30%;
+`
+
+const breachAlertCardsTitleStyle = `
+  background: #eeeeee;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  padding: 12px;
+`
+
+const breachAlertCardsTitleImageStyle = `
+  vertical-align: bottom;
+`
+
+const breachAlertLabelStyle = `
+  color: #5e5e72;
+  font-family: sans-serif;
+  font-size: 13px;
+  font-weight: 300;
+  margin: 0px;
+  padding-bottom: 4px;
+`
+
+const breachAlertValueStyle = `
+  color: #20123a;
+  font-family: sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0px;
+  padding-bottom: 15px;
+`
+
+const breachCardPartial = data => {
+  const { breachData, supportedLocales } = data
+  const { LogoPath, AddedDate, DataClasses, Title } = breachData
+
+  return `
+    <table style='${breachAlertTableStyle}'>
+      <tr>
+        <td>
+          <table style='${breachAlertCardsContainerStyle}'>
+            <tr>
+              <td style='${breachAlertCardsTitleStyle}'>
+                <img
+                  height='25'
+                  src='${LogoPath}'
+                  style='${breachAlertCardsTitleImageStyle}'
+                  width='25'
+                >
+                ${Title}
+              </td>
+            </tr>
+            <tr>
+              <td style='padding: 24px;'>
+                <p style='${breachAlertLabelStyle}'>
+                  ${getMessage('breach-added-label')}
+                </p>
+                <p style='${breachAlertValueStyle}'>
+                  ${formatDate(AddedDate, supportedLocales)}
+                </p>
+
+                ${DataClasses?.length > 0
+                  ? `
+                      <p style='${breachAlertLabelStyle}'>
+                        ${getMessage('compromised-data')}
+                      </p>
+                      <span style='${breachAlertValueStyle}'>
+                        ${DataClasses.map(classKey => getMessage(classKey))
+                          .join(', ')
+                          .trim()}
+                      </span>
+                    `
+                  : ''}
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  `
+}
+
+export { breachCardPartial }

--- a/src/views/partials/email-signup-report.js
+++ b/src/views/partials/email-signup-report.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const signupReportEmailPartial = data => {
+  return `
+    <tr>
+      <td>
+        Signup report email partial
+      </td>
+    </tr>
+  `
+}
+
+export { signupReportEmailPartial }

--- a/src/views/partials/email-signup-report.js
+++ b/src/views/partials/email-signup-report.js
@@ -2,11 +2,96 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { breachCardPartial } from './email-breach-card.js'
+import { getMessage } from '../../utils/fluent.js'
+
+const emailStyle = `
+  color: black;
+  background: #f9f9fa;
+  padding: 36px 0 24px;
+`
+
+const breachSummaryTableStyle = `
+  margin: auto;
+  max-width: 600px;
+`
+
+const breachSummaryCardStyle = `
+  background: #eeeeee;
+  border-radius: 6px;
+  margin: 12px auto;
+  padding: 12px;
+  table-layout: auto;
+  width: 100%;
+`
+
+const statNumberStyle = `
+  font-size: 48px;
+  font-weight: bold;
+  width: 72px;
+`
+
+const statTitleStyle = `
+  text-align: left;
+`
+
+const ctaStyle = `
+  background-color: #0060DF;
+  border-radius: 4px;
+  color: white;
+  display: inline-block;
+  margin: 24px 0;
+  padding: 12px 24px;
+`
+
 const signupReportEmailPartial = data => {
+  const {
+    breachedEmail,
+    emailBreachStats,
+    unsafeBreachesForEmail
+  } = data
+
   return `
     <tr>
-      <td>
-        Signup report email partial
+      <td style='${emailStyle}'>
+        <p>
+          ${
+            unsafeBreachesForEmail.length
+              ? getMessage('fxm-warns-you-no-breaches')
+              : getMessage('email-breach-detected', {
+                  'email-address': `<strong>${breachedEmail}</strong>`
+                })
+          }
+        </p>
+        <table style='${breachSummaryTableStyle}'>
+          <tr>
+            <td>
+              ${emailBreachStats.map(breachStat => `
+                <table style='${breachSummaryCardStyle}'>
+                  <tr>
+                    <td style='${statNumberStyle}'>
+                      ${breachStat.statNumber}
+                    </td>
+                    <td style=${statTitleStyle}>
+                      ${breachStat.statTitle}
+                    </td>
+                  </tr>
+                </table>
+              `).join('')}
+            </td>
+          </tr>
+        </table>
+        ${
+          unsafeBreachesForEmail.map(unsafeBreach => (
+            breachCardPartial(unsafeBreach)
+          )).join('')
+        }
+        <a
+          href='${data.ctaHref}'
+          style='${ctaStyle}'
+        >
+          ${getMessage('email-dashboard-cta')}
+        </a>
       </td>
     </tr>
   `


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1037](https://mozilla-hub.atlassian.net/browse/MNTOR-1037)

<!-- When adding a new feature: -->

# Description

Migrates the sign-up report email template.

# Screenshot

![image](https://user-images.githubusercontent.com/13835474/218777602-2081bc09-20bf-47f0-8b51-0081cea65e2f.png)

# How to test

The ability to preview and send emails from within Monitor is being added by PR #2790. You can view and trigger the email from the emails previewer under `/admin/emails`.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
