### PR TITLE
MNTOR-1475: Wait for custom email select width to be available

### DIFF
--- a/src/client/js/components/custom-select.js
+++ b/src/client/js/components/custom-select.js
@@ -101,9 +101,13 @@ customElements.define('custom-select', class extends HTMLElement {
     temp.className = 'hidden'
     temp.append(selectedOption.cloneNode(true))
     this.shadowRoot.append(temp)
-    temp.w = Math.ceil(temp.getBoundingClientRect().width) + 5 // adds 5px safety for font load delay or other quirks
-    this.style.setProperty('--option-w', `${temp.w}px`)
-    temp.remove()
+
+    // let’s wait for the next tick to make sure that the dimensions of temp are available
+    window.requestAnimationFrame(() => {
+      temp.w = Math.ceil(temp.getBoundingClientRect().width) + 5 // adds 5px safety for font load delay or other quirks
+      this.style.setProperty('--option-w', `${temp.w}px`)
+      temp.remove()
+    })
   }
 
   disconnectedCallback () {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1475](https://mozilla-hub.atlassian.net/browse/MNTOR-1475)

<!-- When adding a new feature: -->

# Description

It’s possible that `temp` has a width of `0` when trying to retrieve its bounding rect. Let’s wait for the next tick to make sure its dimensions are calculated correctly.

# How to test

1. Open Safari on macOS
2. Visit the dashboard `/user/breaches` and reload multiple times (~10-20 always did it for me)
3. Make sure that the width of the select is bigger than `5px`

# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
