### PR TITLE
Disable ESBuild code-splitting

### DIFF
--- a/src/esbuild.js
+++ b/src/esbuild.js
@@ -32,7 +32,7 @@ esbuild.build({
   format: 'esm',
   minify: AppConstants.NODE_ENV !== 'dev',
   sourcemap: AppConstants.NODE_ENV !== 'dev',
-  splitting: true,
+  splitting: false,
   treeShaking: true,
   platform: 'neutral'
 })


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1192



<!-- When adding a new feature: -->

# Description
Upon initial Breaches page load, the email address displayed in zero-state content does not appear.  This is apparently due to a [known bug with ESBuild](https://github.com/evanw/esbuild/issues/399) and flagged in the current [ESBuild docs](https://esbuild.github.io/api/#splitting).

In addition to causing the email variable to initialize before ready, this has potential impact to other portions of the site.  This PR disables the ESBuild code-splitting functionality with the following rationale:

- The complete client bundle is currently only ~10kB transferred; splitting this down further is unlikely to result in significant  load speed gains
- A ticket exists to set up logical code-splitting depending on partial: 
https://mozilla-hub.atlassian.net/browse/MNTOR-1171
The completion of this ticket increases the redundancy of ESBuild's automatic code-splitting feature

# How to test
Using a local dev environment:
1. checkout `main`
2. run the site via `npm start` (this builds the site using ESBuild with code-splitting enabled)
3. visit the breaches page **_using a primary account that has zero breaches_**
4. verify that the email address in the initial zero-state content is blank:
<img width="932" alt="Screen Shot 2023-02-16 at 1 05 23 PM" src="https://user-images.githubusercontent.com/14863500/219486921-0bb2e6a8-4d01-4280-b7b7-679629dde844.png">

5. checkout this branch
6. run the site via `npm start` to build the site with ESBuild code-splitting disabled
7. verify that the email address above is now displayed as expected
