### PR TITLE
Fixes email breaches count on settings page

### DIFF
--- a/src/controllers/settings.js
+++ b/src/controllers/settings.js
@@ -41,12 +41,7 @@ async function settingsPage (req, res) {
 
   const allBreaches = req.app.locals.breaches
   for (const email of emails) {
-    const breaches = await getBreachesForEmail(
-      email.sha1,
-      allBreaches,
-      true,
-      false
-    )
+    const breaches = await getBreachesForEmail(email.sha1, allBreaches, true)
     breachCounts.set(email.email, breaches?.length || 0)
   }
 

--- a/src/utils/breaches.js
+++ b/src/utils/breaches.js
@@ -1,5 +1,5 @@
 import { getUserEmails } from '../db/tables/email_addresses.js'
-import { getBreachesForEmail, filterBreaches } from './hibp.js'
+import { getBreachesForEmail, getFilteredBreaches } from './hibp.js'
 import { getSha1 } from './fxa.js'
 import { filterBreachDataTypes } from './breach-resolution.js'
 
@@ -85,7 +85,7 @@ async function bundleVerifiedEmails (options) {
   }
 
   // filter out irrelevant breaches based on HIBP
-  const filteredAnnotatedFoundBreaches = filterBreaches(foundBreachesWithRecency)
+  const filteredAnnotatedFoundBreaches = getFilteredBreaches(foundBreachesWithRecency)
 
   const emailEntry = {
     email,

--- a/src/utils/hibp.js
+++ b/src/utils/hibp.js
@@ -176,13 +176,29 @@ function getAddressesAndLanguageForEmail (recipient) {
 }
 
 /**
+ * Filter breaches that we would not like to show.
+ *
+ * @param {Array} breaches
+ * @returns {Array} filteredBreaches
+ */
+function getFilteredBreaches (breaches) {
+  return breaches.filter(breach => (
+    !breach.IsRetired &&
+    !breach.IsSpamList &&
+    !breach.IsFabricated &&
+    breach.IsVerified &&
+    breach.Domain !== ''
+  ))
+}
+
+/**
 A range of hashes can be searched by passing the hash prefix in a GET request:
 GET /breachedaccount/range/[hash prefix]
 
  * @param {string} sha1 first 6 chars of email sha1
- * @param {*} allBreaches
- * @param {*} includeSensitive
- * @param {*} filterBreaches
+ * @param {Array} allBreaches
+ * @param {Boolean} includeSensitive
+ * @param {Boolean} filterBreaches
  * @returns
  */
 async function getBreachesForEmail (sha1, allBreaches, includeSensitive = false, filterBreaches = true) {
@@ -203,7 +219,7 @@ async function getBreachesForEmail (sha1, allBreaches, includeSensitive = false,
     if (sha1.toUpperCase() === sha1Prefix + breachedAccount.hashSuffix) {
       foundBreaches = allBreaches.filter(breach => breachedAccount.websites.includes(breach.Name))
       if (filterBreaches) {
-        foundBreaches = filterBreaches(foundBreaches)
+        foundBreaches = getFilteredBreaches(foundBreaches)
       }
 
       // NOTE: DO NOT CHANGE THIS SORT LOGIC
@@ -232,16 +248,6 @@ function getBreachByName (allBreaches, breachName) {
   }
   const foundBreach = allBreaches.find(breach => breach.Name.toLowerCase() === breachName)
   return foundBreach
-}
-
-function filterBreaches (breaches) {
-  return breaches.filter(
-    breach => !breach.IsRetired &&
-                !breach.IsSpamList &&
-                !breach.IsFabricated &&
-                breach.IsVerified &&
-                breach.Domain !== ''
-  )
 }
 
 /**
@@ -296,7 +302,7 @@ export {
   getBreachesForEmail,
   getBreachByName,
   getAllBreachesFromDb,
-  filterBreaches,
+  getFilteredBreaches,
   subscribeHash,
   deleteSubscribedHash
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1173](https://mozilla-hub.atlassian.net/browse/MNTOR-1173)

<!-- When adding a new feature: -->

# Description

Makes sure that the count of breaches shown on the settings page for a monitored email aligns with the count that is shown in the breaches table. Before this PR the list of breaches was not filtered for breaches that are not valid.

# Screenshot

<img width="595" alt="pr-1173-screenshot" src="https://user-images.githubusercontent.com/13835474/219092907-01eb5928-6c33-4cef-abbe-6383400c2dd3.png">

# How to test

1. Have an email to be monitored added that has associated breaches.
2. Navigate to the settings page.
3. Check the number of breaches mentioned in the subheader under the email card.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
