### PR TITLE
Don't pause server start for icon download

### DIFF
--- a/src/utils/hibp.js
+++ b/src/utils/hibp.js
@@ -146,8 +146,13 @@ async function loadBreachesIntoApp (app) {
       // sync the "breaches" table with the latest from HIBP
       await upsertBreaches(breaches)
     }
-    const breachLogoMap = await downloadBreachIcons(breaches)
-    app.locals.breachLogoMap = breachLogoMap
+    // This will be replaced by a map with the breach logos when
+    // `downloadBreachIcons` resolves, but by setting it to an empty Map first,
+    // we don't delay the server start - we just won't have breach logos yet.
+    app.locals.breachLogoMap = new Map()
+    downloadBreachIcons(breaches).then(breachLogoMap => {
+      app.locals.breachLogoMap = breachLogoMap
+    })
     app.locals.breaches = breaches
     app.locals.breachesLoadedDateTime = Date.now()
   } catch (error) {


### PR DESCRIPTION
Instead of waiting for the icon downloads to finish (which can take a while, even if we already have a cache of the images - disk access is slow), we just continue starting the server, and any sessions that load before the icon download has finished will show the fallback letter-based icons. A page refresh should then result in the actual icons being shown.