### PR TITLE
fix broken company ellipses and fallback icon

### DIFF
--- a/src/client/css/partials/breaches.css
+++ b/src/client/css/partials/breaches.css
@@ -215,19 +215,11 @@
   display: none;
 }
 
-.breach-row .breach-company {
-  display: flex;
-  align-items: center;
-  gap: var(--padding-sm);
-  text-decoration: none;
-}
-
-.breach-row a.breach-company:hover {
-  text-decoration: underline;
-}
-
 .breach-row .breach-company .breach-logo {
   height: 1.5rem;
+  display: inline-block;
+  vertical-align: bottom;
+  margin-right: var(--padding-xs);
 }
 
 .breach-row .breach-company span.breach-logo {

--- a/src/views/partials/breaches.js
+++ b/src/views/partials/breaches.js
@@ -39,10 +39,7 @@ function createBreachRows (data, logos) {
       return `
       <details class='breach-row' data-status=${status} data-email=${account.email} data-classes='${dataClassesTranslated}' ${isHidden ? 'hidden' : ''}>
         <summary>
-          <span class='breach-company'>
-            ${logo}
-            ${breach.Title}
-          </span>
+          <span class='breach-company'>${logo} ${breach.Title}</span>
           <span>${shortList.format(dataClassesTranslated)}</span>
           <span>
             <span class='resolution-badge is-resolved'>${getMessage('column-status-badge-resolved')}</span>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1350 & MNTOR-1406


<!-- When adding a new feature: -->

# Description
With the addition of company logos, the company name ellipses broke.  Additionally, fallback logos created from the company's first initial are squished/cut-off.  This PR aims to fix both issues.


# Screenshot (if applicable)

<img width="171" alt="Screen Shot 2023-03-16 at 1 39 29 PM" src="https://user-images.githubusercontent.com/14863500/225772253-83244ec5-47ad-4345-8454-b99c233f8b4e.png">
<img width="305" alt="Screen Shot 2023-03-15 at 10 28 14 AM" src="https://user-images.githubusercontent.com/14863500/225772286-81e669f6-c882-4067-9291-a72c74709383.png">


# How to test
You'll need a breach with company name that's longer than most, and a breached company that does not have a logo (falls back on circle with company initial)
- Visit the breaches page
- reduce your viewport width until company name no longer fits within the column
- confirm ellipses show up and that the text is not abruptly cut-off
- confirm any fallback items are not squished/cut-off

