### PR TITLE
MNTOR-1440 fixup: include data_class with Breach Item GA event

### DIFF
--- a/src/client/js/partials/breaches.js
+++ b/src/client/js/partials/breaches.js
@@ -59,7 +59,8 @@ function handleEvent (e) {
       updateBreachStatus(e.target)
       window.gtag('event', 'Breach Item', {
         action: e.target.checked ? 'resolved' : 'unresolved',
-        page_location: location.href
+        page_location: location.href,
+        data_class: e.target.value
       })
       break
     case e.type === 'email-added':


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1440
# Description

Small followup to MNTOR-1440 to include `data-classes` (email-adress, ip-address, etc)