### PR TITLE
Add relevant links to breach resolutions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,14 @@
             2
         ],
         "jsdoc/require-jsdoc": "off",
-        "jsdoc/require-param-description": "off"
+        "jsdoc/require-param-description": "off",
+        // Unused vars explicitly marked as such with an understore prefix are allowed:
+        "no-unused-vars": [
+            "warn",
+            {
+                "argsIgnorePattern": "^_",
+                "varsIgnorePattern": "^_"
+            }
+        ]
     }
 }

--- a/locales/en/breaches.ftl
+++ b/locales/en/breaches.ftl
@@ -56,15 +56,31 @@ breaches-all-resolved-cta-button = Add email address
 # $breachDate and $addedDate are dates that should be localized via JS DateTimeFormat(). $dataClasses is a list of strings from data-classes.ftl that should be localized via JS ListFormat()
 breach-description = On { $breachDate }, { $companyName } was breached. Once the breach was discovered and verified, it was added to our database on { $addedDate }. This breach included: { $dataClasses }
 
+## Links that we might refer to when prompting the user to make changes after a breach
+
+breach-checklist-link-firefox-relay = { -brand-relay }
+breach-checklist-link-password-manager = { -brand-firefox } Password Manager
+breach-checklist-link-mozilla-vpn = { -brand-mozilla-vpn }
+
 ## Prompts the user for changes when there is a breach detected of password
 
-# NOTE: { $breachedCompanyUrl } is a placeholder for the URL to the website of the company where the breach occurred 
+# Deprecated
 breach-checklist-pw-header = Go to <a>{$breachedCompanyUrl}</a> to change your password and enable two-factor authentication (2FA). 
+# { $breachedCompanyLink } will link to the website of the company where the breach occurred
+breach-checklist-pw-header-2 = Go to the company’s website to change your password and enable two-factor authentication (2FA).
+# Deprecated
 breach-checklist-pw-body = Make sure your password is unique and hard to guess. If this password is used on any other accounts, be sure to change it there too. <a>{-brand-firefox} Password Manager</a> can help you securely keep track of all of your passwords.
+# Variables:
+#   $passwordManagerLink (string) - a link to the password manager documentation, with { -breach-checklist-link-password-manager } as the label
+breach-checklist-pw-body-2 = Make sure your password is unique and hard to guess. If this password is used on any other accounts, be sure to change it there too. { $passwordManagerLink } can help you securely keep track of all of your passwords.
 
 ## Prompts the user for changes when there is a breach detected of email
 
+# Deprecated
 breach-checklist-email-header = Protect your email with an email masking service like <a>{-brand-relay}</a>.
+# Variables:
+#   $firefoxRelayLink (string) - a link to Firefox Relay, with { -breach-checklist-link-firefox-relay } as the label
+breach-checklist-email-header-2 = Protect your email with an email masking service like { $firefoxRelayLink }.
 breach-checklist-email-body = This can hide your true email address while forwarding emails to your real inbox.
 
 ## Prompts the user for changes when there is a breach detected of social security number
@@ -72,10 +88,17 @@ breach-checklist-email-body = This can hide your true email address while forwar
 # Credit reports list your bill payment history, loans, current debt, and other financial information. 
 # They show where you work and live and whether you've been sued, arrested, or filed for bankruptcy.
 breach-checklist-ssn-header = Monitor your credit report for accounts, loans, or credit cards you don’t recognize.
+# Deprecated
+breach-checklist-ssn-body = You can also consider freezing your credit on <a>Equifax</a>, <a>Experian</a> and <a>TransUnion</a> to stop scammers from opening new accounts in your name. It’s free and won’t affect your credit score.
 # A security freeze prevents prospective creditors from accessing your credit file. 
 # Creditors typically won't offer you credit if they can't access your credit reporting file, 
 # so a security freeze, also called a credit freeze, prevents you or others from opening accounts in your name.
-breach-checklist-ssn-body = You can also consider freezing your credit on <a>Equifax</a>, <a>Experian</a> and <a>TransUnion</a> to stop scammers from opening new accounts in your name. It’s free and won’t affect your credit score.
+# This will only be shown to users in the US.
+# Variables:
+#   $equifaxLink (string) - a link to the Equifax website, with { -breach-checklist-link-equifax } as the label
+#   $experianLink (string) - a link to the Experian website, with { -breach-checklist-link-experian } as the label
+#   $transUnionLink (string) - a link to the TransUnion website, with { -breach-checklist-link-transunion } as the label
+breach-checklist-ssn-body-2 = You can also consider freezing your credit on { $equifaxLink }, { $experianLink } and { $transUnionLink } to stop scammers from opening new accounts in your name. It’s free and won’t affect your credit score.
 
 ## Prompts the user for changes when there is a breach detected of credit card
 
@@ -94,7 +117,11 @@ breach-checklist-pin-body = Make sure your new PIN, or any other PIN, doesn’t 
 
 ## Prompts the user for changes when there is a breach detected of IP address
 
+# Deprecated
 breach-checklist-ip-header = Use the internet privately with a VPN, such as <a>{-brand-mozilla-vpn}</a>.
+# Variables:
+#   $mozillaVpnLink (string) - a link to the Mozilla VPN website, with { -breach-checklist-link-mozilla-vpn } as the label
+breach-checklist-ip-header-2 = Use the internet privately with a VPN, such as { $mozillaVpnLink }.
 breach-checklist-ip-body = Your IP address (Internet Protocol address) pinpoints your location and internet service provider. A VPN can hide your real IP address so you can use the internet privately.   
 
 ## Prompts the user for changes when there is a breach detected of physical address
@@ -109,18 +136,28 @@ breach-checklist-dob-body = Birth dates are easy to find in public records, and 
 
 ## Prompts the user for changes when there is a breach detected of phone number
 
+# Deprecated
 breach-checklist-phone-header = Protect your phone number with a masking service like <a>{-brand-relay}</a>, which hides your true phone number. 
+# Variables:
+#   $firefoxRelayLink (string) - a link to Firefox Relay, with { -breach-checklist-link-firefox-relay } as the label
+breach-checklist-phone-header-2 = Protect your phone number with a masking service like { $firefoxRelayLink }, which hides your true phone number.
 
 ## Prompts the user for changes when there is a breach detected of security questions
 
-# NOTE: { $breachedCompanyUrl } is a placeholder for the URL to the website of the company where the breach occurred 
+# Deprecated
 breach-checklist-sq-header = Update your security questions on <a>{$breachedCompanyUrl}</a>. 
+# { $breachedCompanyLink } will link to the website of the company where the breach occurred
+breach-checklist-sq-header-2 = Update your security questions on the company’s website.
 breach-checklist-sq-body = Use long, random answers, and store them somewhere safe. Do this anywhere else you’ve used the same security questions.
 
 ## Prompts the user for changes when there is a breach detected of historical password
 
 breach-checklist-hp-header = Create unique, strong passwords for any account where you’ve re-used passwords.
+# Deprecated
 breach-checklist-hp-body = A password manager like <a>{-brand-firefox} Password Manager</a> (which is free and built-in to the {-brand-firefox} browser) can help you keep track of all your passwords and access them securely from all your devices. 
+# Variables:
+#   $passwordManagerLink (string) - a link to the password manager documentation, with { -breach-checklist-link-password-manager } as the label
+breach-checklist-hp-body-2 = A password manager like { $passwordManagerLink } (which is free and built-in to the {-brand-firefox} browser) can help you keep track of all your passwords and access them securely from all your devices.
 
 ## Prompts the user for changes when there is a breach detected of other types
 

--- a/locales/en/breaches.ftl
+++ b/locales/en/breaches.ftl
@@ -64,20 +64,14 @@ breach-checklist-link-mozilla-vpn = { -brand-mozilla-vpn }
 
 ## Prompts the user for changes when there is a breach detected of password
 
-# Deprecated
-breach-checklist-pw-header = Go to <a>{$breachedCompanyUrl}</a> to change your password and enable two-factor authentication (2FA). 
 # { $breachedCompanyLink } will link to the website of the company where the breach occurred
 breach-checklist-pw-header-2 = Go to the company’s website to change your password and enable two-factor authentication (2FA).
-# Deprecated
-breach-checklist-pw-body = Make sure your password is unique and hard to guess. If this password is used on any other accounts, be sure to change it there too. <a>{-brand-firefox} Password Manager</a> can help you securely keep track of all of your passwords.
 # Variables:
 #   $passwordManagerLink (string) - a link to the password manager documentation, with { -breach-checklist-link-password-manager } as the label
 breach-checklist-pw-body-2 = Make sure your password is unique and hard to guess. If this password is used on any other accounts, be sure to change it there too. { $passwordManagerLink } can help you securely keep track of all of your passwords.
 
 ## Prompts the user for changes when there is a breach detected of email
 
-# Deprecated
-breach-checklist-email-header = Protect your email with an email masking service like <a>{-brand-relay}</a>.
 # Variables:
 #   $firefoxRelayLink (string) - a link to Firefox Relay, with { -breach-checklist-link-firefox-relay } as the label
 breach-checklist-email-header-2 = Protect your email with an email masking service like { $firefoxRelayLink }.
@@ -88,8 +82,6 @@ breach-checklist-email-body = This can hide your true email address while forwar
 # Credit reports list your bill payment history, loans, current debt, and other financial information. 
 # They show where you work and live and whether you've been sued, arrested, or filed for bankruptcy.
 breach-checklist-ssn-header = Monitor your credit report for accounts, loans, or credit cards you don’t recognize.
-# Deprecated
-breach-checklist-ssn-body = You can also consider freezing your credit on <a>Equifax</a>, <a>Experian</a> and <a>TransUnion</a> to stop scammers from opening new accounts in your name. It’s free and won’t affect your credit score.
 # A security freeze prevents prospective creditors from accessing your credit file. 
 # Creditors typically won't offer you credit if they can't access your credit reporting file, 
 # so a security freeze, also called a credit freeze, prevents you or others from opening accounts in your name.
@@ -117,8 +109,6 @@ breach-checklist-pin-body = Make sure your new PIN, or any other PIN, doesn’t 
 
 ## Prompts the user for changes when there is a breach detected of IP address
 
-# Deprecated
-breach-checklist-ip-header = Use the internet privately with a VPN, such as <a>{-brand-mozilla-vpn}</a>.
 # Variables:
 #   $mozillaVpnLink (string) - a link to the Mozilla VPN website, with { -breach-checklist-link-mozilla-vpn } as the label
 breach-checklist-ip-header-2 = Use the internet privately with a VPN, such as { $mozillaVpnLink }.
@@ -136,16 +126,12 @@ breach-checklist-dob-body = Birth dates are easy to find in public records, and 
 
 ## Prompts the user for changes when there is a breach detected of phone number
 
-# Deprecated
-breach-checklist-phone-header = Protect your phone number with a masking service like <a>{-brand-relay}</a>, which hides your true phone number. 
 # Variables:
 #   $firefoxRelayLink (string) - a link to Firefox Relay, with { -breach-checklist-link-firefox-relay } as the label
 breach-checklist-phone-header-2 = Protect your phone number with a masking service like { $firefoxRelayLink }, which hides your true phone number.
 
 ## Prompts the user for changes when there is a breach detected of security questions
 
-# Deprecated
-breach-checklist-sq-header = Update your security questions on <a>{$breachedCompanyUrl}</a>. 
 # { $breachedCompanyLink } will link to the website of the company where the breach occurred
 breach-checklist-sq-header-2 = Update your security questions on the company’s website.
 breach-checklist-sq-body = Use long, random answers, and store them somewhere safe. Do this anywhere else you’ve used the same security questions.
@@ -153,8 +139,6 @@ breach-checklist-sq-body = Use long, random answers, and store them somewhere sa
 ## Prompts the user for changes when there is a breach detected of historical password
 
 breach-checklist-hp-header = Create unique, strong passwords for any account where you’ve re-used passwords.
-# Deprecated
-breach-checklist-hp-body = A password manager like <a>{-brand-firefox} Password Manager</a> (which is free and built-in to the {-brand-firefox} browser) can help you keep track of all your passwords and access them securely from all your devices. 
 # Variables:
 #   $passwordManagerLink (string) - a link to the password manager documentation, with { -breach-checklist-link-password-manager } as the label
 breach-checklist-hp-body-2 = A password manager like { $passwordManagerLink } (which is free and built-in to the {-brand-firefox} browser) can help you keep track of all your passwords and access them securely from all your devices.

--- a/src/client/css/partials/breaches.css
+++ b/src/client/css/partials/breaches.css
@@ -259,6 +259,14 @@
   padding-left: 0;
 }
 
+.breaches-table details .resolve-list a {
+  text-decoration: underline;
+}
+
+.breaches-table details .resolve-list a:hover {
+  color: var(--gray-40);
+}
+
 .breaches-table details .resolve-list-item {
   position: relative;
   padding-right: calc(var(--padding-lg) * 2 + var(--checkbox-w));

--- a/src/controllers/breaches.js
+++ b/src/controllers/breaches.js
@@ -8,13 +8,14 @@ import { setBreachResolution, updateBreachStats } from '../db/tables/subscribers
 import { appendBreachResolutionChecklist } from '../utils/breach-resolution.js'
 import { generateToken } from '../utils/csrf.js'
 import { getAllEmailsAndBreaches } from '../utils/breaches.js'
+import { getCountryCode } from '../utils/country-code.js'
 
 async function breachesPage (req, res) {
   // TODO: remove: to test out getBreaches call with JSON returns
   const breachesData = await getAllEmailsAndBreaches(req.user, req.app.locals.breaches)
   const emailVerifiedCount = breachesData.verifiedEmails?.length ?? 0
   const emailTotalCount = emailVerifiedCount + (breachesData.unverifiedEmails?.length ?? 0)
-  appendBreachResolutionChecklist(breachesData)
+  appendBreachResolutionChecklist(breachesData, { countryCode: getCountryCode(req) })
   const cookies = req.cookies
   const selectedEmailIndex = typeof cookies['monitor.selected-email-index'] !== 'undefined'
     ? Number.parseInt(cookies['monitor.selected-email-index'], 10)

--- a/src/utils/breach-resolution.js
+++ b/src/utils/breach-resolution.js
@@ -28,22 +28,26 @@ const BreachDataTypes = {
 /**
  * TODO: Map from google doc: https://docs.google.com/document/d/1KoItFsTYVIBInIG2YmA7wSxkKS4vti_X0A0td_yaHVM/edit#
  * Hardcoded map of breach resolution data types
+ *
+ * @type { Record<keyof BreachDataTypes, { priority: number, header: string, body?: string, applicableCountryCodes?: string[] }> }
  */
 const breachResolutionDataTypes = {
   [BreachDataTypes.Passwords]: {
     priority: 1,
-    header: 'breach-checklist-pw-header',
-    body: 'breach-checklist-pw-body'
+    header: 'breach-checklist-pw-header-2',
+    body: 'breach-checklist-pw-body-2'
   },
   [BreachDataTypes.Email]: {
     priority: 2,
-    header: 'breach-checklist-email-header',
+    header: 'breach-checklist-email-header-2',
     body: 'breach-checklist-email-body'
   },
   [BreachDataTypes.SSN]: {
     priority: 3,
     header: 'breach-checklist-ssn-header',
-    body: 'breach-checklist-ssn-body'
+    body: 'breach-checklist-ssn-body-2',
+    // The resolution involves American companies, and thus does not apply in other countries:
+    applicableCountryCodes: ['us']
   },
   [BreachDataTypes.CreditCard]: {
     priority: 4,
@@ -62,7 +66,7 @@ const breachResolutionDataTypes = {
   },
   [BreachDataTypes.IP]: {
     priority: 7,
-    header: 'breach-checklist-ip-header',
+    header: 'breach-checklist-ip-header-2',
     body: 'breach-checklist-ip-body'
   },
   [BreachDataTypes.Address]: {
@@ -77,17 +81,17 @@ const breachResolutionDataTypes = {
   },
   [BreachDataTypes.Phone]: {
     priority: 10,
-    header: 'breach-checklist-phone-header'
+    header: 'breach-checklist-phone-header-2'
   },
   [BreachDataTypes.SecurityQuestions]: {
     priority: 11,
-    header: 'breach-checklist-sq-header',
+    header: 'breach-checklist-sq-header-2',
     body: 'breach-checklist-sq-body'
   },
   [BreachDataTypes.HistoricalPasswords]: {
     priority: 12,
     header: 'breach-checklist-hp-header',
-    body: 'breach-checklist-hp-body'
+    body: 'breach-checklist-hp-body-2'
   },
   [BreachDataTypes.General]: {
     priority: 13,
@@ -100,18 +104,24 @@ const breachResolutionDataTypes = {
  * The checklist serves the UI with relevant recommendations based on the array of datatypes leaked during a breach.
  *
  * @param {Array} userBreachData contains monitored verified emails array. Each email may contain a breaches array
+ * @param {Partial<{ countryCode: string }>} options
  * @returns {*} void
  */
-function appendBreachResolutionChecklist (userBreachData) {
+function appendBreachResolutionChecklist (userBreachData, options = {}) {
   const { verifiedEmails } = userBreachData
   for (const { breaches } of verifiedEmails) {
     breaches.forEach(b => {
       const dataClasses = b.DataClasses
       const args = {
         companyName: b.Name,
-        breachedCompanyUrl: `https://${b.Domain}`
+        firefoxRelayLink: `<a href="https://relay.firefox.com" target="_blank">${getMessage('breach-checklist-link-firefox-relay')}</a>`,
+        passwordManagerLink: `<a href="https://www.mozilla.org/firefox/features/password-manager/" target="_blank">${getMessage('breach-checklist-link-password-manager')}</a>`,
+        mozillaVpnLink: `<a href="https://www.mozilla.org/products/vpn/" target="_blank">${getMessage('breach-checklist-link-mozilla-vpn')}</a>`,
+        equifaxLink: '<a href="https://www.equifax.com/personal/credit-report-services/credit-freeze/" target="_blank">Equifax</a>',
+        experianLink: '<a href="https://www.experian.com/freeze/center.html" target="_blank">Experian</a>',
+        transUnionLink: '<a href="https://www.transunion.com/credit-freeze" target="_blank">TransUnion</a>'
       }
-      b.breachChecklist = getResolutionRecsPerBreach(dataClasses, args)
+      b.breachChecklist = getResolutionRecsPerBreach(dataClasses, args, { ...options, hideBreachLink: b.Domain.length <= 0 })
     })
   }
 }
@@ -124,27 +134,40 @@ function appendBreachResolutionChecklist (userBreachData) {
  * @param {object} args contains necessary variables for the fluent file
  *  - companyName
  *  - breachedCompanyUrl
+ * @param {Partial<{ countryCode: string, hideBreachLink: boolean }>} options
  * @returns {Map} map of relevant breach resolution recommendations
  */
-function getResolutionRecsPerBreach (dataTypes, args) {
+function getResolutionRecsPerBreach (dataTypes, args, options = {}) {
   const filteredBreachRecs = {}
-
-  // if datatypes is empty or null, return general only.
-  if (!dataTypes?.length) dataTypes = [BreachDataTypes.General]
 
   // filter breachResolutionDataTypes based on relevant data types passed in
   for (const [key, value] of Object.entries(breachResolutionDataTypes)) {
-    if (dataTypes.includes(key)) {
-      // find fluent text based on fluent ids
-      let { header, body, priority } = value
-      header = header ? getMessage(header, args) : ''
-      body = body ? getMessage(body, args) : ''
-      filteredBreachRecs[key] = { header, body, priority }
+    if (
+      dataTypes.includes(key) &&
+      // Hide the security question or password resolution if we can't link to the breached site:
+      (![BreachDataTypes.Passwords, BreachDataTypes.SecurityQuestions].includes(key) || !options.hideBreachLink) &&
+      // Hide resolutions that apply to other countries than the user's:
+      (!options.countryCode || !Array.isArray(value.applicableCountryCodes) || value.applicableCountryCodes.includes(options.countryCode.toLowerCase()))
+    ) {
+      filteredBreachRecs[key] = getRecommendationFromResolution(value, args)
     }
+  }
+
+  // If we did not have any recommendations, add a generic recommendation:
+  if (Object.keys(filteredBreachRecs).length === 0) {
+    filteredBreachRecs[BreachDataTypes.General] = getRecommendationFromResolution(breachResolutionDataTypes[BreachDataTypes.General], args)
   }
 
   // loop through the breach recs
   return filteredBreachRecs
+}
+
+// find fluent text based on fluent ids
+function getRecommendationFromResolution (resolution, args) {
+  let { header, body, priority } = resolution
+  header = header ? getMessage(header, args) : ''
+  body = body ? getMessage(body, args) : ''
+  return { header, body, priority }
 }
 
 /**

--- a/src/utils/breach-resolution.test.js
+++ b/src/utils/breach-resolution.test.js
@@ -31,10 +31,9 @@ test('appendBreachResolutionChecklist: two data classes', t => {
     unverifiedEmails: []
   }
   appendBreachResolutionChecklist(userBreachData)
-  console.log(JSON.stringify(userBreachData))
   t.truthy(userBreachData.verifiedEmails[0].breaches[0].breachChecklist)
   t.is(userBreachData.verifiedEmails[0].breaches[0].breachChecklist[BreachDataTypes.Passwords].header,
-    'Go to <a>https://companyName.com</a> to change your password and enable two-factor authentication (2FA).')
+    'Go to the company’s website to change your password and enable two-factor authentication (2FA).')
   t.is(userBreachData.verifiedEmails[0].breaches[0].breachChecklist[BreachDataTypes.Passwords].priority, 1)
 })
 
@@ -51,9 +50,127 @@ test('appendBreachResolutionChecklist: no data classes', t => {
     unverifiedEmails: []
   }
   appendBreachResolutionChecklist(userBreachData)
-  console.log(JSON.stringify(userBreachData))
   t.truthy(userBreachData.verifiedEmails[0].breaches[0].breachChecklist)
   t.is(userBreachData.verifiedEmails[0].breaches[0].breachChecklist[BreachDataTypes.General].header,
     'Reach out to companyName to inform them about this breach and ask for specific steps you can take.')
   t.is(userBreachData.verifiedEmails[0].breaches[0].breachChecklist[BreachDataTypes.General].priority, 13)
+})
+
+test('appendBreachResolutionChecklist: only non-applicable data classes', t => {
+  const userBreachData = {
+    verifiedEmails: [{
+      email: 'affected@email.com',
+      breaches: [{
+        DataClasses: [BreachDataTypes.SSN],
+        Name: 'companyName',
+        Domain: 'companyName.com'
+      }]
+    }],
+    unverifiedEmails: []
+  }
+  appendBreachResolutionChecklist(userBreachData, { countryCode: 'not-us' })
+  t.truthy(userBreachData.verifiedEmails[0].breaches[0].breachChecklist)
+  t.is(userBreachData.verifiedEmails[0].breaches[0].breachChecklist[BreachDataTypes.General].header,
+    'Reach out to companyName to inform them about this breach and ask for specific steps you can take.')
+  t.is(userBreachData.verifiedEmails[0].breaches[0].breachChecklist[BreachDataTypes.General].priority, 13)
+})
+
+test('appendBreachResolutionChecklist: data class with a resolution not applicable to the user\'s country', t => {
+  const userBreachData = {
+    verifiedEmails: [{
+      email: 'affected@email.com',
+      breaches: [{
+        DataClasses: [BreachDataTypes.Email, BreachDataTypes.SSN],
+        Name: 'companyName',
+        Domain: 'companyName.com'
+      }]
+    }],
+    unverifiedEmails: []
+  }
+  appendBreachResolutionChecklist(userBreachData, { countryCode: 'not-us-or-ca' })
+  // There should only be a resolution for `BreachDataTypes.Email`, as
+  // `BreachDataTypes.SSN` refers to American companies like Equifax:
+  t.deepEqual(
+    Object.keys(userBreachData.verifiedEmails[0].breaches[0].breachChecklist),
+    [BreachDataTypes.Email]
+  )
+})
+
+test('appendBreachResolutionChecklist: data class with a resolution applicable to the user\'s country, Canada', t => {
+  const userBreachData = {
+    verifiedEmails: [{
+      email: 'affected@email.com',
+      breaches: [{
+        DataClasses: [BreachDataTypes.Phone, BreachDataTypes.Email, BreachDataTypes.SSN],
+        Name: 'companyName',
+        Domain: 'companyName.com'
+      }]
+    }],
+    unverifiedEmails: []
+  }
+  appendBreachResolutionChecklist(userBreachData, { countryCode: 'ca' })
+  t.deepEqual(
+    Object.keys(userBreachData.verifiedEmails[0].breaches[0].breachChecklist),
+    [BreachDataTypes.Email, BreachDataTypes.Phone]
+  )
+})
+
+test('appendBreachResolutionChecklist: data class with a resolution applicable to the user\'s country, US', t => {
+  const userBreachData = {
+    verifiedEmails: [{
+      email: 'affected@email.com',
+      breaches: [{
+        DataClasses: [BreachDataTypes.Phone, BreachDataTypes.Email, BreachDataTypes.SSN],
+        Name: 'companyName',
+        Domain: 'companyName.com'
+      }]
+    }],
+    unverifiedEmails: []
+  }
+  appendBreachResolutionChecklist(userBreachData, { countryCode: 'us' })
+  t.deepEqual(
+    Object.keys(userBreachData.verifiedEmails[0].breaches[0].breachChecklist),
+    [BreachDataTypes.Email, BreachDataTypes.SSN, BreachDataTypes.Phone]
+  )
+})
+
+test('appendBreachResolutionChecklist: data class with a resolution referring to the breach\'s domain, which is not available', t => {
+  const userBreachData = {
+    verifiedEmails: [{
+      email: 'affected@email.com',
+      breaches: [{
+        DataClasses: [BreachDataTypes.SecurityQuestions, BreachDataTypes.Phone, BreachDataTypes.Passwords],
+        Name: 'companyName',
+        Domain: ''
+      }]
+    }],
+    unverifiedEmails: []
+  }
+  appendBreachResolutionChecklist(userBreachData)
+  // There should only be a resolution for `BreachDataTypes.Phone`, as
+  // `BreachDataTypes.Passwords` and `BreachDataTypes.SecurityQuestions` refer
+  // to the breached company's domain, which we don't know:
+  t.deepEqual(
+    Object.keys(userBreachData.verifiedEmails[0].breaches[0].breachChecklist),
+    [BreachDataTypes.Phone]
+  )
+})
+
+test('appendBreachResolutionChecklist: data class with a resolution referring to the breach\'s domain, which is available', t => {
+  const userBreachData = {
+    verifiedEmails: [{
+      email: 'affected@email.com',
+      breaches: [{
+        DataClasses: [BreachDataTypes.SecurityQuestions, BreachDataTypes.Phone, BreachDataTypes.Passwords],
+        Name: 'companyName',
+        Domain: 'companyName.com'
+      }]
+    }],
+    unverifiedEmails: []
+  }
+  appendBreachResolutionChecklist(userBreachData)
+  t.deepEqual(
+    Object.keys(userBreachData.verifiedEmails[0].breaches[0].breachChecklist),
+    [BreachDataTypes.Passwords, BreachDataTypes.Phone, BreachDataTypes.SecurityQuestions]
+  )
 })

--- a/src/utils/country-code.js
+++ b/src/utils/country-code.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export function getCountryCode (request) {
+  // GCP can detect the user's country from their IP addresses, and pass it to
+  // us through this header:
+  const gcpDetectedRegion = request.get('X-Client-Region')
+  if (gcpDetectedRegion) {
+    return gcpDetectedRegion.toLowerCase()
+  }
+  // On stage and production, the `X-Client-Region` should be available. To be
+  // able to locally test country-specific behaviour, we fall back to the
+  // Accept-Language:
+  const acceptLanguage = request.get('Accept-Language')
+  if (acceptLanguage) {
+    const acceptedLocales = acceptLanguage.split(',')
+    const primaryLocale = acceptedLocales[0] ?? ''
+    const [locale, _weight] = primaryLocale.split(';')
+    const [_language, country] = (locale ?? '').split('-')
+    if (country) {
+      return country.toLowerCase()
+    }
+  }
+  return 'us'
+}

--- a/src/utils/country-code.test.js
+++ b/src/utils/country-code.test.js
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import test from 'ava'
+
+import { getCountryCode } from './country-code.js'
+
+test('getCountryCode: GCP-detected country', t => {
+  const getHeader = (header) => {
+    if (header === 'X-Client-Region') {
+      return 'NL'
+    }
+    return undefined
+  }
+  t.is(getCountryCode({ get: getHeader }), 'nl')
+})
+
+test('getCountryCode: Accept-Language with a single locale', t => {
+  const getHeader = (header) => {
+    if (header === 'Accept-Language') {
+      return 'nl-NL'
+    }
+    return undefined
+  }
+  t.is(getCountryCode({ get: getHeader }), 'nl')
+})
+
+test('getCountryCode: Accept-Language with multiple locales', t => {
+  const getHeader = (header) => {
+    if (header === 'Accept-Language') {
+      return 'nl-NL, en-US'
+    }
+    return undefined
+  }
+  t.is(getCountryCode({ get: getHeader }), 'nl')
+})
+
+test('getCountryCode: Accept-Language with multiple locales, with weightings', t => {
+  const getHeader = (header) => {
+    if (header === 'Accept-Language') {
+      return 'nl-NL;q=0.8, en-US'
+    }
+    return undefined
+  }
+  t.is(getCountryCode({ get: getHeader }), 'nl')
+})
+
+test('getCountryCode: Accept-Language with a language without a country code', t => {
+  const getHeader = (header) => {
+    if (header === 'Accept-Language') {
+      return 'nl;q=0.8, en-US'
+    }
+    return undefined
+  }
+  t.is(getCountryCode({ get: getHeader }), 'us')
+})
+
+test('getCountryCode: defaults to US', t => {
+  t.is(getCountryCode({ get: () => undefined }), 'us')
+})


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1322
Figma: N/A


<!-- When adding a new feature: -->

# Description

Some of the breach resolutions reference external services; this PR turns those into links. Also tagging @mansaj, since he added the original `<a>` tags to a couple of strings, just in case he had a plan for turning those into links that I missed.

Not all resolutions apply to all countries. I've added some code to detect the user's country through their IP address based on [similar code in Relay](https://github.com/mozilla/fx-private-relay/blob/0d14ccf6f894b09b0ae13026a4b54226ac12c025/privaterelay/utils.py#L20-L27), which I think is also applicable to Monitor. Additionally, I added a guard that checks that we do not show resolutions that involve going to the breached company's website when we don't actually know where that website is.

The way I implemented the links is by creating separate strings with the link contents, and then injected those into the resolution strings using variables. Not sure if that's the best way, but it does work /cc @flodolo.

# Screenshot (if applicable)

[Screencast from 2023-03-13 15-38-32.webm](https://user-images.githubusercontent.com/4251/224734373-0755d1f6-3b8b-4126-be0d-9c1992b6b39f.webm)

# How to test

View a breach resolution that refers to other website, and verify that it links to those websites. Additionally, the SSN and phone breach resolutions shouldn't show up outside of the US and Canada (you can set this by settings your Accept-Language), and password and security question resolutions shouldn't show up for sites that we do not have a Domain for.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
