### PR TITLE
Disable non-auth previews on prod

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import AppConstants from '../app-constants.js'
 import express from 'express'
 
 import adminRoutes from './admin.js'
@@ -29,8 +30,12 @@ router.use('/admin', adminRoutes)
 router.use('/api/v1/hibp/', hibpApiRoutes)
 router.use('/api/v1/user/', userApiRoutes)
 router.use('/oauth', authRoutes)
-router.use('/preview', previewRoutes)
 router.use('/user', userRoutes)
+
+// Do not make the non-auth previews available on prod
+if (AppConstants.NODE_ENV !== 'production') {
+  router.use('/preview', previewRoutes)
+}
 
 router.use(notFound)
 router.use(notFoundPage)


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1264](https://mozilla-hub.atlassian.net/browse/MNTOR-1264)

<!-- When adding a new feature: -->

# Description

Do not enable the non-auth preview route on prod.

# Screenshot (if applicable)

Not applicable.

# How to test

Navigate to `/preview/emails`: Dev should work as expected and staging is expected to show a `404`.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
