### PR TITLE
Always enable source maps

### DIFF
--- a/src/esbuild.js
+++ b/src/esbuild.js
@@ -31,7 +31,7 @@ esbuild.build({
   outdir: '../dist',
   format: 'esm',
   minify: AppConstants.NODE_ENV !== 'dev',
-  sourcemap: AppConstants.NODE_ENV !== 'dev',
+  sourcemap: 'linked',
   splitting: true,
   treeShaking: true,
   platform: 'neutral'


### PR DESCRIPTION
We're an open source project, so no need to make it harder to read our source code. By generating source maps as separate files, they also don't add to the page weight.

Besides being more transparent, this also makes it easier for us debug issues that don't arise in our dev environments.
