### PR TITLE
Link to dashboard in monthly "unresolved" e-mail

### DIFF
--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -270,7 +270,7 @@ const getVerificationDummyData = (recipient) => ({
  */
 const getMonthlyDummyData = (recipient) => ({
   breachedEmail: 'breached@email.com',
-  ctaHref: SERVER_URL,
+  ctaHref: `${SERVER_URL}/user/breaches`,
   heading: getMessage('email-unresolved-heading'),
   monitoredEmails: {
     count: 2


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1426
Figma: N/A


<!-- When adding a new feature: -->

# Description

The "resolve breaches" link in the monthly "unresolved breaches" email (that we're not currently sending, IIRC) should go to the dashboard, rather than the landing page.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/227959022-75e10718-9213-40ae-a551-6c5c8919c18d.png)

# How to test

Open http://localhost:6060/admin/emails/monthly, trigger the test email. The CTA should go to the dashboard.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
