### PR TITLE
fix null unsubscribeButton on irrelevant pages

### DIFF
--- a/src/client/js/partials/unsubscribe.js
+++ b/src/client/js/partials/unsubscribe.js
@@ -2,9 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const unsubscribeButton = document.querySelector('.js-unsubscribe-button')
+const unsubscribePartial = document.querySelector('[data-partial="unsubscribe"]')
 
-unsubscribeButton.addEventListener('click', async event => {
+function init () {
+  unsubscribePartial.querySelector('.js-unsubscribe-button').addEventListener('click', handleEvent)
+}
+
+async function handleEvent (event) {
   // TODO: Use more specific messages when we reinstate
   // unsubscribing from all emails.
   const errorMessage = 'Unsubscribing failed.'
@@ -43,4 +47,6 @@ unsubscribeButton.addEventListener('click', async event => {
   } catch (error) {
     throw new Error(errorMessage)
   }
-})
+}
+
+if (unsubscribePartial) init()


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1355



# How to test
- confirm the following error or similar no longer appears on non-unsubscribe pages:
```
Uncaught TypeError: unsubscribeButton is null
    <anonymous> http://localhost:6060/js/partials/unsubscribe.js:7
```
- confirm the "Add email" button on the settings page triggers the modal/works as expected.
