### PR TITLE
Fix sign-up email template for emails with no breaches

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -110,14 +110,14 @@ async function confirmed (req, res, next, client = FxAOAuthClient) {
 
     // Send report email
     const utmCampaignId = 'report'
-    const heading = unsafeBreachesForEmail?.length
+    const subject = unsafeBreachesForEmail?.length
       ? getMessage('email-subject-found-breaches')
       : getMessage('email-subject-no-breaches')
 
     const data = {
       breachedEmail: email,
       ctaHref: getEmailCtaHref(utmCampaignId, 'dashboard-cta'),
-      heading,
+      heading: getMessage('email-breach-summary'),
       recipientEmail: email,
       subscriberId: verifiedSubscriber,
       unsafeBreachesForEmail,
@@ -125,7 +125,6 @@ async function confirmed (req, res, next, client = FxAOAuthClient) {
       utmCampaign: utmCampaignId
     }
     const emailTemplate = getTemplate(data, signupReportEmailPartial)
-    const subject = getMessage('breach-alert-subject')
 
     await sendEmail(data.recipientEmail, subject, emailTemplate)
 

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -110,7 +110,7 @@ async function confirmed (req, res, next, client = FxAOAuthClient) {
 
     // Send report email
     const utmCampaignId = 'report'
-    const heading = unsafeBreachesForEmail?.length
+    const heading = unsafeBreachesForEmail?.length > 0
       ? getMessage('email-subject-found-breaches')
       : getMessage('email-subject-no-breaches')
 
@@ -142,8 +142,9 @@ async function confirmed (req, res, next, client = FxAOAuthClient) {
 
 /**
  * Controller to trigger a logout for user
- * @param {object} req contains session.user
- * @param {object} res redirects to homepage
+ *
+ * @param {object} req Contains session.user
+ * @param {object} res Redirects to homepage
  */
 async function logout (req, res) {
   const subscriber = req.session?.user

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -110,7 +110,7 @@ async function confirmed (req, res, next, client = FxAOAuthClient) {
 
     // Send report email
     const utmCampaignId = 'report'
-    const heading = unsafeBreachesForEmail?.length > 0
+    const heading = unsafeBreachesForEmail?.length
       ? getMessage('email-subject-found-breaches')
       : getMessage('email-subject-no-breaches')
 

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -39,6 +39,7 @@ async function initEmail (smtpUrl = AppConstants.SMTP_URL) {
 
 /**
  * Send Email
+ *
  * @param {string} recipient
  * @param {string} subject
  * @param {string} html
@@ -212,7 +213,7 @@ const getMonthlyDummyData = (recipient) => ({
 
 const getSignupReportDummyData = (recipient) => {
   const unsafeBreachesForEmail = [
-    getNotifictionDummyData(recipient)
+    getNotifictionDummyData(recipient).breachData
   ]
   const breachesCount = unsafeBreachesForEmail.length
   const numPasswordsExposed = 1

--- a/src/views/emails/email-breach-alert.js
+++ b/src/views/emails/email-breach-alert.js
@@ -22,7 +22,7 @@ const breachAlertCtaStyle = `
 `
 
 const breachAlertEmailPartial = data => {
-  const { breachedEmail, ctaHref } = data
+  const { breachData, breachedEmail, ctaHref } = data
 
   return `
     <tr>
@@ -32,7 +32,7 @@ const breachAlertEmailPartial = data => {
             'email-address': `<strong>${breachedEmail}</strong>`
           })}
         </p>
-        ${breachCardPartial(data)}
+        ${breachCardPartial(breachData)}
         <a
           href='${ctaHref}'
           style='${breachAlertCtaStyle}'

--- a/src/views/emails/email-breach-card.js
+++ b/src/views/emails/email-breach-card.js
@@ -79,7 +79,7 @@ const breachCardPartial = data => {
                   ${formatDate(AddedDate, supportedLocales)}
                 </p>
 
-                ${DataClasses?.length > 0
+                ${DataClasses?.length
                   ? `
                       <p style='${breachAlertLabelStyle}'>
                         ${getMessage('compromised-data')}

--- a/src/views/emails/email-breach-card.js
+++ b/src/views/emails/email-breach-card.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getMessage } from '../../utils/fluent.js'
+import { getLocale, getMessage } from '../../utils/fluent.js'
 import { formatDate } from '../../utils/format-date.js'
 
 const breachAlertTableStyle = `
@@ -50,9 +50,13 @@ const breachAlertValueStyle = `
   padding-bottom: 15px;
 `
 
-const breachCardPartial = data => {
-  const { breachData, supportedLocales } = data
-  const { LogoPath, AddedDate, DataClasses, Title } = breachData
+const breachCardPartial = breachData => {
+  const {
+    LogoPath,
+    AddedDate,
+    DataClasses,
+    Title
+  } = breachData
 
   return `
     <table style='${breachAlertTableStyle}'>
@@ -76,7 +80,7 @@ const breachCardPartial = data => {
                   ${getMessage('breach-added-label')}
                 </p>
                 <p style='${breachAlertValueStyle}'>
-                  ${formatDate(AddedDate, supportedLocales)}
+                  ${formatDate(AddedDate, getLocale())}
                 </p>
 
                 ${DataClasses?.length

--- a/src/views/emails/email-signup-report.js
+++ b/src/views/emails/email-signup-report.js
@@ -51,14 +51,12 @@ const signupReportEmailPartial = data => {
     unsafeBreachesForEmail
   } = data
 
-  const hasUnsafeBreaches = unsafeBreachesForEmail?.length > 0
-
   return `
     <tr>
       <td style='${emailStyle}'>
         <p>
           ${
-            hasUnsafeBreaches
+            unsafeBreachesForEmail?.length
               ? getMessage('email-breach-detected', {
                   'email-address': `<strong>${breachedEmail}</strong>`
                 })
@@ -66,7 +64,7 @@ const signupReportEmailPartial = data => {
           }
         </p>
         ${
-          emailBreachStats?.length > 0
+          emailBreachStats?.length
             ? `
                 <table style='${breachSummaryTableStyle}'>
                   <tr>
@@ -90,7 +88,7 @@ const signupReportEmailPartial = data => {
             : ''
         }
         ${
-          hasUnsafeBreaches
+          unsafeBreachesForEmail?.length
             ? unsafeBreachesForEmail.map(unsafeBreach => (
                 breachCardPartial(unsafeBreach)
               )).join('')

--- a/src/views/emails/email-signup-report.js
+++ b/src/views/emails/email-signup-report.js
@@ -51,40 +51,50 @@ const signupReportEmailPartial = data => {
     unsafeBreachesForEmail
   } = data
 
+  const hasUnsafeBreaches = unsafeBreachesForEmail?.length > 0
+
   return `
     <tr>
       <td style='${emailStyle}'>
         <p>
           ${
-            unsafeBreachesForEmail.length
-              ? getMessage('fxm-warns-you-no-breaches')
-              : getMessage('email-breach-detected', {
+            hasUnsafeBreaches
+              ? getMessage('email-breach-detected', {
                   'email-address': `<strong>${breachedEmail}</strong>`
                 })
+              : getMessage('fxm-warns-you-no-breaches')
           }
         </p>
-        <table style='${breachSummaryTableStyle}'>
-          <tr>
-            <td>
-              ${emailBreachStats?.map(breachStat => `
-                <table style='${breachSummaryCardStyle}'>
+        ${
+          emailBreachStats?.length > 0
+            ? `
+                <table style='${breachSummaryTableStyle}'>
                   <tr>
-                    <td style='${statNumberStyle}'>
-                      ${breachStat.statNumber}
-                    </td>
-                    <td style=${statTitleStyle}>
-                      ${breachStat.statTitle}
+                    <td>
+                      ${emailBreachStats.map(breachStat => `
+                        <table style='${breachSummaryCardStyle}'>
+                          <tr>
+                            <td style='${statNumberStyle}'>
+                              ${breachStat.statNumber}
+                            </td>
+                            <td style=${statTitleStyle}>
+                              ${breachStat.statTitle}
+                            </td>
+                          </tr>
+                        </table>
+                      `).join('')}
                     </td>
                   </tr>
                 </table>
-              `).join('')}
-            </td>
-          </tr>
-        </table>
+              `
+            : ''
+        }
         ${
-          unsafeBreachesForEmail.map(unsafeBreach => (
-            breachCardPartial(unsafeBreach)
-          )).join('')
+          hasUnsafeBreaches
+            ? unsafeBreachesForEmail.map(unsafeBreach => (
+                breachCardPartial(unsafeBreach)
+              )).join('')
+            : ''
         }
         <a
           href='${data.ctaHref}'


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1258](https://mozilla-hub.atlassian.net/browse/MNTOR-1258)


<!-- When adding a new feature: -->

# Description

Fix the generation of the sign-up email template for users that sign up with an email that is not involved in a relevant breach.

# Screenshot

![mntor-1258-screenshot](https://user-images.githubusercontent.com/13835474/220355245-a1e203e0-28e0-4a76-845c-ffd6035ca019.png)

# How to test

1. Sign up with an email address that has no relevant associated breaches.
2. Check out the email that we send upon sign-up.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
