### PR TITLE
Prevent search engines from indexing non-prod envs

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -24,6 +24,7 @@ import { loadBreachesIntoApp } from './utils/hibp.js'
 import { RateLimitError } from './utils/error.js'
 import { initEmail } from './utils/email.js'
 import indexRouter from './routes/index.js'
+import { noSearchEngineIndex } from './middleware/noSearchEngineIndex.js'
 
 const app = express()
 const isDev = AppConstants.NODE_ENV === 'dev'
@@ -169,6 +170,7 @@ try {
   console.error('Error loading breaches into app.locals', error)
 }
 
+app.use(noSearchEngineIndex)
 app.use(express.static(staticPath))
 app.use(express.json())
 app.use(cookieParser(AppConstants.COOKIE_SECRET))

--- a/src/middleware/noSearchEngineIndex.js
+++ b/src/middleware/noSearchEngineIndex.js
@@ -5,20 +5,12 @@
 import AppConstants from '../app-constants.js'
 
 const { NODE_ENV } = AppConstants
+const noindexEnvs = ['dev', 'heroku', 'stage']
+const noSearchEngineIndex = !noindexEnvs.includes(NODE_ENV)
+  ? (_req, _res, next) => next()
+  : (_req, res, next) => {
+      res.header('X-Robots-Tag', 'noindex')
+      next()
+    }
 
-const allow = `user-agent: *
-allow: /
-`
-
-const disallow = `user-agent: *
-disallow: /
-`
-
-const rules = ['dev', 'heroku', 'stage'].includes(NODE_ENV) ? disallow : allow
-
-function robotsTxt (req, res) {
-  res.type('text/plain')
-  res.send(rules)
-}
-
-export { robotsTxt }
+export { noSearchEngineIndex }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -17,12 +17,10 @@ import { dialog } from '../controllers/dialog.js'
 import { landingPage } from '../controllers/landing.js'
 import { notFoundPage } from '../controllers/notFound.js'
 import { notFound } from '../middleware/error.js'
-import { robotsTxt } from '../middleware/robots.js'
 
 const router = express.Router()
 
 router.get('/', landingPage)
-router.get('/robots.txt', robotsTxt)
 router.get('*/dialog/:name', dialog)
 
 router.use('/', dockerFlowRoutes)


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1351
Figma: N/A


<!-- When adding a new feature: -->

# Description

Previously we provided a robots.txt, telling search engines and other bots not to proactively visit our stage and dev sites. That's good for reducing the load, but won't tell them not to add our dev and stage sites to their search indexes. The X-Robots-Tag: noindex header does.

Note that this also required removing the robots.txt, since otherwise that would tell search engines not to crawl those headers, apparently.

See also:
https://developers.google.com/search/docs/crawling-indexing/block-indexing

# How to test

Visit a resource locally, and verify that it has the ` X-Robots-Tag: noindex` header. That doesn't test all the way until seeing that search engines actually do not index our content, but I don't know of a way to do that.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met. - Acceptance criteria mentioned adding this _also_, on top of robots.txt, but Google's instructions say that that's wrong.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
