### PR TITLE
Disable step checkbox while applying changes

### DIFF
--- a/src/client/js/partials/breaches.js
+++ b/src/client/js/partials/breaches.js
@@ -60,10 +60,14 @@ function handleEvent (e) {
   }
 }
 
+/**
+ * @param {HTMLInputElement} input
+ */
 async function updateBreachStatus (input) {
   const affectedEmail = state.selectedEmail
   const breachId = input.name
   const checkedInputs = Array.from(input.closest('.resolve-list').querySelectorAll('input:checked'))
+  input.disabled = true
 
   try {
     const res = await fetch('/api/v1/user/breaches', {
@@ -86,6 +90,8 @@ async function updateBreachStatus (input) {
     renderResolvedCounts()
   } catch (e) {
     console.error('Could not update user breach resolve status:', e)
+  } finally {
+    input.disabled = false
   }
 }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1134
Figma: N/A

<!-- When adding a new feature: -->

# Description

Whenever a user ticks a checkbox on the Breaches page, a call to the server is made to store the updated data.  In order to deter “button mashing” and flooding the server with calls, these checkbox is now in a disabled state until the server call has completed.

# Screenshot (if applicable)

[Screencast from 2023-02-20 17-54-06.webm](https://user-images.githubusercontent.com/4251/220164213-3bf0e7cf-2976-47c2-ba27-edae6e58b5e5.webm)

# How to test

Check a breach step, then try to check it again while it's submitting.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
