### PR TITLE
Don't call methods on objects that are `null`

### DIFF
--- a/src/client/js/partials/notFound.js
+++ b/src/client/js/partials/notFound.js
@@ -4,7 +4,7 @@
 
 if (window.history.length > 1) {
   const backCta = document.getElementById('back-cta')
-  backCta.addEventListener('click', () => {
+  backCta?.addEventListener('click', () => {
     window.history.back()
 
     // The call to `window.history.back()` might do nothing; for example, if the
@@ -19,5 +19,5 @@ if (window.history.length > 1) {
     }, 500)
   })
   document.getElementById('home-cta')?.toggleAttribute('hidden', true)
-  backCta.toggleAttribute('hidden', false)
+  backCta?.toggleAttribute('hidden', false)
 }


### PR DESCRIPTION
Well well well, if it isn't my code without TypeScript's guard rails :sweat_smile: 

The JS for the 404 page assumes the DOM elements of the 404 page, which will obviously fail if it's not on the 404 page.