### PR TITLE
reload Settings page to show newly added email

### DIFF
--- a/src/client/js/app.js
+++ b/src/client/js/app.js
@@ -1,5 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-console.log('Hello World from app.js')

--- a/src/client/js/index.js
+++ b/src/client/js/index.js
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import './app.js'
 import './scroll-observer.js'
 import './resize-observer.js'
 import './components/circle-chart.js'

--- a/src/client/js/partials/add-email.js
+++ b/src/client/js/partials/add-email.js
@@ -30,7 +30,7 @@ async function handleSubmit (e) {
       })
     })
 
-    if (!res.ok) throw new Error('Bad fetch response')
+    if (!res.ok) throw new Error()
 
     const { newEmailCount } = await res.json()
 
@@ -41,8 +41,8 @@ async function handleSubmit (e) {
   } catch (e) {
     // TODO: localize error messages
     const toast = document.createElement('toast-alert')
-    toast.textContent = `Could not add email: ${e.message}`
-    document.body.append(toast)
+    toast.textContent = `Could not add email. ${e.message}`
+    dialogEl.append(toast)
     console.error('Could not add email.', e)
   } finally {
     form.elements['email-submit'].toggleAttribute('disabled', false)

--- a/src/client/js/partials/settings.js
+++ b/src/client/js/partials/settings.js
@@ -2,8 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const settingsAlertOptionsInputs = document.getElementsByClassName('js-settings-alert-options-input')
+const settingsPartial = document.querySelector("[data-partial='settings']")
 
+function init () {
+  document.body.addEventListener('email-added', handleEvent)
+}
+
+function handleEvent (e) {
+  switch (true) {
+    case e.type === 'email-added':
+      document.querySelector('dialog[data-partial="add-email"]')
+        .addEventListener('close', () => window.location.reload(), { once: true })
+      break
+  }
+}
+
+const settingsAlertOptionsInputs = document.getElementsByClassName('js-settings-alert-options-input')
 if (settingsAlertOptionsInputs?.length) {
   for (const inputElement of settingsAlertOptionsInputs) {
     inputElement.addEventListener('change', async event => {
@@ -104,3 +118,5 @@ if (settingsResendEmailLinks?.length) {
     })
   }
 }
+
+if (settingsPartial) init()


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1189


<!-- When adding a new feature: -->

# Description
After a user adds a new email from the dialog on the Settings page, if they click the close button (x) they return to the settings screen which has not been updated with the newly added email.  This PR listens for that sequence of events (add email -> close dialog) and reloads the page if triggered.

This is a preliminary measure – for future updates/refactor we could look into making this page reactive to avoid reload.

Also included in this PR is a related bug fix for toast errors not displaying over the dialog scrim.  This error message is not localized and requires more work under [separate PR](https://mozilla-hub.atlassian.net/browse/MNTOR-1271).

# How to test
1. visit the Settings page
2. add a new email
3. close the dialog via the "x" close button
4. confirm the new email is displayed on the list
5. attempt to add the same email
6. confirm the "toast" error displays over the dialog alerting the user the email was not able to be added
7. add enough emails to reach the cap of 5, then close the dialog via the "x" close button
8. confirm the "Add email address" button is disabled


# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
