### PR TITLE
Make breach cards fit in small screens

### DIFF
--- a/src/client/css/partials/allBreaches.css
+++ b/src/client/css/partials/allBreaches.css
@@ -39,7 +39,7 @@
   align-items: start;
   display: grid;
   grid-gap: var(--gap);
-  grid-template-columns: repeat(auto-fit, minmax(calc(var(--min-width) + 2 * var(--padding-md)), 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(var(--min-width), 1fr));
 }
 
 .breach-card {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1481
Figma: N/A

<!-- When adding a new feature: -->

# Description

Breach cards used to have a minimum size of
min-width + 2 * padding-md, but with the container's marging added to that, that wouldn't fit on screens as small as 360px wide. Thus, the cards are now constrained to min-width, and extra padding is subtracted from that.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/228229134-99d5abfe-253c-458f-a589-0433216c4304.png)

# How to test

Go to `/breaches`, resize your screen.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
