### PR TITLE
Update fluent linter, fix placeables and variable comments

### DIFF
--- a/.github/linter_config.yml
+++ b/.github/linter_config.yml
@@ -48,5 +48,9 @@ CO01:
             - rec-bank-acc-subhead
             - rec-cc-subhead
         files: []
+# Variable comments
+VC:
+    disabled: false
+# Placeables style
 PS01:
     disabled: false

--- a/.github/linter_config.yml
+++ b/.github/linter_config.yml
@@ -48,3 +48,5 @@ CO01:
             - rec-bank-acc-subhead
             - rec-cc-subhead
         files: []
+PS01:
+    disabled: false

--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,1 +1,1 @@
-moz-fluent-linter==0.2.*
+moz-fluent-linter==0.4.*

--- a/.github/workflows/reference_linter.yaml
+++ b/.github/workflows/reference_linter.yaml
@@ -1,11 +1,17 @@
 name: Lint Reference Files
 on:
   push:
-    paths: ['locales/en/**.ftl' ]
-    branches: [ main, localization ]
+    paths:
+      - 'locales/en/**.ftl'
+    branches:
+      - main
+      - localization
   pull_request:
-    paths: ['locales/en/**.ftl' ]
-    branches: [ main, localization ]
+    paths:
+      - 'locales/en/**.ftl'
+    branches:
+      - main
+      - localization ]
   workflow_dispatch:
 jobs:
   linter:
@@ -16,7 +22,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v3
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           cache: 'pip'
       - name: Install Python dependencies
         run: |

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -4,7 +4,7 @@
 ## unless otherwise indicated.
 
 -product-name = Firefox Monitor
--product-name-nowrap = <span class="nowrap">{-product-name}</span>
+-product-name-nowrap = <span class="nowrap">{ -product-name }</span>
 -product-short-name = Monitor
 -brand-name = Firefox
 -brand-Mozilla = Mozilla
@@ -23,33 +23,33 @@ GitHub-link-title = GitHub
 
 error-scan-page-token = You tried to scan too many email addresses in a short time period. For security reasons, we’ve temporarily blocked you from new searches. You’ll be able to try again later.
 error-could-not-add-email = Could not add email address to database.
-error-not-subscribed = This email address is not subscribed to {-product-name}.
-error-hibp-throttled = Too many connections to {-brand-HIBP}.
-error-hibp-connect = Error connecting to {-brand-HIBP}.
+error-not-subscribed = This email address is not subscribed to { -product-name }.
+error-hibp-throttled = Too many connections to { -brand-HIBP }.
+error-hibp-connect = Error connecting to { -brand-HIBP }.
 error-hibp-load-breaches = Could not load breaches.
-error-must-be-signed-in = You must be signed in to your {-brand-fxa}.
-error-to-finish-verifying = To finish verifying this email for {-product-name}, you must be signed in under your primary account email.
+error-must-be-signed-in = You must be signed in to your { -brand-fxa }.
+error-to-finish-verifying = To finish verifying this email for { -product-name }, you must be signed in under your primary account email.
 
-home-title = {-product-name}
+home-title = { -product-name }
 home-not-found = Page not found.
 
 oauth-invalid-session = Invalid session
 
-scan-title = {-product-name} : Scan Results
+scan-title = { -product-name } : Scan Results
 
 user-add-invalid-email = Invalid Email
 user-add-too-many-emails = You are monitoring the maximum number of email addresses.
-user-add-email-verify-subject = Verify your subscription to {-product-name}.
-user-add-duplicate-email = This email has already been added to {-product-name}.
+user-add-email-verify-subject = Verify your subscription to { -product-name }.
+user-add-duplicate-email = This email has already been added to { -product-name }.
 user-add-duplicate-email-part-2 = Visit your { $preferencesLink } to check the status of { $userEmail }.
 
 error-headline = Error
 user-verify-token-error = Verification token is required.
-user-verify-email-report-subject = Your {-product-name} report
+user-verify-email-report-subject = Your { -product-name } report
 
 user-unsubscribe-token-error = Unsubscribing requires a token.
 user-unsubscribe-token-email-error = Unsubscribing requires a token and emailHash.
-user-unsubscribe-title = {-product-name} : Unsubscribe
+user-unsubscribe-title = { -product-name } : Unsubscribe
 
 pwt-section-headline = Stronger Passwords = Better Protection
 
@@ -59,15 +59,15 @@ scan-placeholder = Enter Email Address
 scan-submit = Search Your Email
 scan-error = Must be a valid email.
 
-download-firefox-banner-button = Download {-brand-name}
+download-firefox-banner-button = Download { -brand-name }
 
-# Appears after Firefox Monitor has sent a verification email to a new user. 
+# Appears after Firefox Monitor has sent a verification email to a new user.
 signup-modal-sent = Sent!
 
 sign-up = Sign Up
 form-signup-error = Must be a valid email
 
-# breach-date = the calendar date a particular data theft occurred. 
+# breach-date = the calendar date a particular data theft occurred.
 breach-date = Breach date:
 
 # compromised accounts = the total number of user accounts exposed in data breach
@@ -76,17 +76,17 @@ compromised-accounts = Compromised accounts:
 # compromised-data = the kind of user data exposed to hackers in data breach.
 compromised-data = Compromised data:
 
-unsub-headline = Unsubscribe from {-product-name-nowrap}
-unsub-blurb = This will remove your email from the {-product-name-nowrap} list and you will no longer receive alerts when new breaches are announced. 
+unsub-headline = Unsubscribe from { -product-name-nowrap }
+unsub-blurb = This will remove your email from the { -product-name-nowrap } list and you will no longer receive alerts when new breaches are announced.
 unsub-button = Unsubscribe
 
 # Breach data provided by Have I Been Pwned.
 hibp-attribution = Breach data provided by { $hibp-link }
 
-share-twitter = Most people have about 100 online accounts. Have any of yours been exposed in a data breach? Find out. 
+share-twitter = Most people have about 100 online accounts. Have any of yours been exposed in a data breach? Find out.
 share-facebook-headline = Find out if you’ve been part of a data breach
 share-facebook-blurb = Have your online accounts been exposed in a data breach?
-og-site-description = Find out if you’ve been part of a data breach with {-product-name}. Sign up for alerts about future breaches and get tips to keep your accounts safe. 
+og-site-description = Find out if you’ve been part of a data breach with { -product-name }. Sign up for alerts about future breaches and get tips to keep your accounts safe.
 
 show-all = Show All
 
@@ -95,43 +95,43 @@ fxa-scan-another-email = Want to check another email?
 sign-out = Sign Out
 
 # Manage Firefox Account, link to page where account holders can change their account settings.
-manage-fxa = Manage {-brand-fxa}
+manage-fxa = Manage { -brand-fxa }
 
 have-an-account = Have an account?
 
 fxa-pwt-summary-2 =
-  Short, single-word passwords are easy for hackers to guess. 
+  Short, single-word passwords are easy for hackers to guess.
   Use at least two words and a combination of letters, digits, and special characters.
 
 fxa-pwt-summary-4 =
-  Password managers like 1Password, LastPass, Dashlane, and Bitwarden store your 
+  Password managers like 1Password, LastPass, Dashlane, and Bitwarden store your
   passwords and fill them in to websites for you. They’ll even help you make strong passwords.
 
 fxa-pwt-summary-6 =
-  Data breaches are on the rise. If your personal info appears in a new data breach, 
-  {-product-name} sends you an alert — so you can take action and protect your accounts. 
+  Data breaches are on the rise. If your personal info appears in a new data breach,
+  { -product-name } sends you an alert — so you can take action and protect your accounts.
 
 fxa-what-to-do-blurb-1 =
-  If you can’t log in, contact the website to ask how to update it. 
-  See an account you don’t recognize? Your data could have been sold 
-  or redistributed. This could also be an account you forgot you 
+  If you can’t log in, contact the website to ask how to update it.
+  See an account you don’t recognize? Your data could have been sold
+  or redistributed. This could also be an account you forgot you
   created or a company that changed names.
 
 fxa-what-to-do-subhead-2 = Stop using the exposed password, and change it everywhere you’ve used it.
 fxa-wtd-blurb-2 =
-  Hackers may try to use that same password and your email to get in to other accounts.  
-  Create a different and unique password for every account, especially for your bank account, 
+  Hackers may try to use that same password and your email to get in to other accounts.
+  Create a different and unique password for every account, especially for your bank account,
   email, and other websites where you save personal information.
 
-fxa-what-to-do-blurb-3 = 
-  Most breaches only expose emails and passwords, but some do include sensitive financial information. 
-  If your bank account or credit card numbers were exposed, alert your bank to possible fraud. 
+fxa-what-to-do-blurb-3 =
+  Most breaches only expose emails and passwords, but some do include sensitive financial information.
+  If your bank account or credit card numbers were exposed, alert your bank to possible fraud.
   Monitor statements for charges you don’t recognize.
 
 fxa-what-to-do-subhead-4 = Get help remembering all your passwords and keeping them safe.
 fxa-what-to-do-blurb-4 =
-  Password managers like 1Password, LastPass, Dashlane, and Bitwarden store your 
-  passwords securely and fill them into websites for you. Use a password manager 
+  Password managers like 1Password, LastPass, Dashlane, and Bitwarden store your
+  passwords securely and fill them into websites for you. Use a password manager
   on your phone and computer so you don’t have to remember them all.
 
 # Alerts is a noun
@@ -140,7 +140,7 @@ sign-up-for-alerts = Sign Up for Alerts
 # Link title
 frequently-asked-questions = Frequently Asked Questions
 
-about-firefox-monitor = About {-product-name}
+about-firefox-monitor = About { -product-name }
 
 # Link title
 preferences = Preferences
@@ -154,10 +154,10 @@ breaches = Breaches
 # Link title
 security-tips = Security Tips
 
-fxa-account = {-brand-fxa}
+fxa-account = { -brand-fxa }
 
 # Aria button message to open menu. "Open Firefox Account Navigation"
-open-fxa-menu = Open {-brand-fxa} navigation
+open-fxa-menu = Open { -brand-fxa } navigation
 
 # Appears above a snippet about the breach most recently reported to Firefox Monitor.
 latest-breach = LATEST BREACH ADDED
@@ -171,7 +171,7 @@ read-more-tips = Read More Security Tips
 
 how-hackers-work = Understand how hackers work
 
-monitor-your-online-accounts = Sign up for breach monitoring with a {-brand-fxa}.
+monitor-your-online-accounts = Sign up for breach monitoring with a { -brand-fxa }.
 stay-alert = Stay alert to new breaches
 if-your-info = If your information surfaces in a new data breach, we’ll send you an alert.
 search-all-emails = Search all your email addresses for breaches and get alerts about new threats.
@@ -193,53 +193,53 @@ spam-list-breach-plural = Spam List Breaches
 
 what-data = What data was compromised:
 
-sensitive-sites = How does {-product-name} treat sensitive sites?
-sensitive-sites-copy = {-product-name} only reveals accounts associated with these 
-  types of breaches after an email address has been verified. This means you’re the 
-  only person who can see if your information was in this breach (unless someone 
+sensitive-sites = How does { -product-name } treat sensitive sites?
+sensitive-sites-copy = { -product-name } only reveals accounts associated with these
+  types of breaches after an email address has been verified. This means you’re the
+  only person who can see if your information was in this breach (unless someone
   else has access to your email account).
 
 delayed-reporting-headline = Why did it take so long to report this breach?
-delayed-reporting-copy = It can sometimes take months or years for credentials exposed 
-  in a data breach to appear on the dark web. Breaches get added to our database as 
-  soon as they have been discovered and verified. 
+delayed-reporting-copy = It can sometimes take months or years for credentials exposed
+  in a data breach to appear on the dark web. Breaches get added to our database as
+  soon as they have been discovered and verified.
 
-about-fxm-headline = About {-product-name}
-about-fxm-blurb = {-product-name} warns if your online accounts were involved in a 
-  data breach. Find out if you’ve been in a data breach, get alerts about new breaches, 
-  and take steps to protect your online accounts. {-product-name} is provided 
-  by {-brand-Mozilla}.
+about-fxm-headline = About { -product-name }
+about-fxm-blurb = { -product-name } warns if your online accounts were involved in a
+  data breach. Find out if you’ve been in a data breach, get alerts about new breaches,
+  and take steps to protect your online accounts. { -product-name } is provided
+  by { -brand-Mozilla }.
 
-fxm-warns-you = {-product-name} warns you if your email address has been exposed 
-  in an online data breach. See if your information has been exposed, learn how 
-  to better protect your online accounts, and get alerted if your email address 
+fxm-warns-you = { -product-name } warns you if your email address has been exposed
+  in an online data breach. See if your information has been exposed, learn how
+  to better protect your online accounts, and get alerted if your email address
   appears in a new breach.
 
 # How Firefox Monitor works
-how-fxm-works = How {-product-name} works
+how-fxm-works = How { -product-name } works
 
 how-fxm-1-headline = Conduct a basic search
-how-fxm-1-blurb = Search for your email address in public data breaches going 
-  back to 2007. This basic search will surface most data breaches, but not 
+how-fxm-1-blurb = Search for your email address in public data breaches going
+  back to 2007. This basic search will surface most data breaches, but not
   ones that contain sensitive personal information.
 
 how-fxm-2-headline = Sign up for breach monitoring
-how-fxm-2-blurb = Create a {-brand-fxa} to monitor your email for ongoing breaches. 
-  Once you’ve verified your email, you’ll also receive a full report of past breaches, 
-  including sensitive breaches. 
+how-fxm-2-blurb = Create a { -brand-fxa } to monitor your email for ongoing breaches.
+  Once you’ve verified your email, you’ll also receive a full report of past breaches,
+  including sensitive breaches.
 
 how-fxm-3-headline = Get notifications in your browser
-how-fxm-3-blurb = If you use {-brand-name}, you’ll receive a notification if you visit a 
-  site that’s been breached. Find out right away if you were part of that breach 
+how-fxm-3-blurb = If you use { -brand-name }, you’ll receive a notification if you visit a
+  site that’s been breached. Find out right away if you were part of that breach
   and what you can do about it.
 
 wtd-after-website = What to do after a website breach:
 wtd-after-data-agg = What to do after a data aggregator breach:
 
 what-is-data-agg = What is a data aggregator?
-what-is-data-agg-blurb = Data aggregators, or data brokers, collect information from public 
-  records and buy it from other companies. They compile this data to sell it to companies 
-  for marketing purposes. Victims of these breaches are less likely to experience financial 
+what-is-data-agg-blurb = Data aggregators, or data brokers, collect information from public
+  records and buy it from other companies. They compile this data to sell it to companies
+  for marketing purposes. Victims of these breaches are less likely to experience financial
   fraud, but hackers could use this data to impersonate or profile them.
 
 protect-your-privacy = Protect your online privacy
@@ -262,14 +262,14 @@ stop-reusing-pw = Stop reusing the same passwords
 create-unique-pw = Create unique passwords and save them somewhere safe, like a password manager.
 five-myths = 5 myths about password managers
 
-create-a-fxa = Create a {-brand-fxa} for your full report of breaches and to get alerts.
+create-a-fxa = Create a { -brand-fxa } for your full report of breaches and to get alerts.
 
 feat-security-tips = Security tips to protect your accounts
 feat-sensitive = Advanced search in sensitive breaches
 feat-enroll-multiple = Enroll multiple emails in breach monitoring
 
 # This string is shown beneath each of the user’s email addresses to indicate
-# how many known breaches that email address was found in. 
+# how many known breaches that email address was found in.
 appears-in-x-breaches =
   { $breachCount ->
         [one] Appears in { $breachCount } known breach.
@@ -295,7 +295,7 @@ send-verification = Send Verification Link
 # This string is a header on the user preferences page and
 # appears above a check-box list of user options which allow
 # the user to choose whether or not they want to receive breach
-# alerts for all of their monitored email addresses to a single 
+# alerts for all of their monitored email addresses to a single
 # email address.
 breach-summary = Breach Summary
 
@@ -303,8 +303,8 @@ show-breaches-for-this-email = Show all breaches for this email.
 
 link-change-primary = Change Primary Email Address
 
-remove-fxm = Remove {-product-name}
-remove-fxm-blurb = Turn off {-product-name} alerts. Your {-brand-fxa} will remain active, and you may receive 
+remove-fxm = Remove { -product-name }
+remove-fxm-blurb = Turn off { -product-name } alerts. Your { -brand-fxa } will remain active, and you may receive
   other account-related communications.
 
 # Button title
@@ -318,35 +318,35 @@ welcome-user = Welcome, { $userName }!
 
 
 
-breach-alert-subject = {-product-name} found your email in a new data breach
+breach-alert-subject = { -product-name } found your email in a new data breach
 
 
 your-info-was-discovered-headline = Your information was discovered in a new data breach.
-your-info-was-discovered-blurb = You’re signed up to receive {-product-name} alerts 
+your-info-was-discovered-blurb = You’re signed up to receive { -product-name } alerts
   when your email appears in a data breach. Here’s what we know about this breach.
 
 what-to-do-after-breach = What to do after a data breach
 
 ba-next-step-1 = Change your password to a strong, unique password.
 ba-next-step-blurb-1 =
-  A strong password uses a combination of upper and lowercase letters, 
-  special characters, and numbers. It doesn’t contain personal info like 
+  A strong password uses a combination of upper and lowercase letters,
+  special characters, and numbers. It doesn’t contain personal info like
   your address, birthday, or family names.
 
 ba-next-step-2 = Stop using that exposed password entirely.
 ba-next-step-blurb-2 =
-  Cyber criminals could find your password on the dark web and use it 
-  to log in to your other accounts. The best way to protect your accounts 
+  Cyber criminals could find your password on the dark web and use it
+  to log in to your other accounts. The best way to protect your accounts
   is to use unique passwords for each one.
 
 ba-next-step-3 = Get help creating better passwords and keeping them safe.
 ba-next-step-blurb-3 =
-  Use a password manager to create strong, unique passwords. Password managers securely store all your 
+  Use a password manager to create strong, unique passwords. Password managers securely store all your
   logins so you can access them across all your devices.
 
 faq1 = I don’t recognize this company or website. Why am I in this breach?
 faq2 = Why did it take so long to notify me of this breach?
-faq3 = How do I know this is a legitimate email from {-product-name}?
+faq3 = How do I know this is a legitimate email from { -product-name }?
 
 new-breaches-found =
   { $breachCount ->
@@ -354,8 +354,8 @@ new-breaches-found =
       [other] { $breachCount } NEW BREACHES FOUND
   }
 
-sign-up-headline-1 = Get ongoing alerts with a {-brand-fxa}.
-account-not-required = {-brand-name} browser not required for a {-brand-fxa}. You may receive info about {-brand-Mozilla} services.
+sign-up-headline-1 = Get ongoing alerts with a { -brand-fxa }.
+account-not-required = { -brand-name } browser not required for a { -brand-fxa }. You may receive info about { -brand-Mozilla } services.
 
 was-your-info-exposed = Was your info exposed in the { $breachName } data breach?
 find-out-if = Find out if your data was exposed in this breach.
@@ -365,11 +365,11 @@ fb-not-comp = This email did not appear in the { $breachName } breach.
 other-breaches-found =
   { $breachCount ->
     [one] However, it did appear in { $breachCount } other breach.
-   *[other] However, it did appear in { $breachCount } other breaches. 
+   *[other] However, it did appear in { $breachCount } other breaches.
   }
 
 fb-comp-only = This email appeared in the { $breachName } breach.
-fb-comp-and-others = 
+fb-comp-and-others =
   { $breachCount ->
    *[other] This email appeared in { $breachCount } known data breaches, including { $breachName }.
   }
@@ -377,7 +377,7 @@ fb-comp-and-others =
 no-other-breaches-found = No other breaches found from a basic search.
 
 no-results-blurb = Sorry, that breach is not in our database.
-all-breaches-headline = All breaches in {-product-name}
+all-breaches-headline = All breaches in { -product-name }
 search-breaches = Search Breaches
 
 # This string contains nested markup that is later used to style and link the text inside of it.
@@ -393,7 +393,7 @@ facebook-breach-note = <span>Your email doesn’t appear in this leak,
 # Please do not modify or remove "<a>", "</a>", "<span>" and "</span>".
 facebook-breach-what-to-do-1-headline = <span>Set your information to “Only me” or other non-public setting in <a>your Facebook profile</a>.</span>
 
-facebook-breach-what-to-do-1-copy = During this leak, hackers took profile 
+facebook-breach-what-to-do-1-copy = During this leak, hackers took profile
   information that was set as “open to the public” or “shared with friends.”
   This information can be combined with other data to access even more of
   your personal information and accounts.
@@ -415,22 +415,22 @@ currently-showing = Showing:
 ## Updated error messages
 
 error-bot-headline = Searches temporarily suspended
-error-bot-blurb = We’re worried you might be a bot because you searched 
-  several email addresses in a short time period. For now, you’re blocked 
+error-bot-blurb = We’re worried you might be a bot because you searched
+  several email addresses in a short time period. For now, you’re blocked
   from new searches. You can try again later.
 
 error-csrf-headline = Session timed out
 error-csrf-blurb = Select your browser’s back button, reload the page, and try again.
 
-error-invalid-unsub = How to unsubscribe from {-product-name} alerts
-error-invalid-unsub-blurb = You’ll need to unsubscribe from one of the 
-  emails {-product-name} sent you. Check your inbox for messages from 
-  {-brand-team-email}. Select the unsubscribe link at the bottom of the email.
+error-invalid-unsub = How to unsubscribe from { -product-name } alerts
+error-invalid-unsub-blurb = You’ll need to unsubscribe from one of the
+  emails { -product-name } sent you. Check your inbox for messages from
+  { -brand-team-email }. Select the unsubscribe link at the bottom of the email.
 
 # This string is displayed under a large numeral that indicates the total number
 # of email address a user has signed up for monitoring. Don’t add $emails to
 # your localization, because it would result in the number showing twice.
-email-addresses-being-monitored = 
+email-addresses-being-monitored =
   { $emails ->
    *[one] Email address being monitored
     [other] Email addresses being monitored
@@ -440,7 +440,7 @@ email-addresses-being-monitored =
 # This string is displayed under a large numeral that indicates the total number
 # of data breaches that exposed a user’s password. Don’t add $passwords to
 # your localization, because it would result in the number showing twice.
-passwords-exposed = 
+passwords-exposed =
   { $passwords ->
     [one] Password exposed across all breaches
    *[other] Passwords exposed across all breaches
@@ -469,9 +469,9 @@ scan-results-known-breaches =
 # In page, it reads "Results for: searchedEmail@monitor.com"
 results-for = Results for: { $userEmail }
 
-other-monitored-emails = Other Monitored Emails 
-email-verification-required = Email Verification Required 
-fxa-primary-email = {-brand-fxa} Email - Primary
+other-monitored-emails = Other Monitored Emails
+email-verification-required = Email Verification Required
+fxa-primary-email = { -brand-fxa } Email - Primary
 
 what-is-a-website-breach = What is a website breach?
 website-breach-blurb = A website data breach happens when cyber criminals steal, copy, or expose personal information from online accounts. It’s usually a result of hackers finding a weak spot in the website’s security. Breaches can also happen when account information gets leaked by accident.
@@ -487,14 +487,14 @@ see-if-youve-been-part = See if you’ve been part of an online data breach.
 get-ongoing-breach-monitoring = Get ongoing breach monitoring for multiple email addresses.
 
 # This is a button and follows a headline reading "Was your info exposed in the ___ breach?"
-find-out = Find Out 
+find-out = Find Out
 
-new-unsub-error = You’ll need to unsubscribe from one of the emails {-product-name} sent.
+new-unsub-error = You’ll need to unsubscribe from one of the emails { -product-name } sent.
 
 other-known-breaches-found =
   { $breachCount ->
     [one] However, it did appear in { $breachCount } other known breach.
-   *[other] However, it did appear in { $breachCount } other known breaches. 
+   *[other] However, it did appear in { $breachCount } other known breaches.
   }
 
 # This string appears on breach detail pages and is followed by a list
@@ -513,23 +513,23 @@ breach-overview-title = Overview
 # $breachDate and $addedDate are calendar dates.
 breach-overview-new = On { $breachDate }, { $breachTitle } was breached. Once the breach was discovered and verified, it was added to our database on { $addedDate }.
 
-# Title appearing on the Preferences dashboard. 
-monitor-preferences = {-product-short-name} Preferences
+# Title appearing on the Preferences dashboard.
+monitor-preferences = { -product-short-name } Preferences
 
-# When a user is signed in, this appears in the drop down menu 
-# and is followed by the user's primary Firefox Account email. 
+# When a user is signed in, this appears in the drop down menu
+# and is followed by the user's primary Firefox Account email.
 signed-in-as = Signed in as: { $userEmail }
 
 # Appears on the All Breaches page and is followed by a list of filter options
 # that a user can filter the visible breaches by.
-filter-by = Filter by Category: 
+filter-by = Filter by Category:
 
 # Title that appears in the mobile menu bar and opens the mobile menu when clicked.
 menu = Menu
 to-affected-email = Send breach alerts to the affected email address
 
 # This string appears in a banner at the top of each page and is followed by a "Learn More" link.
-join-firefox = There is a way to protect your privacy. Join {-brand-name}.
+join-firefox = There is a way to protect your privacy. Join { -brand-name }.
 
 # Link title
 learn-more-link = Learn more.
@@ -541,7 +541,7 @@ want-to-add = Want to add another email?
 
 # This is part of a confirmation message that appears after a user has submitted
 # the form to add an additional email to Firefox Monitor.
-verify-the-link = Verify the link sent to { $userEmail } to add it to {-product-name}.
+verify-the-link = Verify the link sent to { $userEmail } to add it to { -product-name }.
 
 ## These are part of a confirmation page that appears after a user has verified
 ## an additional email to Firefox Monitor.
@@ -566,12 +566,12 @@ manage-all-emails = Manage all email addresses in { $preferencesLink }.
 # This string is a header on the user preferences page and
 # appears above a check-box list of user options which allow
 # the user to choose whether or not they want to receive breach
-# alerts for all of their monitored email addresses to a single 
+# alerts for all of their monitored email addresses to a single
 # email address.
 breach-alert-notifications = Breach Alert Notifications
 
 # This string is a label for the calendar date a breach is added to the database
-# and is followed by that date. 
+# and is followed by that date.
 breach-added-label = Breach added:
 
 how-hackers-work-desc = Protect your passwords from cyber criminals, since that’s what they care about most.
@@ -611,9 +611,9 @@ marking-this-subhead = Marking this breach as resolved
 
 # This string contains nested markup that is later used to style the text inside of it.
 # Please do not modify or remove "<span>" and "</span>".
-marking-this-body = 
+marking-this-body =
   <span>Once you’ve taken the steps you can to address this breach</span>,
-  you can mark it as resolved. You can still access details about the breach 
+  you can mark it as resolved. You can still access details about the breach
   from your dashboard at any time.
 
 
@@ -634,7 +634,7 @@ confirmation-3-subhead = Another one down. Nice work!
 confirmation-3-body = Is your new password unique, strong, and hard to guess? <a>Find out</a>
 
 generic-confirmation-subhead = This breach has been marked as resolved
-generic-confirmation-message = 
+generic-confirmation-message =
   { $numUnresolvedBreaches ->
      [one] To see the remaining breach, go to your dashboard.
     *[other] To see all remaining breaches, go to your dashboard.
@@ -649,41 +649,41 @@ progress-percent-complete = { $percentComplete }% complete
 
 # This string appears in the purple callouts at the top of the user dashboard and shows
 # the total number of breaches a user has resolved. For instance, "5 Resolved".
-num-resolved = 
+num-resolved =
   { $numResolvedBreaches ->
      *[other] { $numResolvedBreaches } Resolved
   }
 
 progress-intro-subhead = New in { -product-name }: Mark breaches as resolved
 progress-intro-message =
-  After reviewing the details about a breach and taking steps to protect 
+  After reviewing the details about a breach and taking steps to protect
   your personal info, you can mark breaches as resolved.
-progress-status = 
+progress-status =
   { $numTotalBreaches ->
-     *[other] { $numResolvedBreaches} out of { $numTotalBreaches } breaches marked as resolved
+     *[other] { $numResolvedBreaches } out of { $numTotalBreaches } breaches marked as resolved
   }
 progress-complete = All known breaches have been marked as resolved
 
 ## These strings contain nested markup that is later used to style the text inside of it.
 ## Please do not modify or remove "<span>" and "</span>".
 
-progress-message-1 = 
-  <span>You’re off to a great start!</span> Check out the remaining breaches to learn 
-  what steps to take.  
-progress-message-2 = 
-  <span>Keep it up!</span> Small changes like updating passwords have a big impact on 
+progress-message-1 =
+  <span>You’re off to a great start!</span> Check out the remaining breaches to learn
+  what steps to take.
+progress-message-2 =
+  <span>Keep it up!</span> Small changes like updating passwords have a big impact on
   keeping your personal info safe.
 progress-message-3 = <span>Nice work resolving those breaches!</span> Keep it up. You’ve got a few more to go.
 progress-message-4 = <span>Almost done!</span> You’re close to the finish line.
-progress-complete-message = 
-  <span>Feels good, right?</span> If you want to keep going, this is a good time to 
+progress-complete-message =
+  <span>Feels good, right?</span> If you want to keep going, this is a good time to
   update other logins with stronger passwords.
 
 ##
 
 resolve-this-breach-link = Resolve this breach
 
-# This string appears in resolved breach cards and is followed by 
+# This string appears in resolved breach cards and is followed by
 # the date the user marked the breach as resolved.
 marked-resolved = Marked resolved:
 
@@ -696,7 +696,7 @@ unresolved-passwords-exposed =
    *[other] Passwords exposed in unresolved breaches
   }
 
-known-data-breaches-resolved = 
+known-data-breaches-resolved =
   { $numResolvedBreaches ->
     [one] Known data breach marked as resolved
    *[other] Known data breaches marked as resolved
@@ -706,8 +706,8 @@ known-data-breaches-resolved =
 new-breach = New
 
 mobile-promo-headline = Bring { -brand-name } to your phone and tablet
-mobile-promo-body = 
-  Fast, private, and safe browsing everywhere you go. Find { -brand-name } in the Google Play and App Store. 
+mobile-promo-body =
+  Fast, private, and safe browsing everywhere you go. Find { -brand-name } in the Google Play and App Store.
 mobile-promo-cta = Get { -brand-name } on Android and iOS
 
 promo-lockwise-headline = Take your passwords everywhere
@@ -716,7 +716,7 @@ lockwise-promo-body =
 promo-lockwise-cta = Get { -brand-lockwise }
 
 fpn-promo-headline = Mask your location from websites and trackers
-promo-fpn-body = 
+promo-fpn-body =
   { -brand-fpn } throws off the websites and data collectors that profile you with ads by masking your real IP address.
 promo-fpn-cta = Get { -brand-fpn }
 
@@ -725,14 +725,14 @@ monitor-promo-body =
   Get notified the next time your personal info gets exposed in a known breach.
 
 ecosystem-promo-headline = Protect your life online with privacy-first products
-ecosystem-promo-body = 
+ecosystem-promo-body =
   All { -brand-name } products honor our Personal Data Promise: Take less. Keep it safe. No secrets.
 promo-ecosystem-cta = See All Products
 
 steps-to-resolve-headline = Steps to resolve this breach
 
 vpn-promo-headline = Now’s the time to boost your safety online.
-vpn-promo-copy = { -brand-Mozilla }’s Virtual Private Network helps shield your internet connection from hackers and spies. 
+vpn-promo-copy = { -brand-Mozilla }’s Virtual Private Network helps shield your internet connection from hackers and spies.
 vpn-promo-cta = Get { -brand-mozilla-vpn }
 
 vpn-promo-headline-new = Save 50% with a full year subscription
@@ -816,11 +816,11 @@ ad-unit-6-before-you-complete = Before you complete that next signup, use an ema
 
 ## Search Engine Optimization
 
-meta-desc = Find out if you’ve been part of a data breach with {-brand-fx-monitor}. Sign up for alerts about future breaches and get tips to keep your accounts safe. 
+meta-desc = Find out if you’ve been part of a data breach with { -brand-fx-monitor }. Sign up for alerts about future breaches and get tips to keep your accounts safe.
 
 ## Header
 
-brand-fx-monitor = {-brand-fx-monitor}
+brand-fx-monitor = { -brand-fx-monitor }
 sign-in = Sign In
 
 ## Site navigation
@@ -834,16 +834,16 @@ site-nav-help-link = Help and Support
 menu-button-title = User menu
 menu-button-alt = Open user menu
 menu-list-accessible-label = Account menu
-menu-item-fxa = Manage your {-brand-fx-account}
+menu-item-fxa = Manage your { -brand-fx-account }
 menu-item-settings = Settings
 menu-item-help = Help and support
 menu-item-logout = Sign out
 
 ## Footer
 
-mozilla = {-brand-mozilla}
+mozilla = { -brand-Mozilla }
 terms-and-privacy = Terms & Privacy
-github = {-brand-github}
+github = { -brand-github }
 
 ## Error page
 

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -41,6 +41,9 @@ user-add-invalid-email = Invalid Email
 user-add-too-many-emails = You are monitoring the maximum number of email addresses.
 user-add-email-verify-subject = Verify your subscription to { -product-name }.
 user-add-duplicate-email = This email has already been added to { -product-name }.
+# Variables:
+#   $preferencesLink (String) - Link to preferences
+#   $userEmail (String) - User email address
 user-add-duplicate-email-part-2 = Visit your { $preferencesLink } to check the status of { $userEmail }.
 
 error-headline = Error
@@ -81,6 +84,8 @@ unsub-blurb = This will remove your email from the { -product-name-nowrap } list
 unsub-button = Unsubscribe
 
 # Breach data provided by Have I Been Pwned.
+# Variables:
+#   $hibp-link (String) - Link to Have I Been Pwned
 hibp-attribution = Breach data provided by { $hibp-link }
 
 share-twitter = Most people have about 100 online accounts. Have any of yours been exposed in a data breach? Find out.
@@ -270,6 +275,8 @@ feat-enroll-multiple = Enroll multiple emails in breach monitoring
 
 # This string is shown beneath each of the user’s email addresses to indicate
 # how many known breaches that email address was found in.
+# Variables:
+#   $breachCount (Integer) - Number of breaches
 appears-in-x-breaches =
   { $breachCount ->
         [one] Appears in { $breachCount } known breach.
@@ -284,6 +291,8 @@ search-for-your-email = Search for your email address in public data breaches go
 back-to-top = Back to Top
 
 comm-opt-0 = Email me if one of my email addresses below appears in a data breach.
+# Variables:
+#   $primaryEmail (String) - User primary email address
 comm-opt-1 = Send all breach alerts to { $primaryEmail }.
 
 stop-monitoring-this = Stop monitoring this email.
@@ -313,10 +322,13 @@ manage-email-addresses = Manage Email Addresses
 # Link title
 latest-breach-link = See if you were in this breach
 
+## Variables:
+##   $userName (String) - Username
+
 welcome-back = Welcome back, { $userName }!
 welcome-user = Welcome, { $userName }!
 
-
+##
 
 breach-alert-subject = { -product-name } found your email in a new data breach
 
@@ -348,6 +360,8 @@ faq1 = I don’t recognize this company or website. Why am I in this breach?
 faq2 = Why did it take so long to notify me of this breach?
 faq3 = How do I know this is a legitimate email from { -product-name }?
 
+# Variables:
+#   $breachCount (Integer) - Number of breaches
 new-breaches-found =
   { $breachCount ->
      *[one] { $breachCount } NEW BREACH FOUND
@@ -357,11 +371,16 @@ new-breaches-found =
 sign-up-headline-1 = Get ongoing alerts with a { -brand-fxa }.
 account-not-required = { -brand-name } browser not required for a { -brand-fxa }. You may receive info about { -brand-Mozilla } services.
 
+## Variables:
+##   $breachName (String) - Number of the breach
+
 was-your-info-exposed = Was your info exposed in the { $breachName } data breach?
 find-out-if = Find out if your data was exposed in this breach.
 
 fb-not-comp = This email did not appear in the { $breachName } breach.
 
+# Variables:
+#   $breachCount (Integer) - Number of breaches
 other-breaches-found =
   { $breachCount ->
     [one] However, it did appear in { $breachCount } other breach.
@@ -369,10 +388,14 @@ other-breaches-found =
   }
 
 fb-comp-only = This email appeared in the { $breachName } breach.
+# Variables:
+#   $breachCount (Integer) - Number of breaches
 fb-comp-and-others =
   { $breachCount ->
    *[other] This email appeared in { $breachCount } known data breaches, including { $breachName }.
   }
+
+##
 
 no-other-breaches-found = No other breaches found from a basic search.
 
@@ -458,6 +481,8 @@ known-data-breaches-exposed =
 # Button
 see-additional-breaches = See Additional Breaches
 
+# Variables:
+#   $breachCount (Integer) - Number of breaches
 scan-results-known-breaches =
   { $breachCount ->
       [one] This email appeared in 1 known data breach.
@@ -467,6 +492,8 @@ scan-results-known-breaches =
 # This string is shown at the top of the scan results page and is followed
 # by the email address that the user searched.
 # In page, it reads "Results for: searchedEmail@monitor.com"
+# Variables:
+#   $userEmail (String) - User email address
 results-for = Results for: { $userEmail }
 
 other-monitored-emails = Other Monitored Emails
@@ -491,6 +518,8 @@ find-out = Find Out
 
 new-unsub-error = You’ll need to unsubscribe from one of the emails { -product-name } sent.
 
+# Variables:
+#   $breachCount (Integer) - Number of breaches
 other-known-breaches-found =
   { $breachCount ->
     [one] However, it did appear in { $breachCount } other known breach.
@@ -518,6 +547,8 @@ monitor-preferences = { -product-short-name } Preferences
 
 # When a user is signed in, this appears in the drop down menu
 # and is followed by the user's primary Firefox Account email.
+# Variables:
+#   $userEmail (String) - User email address
 signed-in-as = Signed in as: { $userEmail }
 
 # Appears on the All Breaches page and is followed by a list of filter options
@@ -541,12 +572,16 @@ want-to-add = Want to add another email?
 
 # This is part of a confirmation message that appears after a user has submitted
 # the form to add an additional email to Firefox Monitor.
+# Variables:
+#   $userEmail (String) - User email address
 verify-the-link = Verify the link sent to { $userEmail } to add it to { -product-name }.
 
 ## These are part of a confirmation page that appears after a user has verified
 ## an additional email to Firefox Monitor.
 
 email-verified = Email Successfully Verified!
+# Variables:
+#   $email (String) - User email address
 email-added-to-subscription = We’ll alert you if { $email } appears in a data breach.
 
 # This message is displayed after the user has verified their email address.
@@ -561,6 +596,8 @@ sign-in-nested = sign in
 # form to add an additional email to Firefox Monitor. { $preferencesLink } is a link
 # to the Preferences page. The code and text for the link is generated elsewhere
 # using the { preferences } string.
+# Variables:
+#   $preferencesLink (String) - Link to preferences
 manage-all-emails = Manage all email addresses in { $preferencesLink }.
 
 # This string is a header on the user preferences page and
@@ -598,8 +635,12 @@ see-additional-recs = See Additional Recommendations
 ## This string contains nested markup that becomes a link later in the code.
 ## Please do not modify or remove "<a>" and "</a>".
 
+# Variables:
+#   $affectedEmail (String) - User email address
 resolve-top-notification = { $affectedEmail } appeared in this breach. <a>What to do next</a>
 
+# Variables:
+#   $numAffectedEmails (Integer) - Number of affected email address
 resolve-top-notification-plural =
   { $numAffectedEmails ->
     *[other] { $numAffectedEmails } of your email addresses appeared in this breach. <a>What to do next</a>
@@ -634,6 +675,8 @@ confirmation-3-subhead = Another one down. Nice work!
 confirmation-3-body = Is your new password unique, strong, and hard to guess? <a>Find out</a>
 
 generic-confirmation-subhead = This breach has been marked as resolved
+# Variables:
+#   $numUnresolvedBreaches (Integer) - Number of resolved breaches
 generic-confirmation-message =
   { $numUnresolvedBreaches ->
      [one] To see the remaining breach, go to your dashboard.
@@ -645,10 +688,14 @@ go-to-dashboard-link = Go to Dashboard
 
 # This string appears above a breach resolution progress bar and indicates
 # the percentage of breaches a user has resolved. For instance, "27% complete".
+# Variables:
+#   $percentComplete (String) - Completion percentage
 progress-percent-complete = { $percentComplete }% complete
 
 # This string appears in the purple callouts at the top of the user dashboard and shows
 # the total number of breaches a user has resolved. For instance, "5 Resolved".
+# Variables:
+#   $numResolvedBreaches (Integer) - Number of resolved breaches
 num-resolved =
   { $numResolvedBreaches ->
      *[other] { $numResolvedBreaches } Resolved
@@ -658,6 +705,9 @@ progress-intro-subhead = New in { -product-name }: Mark breaches as resolved
 progress-intro-message =
   After reviewing the details about a breach and taking steps to protect
   your personal info, you can mark breaches as resolved.
+# Variables:
+#   $numResolvedBreaches (Integer) - Number of resolved breaches
+#   $numTotalBreaches (Integer) - Total number of breaches
 progress-status =
   { $numTotalBreaches ->
      *[other] { $numResolvedBreaches } out of { $numTotalBreaches } breaches marked as resolved
@@ -690,12 +740,16 @@ marked-resolved = Marked resolved:
 hide-resolved-button = Hide Resolved
 show-resolved-button = Show Resolved
 
+# Variables:
+#   $numPasswords (Integer) - Number of exposed passwords
 unresolved-passwords-exposed =
   { $numPasswords ->
     [one] Password exposed in unresolved breaches
    *[other] Passwords exposed in unresolved breaches
   }
 
+# Variables:
+#   $numResolvedBreaches (Integer) - Number of resolved breaches
 known-data-breaches-resolved =
   { $numResolvedBreaches ->
     [one] Known data breach marked as resolved
@@ -740,7 +794,10 @@ vpn-promo-copy-new = Protect your online data—and choose a VPN subscription pl
 
 ## VPN promotional banner.  HTML tags should not be translated, e.g. `<em>`
 
-# user's IP location is determined dynamically by 3rd-party, eg: "Your location: Los Angeles, CA".  The 3rd-party service provides its own localization.
+# Variables:
+#   $ip-location (String) - User's IP location is determined dynamically by 3rd-party,
+#                           eg: "Your location: Los Angeles, CA".  The 3rd-party service
+#                           provides its own localization.
 vpn-banner-location = Your location: { $ip-location }
 vpn-banner-protect-yourself-with-vpn = <em>Protect yourself</em> with { -brand-mozilla-vpn }.
 vpn-banner-protected-with-vpn = <em>Protected</em> with { -brand-mozilla-vpn }.
@@ -749,7 +806,8 @@ vpn-banner-title-2 = Your location can be tracked if you don’t use a VPN.
 vpn-banner-subtitle-2 = Protect your location and browse securely in 3 steps
 vpn-banner-status-protected = Current status: <em>Protected ✓</em>
 vpn-banner-status-not-protected = Current status: <em>Not protected ⚠</em>
-# user's IP address is determined dynamically, eg: "IP address: 192.168.1.1"
+# Variables:
+#   $ip-address (String) - User's IP address is determined dynamically, eg: "IP address: 192.168.1.1"
 vpn-banner-ip-address = IP address: { $ip-address }
 vpn-banner-step-1 = Subscribe to { -brand-mozilla-vpn }
 vpn-banner-step-2 = Select a VPN location

--- a/locales/en/bento.ftl
+++ b/locales/en/bento.ftl
@@ -1,24 +1,24 @@
-fx-monitor = {-product-name}
-pocket = {-brand-pocket}
-fx-send = {-brand-send}
-fx-lockwise = {-brand-lockwise}
+fx-monitor = { -product-name }
+pocket = { -brand-pocket }
+fx-send = { -brand-send }
+fx-lockwise = { -brand-lockwise }
 
-## If possible, keep "Firefox Browser" in English, but feel free 
+## If possible, keep "Firefox Browser" in English, but feel free
 ## to translate browser if that doesn't work for your language.
 
-fx-desktop = {-brand-name} Browser for Desktop
-fx-mobile = {-brand-name} Browser for Mobile
+fx-desktop = { -brand-name } Browser for Desktop
+fx-mobile = { -brand-name } Browser for Mobile
 
 ##
 
 # Aria label for the Bento button
-bento-button-title = {-brand-name} apps and services
+bento-button-title = { -brand-name } apps and services
 
 # Bento headline
-fx-makes-tech = {-brand-name} is tech that fights for your online privacy.
+fx-makes-tech = { -brand-name } is tech that fights for your online privacy.
 
 # A link at the bottom of the Bento menu
-made-by-mozilla = Made by {-brand-Mozilla}
+made-by-mozilla = Made by { -brand-Mozilla }
 
 # Aria label for button that closes the Bento menu
 mobile-close-bento-button-title = Close menu

--- a/locales/en/breaches.ftl
+++ b/locales/en/breaches.ftl
@@ -11,7 +11,7 @@ breach-chart-title = Breached data
 breach-heading-email = Data breaches for { $email-select }
 
 # $count is the number of emails a user has added out of $total allowed
-emails-monitored = 
+emails-monitored =
   {
     $total ->
       [one] { $count } of { $total } email monitored
@@ -79,11 +79,11 @@ breach-checklist-email-body = This can hide your true email address while forwar
 
 ## Prompts the user for changes when there is a breach detected of social security number
 
-# Credit reports list your bill payment history, loans, current debt, and other financial information. 
+# Credit reports list your bill payment history, loans, current debt, and other financial information.
 # They show where you work and live and whether you've been sued, arrested, or filed for bankruptcy.
 breach-checklist-ssn-header = Monitor your credit report for accounts, loans, or credit cards you don’t recognize.
-# A security freeze prevents prospective creditors from accessing your credit file. 
-# Creditors typically won't offer you credit if they can't access your credit reporting file, 
+# A security freeze prevents prospective creditors from accessing your credit file.
+# Creditors typically won't offer you credit if they can't access your credit reporting file,
 # so a security freeze, also called a credit freeze, prevents you or others from opening accounts in your name.
 # This will only be shown to users in the US.
 # Variables:
@@ -112,16 +112,16 @@ breach-checklist-pin-body = Make sure your new PIN, or any other PIN, doesn’t 
 # Variables:
 #   $mozillaVpnLink (string) - a link to the Mozilla VPN website, with { -breach-checklist-link-mozilla-vpn } as the label
 breach-checklist-ip-header-2 = Use the internet privately with a VPN, such as { $mozillaVpnLink }.
-breach-checklist-ip-body = Your IP address (Internet Protocol address) pinpoints your location and internet service provider. A VPN can hide your real IP address so you can use the internet privately.   
+breach-checklist-ip-body = Your IP address (Internet Protocol address) pinpoints your location and internet service provider. A VPN can hide your real IP address so you can use the internet privately.
 
 ## Prompts the user for changes when there is a breach detected of physical address
 
-breach-checklist-address-header = Change any passwords or PINs that include any part of your address.   
-breach-checklist-address-body = Addresses are easy to find in public records and can make those passwords and PINs easy to guess.   
+breach-checklist-address-header = Change any passwords or PINs that include any part of your address.
+breach-checklist-address-body = Addresses are easy to find in public records and can make those passwords and PINs easy to guess.
 
 ## Prompts the user for changes when there is a breach detected of date of birth
 
-breach-checklist-dob-header = Change any passwords or PINs that include your date of birth.  
+breach-checklist-dob-header = Change any passwords or PINs that include your date of birth.
 breach-checklist-dob-body = Birth dates are easy to find in public records, and people who find it could easily guess your PIN.
 
 ## Prompts the user for changes when there is a breach detected of phone number
@@ -145,5 +145,5 @@ breach-checklist-hp-body-2 = A password manager like { $passwordManagerLink } (w
 
 ## Prompts the user for changes when there is a breach detected of other types
 
-# NOTE: { $companyName } is a placeholder for the name of the company where the breach occurred 
-breach-checklist-general-header = Reach out to {$companyName} to inform them about this breach and ask for specific steps you can take.
+# NOTE: { $companyName } is a placeholder for the name of the company where the breach occurred
+breach-checklist-general-header = Reach out to { $companyName } to inform them about this breach and ask for specific steps you can take.

--- a/locales/en/breaches.ftl
+++ b/locales/en/breaches.ftl
@@ -54,6 +54,9 @@ breaches-all-resolved-cta-blurb = Would you like to monitor another email?
 breaches-all-resolved-cta-button = Add email address
 
 # $breachDate and $addedDate are dates that should be localized via JS DateTimeFormat(). $dataClasses is a list of strings from data-classes.ftl that should be localized via JS ListFormat()
+# Variables:
+#   $breachDate (String) - Date of the breach
+#   $companyName (String) - Name of the company where the breach occurred
 breach-description = On { $breachDate }, { $companyName } was breached. Once the breach was discovered and verified, it was added to our database on { $addedDate }. This breach included: { $dataClasses }
 
 ## Links that we might refer to when prompting the user to make changes after a breach
@@ -145,5 +148,7 @@ breach-checklist-hp-body-2 = A password manager like { $passwordManagerLink } (w
 
 ## Prompts the user for changes when there is a breach detected of other types
 
-# NOTE: { $companyName } is a placeholder for the name of the company where the breach occurred
+# Variables:
+#   $breachDate (String) - Date of the breach
+#   $companyName (String) - Name of the company where the breach occurred
 breach-checklist-general-header = Reach out to { $companyName } to inform them about this breach and ask for specific steps you can take.

--- a/locales/en/email-strings.ftl
+++ b/locales/en/email-strings.ftl
@@ -44,6 +44,9 @@ email-verify-blurb = Verify your email to add it to { -product-name } and sign u
 # Email headline
 email-found-breaches-hl = Here’s your summary of past data breaches
 
+## Variables:
+##   $userEmail (string) - User email address
+
 # Email headline
 email-breach-summary-for-email = Breach summary for { $userEmail }
 
@@ -52,6 +55,8 @@ email-no-breaches-hl = { $userEmail } appeared in 0 known data breaches
 
 # Email headline
 email-alert-hl = { $userEmail } appeared in a new data breach
+
+##
 
 # Subject line of email
 email-subject-found-breaches = { -product-name } found your info in these breaches
@@ -62,7 +67,8 @@ email-subject-no-breaches = { -product-name } found no known breaches
 # Subject line of email
 email-subject-verify = Verify your email for { -product-name }
 
-# { $fxmLink } is a link to Firefox Monitor and uses the text from { -product-name }.
+# Variables:
+#   $fxmLink (string) - Link to Firefox Monitor that uses the text from { -product-name }.
 learn-more-about-fxm = Learn more about { $fxmLink }
 
 email-sensitive-disclaimer = Due to the sensitive nature of this breach, emails involved are not publicly discoverable.
@@ -83,11 +89,17 @@ monitor-another-email = Want to monitor another email?
 
 ## 2022 email template. HTML tags should not be translated, e.g. `<a>`
 
+# Variables:
+#   $unsubscribe-link-attr (string) - Link to email unsubscribe
 email-2022-unsubscribe = You’re receiving this automated email as a subscriber of { -product-name }. <br>Feel free to change your email preferences at any time <a { $unsubscribe-link-attr }>here</a>.
 # Have I Been Pwned attribution
+# Variables:
+#   $hibp-link-attr (String) - Link to Have I Been Pwned
 email-2022-hibp-attribution = Breach data provided by <a { $hibp-link-attr }>{ -brand-HIBP }</a>
 
 ## Monthly email for unresolved breaches. HTML tags should not be translated, e.g. `<br>`
+## Variables:
+##   $email-address (string) - Email address
 
 email-unresolved-heading = You have unresolved breaches
 email-unresolved-subhead = Your email has been exposed. <br>Fix it right away with { -product-name }.
@@ -111,6 +123,8 @@ email-verify-subhead = Verify your email to start protecting your data after a b
 email-verify-simply-click = Simply click the link below to finish verifying your account.
 
 ## Breach report
+## Variables:
+##   $email-address (string) - Email address
 
 email-breach-summary = Here’s your data breach summary
 email-breach-detected = Search results for your { $email-address } account have detected that your email may have been exposed. We recommend you act now to resolve this breach.

--- a/locales/en/email-strings.ftl
+++ b/locales/en/email-strings.ftl
@@ -9,7 +9,7 @@
 -product-name-vpn = Mozilla VPN
 
 # A Firefox Monitor Report is an emailed statement from Firefox Monitor containing a list of known data breaches where the user’s email address was found amongst the stolen data.
-firefox-monitor-report = {-product-name} Report 
+firefox-monitor-report = { -product-name } Report
 report-date = Report Date:
 email-address = Email Address:
 
@@ -21,14 +21,14 @@ email-unsub-link =  Unsubscribe
 
 # This string appears in the footer of breach report and breach alert emails.
 # { $unsubLink } is a link to the user's dashboard where they can unsubscribe from Monitor
-# and uses the text from { email-unsub-link }. { $faqLink } is a link to the 
+# and uses the text from { email-unsub-link }. { $faqLink } is a link to the
 # Firefox Monitor SUMO page and uses the text from { frequently-asked-questions }.
-email-footer-blurb = You’re receiving this email because you signed up for {-product-name} 
+email-footer-blurb = You’re receiving this email because you signed up for { -product-name }
   alerts. No longer want these emails? { $unsubLink }. This is an automated email. For support, visit { $faqLink }.
 
 # This string appears in the footer of verification emails. { $faqLink } is a link
 # to the Firefox Monitor SUMO page and uses the text from { frequently-asked-questions }.
-email-verify-footer-copy = You’re receiving this email because you signed up for {-product-name} alerts. 
+email-verify-footer-copy = You’re receiving this email because you signed up for { -product-name } alerts.
   This is an automated email. For support, visit { $faqLink }.
 
 # Button text
@@ -39,7 +39,7 @@ see-all-breaches = See All Breaches
 
 # Headline of verification email
 email-link-expires = This link expires in 24 hours
-email-verify-blurb = Verify your email to add it to {-product-name} and sign up for breach alerts.
+email-verify-blurb = Verify your email to add it to { -product-name } and sign up for breach alerts.
 
 # Email headline
 email-found-breaches-hl = Here’s your summary of past data breaches
@@ -54,28 +54,28 @@ email-no-breaches-hl = { $userEmail } appeared in 0 known data breaches
 email-alert-hl = { $userEmail } appeared in a new data breach
 
 # Subject line of email
-email-subject-found-breaches = {-product-name} found your info in these breaches
+email-subject-found-breaches = { -product-name } found your info in these breaches
 
 # Subject line of email
-email-subject-no-breaches = {-product-name} found no known breaches
+email-subject-no-breaches = { -product-name } found no known breaches
 
 # Subject line of email
-email-subject-verify = Verify your email for {-product-name}
+email-subject-verify = Verify your email for { -product-name }
 
 # { $fxmLink } is a link to Firefox Monitor and uses the text from { -product-name }.
 learn-more-about-fxm = Learn more about { $fxmLink }
 
-email-sensitive-disclaimer = Due to the sensitive nature of this breach, emails involved are not publicly discoverable. 
+email-sensitive-disclaimer = Due to the sensitive nature of this breach, emails involved are not publicly discoverable.
   You’re receiving this alert because you’re the verified owner of this email address.
 
-fxm-warns-you-no-breaches = {-product-name} warns you about data breaches involving your personal info. 
+fxm-warns-you-no-breaches = { -product-name } warns you about data breaches involving your personal info.
   So far, no breaches were found. We’ll send you an alert if your email address appears in a new breach.
 
-fxm-warns-you-found-breaches = {-product-name} warns you about data breaches involving your personal info. 
+fxm-warns-you-found-breaches = { -product-name } warns you about data breaches involving your personal info.
   You’re also signed up to receive alerts if your email address appears in a new breach.
 
-email-breach-alert-blurb = 
-  {-product-name} warns you about data breaches involving your personal info. 
+email-breach-alert-blurb =
+  { -product-name } warns you about data breaches involving your personal info.
   We just received details about another company’s data breach.
 
 # Section headline
@@ -92,7 +92,7 @@ email-2022-hibp-attribution = Breach data provided by <a { $hibp-link-attr }>{ -
 email-unresolved-heading = You have unresolved breaches
 email-unresolved-subhead = Your email has been exposed. <br>Fix it right away with { -product-name }.
 email-is-affected = Your email, { $email-address }, is affected by at least one data breach
-email-more-detail = Sign in to { -product-name } now to see more details about your breaches (including when they occurred and what data was exposed), and learn what you should do when your email’s been exposed in a data breach. 
+email-more-detail = Sign in to { -product-name } now to see more details about your breaches (including when they occurred and what data was exposed), and learn what you should do when your email’s been exposed in a data breach.
 email-breach-status = Current breach status
 # table row 1 label
 email-monitored = Total emails monitored:
@@ -114,7 +114,7 @@ email-verify-simply-click = Simply click the link below to finish verifying your
 
 email-breach-summary = Here’s your data breach summary
 email-breach-detected = Search results for your { $email-address } account have detected that your email may have been exposed. We recommend you act now to resolve this breach.
-email-no-breach-detected = Great news! We’ve found no data breaches that affect your email, { $email-address }. 
+email-no-breach-detected = Great news! We’ve found no data breaches that affect your email, { $email-address }.
 email-dashboard-cta = Go to Dashboard
 
 ## Breach alert

--- a/locales/en/landing.ftl
+++ b/locales/en/landing.ftl
@@ -8,7 +8,7 @@ get-started = Get started
 
 ## Why use Firefox Monitor?
 
-why-use-monitor = Why use {-brand-fx-monitor}?
+why-use-monitor = Why use { -brand-fx-monitor }?
 identifying-breaches = Identifying and resolving data breaches is an important step in ensuring your online privacy.
 protect-account = Protect your accounts
 protect-account-prevent-hackers = Prevent hackers from getting into your accounts with breached passwords.
@@ -30,13 +30,13 @@ alerts-for-breaches-monitor-new = We’ll continually monitor for new data breac
 ## Your privacy is safe with us
 
 safe-with-us = Your privacy is safe with us
-parent-company = At {-brand-Mozilla}, the parent company of {-brand-firefox} and {-brand-fx-monitor}, we believe individuals’ security and privacy on the internet is fundamental and must not be treated as optional.
-our-mission = Our mission is to build a better internet — one where people can shape their own experiences, feel empowered and stay safe. We’re wholly owned by the {-brand-mozilla-foundation}, a non-profit, which enables us to put individual and public benefit over profit.
+parent-company = At { -brand-Mozilla }, the parent company of { -brand-firefox } and { -brand-fx-monitor }, we believe individuals’ security and privacy on the internet is fundamental and must not be treated as optional.
+our-mission = Our mission is to build a better internet — one where people can shape their own experiences, feel empowered and stay safe. We’re wholly owned by the { -brand-mozilla-foundation }, a non-profit, which enables us to put individual and public benefit over profit.
 learn-more-mission = Learn more about our mission
 
 ## Top questions about Firefox Monitor
 
-top-questions-about-monitor = Top questions about {-brand-fx-monitor}
+top-questions-about-monitor = Top questions about { -brand-fx-monitor }
 see-all-faq = See all FAQs
 
 # question and answer
@@ -45,11 +45,11 @@ when-info-exposed = A data breach happens when personal or private information g
 
 # question and answer
 what-do-i-do = I just found out I’m in a data breach. What do I do?
-visit-monitor-to-learn = Visit {-brand-fx-monitor} to learn what to do after a data breach. Hackers rely on people reusing passwords, so it’s important to create strong, unique passwords for all your accounts. Keep your passwords in a safe place that only you have access to; this could be the same place where you store important documents or a password manager. 
+visit-monitor-to-learn = Visit { -brand-fx-monitor } to learn what to do after a data breach. Hackers rely on people reusing passwords, so it’s important to create strong, unique passwords for all your accounts. Keep your passwords in a safe place that only you have access to; this could be the same place where you store important documents or a password manager.
 
 # question and answer
 what-gets-exposed = What information gets exposed in data breaches?
-depends-on-hackers = Not all breaches expose all the same info. It just depends on what hackers can access. Many data breaches expose email addresses and passwords. Others expose more sensitive information such as credit card numbers, passport numbers and social security numbers. 
+depends-on-hackers = Not all breaches expose all the same info. It just depends on what hackers can access. Many data breaches expose email addresses and passwords. Others expose more sensitive information such as credit card numbers, passport numbers and social security numbers.
 
 ## See if you’ve been in a data breach
 


### PR DESCRIPTION
This switches to v0.4.* of the linter, which includes checks for missing variable comments, and style checks when using placeables (variables, term and message references)