### PR TITLE
Don't pass unsanitised user input into HTML

### DIFF
--- a/src/client/js/partials/unsubscribe.js
+++ b/src/client/js/partials/unsubscribe.js
@@ -9,7 +9,7 @@ function init () {
 }
 
 async function handleEvent (event) {
-  // TODO: Use more specific messages when we reinstate
+  // TODO: Use more specific and localised messages when we reinstate
   // unsubscribing from all emails.
   const errorMessage = 'Unsubscribing failed.'
   const successMessage = 'Unsubscribed successfully.'
@@ -17,7 +17,14 @@ async function handleEvent (event) {
   try {
     const target = event.target
     const csrfToken = target.getAttribute('data-csrf-token')
-    const queryParams = target.getAttribute('data-query-params')
+    const unsubscribeParameters = getUnsubscribeParameters()
+
+    if (unsubscribeParameters === null) {
+      const missingParametersToast = document.createElement('toast-alert')
+      missingParametersToast.textContent = errorMessage
+      document.body.append(missingParametersToast)
+      return
+    }
 
     const response = await fetch('/user/unsubscribe', {
       headers: {
@@ -26,7 +33,7 @@ async function handleEvent (event) {
       },
       mode: 'same-origin',
       method: 'POST',
-      body: queryParams
+      body: JSON.stringify(unsubscribeParameters)
     })
 
     if (response?.redirected) {
@@ -47,6 +54,19 @@ async function handleEvent (event) {
   } catch (error) {
     throw new Error(errorMessage)
   }
+}
+
+/**
+ * @returns { null | { hash: string; token: string; } }
+ */
+function getUnsubscribeParameters () {
+  const queryParams = new URLSearchParams(document.location.search)
+  const token = queryParams.get('token')
+  const hash = queryParams.get('hash')
+  if (typeof token === 'string' && typeof hash === 'string') {
+    return { hash, token }
+  }
+  return null
 }
 
 if (unsubscribePartial) init()

--- a/src/controllers/unsubscribe.js
+++ b/src/controllers/unsubscribe.js
@@ -13,8 +13,7 @@ import { unsubscribeFromMonthlyReport } from '../utils/email.js'
 function unsubscribePage (req, res) {
   const data = {
     csrfToken: generateToken(res),
-    partial: unsubscribe,
-    queryParams: req.query
+    partial: unsubscribe
   }
 
   res.send(guestLayout(data))
@@ -30,8 +29,7 @@ async function unsubscribeMonthlyPage (req, res) {
 
   const data = {
     csrfToken: generateToken(res),
-    partial: unsubscribeMonthly,
-    queryParams: req.query
+    partial: unsubscribeMonthly
   }
 
   res.send(guestLayout(data))

--- a/src/views/partials/unsubscribe.js
+++ b/src/views/partials/unsubscribe.js
@@ -11,7 +11,6 @@ const unsubscribe = data => `
     <button
       class='primary js-unsubscribe-button'
       data-csrf-token='${data.csrfToken}'
-      data-query-params='${JSON.stringify(data.queryParams)}'
     >
       ${getMessage('unsub-button')}
     </button>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1438
Figma: N/A

<!-- When adding a new feature: -->

# Description

It should now no longer be possible to pass arbitrary HTML (e.g. including malicious JS, though our CSP blocks that) into the query parameters and have that show up on the unsubscribe page. Additionally, the query parameters get validated, and only the relevant parameters are sent to the back-end.

Note: I don't actually know how to get to the unsubscribe page with valid parameters, so I haven't been able to verify that I'm not actually breaking unsubscription - would be good to get some input there.

# How to test

Visit `/user/unsubscribe?'"><marquee><h1>In ur HTML</h1></marquee>` - you should just see an unmodified "Unsubscribe" button.

Also, visit `/user/unsubscribe?token={"__proto__":"{"test":"ouch"}}&hash=hi`, and verify that the token is passed as a verbatim string to the body of the HTTP request sent when you click the "Unsubscribe" button.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - Lack of UI testing infra.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
