### PR TITLE
Don't stop the server if icons couldn't be fetched

### DIFF
--- a/src/utils/hibp.js
+++ b/src/utils/hibp.js
@@ -189,6 +189,8 @@ async function downloadBreachIcons (breaches) {
             resolve([breachDomain, `/images/logo_cache/${breachDomain.toLowerCase()}.ico`])
           })
           file.on('error', (error) => reject(error))
+        }).on('error', (_error) => {
+          resolve(null)
         })
       })
     })


### PR DESCRIPTION
# Description

We already handled non-success responses when fetching a site's favicon by simply not storing an icon. However, if the request failed (i.e. no response came in in the first place, e.g. because the network is down), we didn't handle the error. This change ensures that in those cases, too, we just do not save an icon.

# How to test

Disable your internet, then start the server. It should not stop initialising with a bunch of errors trying to fetch

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - Relying on external connection not working, so I don't think it'd add much value if I mocked that?
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process. - N/A
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage. - N/A
