### PR TITLE
Prevent non-unsubscribe pages from breaking

### DIFF
--- a/src/client/js/partials/unsubscribe.js
+++ b/src/client/js/partials/unsubscribe.js
@@ -2,45 +2,51 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const unsubscribeButton = document.querySelector('.js-unsubscribe-button')
+const unsubscribePartial = document.querySelector("[data-partial='unsubscribe']")
 
-unsubscribeButton.addEventListener('click', async event => {
-  // TODO: Use more specific messages when we reinstate
-  // unsubscribing from all emails.
-  const errorMessage = 'Unsubscribing failed.'
-  const successMessage = 'Unsubscribed successfully.'
+function init () {
+  const unsubscribeButton = document.querySelector('.js-unsubscribe-button')
 
-  try {
-    const target = event.target
-    const csrfToken = target.getAttribute('data-csrf-token')
-    const queryParams = target.getAttribute('data-query-params')
+  unsubscribeButton.addEventListener('click', async event => {
+    // TODO: Use more specific messages when we reinstate
+    // unsubscribing from all emails.
+    const errorMessage = 'Unsubscribing failed.'
+    const successMessage = 'Unsubscribed successfully.'
 
-    const response = await fetch('/user/unsubscribe', {
-      headers: {
-        'Content-Type': 'application/json',
-        'x-csrf-token': csrfToken
-      },
-      mode: 'same-origin',
-      method: 'POST',
-      body: queryParams
-    })
+    try {
+      const target = event.target
+      const csrfToken = target.getAttribute('data-csrf-token')
+      const queryParams = target.getAttribute('data-query-params')
 
-    if (response?.redirected) {
-      throw response.error
+      const response = await fetch('/user/unsubscribe', {
+        headers: {
+          'Content-Type': 'application/json',
+          'x-csrf-token': csrfToken
+        },
+        mode: 'same-origin',
+        method: 'POST',
+        body: queryParams
+      })
+
+      if (response?.redirected) {
+        throw response.error
+      }
+
+      let toast
+      if (!response.ok) {
+        toast = document.createElement('toast-alert')
+        toast.textContent = errorMessage
+      } else {
+        toast = document.createElement('toast-alert')
+        toast.setAttribute('type', 'success')
+        toast.textContent = successMessage
+      }
+
+      document.body.append(toast)
+    } catch (error) {
+      throw new Error(errorMessage)
     }
+  })
+}
 
-    let toast
-    if (!response.ok) {
-      toast = document.createElement('toast-alert')
-      toast.textContent = errorMessage
-    } else {
-      toast = document.createElement('toast-alert')
-      toast.setAttribute('type', 'success')
-      toast.textContent = successMessage
-    }
-
-    document.body.append(toast)
-  } catch (error) {
-    throw new Error(errorMessage)
-  }
-})
+if (unsubscribePartial) init()


### PR DESCRIPTION
The query selector from the unsubscribe script failed on other pages (where the script gets loaded as well), leading to an attempt to call a method on `undefined`, halting all JS execution.
