### PR TITLE
MNTOR-1491: fix null pointer exception

### DIFF
--- a/src/db/tables/subscribers.js
+++ b/src/db/tables/subscribers.js
@@ -234,7 +234,7 @@ async function deleteResolutionsWithEmail (id, email) {
   if (breachResolution && breachResolution[email]) {
     delete breachResolution[email]
     console.info(`Deleting resolution with email: ${email}`)
-    await setBreachResolution(subscriber, breachResolution)
+    return await setBreachResolution(subscriber, breachResolution)
   }
   console.info(`No resolution with ${email} found, skip`)
 }

--- a/src/db/tables/subscribers.js
+++ b/src/db/tables/subscribers.js
@@ -236,7 +236,7 @@ async function deleteResolutionsWithEmail (id, email) {
     console.info(`Deleting resolution with email: ${email}`)
     await setBreachResolution(subscriber, breachResolution)
   }
-  console.info(`No resolution with ${email} found, no need to delete`)
+  console.info(`No resolution with ${email} found, skip`)
 }
 
 async function updateBreachStats (id, stats) {

--- a/src/db/tables/subscribers.js
+++ b/src/db/tables/subscribers.js
@@ -231,11 +231,12 @@ async function deleteResolutionsWithEmail (id, email) {
   })
   const { breach_resolution: breachResolution } = subscriber
   // if email exists in breach resolution, remove it
-  if (breachResolution[email]) {
+  if (breachResolution && breachResolution[email]) {
     delete breachResolution[email]
+    console.info(`Deleting resolution with email: ${email}`)
+    await setBreachResolution(subscriber, breachResolution)
   }
-
-  return await setBreachResolution(subscriber, breachResolution)
+  console.info(`No resolution with ${email} found, no need to delete`)
 }
 
 async function updateBreachStats (id, stats) {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1491


<!-- When adding a new feature: -->

# Description
This ticket addresses a bug for deleting resolution when a user deletes a secondary email. The code currently does not handle the case when resolution field is empty

# How to test
* add a secondary email to an account
* make sure the account does not have breaches resolved or checked (column null in database)
* delete the email
* you should see a log `No resolution with [email] found, skip`


# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
