### PR TITLE
fix mobile nav bottom placement of promos

### DIFF
--- a/src/client/css/nav.css
+++ b/src/client/css/nav.css
@@ -6,7 +6,7 @@ nav.site-nav {
   position: fixed;
   top: var(--header-h);
   left: 0;
-  height: calc(100vh - var(--header-h));
+  height: calc(100% - var(--header-h));
   display: inline-flex;
   flex-flow: column nowrap;
   padding: var(--padding-lg) var(--padding-md) var(--footer-h);


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1477


# Screenshot (if applicable)
Before: 
<img width="600" alt="Screen Shot 2023-03-27 at 12 51 32 PM" src="https://user-images.githubusercontent.com/14863500/228051327-62315d66-af36-4b4b-870f-d1b60556e2ab.png">

After:
<img width="600" alt="Screen Shot 2023-03-27 at 12 51 10 PM" src="https://user-images.githubusercontent.com/14863500/228051358-18a6b554-96a6-4b44-88cc-6a2f6b11225f.png">


# How to test
using a mobile device or simulator, confirm that the Firefox Relay and Mozilla VPN promos are correctly placed towards the bottom of the mobile nav



