### PR TITLE
set `Accept` header to request localized dialog

### DIFF
--- a/src/client/js/dialog.js
+++ b/src/client/js/dialog.js
@@ -48,7 +48,11 @@ async function openDialog (path) {
   dialogEl.addEventListener('close', resetDialog)
 
   try {
-    const res = await fetch(path)
+    const res = await fetch(path, {
+      headers: {
+        Accept: 'text/html' // set to request localized response
+      }
+    })
 
     if (!res.ok) throw new Error('Bad fetch response')
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1275


<!-- When adding a new feature: -->

# Description
To serve localized content, the app listens for `text/html` requests and updates the locale accordingly.  The dialog/modal fetch did not specify that it needs a `text/html` response and therefore locale was ignored.  This PR adds the required `Accept` header to a dialog request, enabling localization.


# Screenshot (if applicable)

Not applicable.

# How to test
1. change your preferred website language to something other than English
2. login to an account that allows adding additional emails
3. trigger the "Add new email" dialog by clicking the button in Settings or in Breaches zero-state.
4. confirm the dialog is displayed in the specified language.