### PR TITLE
Disable server restart for client file changes

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -26,6 +26,9 @@
       "../.env-dist",
       "../locales/en/*"
     ],
+    "ignore": [
+      "src/client/*"
+    ],
     "ext": "js,css,json,ftl"
   },
   "repository": {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1255


<!-- When adding a new feature: -->

# Description
This PR disables server restart for client changes.

Currently when making changes to client code, “nodemon” restarts the server.  This important for server changes but is often not necessary for client changes.  Restarting the server means a developer needs to re-login for every change – this can be very time-consuming.  

Note that this change does not include template/partial files in `src/views` because they are technically server-side code.  Disabling server reload for these files might yield unexpected results during development.


# How to test
- visit the Breaches page after logging in
- make a change to the Breaches page in CSS or client JS, e.g. in `init()` add:
```js
  document.body.insertAdjacentHTML('afterbegin', '<h1>TESTING TESTING 123</h1>')
``` 
- reload the Breaches page and confirm your changes exist without having to repeat the login process