### PR TITLE
Also use cached favicon on breach detail page

### DIFF
--- a/src/client/css/partials/breachDetails.css
+++ b/src/client/css/partials/breachDetails.css
@@ -6,6 +6,21 @@
   padding: var(--padding-xl) var(--padding-sm);
 }
 
+.breach-detail-header .breach-logo {
+  height: 5rem;
+  display: inline-block;
+}
+
+.breach-detail-header span.breach-logo {
+  line-height: 5rem;
+  width: 5rem;
+  border-radius: 5rem;
+  font-size: 3rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  text-align: center;
+}
+
 .breach-detail-meta {
   display: flex;
   flex-direction: column;

--- a/src/controllers/breach-details.js
+++ b/src/controllers/breach-details.js
@@ -31,6 +31,7 @@ async function breachDetailsPage (req, res) {
   const data = {
     partial: breachDetails,
     breach: featuredBreach,
+    breachLogos: req.app.locals.breachLogoMap,
     nonce: res.locals.nonce
   }
 

--- a/src/views/partials/breach-detail.js
+++ b/src/views/partials/breach-detail.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { getBreachLogo } from '../../utils/breach-logo.js'
 import { getLocale, getMessage } from '../../utils/fluent.js'
 import { getAllPriorityDataClasses, getAllGenericRecommendations } from '../../utils/recommendations.js'
 
@@ -129,7 +130,7 @@ function makeBreachDetails (breach) {
 
 export const breachDetails = data => `
   <header class="breach-detail-header">
-    <img class="breach-detail-logo breach-logo" alt="" src="https://monitor.cdn.mozilla.net/img/logos/${data.breach.LogoPath}" />
+    ${getBreachLogo(data.breach, data.breachLogos)}
     <div class="breach-detail-meta">
       <h1>${data.breach.Title}</h1>
       ${getBreachCategory(data.breach) === 'website-breach'


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1494
Figma: N/A


<!-- When adding a new feature: -->

# Description

It'll be lower quality than the organic, free-range, hand-crafted logos served from our CDN, but at least it'll free up Maxx to learn some Qt. Meanwhile design can come up with a new design that doesn't feature the logos at this size.

# Screenshot (if applicable)

An ugly one:

![image](https://user-images.githubusercontent.com/4251/228822552-ca7d1ce1-b6b0-4938-a413-8d0ca7ef3be6.png)

[(Current)](https://monitor.firefox.com/breach-details/SlideTeam)

An OK one:

![image](https://user-images.githubusercontent.com/4251/228822724-465fdcb3-f333-47e9-aefd-ddc588bb1cf9.png)

([Current](https://monitor.firefox.com/breach-details/FaceUP) uses a logo rather than an icon.)

Without a found favicon:

![image](https://user-images.githubusercontent.com/4251/228823018-cf3b0050-f09a-412f-b1aa-067199e6e708.png)


# How to test

Visit http://localhost:6060/breaches, then open a couple of individual breaches.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
