### PR TITLE
MNTOR-1440 fixup: allow third-party GA cookie for Firefox standard tracking protection

### DIFF
--- a/src/views/guestLayout.js
+++ b/src/views/guestLayout.js
@@ -41,7 +41,7 @@ const guestLayout = data => `
     <script src='/js/index.js' type='module'></script>
 
     <!-- Google tag (gtag.js) -->
-    <script nonce='${data.nonce}' type='module'>
+    <script nonce='${data.nonce}'>
       if (navigator.doNotTrack !== '1') {
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -50,10 +50,13 @@ const guestLayout = data => `
         n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','${AppConstants.GA4_MEASUREMENT_ID}');
         function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date()); gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}');
         ${AppConstants.GA4_DEBUG_MODE
           ? `gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}', { 'debug_mode': true })`
           : ''}
+        gtag('js', new Date());
+        gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}',
+          { cookie_domain: window.location.hostname, cookie_flags: "SameSite=None;Secure" }
+        );
         window.gtag = gtag
       } else {
         function gtag() {
@@ -68,6 +71,7 @@ const guestLayout = data => `
       )
       </script>
     <!-- End Google tag (gtag.js) -->
+
   </head>
   <body>
     <header>

--- a/src/views/mainLayout.js
+++ b/src/views/mainLayout.js
@@ -41,7 +41,7 @@ const mainLayout = data => `
     <script src='/js/index.js' type='module'></script>
 
     <!-- Google tag (gtag.js) -->
-    <script nonce='${data.nonce}' type='module'>
+    <script nonce='${data.nonce}'>
       if (navigator.doNotTrack !== '1') {
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -50,10 +50,13 @@ const mainLayout = data => `
         n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','${AppConstants.GA4_MEASUREMENT_ID}');
         function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date()); gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}');
         ${AppConstants.GA4_DEBUG_MODE
           ? `gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}', { 'debug_mode': true })`
           : ''}
+        gtag('js', new Date());
+        gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}',
+          { cookie_domain: window.location.hostname, cookie_flags: "SameSite=None;Secure" }
+        );
         window.gtag = gtag
       } else {
         function gtag() {
@@ -61,7 +64,7 @@ const mainLayout = data => `
         }
         window.gtag = gtag
       }
-      </script>
+    </script>
     <!-- End Google tag (gtag.js) -->
   </head>
   <body>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1440

<!-- When adding a new feature: -->

# Description

`gtag.js` appears to load fine in Firefox, but fails when trying to submit data:

`
Cookie “_ga_[...]” does not have a proper “SameSite” attribute value. Soon, cookies without the “SameSite” attribute or with an invalid value will be treated as “Lax”. This means that the cookie will no longer be sent in third-party contexts. If your application depends on this cookie being available in such contexts, please add the “SameSite=None“ attribute to it. To know more about the “SameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite
`

Followed by:
`
Cookie “_ga_[...]” has been rejected for invalid domain.
`

# How to test

Use the site with Firefox network devtools open:

## Expected

HTTP `POST` to `https://www.google-analytics.com/g/collect` succeeds with HTTP status `200`

## Actual

HTTP `POST` to `https://www.google-analytics.com/g/collect` fails and devtools displays `Blocked` in the "Status" column and `NS_ERROR_ABORT` in the "Transferred" column.