### PR TITLE
Mntor 1188/breaches email count

### DIFF
--- a/locales/en/breaches.ftl
+++ b/locales/en/breaches.ftl
@@ -15,7 +15,8 @@ emails-monitored =
      *[other] { $count } of { $total } emails monitored
   }
 
-add-email-link = Add email address
+# link to Settings page where user can add/remove emails and set message preferences
+manage-emails-link = Manage emails
 
 ## Breaches resolved filter
 

--- a/src/client/js/partials/add-email.js
+++ b/src/client/js/partials/add-email.js
@@ -32,7 +32,12 @@ async function handleSubmit (e) {
 
     if (!res.ok) throw new Error('Bad fetch response')
 
-    renderSuccess(form.elements['email-address'].value)
+    const { newEmailCount } = await res.json()
+
+    renderSuccess({
+      email: form.elements['email-address'].value,
+      newEmailCount
+    })
   } catch (e) {
     console.error('Could not add new email.', e)
   } finally {
@@ -40,13 +45,18 @@ async function handleSubmit (e) {
   }
 }
 
-function renderSuccess (email) {
+function renderSuccess (data) {
   const content = dialogEl.querySelector('template[data-success]').content.cloneNode(true)
   const messageEl = content.querySelector('p.add-email-success')
 
   messageEl.style.setProperty('--form-height', `${form.clientHeight}px`)
-  messageEl.querySelector('.current-email').textContent = email
+  messageEl.querySelector('.current-email').textContent = data.email
   form.replaceWith(content)
+  dialogEl.dispatchEvent(new CustomEvent('email-added', {
+    bubbles: true, 
+    detail: data
+  }))
+
 }
 
 function kill () {

--- a/src/client/js/partials/add-email.js
+++ b/src/client/js/partials/add-email.js
@@ -53,10 +53,9 @@ function renderSuccess (data) {
   messageEl.querySelector('.current-email').textContent = data.email
   form.replaceWith(content)
   dialogEl.dispatchEvent(new CustomEvent('email-added', {
-    bubbles: true, 
+    bubbles: true,
     detail: data
   }))
-
 }
 
 function kill () {

--- a/src/client/js/partials/breaches.js
+++ b/src/client/js/partials/breaches.js
@@ -37,6 +37,7 @@ function init () {
   emailSelect.addEventListener('change', handleEvent)
   statusFilter.addEventListener('change', handleEvent)
   breachesTable.addEventListener('change', handleEvent)
+  document.body.addEventListener('email-added', handleEvent)
 }
 
 function handleEvent (e) {
@@ -51,6 +52,10 @@ function handleEvent (e) {
       break
     case e.target.matches('.resolve-list-item [type="checkbox"]'):
       updateBreachStatus(e.target)
+      break
+    case e.type === 'email-added':
+      state.emailCount = e.detail.newEmailCount
+      renderZeroState()
       break
   }
 }

--- a/src/controllers/breaches.js
+++ b/src/controllers/breaches.js
@@ -10,14 +10,16 @@ import { generateToken } from '../utils/csrf.js'
 import { getAllEmailsAndBreaches } from '../utils/breaches.js'
 
 async function breachesPage (req, res) {
-  const emailCount = 1 + (req.user.email_addresses?.length || 0) // +1 because user.email_addresses does not include primary
   // TODO: remove: to test out getBreaches call with JSON returns
   const breachesData = await getAllEmailsAndBreaches(req.user, req.app.locals.breaches)
+  const emailVerifiedCount = breachesData.verifiedEmails?.length ?? 0
+  const emailTotalCount = emailVerifiedCount + (breachesData.unverifiedEmails?.length ?? 0)
   appendBreachResolutionChecklist(breachesData)
 
   const data = {
     breachesData,
-    emailCount,
+    emailVerifiedCount,
+    emailTotalCount,
     partial: breaches,
     csrfToken: generateToken(res),
     fxaProfile: req.user.fxa_profile_json,

--- a/src/controllers/settings.js
+++ b/src/controllers/settings.js
@@ -71,12 +71,13 @@ async function addEmail (req, res) {
   // Use the same regex as HTML5 email input type
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#basic_validation
   const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+  const emailCount = 1 + (req.user.email_addresses?.length ?? 0) // primary + verified + unverified emails
 
   if (!email || !emailRegex.test(email)) {
     throw new UserInputError(getMessage('user-add-invalid-email'))
   }
 
-  if (sessionUser.email_addresses.length >= AppConstants.MAX_NUM_ADDRESSES - 1) {
+  if (emailCount >= AppConstants.MAX_NUM_ADDRESSES) {
     throw new UserInputError(getMessage('user-add-too-many-emails'))
   }
 
@@ -92,6 +93,7 @@ async function addEmail (req, res) {
   return res.json({
     success: true,
     status: 200,
+    newEmailCount: emailCount + 1,
     message: 'Sent the verification email'
   })
 }

--- a/src/controllers/settings.test.js
+++ b/src/controllers/settings.test.js
@@ -66,6 +66,7 @@ test.serial('user add POST with email adds unverified subscriber and sends verif
   t.deepEqual(resp._getJSONData(), {
     message: 'Sent the verification email',
     status: 200,
+    newEmailCount: 3,
     success: true
   })
 })

--- a/src/views/partials/breaches.js
+++ b/src/views/partials/breaches.js
@@ -88,11 +88,11 @@ export const breaches = data => `
         <label>Unresolved</label>
       </figcaption>
     </figure>
-    <figure class='email-stats' data-count=${data.emailCount} data-total=${AppConstants.MAX_NUM_ADDRESSES}>
+    <figure class='email-stats' data-count=${data.emailTotalCount} data-total=${AppConstants.MAX_NUM_ADDRESSES}>
       <img src='/images/icon-email.svg' width='55' height='30'>
       <figcaption>
-        <strong>${getMessage('emails-monitored', { count: data.emailCount, total: AppConstants.MAX_NUM_ADDRESSES })}</strong>
-        ${createEmailCTA(data.emailCount)}
+        <strong>${getMessage('emails-monitored', { count: data.emailVerifiedCount, total: AppConstants.MAX_NUM_ADDRESSES })}</strong>
+        ${createEmailCTA(data.emailTotalCount)}
       </figcaption>
     </figure>
   </header>

--- a/src/views/partials/breaches.js
+++ b/src/views/partials/breaches.js
@@ -12,14 +12,6 @@ function createEmailOptions (data) {
   return optionElements.join('')
 }
 
-function createEmailCTA (count) {
-  const total = parseInt(AppConstants.MAX_NUM_ADDRESSES)
-
-  if (count >= total) return '' // don't show CTA if additional emails are not available for monitor
-
-  return `<a href='/user/settings'>${getMessage('add-email-link')}</a>`
-}
-
 function createBreachRows (data) {
   const locale = getLocale()
   const shortDate = new Intl.DateTimeFormat(locale, { year: 'numeric', month: '2-digit', day: '2-digit', timeZone: 'UTC' })
@@ -92,7 +84,7 @@ export const breaches = data => `
       <img src='/images/icon-email.svg' width='55' height='30'>
       <figcaption>
         <strong>${getMessage('emails-monitored', { count: data.emailVerifiedCount, total: AppConstants.MAX_NUM_ADDRESSES })}</strong>
-        ${createEmailCTA(data.emailTotalCount)}
+        <a href='/user/settings'>${getMessage('manage-emails-link')}</a>
       </figcaption>
     </figure>
   </header>

--- a/src/views/partials/breaches.js
+++ b/src/views/partials/breaches.js
@@ -17,7 +17,7 @@ function createEmailCTA (count) {
 
   if (count >= total) return '' // don't show CTA if additional emails are not available for monitor
 
-  return `<a href='dialog/add-email'>${getMessage('add-email-link')}</a>`
+  return `<a href='/user/settings'>${getMessage('add-email-link')}</a>`
 }
 
 function createBreachRows (data) {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1188


<!-- When adding a new feature: -->

# Description
With this PR:
- the "monitored email" count in the header panel should only display verified email count
- the “Add email address” link in the header panel should open the “Settings” page instead of the “Add email” dialog
- the “Add email address” buttons in the Breaches table “zero-state” should continue to open the “Add email” dialog
- the “Add email address” buttons in the Breaches table “zero-state” should dynamically disappear after the user has reached their limit

TODO: Waiting for UX decision on whether the header link should read "manage emails" instead of "add email address".


# Screenshot (if applicable)

<img width="1204" alt="Screen Shot 2023-02-16 at 9 15 54 PM" src="https://user-images.githubusercontent.com/14863500/219556921-c949880e-998e-4eed-b1c4-c58233639fd4.png">


# How to test
Visit the breaches page and test the acceptance criteria above.


# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
