### PR TITLE
Remove spaces around links in email footer

### DIFF
--- a/src/views/emails/email-2022.js
+++ b/src/views/emails/email-2022.js
@@ -107,14 +107,8 @@ const emailHeader = (data) => `
 `
 
 function getUnsubscribeCopy (data) {
-  const unsubLink = `
-    <a href='${data.unsubscribeUrl}'>
-      ${getMessage('email-unsub-link')}
-    </a>
-  `
-  const faqLink = `
-    <a href='${links(data).faq}'>${getMessage('frequently-asked-questions')}</a>
-  `
+  const unsubLink = `<a href='${data.unsubscribeUrl}'>${getMessage('email-unsub-link')}</a>`
+  const faqLink = `<a href='${links(data).faq}'>${getMessage('frequently-asked-questions')}</a>`
 
   return getMessage('email-footer-blurb', {
     unsubLink,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1468
Figma: N/A


<!-- When adding a new feature: -->

# Description

The Unsubscribe and FAQ links in the footer used to have spaces preceding and following them.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/227953930-9a221bd1-6a2d-4871-8a12-8c48622733a5.png)

# How to test

Open the email admin tool, and verify that there are no spaces around them: http://localhost:6060/admin/emails/

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met. - Changed the other way around - there should be _no_ spaces.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
