### PR TITLE
Use consistent spacing for "Help and support" icon

### DIFF
--- a/src/client/images/icon-help.svg
+++ b/src/client/images/icon-help.svg
@@ -1,5 +1,6 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M9.99996 18.3334C14.6023 18.3334 18.3333 14.6024 18.3333 10C18.3333 5.39765 14.6023 1.66669 9.99996 1.66669C5.39759 1.66669 1.66663 5.39765 1.66663 10C1.66663 14.6024 5.39759 18.3334 9.99996 18.3334Z" stroke="#592ACB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7.57495 7.50003C7.97948 6.35007 9.15444 5.65954 10.3559 5.86563C11.5574 6.07172 12.4351 7.11433 12.4333 8.33337C12.4333 10 9.93328 10.8334 9.93328 10.8334" stroke="#592ACB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M9.99996 15C10.4602 15 10.8333 14.6269 10.8333 14.1667C10.8333 13.7065 10.4602 13.3334 9.99996 13.3334C9.53972 13.3334 9.16663 13.7065 9.16663 14.1667C9.16663 14.6269 9.53972 15 9.99996 15Z" fill="#592ACB"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" fill="none" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <path d="m12 19.143c3.9449 0 7.1428-3.198 7.1428-7.1429 0-3.9449-3.198-7.1428-7.1428-7.1428-3.9449 0-7.1428 3.198-7.1428 7.1428 0 3.9449 3.198 7.1429 7.1428 7.1429z" clip-rule="evenodd" fill-rule="evenodd" stroke="#592acb" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <path d="m9.9214 9.8571c0.34674-0.98568 1.3538-1.5776 2.3837-1.4009 1.0299 0.17665 1.7822 1.0703 1.7806 2.1152 0 1.4285-2.1429 2.1429-2.1429 2.1429" stroke="#592acb" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+ <path d="m12 16.286c0.39449 0 0.71429-0.3198 0.71429-0.71426 0-0.39446-0.3198-0.71426-0.71429-0.71426-0.39449 0-0.71428 0.3198-0.71428 0.71426 0 0.39446 0.31979 0.71426 0.71428 0.71426z" clip-rule="evenodd" fill="#592acb" fill-rule="evenodd" stroke-width=".85714"/>
 </svg>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1471
Figma: N/A

<!-- When adding a new feature: -->

# Description

The other icons are all 16x16, with a canvas size of 24x24. It'd probably be safer if our icons did not include padding inside the images themselves, but had that added through CSS, but that's a larger refactor that would involve checking all our icons and their uses.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/227966612-22927a5c-0ab6-4d2f-9335-cf03a435b510.png)

Previous:

![image](https://user-images.githubusercontent.com/4251/227966693-465dca92-38ba-43eb-9657-039a24732292.png)

# How to test

Open the user menu, verify that all icons are aligned.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
