### PR TITLE
fix heroku/redis 4 crashes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -61,6 +61,11 @@ async function getRedisStore () {
   }
 
   const redisClient = createClient({ url: AppConstants.REDIS_URL })
+  // the following event handlers are currently required for Heroku server stability: https://github.com/Shopify/shopify-app-js/issues/129
+  redisClient.on('error', err => console.error('Redis client error', err))
+  redisClient.on('connect', () => console.log('Redis client is connecting'))
+  redisClient.on('reconnecting', () => console.log('Redis client is reconnecting'))
+  redisClient.on('ready', () => console.log('Redis client is ready'))
   await redisClient.connect().catch(console.error)
   return new RedisStore({ client: redisClient })
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1285

<!-- When adding a new feature: -->

# Description
Fix for broken Heroku servers due to apparent Redis 4 incompatibility