### PR TITLE
Mntor 1470/fix broken seo images

### DIFF
--- a/src/client/css/partials/breachDetails.css
+++ b/src/client/css/partials/breachDetails.css
@@ -154,79 +154,79 @@
 }
 
 .breach-detail-recommendation.rec-pw-1 {
-  background-image: url('../../images/recommendation-icons/change-password.svg');
+  background-image: url('/images/recommendation-icons/change-password.svg');
 }
 
 .breach-detail-recommendation.rec-pw-2 {
-  background-image: url('../../images/recommendation-icons/update-passwords.svg');
+  background-image: url('/images/recommendation-icons/update-passwords.svg');
 }
 
 .breach-detail-recommendation.rec-pw-3 {
-  background-image: url('../../images/recommendation-icons/store-safe-place.svg');
+  background-image: url('/images/recommendation-icons/store-safe-place.svg');
 }
 
 .breach-detail-recommendation.rec-pw-4 {
-  background-image: url('../../images/recommendation-icons/set-2FA.svg');
+  background-image: url('/images/recommendation-icons/set-2FA.svg');
 }
 
 .breach-detail-recommendation.rec-ssn {
-  background-image: url('../../images/recommendation-icons/review-credit.svg');
+  background-image: url('/images/recommendation-icons/review-credit.svg');
 }
 
 .breach-detail-recommendation.rec-bank-acc {
-  background-image: url('../../images/recommendation-icons/monitor-bank.svg');
+  background-image: url('/images/recommendation-icons/monitor-bank.svg');
 }
 
 .breach-detail-recommendation.rec-cc {
-  background-image: url('../../images/recommendation-icons/monitor-credit-cards.svg');
+  background-image: url('/images/recommendation-icons/monitor-credit-cards.svg');
 }
 
 .breach-detail-recommendation.rec-ip-us {
-  background-image: url('../../images/recommendation-icons/use-mask-IP-service.svg');
+  background-image: url('/images/recommendation-icons/use-mask-IP-service.svg');
 }
 
 .breach-detail-recommendation.rec-hist-pw {
-  background-image: url('../../images/recommendation-icons/change-password.svg');
+  background-image: url('/images/recommendation-icons/change-password.svg');
 }
 
 .breach-detail-recommendation.rec-sec-qa {
-  background-image: url('../../images/recommendation-icons/unique-answers.svg');
+  background-image: url('/images/recommendation-icons/unique-answers.svg');
 }
 
 .breach-detail-recommendation.rec-phone-num {
-  background-image: url('../../images/recommendation-icons/avoid-sharing-phone.svg');
+  background-image: url('/images/recommendation-icons/avoid-sharing-phone.svg');
 }
 
 .breach-detail-recommendation.rec-dob {
-  background-image: url('../../images/recommendation-icons/strengthen-pin-security.svg');
+  background-image: url('/images/recommendation-icons/strengthen-pin-security.svg');
 }
 
 .breach-detail-recommendation.rec-pins {
-  background-image: url('../../images/recommendation-icons/strengthen-pin-security.svg');
+  background-image: url('/images/recommendation-icons/strengthen-pin-security.svg');
 }
 
 .breach-detail-recommendation.rec-address {
-  background-image: url('../../images/recommendation-icons/avoid-address.svg');
+  background-image: url('/images/recommendation-icons/avoid-address.svg');
 }
 
 .breach-detail-recommendation.rec-gen-1 {
-  background-image: url('../../images/recommendation-icons/unique-strong-pwds.svg');
+  background-image: url('/images/recommendation-icons/unique-strong-pwds.svg');
 }
 
 .breach-detail-recommendation.rec-gen-2 {
-  background-image: url('../../images/recommendation-icons/store-safe-place.svg');
+  background-image: url('/images/recommendation-icons/store-safe-place.svg');
 }
 
 .breach-detail-recommendation.rec-gen-3 {
-  background-image: url('../../images/recommendation-icons/avoid-personal-info.svg');
+  background-image: url('/images/recommendation-icons/avoid-personal-info.svg');
 }
 
 .breach-detail-recommendation.rec-gen-4 {
-  background-image: url('../../images/recommendation-icons/update-regularly.svg');
+  background-image: url('/images/recommendation-icons/update-regularly.svg');
 }
 
 .breach-detail-recommendation.rec-email {
-  background-image: url('../../images/recommendation-icons/masked-email.svg');
+  background-image: url('/images/recommendation-icons/masked-email.svg');
 }
 
 .breach-detail-recommendation dt {

--- a/src/client/css/partials/breachDetails.css
+++ b/src/client/css/partials/breachDetails.css
@@ -154,79 +154,79 @@
 }
 
 .breach-detail-recommendation.rec-pw-1 {
-  background-image: url('/images/recommendation-icons/change-password.svg');
+  background-image: url('../../images/recommendation-icons/change-password.svg');
 }
 
 .breach-detail-recommendation.rec-pw-2 {
-  background-image: url('/images/recommendation-icons/update-passwords.svg');
+  background-image: url('../../images/recommendation-icons/update-passwords.svg');
 }
 
 .breach-detail-recommendation.rec-pw-3 {
-  background-image: url('/images/recommendation-icons/store-safe-place.svg');
+  background-image: url('../../images/recommendation-icons/store-safe-place.svg');
 }
 
 .breach-detail-recommendation.rec-pw-4 {
-  background-image: url('/images/recommendation-icons/set-2FA.svg');
+  background-image: url('../../images/recommendation-icons/set-2FA.svg');
 }
 
 .breach-detail-recommendation.rec-ssn {
-  background-image: url('/images/recommendation-icons/review-credit.svg');
+  background-image: url('../../images/recommendation-icons/review-credit.svg');
 }
 
 .breach-detail-recommendation.rec-bank-acc {
-  background-image: url('/images/recommendation-icons/monitor-bank.svg');
+  background-image: url('../../images/recommendation-icons/monitor-bank.svg');
 }
 
 .breach-detail-recommendation.rec-cc {
-  background-image: url('/images/recommendation-icons/monitor-credit-cards.svg');
+  background-image: url('../../images/recommendation-icons/monitor-credit-cards.svg');
 }
 
 .breach-detail-recommendation.rec-ip-us {
-  background-image: url('/images/recommendation-icons/use-mask-IP-service.svg');
+  background-image: url('../../images/recommendation-icons/use-mask-IP-service.svg');
 }
 
 .breach-detail-recommendation.rec-hist-pw {
-  background-image: url('/images/recommendation-icons/change-password.svg');
+  background-image: url('../../images/recommendation-icons/change-password.svg');
 }
 
 .breach-detail-recommendation.rec-sec-qa {
-  background-image: url('/images/recommendation-icons/unique-answers.svg');
+  background-image: url('../../images/recommendation-icons/unique-answers.svg');
 }
 
 .breach-detail-recommendation.rec-phone-num {
-  background-image: url('/images/recommendation-icons/avoid-sharing-phone.svg');
+  background-image: url('../../images/recommendation-icons/avoid-sharing-phone.svg');
 }
 
 .breach-detail-recommendation.rec-dob {
-  background-image: url('/images/recommendation-icons/strengthen-pin-security.svg');
+  background-image: url('../../images/recommendation-icons/strengthen-pin-security.svg');
 }
 
 .breach-detail-recommendation.rec-pins {
-  background-image: url('/images/recommendation-icons/strengthen-pin-security.svg');
+  background-image: url('../../images/recommendation-icons/strengthen-pin-security.svg');
 }
 
 .breach-detail-recommendation.rec-address {
-  background-image: url('/images/recommendation-icons/avoid-address.svg');
+  background-image: url('../../images/recommendation-icons/avoid-address.svg');
 }
 
 .breach-detail-recommendation.rec-gen-1 {
-  background-image: url('/images/recommendation-icons/unique-strong-pwds.svg');
+  background-image: url('../../images/recommendation-icons/unique-strong-pwds.svg');
 }
 
 .breach-detail-recommendation.rec-gen-2 {
-  background-image: url('/images/recommendation-icons/store-safe-place.svg');
+  background-image: url('../../images/recommendation-icons/store-safe-place.svg');
 }
 
 .breach-detail-recommendation.rec-gen-3 {
-  background-image: url('/images/recommendation-icons/avoid-personal-info.svg');
+  background-image: url('../../images/recommendation-icons/avoid-personal-info.svg');
 }
 
 .breach-detail-recommendation.rec-gen-4 {
-  background-image: url('/images/recommendation-icons/update-regularly.svg');
+  background-image: url('../../images/recommendation-icons/update-regularly.svg');
 }
 
 .breach-detail-recommendation.rec-email {
-  background-image: url('/images/recommendation-icons/masked-email.svg');
+  background-image: url('../../images/recommendation-icons/masked-email.svg');
 }
 
 .breach-detail-recommendation dt {

--- a/src/package.json
+++ b/src/package.json
@@ -12,7 +12,7 @@
     "start": "node app.js",
     "dev": "nodemon app.js",
     "build": "node esbuild & npm run copy:root & npm run copy:webp & npm run copy:png & npm run build:svg",
-    "build:svg": "svgo -f ./client/images/ -o ../dist/images",
+    "build:svg": "svgo -f ./client/images/ -r -o ../dist/images",
     "copy:root": "mkdir -p ../dist/ && cp ./client/*.* ../dist/",
     "copy:webp": "mkdir -p ../dist/images/ && cp -r ./client/images/*.webp ../dist/images/",
     "copy:png": "mkdir -p ../dist/images/email/ && cp -r ./client/images/email/*.png ../dist/images/email/",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1470


<!-- When adding a new feature: -->

# Description
- ~Fixes path for images displayed on breach details pages~
- Fixes SVGO cli recursive flag not working as expected:
https://github.com/svg/svgo#cli-usage (suggests -f for recursive)
https://github.com/svg/svgo/issues/1269 (suggests -f _and_ -r)



# Screenshot (if applicable)

<img width="529" alt="Screen Shot 2023-03-24 at 8 59 12 AM" src="https://user-images.githubusercontent.com/14863500/227578209-2f4ff857-0a7c-47da-b1b9-ed79d012226e.png">


# How to test
visit a breach detail page and confirm images next to recommendations display as expected (see screenshot above)

