### PR TITLE
MNTOR-1437 fixup: do not use spaces in add_email GA event

### DIFF
--- a/src/client/js/partials/add-email.js
+++ b/src/client/js/partials/add-email.js
@@ -33,7 +33,7 @@ async function handleSubmit (e) {
 
     if (!res.ok) throw new Error()
 
-    window.gtag('event', 'Add Email', { result: 'success' })
+    window.gtag('event', 'add_email', { result: 'success' })
 
     const { newEmailCount } = await res.json()
 
@@ -47,7 +47,7 @@ async function handleSubmit (e) {
     toast.textContent = `Could not add email. ${e.message}`
     dialogEl.append(toast)
     console.error('Could not add email.', e)
-    window.gtag('event', 'Add Email', { result: 'fail' })
+    window.gtag('event', 'add_email', { result: 'fail' })
   } finally {
     form.elements['email-submit'].toggleAttribute('disabled', false)
   }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1437

@pdehaan noticed that I missed an event, GA4 only allows _ as separator in custom event names.