### PR TITLE
MNTOR-1199: email.sha1 does not exist

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -20,7 +20,7 @@ import {
 
 import { getBreachesForEmail } from '../utils/hibp.js'
 import { getMessage } from '../utils/fluent.js'
-import { getProfileData, FxAOAuthClient } from '../utils/fxa.js'
+import { getProfileData, FxAOAuthClient, getSha1 } from '../utils/fxa.js'
 import {
   getEmailCtaHref,
   getUnsubscribeUrl,
@@ -103,7 +103,7 @@ async function confirmed (req, res, next, client = FxAOAuthClient) {
     // Get breaches for email the user signed-up with
     const allBreaches = req.app.locals.breaches
     const unsafeBreachesForEmail = await getBreachesForEmail(
-      email.sha1,
+      getSha1(email),
       allBreaches,
       true
     )

--- a/src/controllers/settings.js
+++ b/src/controllers/settings.js
@@ -19,6 +19,7 @@ import { getMessage } from '../utils/fluent.js'
 import { sendEmail, getVerificationUrl, getUnsubscribeUrl } from '../utils/email.js'
 
 import { getBreachesForEmail } from '../utils/hibp.js'
+import { getSha1 } from '../utils/fxa.js'
 import { generateToken } from '../utils/csrf.js'
 import { RateLimitError, UnauthorizedError, UserInputError } from '../utils/error.js'
 
@@ -41,7 +42,7 @@ async function settingsPage (req, res) {
 
   const allBreaches = req.app.locals.breaches
   for (const email of emails) {
-    const breaches = await getBreachesForEmail(email.sha1, allBreaches, true)
+    const breaches = await getBreachesForEmail(getSha1(email), allBreaches, true)
     breachCounts.set(email.email, breaches?.length || 0)
   }
 

--- a/src/views/partials/email-signup-report.js
+++ b/src/views/partials/email-signup-report.js
@@ -66,7 +66,7 @@ const signupReportEmailPartial = data => {
         <table style='${breachSummaryTableStyle}'>
           <tr>
             <td>
-              ${emailBreachStats.map(breachStat => `
+              ${emailBreachStats?.map(breachStat => `
                 <table style='${breachSummaryCardStyle}'>
                   <tr>
                     <td style='${statNumberStyle}'>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1199
Figma: 


<!-- When adding a new feature: -->

# Description
During auth (especially for sign ups), we are seeing 500s being returned:
```
{"success":false,"status":500,"message":"Cannot read properties of undefined (reading 'slice')","stack":{}}
```
Upon further investigation, the stack trace looks like:
```
ERROR fx-monitor.middleware.error: TypeError: Cannot read properties of undefined (reading 'slice')
  at getBreachesForEmail (file:///app/src/utils/hibp.js:190:27)
  at confirmed (file:///app/src/controllers/auth.js:105:42)
  at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
which appears to be an issue with `email.sha`
I've also correct a similar error in settings

# Screenshot (if applicable)

Not applicable.

# How to test
* Sign up with a new email should not throw the above 500 error anymore


# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
