### PR TITLE
MNTOR-1198: admin middleware json parse fix

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -5,6 +5,7 @@
 import AppConstants from '../app-constants.js'
 import { getSubscriberById, updateFxAProfileData } from '../db/tables/subscribers.js'
 import * as FXA from '../utils/fxa.js'
+import { UnauthorizedError } from '../utils/error.js'
 
 async function getRequestSessionUser (req, res, next) {
   if (req.session && req.session.user) {
@@ -38,15 +39,14 @@ async function requireAdminUser (req, res, next) {
     return res.redirect(`/oauth/init?${queryParams}`)
   }
   const fxaProfileData = await FXA.getProfileData(user.fxa_access_token)
+  if (Object.prototype.hasOwnProperty.call(fxaProfileData, 'name') && fxaProfileData.name === 'HTTPError') {
+    delete req.session.user
+    return res.redirect('/')
+  }
   const admins = AppConstants.ADMINS?.split(',') || []
   const isAdmin = admins.includes(JSON.parse(fxaProfileData).email)
-
-  const hasFxaError = Object.prototype.hasOwnProperty.call(fxaProfileData, 'name') && fxaProfileData.name
-  if (hasFxaError) {
-    delete req.session.user
-  }
-  if (!isAdmin || hasFxaError) {
-    return res.sendStatus(401)
+  if (!isAdmin) {
+    next(new UnauthorizedError('User is not an admin'))
   }
 
   await updateFxAProfileData(user, fxaProfileData)


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1198
Figma: n/a


<!-- When adding a new feature: -->

# Description
Stage and Heroku crashed because of a bug in admin check middleware:

1. getProfileData errors out (401?) returns e here
```
catch (e) {
    console.warn('getProfileData', { stack: e.stack })
    return e
  }
```
2. requireAdmin middleware thinks it's a json, tries to parse it, cannot parse it
3. Uncaught exception took the server(s) down


# Screenshot (if applicable)

Not applicable.

# How to test
1. A login without auth / with stale auth should now be redirected to login page
2. requireAdmin middleware should now utilize `UnauthorizedError` class instead of returning a `401` status


# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
