### PR TITLE
Add redundant social media preview tags

### DIFF
--- a/src/views/guestLayout.js
+++ b/src/views/guestLayout.js
@@ -16,7 +16,12 @@ const guestLayout = data => `
     <meta name='viewport' content='width=320, initial-scale=1'>
     <meta name='description' content='${getMessage('meta-desc')}'>
     <meta name='twitter:card' content='summary_large_image'>
+    <meta name='twitter:title' content='${getMessage('brand-fx-monitor')}'>
+    <meta name='twitter:description' content='${getMessage('meta-desc')}'>
+    <meta name='twitter:image' content='${AppConstants.SERVER_URL}/images/og-image.webp'>
     <meta property='og:title' content='${getMessage('brand-fx-monitor')}'>
+    <meta property='og:description' content='${getMessage('meta-desc')}'>
+    <meta property='og:site_name' content='${getMessage('brand-fx-monitor')}'>
     <meta property='og:type' content='website'>
     <meta property='og:url' content='${AppConstants.SERVER_URL}'>
     <meta property='og:image' content='${AppConstants.SERVER_URL}/images/og-image.webp'>

--- a/src/views/mainLayout.js
+++ b/src/views/mainLayout.js
@@ -16,7 +16,12 @@ const mainLayout = data => `
     <meta name='viewport' content='width=320, initial-scale=1'>
     <meta name='description' content='${getMessage('meta-desc')}'>
     <meta name='twitter:card' content='summary_large_image'>
+    <meta name='twitter:title' content='${getMessage('brand-fx-monitor')}'>
+    <meta name='twitter:description' content='${getMessage('meta-desc')}'>
+    <meta name='twitter:image' content='${AppConstants.SERVER_URL}/images/og-image.webp'>
     <meta property='og:title' content='${getMessage('brand-fx-monitor')}'>
+    <meta property='og:description' content='${getMessage('meta-desc')}'>
+    <meta property='og:site_name' content='${getMessage('brand-fx-monitor')}'>
     <meta property='og:type' content='website'>
     <meta property='og:url' content='${AppConstants.SERVER_URL}'>
     <meta property='og:image' content='${AppConstants.SERVER_URL}/images/og-image.webp'>


### PR DESCRIPTION
# References: 
Jira: MNTOR-1439
Figma: N/A


<!-- When adding a new feature: -->

# Description

Not all social media websites implement the same (or any) fallbacks for preview cards, so we have to add them redundantly to make sure they show up everywhere.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/227951649-b7e16fae-b8ab-49b1-bcc3-cc5cde636ae4.png)

# How to test

You should be able to use https://cards-dev.twitter.com/validator if you have a Twitter account after it is deployed. Until then, you can only check the meta tags yourself, I suppose.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
