### PR TITLE
Work around race condition with <custom-select>

### DIFF
--- a/src/client/js/partials/breaches.js
+++ b/src/client/js/partials/breaches.js
@@ -32,7 +32,7 @@ function init () {
 
   state.emailCount = parseInt(breachesPartial.querySelector('.email-stats').dataset.count)
   state.emailTotal = parseInt(breachesPartial.querySelector('.email-stats').dataset.total)
-  state.selectedEmail = emailSelect.value // triggers render
+  state.selectedEmail = emailSelect.value ?? emailSelect.querySelector('option:first-child')?.textContent.trim() // triggers render
 
   emailSelect.addEventListener('change', handleEvent)
   statusFilter.addEventListener('change', handleEvent)


### PR DESCRIPTION
The constructor of `<custom-select>` might not have executed yet when the breaches partial's `init()` function runs, and thus it might not yet have a value. If so, we read it directly from the DOM. This does depend on the first `<option>` containing the relevant email address and nothing else though.

I'd like a review by @toufali specifically, since he's probably more familiar with `<custom-select>` and the lifecycle of custom elements. I couldn't reproduce it myself, but Andrei [recorded a Replay](https://app.replay.io/recording/firefox-monitor--0900484c-8620-46a7-b665-4151d8bc5f79) (create an account and let me know to give you access if you want to see it) that clearly shows the `init` running before the constructor. He also says it happens consistently for him, whereas for me, the constructor consistently runs before `init`.

# References: 
Jira: MNTOR-1192
Figma: N/A

# How to test

Not sure, as I couldn't reproduce...

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments - If I better understand what's going on I'd like to add a code comment at least.
- [ ] I've added a unit test to test for potential regressions of this bug. - Still no UI unit tests, I don't think.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege. - N/A
- [a] All acceptance criteria are met.
- [a] Jira ticket has been updated (if needed) to match changes made during the development process.
- [a] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
