### PR TITLE
MNTOR-1180: removal of resolution when email is removed

### DIFF
--- a/src/controllers/settings.js
+++ b/src/controllers/settings.js
@@ -13,7 +13,7 @@ import {
   verifyEmailHash
 } from '../db/tables/email_addresses.js'
 
-import { setAllEmailsToPrimary } from '../db/tables/subscribers.js'
+import { setAllEmailsToPrimary, deleteResolutionsWithEmail } from '../db/tables/subscribers.js'
 
 import { getMessage } from '../utils/fluent.js'
 import { sendEmail, getVerificationUrl } from '../utils/email.js'
@@ -116,11 +116,12 @@ async function removeEmail (req, res) {
   const sessionUser = req.user
   const existingEmail = await getEmailById(emailId)
 
-  if (existingEmail.subscriber_id !== sessionUser.id) {
+  if (existingEmail?.subscriber_id !== sessionUser.id) {
     throw new UserInputError(getMessage('error-not-subscribed'))
   }
 
   removeOneSecondaryEmail(emailId)
+  deleteResolutionsWithEmail(existingEmail.subscriber_id, existingEmail.email)
   res.redirect('/user/settings')
 }
 

--- a/src/db/tables/subscribers.js
+++ b/src/db/tables/subscribers.js
@@ -225,6 +225,19 @@ async function deleteSubscriberByFxAUID (fxaUID) {
   await knex('subscribers').where('fxa_uid', fxaUID).del()
 }
 
+async function deleteResolutionsWithEmail (id, email) {
+  const [subscriber] = await knex('subscribers').where({
+    id
+  })
+  const { breach_resolution: breachResolution } = subscriber
+  // if email exists in breach resolution, remove it
+  if (breachResolution[email]) {
+    delete breachResolution[email]
+  }
+
+  return await setBreachResolution(subscriber, breachResolution)
+}
+
 async function updateBreachStats (id, stats) {
   await knex('subscribers')
     .where('id', id)
@@ -311,5 +324,6 @@ export {
   removeSubscriber,
   removeSubscriberByToken,
   deleteUnverifiedSubscribers,
-  deleteSubscriberByFxAUID
+  deleteSubscriberByFxAUID,
+  deleteResolutionsWithEmail
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1180


<!-- When adding a new feature: -->

# Description
When a user deletes a secondary email from Settings, the email is deleted from the email_addresses table but the breach resolutions aren't updated to reflect the change. This becomes an issue for 1) data retention 2) when we run our migration script, it returns a lot of false positives since our scripts still think those emails exist

# How to test
Current:
* Use a secondary email to resolve some breaches
* Delete secondary email from Settings
* Add email back 
* The breach resolution state remains

Fix:
* Use a secondary email to resolve some breaches
* Delete secondary email from Settings
* Add email back 
* The breach resolution state should be reset (0 marked as resolved)

# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
