### PR TITLE
Add type checking for a couple of files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
             - checkout
             - node/install-packages
             - run: npm run lint:js
+            - run: npm run lint:ts
     lint-css:
         executor: node
         steps:

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,15 +7,18 @@
     },
     "extends": [
         "standard",
-        "plugin:jsdoc/recommended"
+        "plugin:jsdoc/recommended",
+        "plugin:@typescript-eslint/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaVersion": "latest",
         "sourceType": "module"
     },
     "plugins": [
         "header",
-        "jsdoc"
+        "jsdoc",
+        "@typescript-eslint"
     ],
     "rules": {
         "no-prototype-builtins": "warn",
@@ -36,6 +39,12 @@
             {
                 "argsIgnorePattern": "^_",
                 "varsIgnorePattern": "^_"
+            }
+        ],
+        "@typescript-eslint/ban-ts-comment": [
+            "error",
+            {
+                "ts-ignore": "allow-with-description"
             }
         ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "uuid": "3.4.0"
       },
       "devDependencies": {
+        "@types/gtag.js": "^0.0.12",
         "coveralls": "3.1.1",
         "eslint": "^8.15.0",
         "eslint-config-standard": "^17.0.0",
@@ -1579,6 +1580,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/gtag.js": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
+      "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==",
+      "dev": true
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
@@ -12448,6 +12455,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/gtag.js": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
+      "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==",
+      "dev": true
     },
     "@types/http-cache-semantics": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,8 @@
       },
       "devDependencies": {
         "@types/gtag.js": "^0.0.12",
+        "@typescript-eslint/eslint-plugin": "^5.57.0",
+        "@typescript-eslint/parser": "^5.57.0",
         "coveralls": "3.1.1",
         "eslint": "^8.15.0",
         "eslint-config-standard": "^17.0.0",
@@ -726,6 +728,30 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+      "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -1615,6 +1641,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "dev": true,
@@ -1664,6 +1696,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -1688,6 +1726,407 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz",
+      "integrity": "sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/type-utils": "5.57.0",
+        "@typescript-eslint/utils": "5.57.0",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
+      "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz",
+      "integrity": "sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.0.tgz",
+      "integrity": "sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/utils": "5.57.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.0.tgz",
+      "integrity": "sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz",
+      "integrity": "sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.0.tgz",
+      "integrity": "sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz",
+      "integrity": "sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.57.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -7943,6 +8382,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "license": "MIT",
@@ -10654,6 +11099,21 @@
         "node": ">=0.6.x"
       }
     },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -11824,6 +12284,21 @@
       "version": "0.17.8",
       "optional": true
     },
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
+      "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+      "dev": true
+    },
     "@eslint/eslintrc": {
       "version": "1.4.1",
       "dev": true,
@@ -12489,6 +12964,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
     "@types/json5": {
       "version": "0.0.29",
       "dev": true
@@ -12536,6 +13017,12 @@
         "@types/node": "*"
       }
     },
+    "@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -12559,6 +13046,263 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz",
+      "integrity": "sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/type-utils": "5.57.0",
+        "@typescript-eslint/utils": "5.57.0",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
+      "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz",
+      "integrity": "sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.57.0.tgz",
+      "integrity": "sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "@typescript-eslint/utils": "5.57.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.57.0.tgz",
+      "integrity": "sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz",
+      "integrity": "sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/visitor-keys": "5.57.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.57.0.tgz",
+      "integrity": "sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.57.0",
+        "@typescript-eslint/types": "5.57.0",
+        "@typescript-eslint/typescript-estree": "5.57.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz",
+      "integrity": "sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.57.0",
+        "eslint-visitor-keys": "^3.3.0"
+      }
     },
     "abab": {
       "version": "2.0.6",
@@ -16874,6 +17618,12 @@
       "version": "1.4.0",
       "dev": true
     },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
+    },
     "negotiator": {
       "version": "0.6.3"
     },
@@ -18671,6 +19421,15 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+    },
+    "tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,8 @@
         "nodemon": "^2.0.20",
         "redis-mock": "^0.56.3",
         "stylelint": "^14.9.1",
-        "stylelint-config-standard": "^26.0.0"
+        "stylelint-config-standard": "^26.0.0",
+        "typescript": "^5.0.2"
       },
       "engines": {
         "node": "18.12.x",
@@ -10728,6 +10729,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
@@ -18702,6 +18716,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "uuid": "3.4.0"
   },
   "devDependencies": {
+    "@types/gtag.js": "^0.0.12",
     "coveralls": "3.1.1",
     "eslint": "^8.15.0",
     "eslint-config-standard": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "nodemon": "^2.0.20",
     "redis-mock": "^0.56.3",
     "stylelint": "^14.9.1",
-    "stylelint-config-standard": "^26.0.0"
+    "stylelint-config-standard": "^26.0.0",
+    "typescript": "^5.0.2"
   },
   "engines": {
     "node": "18.12.x",
@@ -90,6 +91,7 @@
     "docker:run": "docker run -p 6060:6060 blurts-server",
     "lint": "npm run lint:css && npm run lint:js",
     "lint:js": "eslint .",
+    "lint:ts": "tsc --noEmit",
     "lint:css": "stylelint public/css/",
     "lint:fluent": "moz-fluent-lint ./locales/en --config .github/linter_config.yml",
     "fix": "npm run fix:css && npm run fix:js",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
   },
   "devDependencies": {
     "@types/gtag.js": "^0.0.12",
+    "@typescript-eslint/eslint-plugin": "^5.57.0",
+    "@typescript-eslint/parser": "^5.57.0",
     "coveralls": "3.1.1",
     "eslint": "^8.15.0",
     "eslint-config-standard": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "docker:build": "docker build -t blurts-server .",
     "docker:run": "docker run -p 6060:6060 blurts-server",
     "lint": "npm run lint:css && npm run lint:js",
-    "lint:js": "eslint .",
+    "lint:js": "eslint src",
     "lint:ts": "tsc --noEmit",
     "lint:css": "stylelint public/css/",
     "lint:fluent": "moz-fluent-lint ./locales/en --config .github/linter_config.yml",

--- a/src/app-constants.js
+++ b/src/app-constants.js
@@ -53,6 +53,7 @@ const optionalEnvVars = [
   'SENTRY_DSN_LEGACY'
 ]
 
+/** @type {Record<string, string>} */
 const AppConstants = { }
 
 if (!process.env.SERVER_URL && process.env.NODE_ENV === 'heroku') {
@@ -60,14 +61,16 @@ if (!process.env.SERVER_URL && process.env.NODE_ENV === 'heroku') {
 }
 
 for (const v of requiredEnvVars) {
-  if (process.env[v] === undefined) {
+  const value = process.env[v]
+  if (value === undefined) {
     throw new Error(`Required environment variable was not set: ${v}`)
   }
-  AppConstants[v] = process.env[v]
+  AppConstants[v] = value
 }
 
 optionalEnvVars.forEach(key => {
-  if (key in process.env) AppConstants[key] = process.env[key]
+  const value = process.env[key]
+  if (value) AppConstants[key] = value
 })
 
 export default Object.freeze(AppConstants)

--- a/src/client/js/components/circle-chart.js
+++ b/src/client/js/components/circle-chart.js
@@ -147,7 +147,7 @@ const html = () => `
 customElements.define('circle-chart', class extends HTMLElement {
   /** @type {Array<{ key: string; name: string; color: string; count: number; }> | null} */
   data
-  /** @type {HTMLElement | null | undefined} */
+  /** @type {Element | null | undefined} */
   chartElement
   /** @type {string} */
   showPercentFor
@@ -321,6 +321,6 @@ customElements.define('circle-chart', class extends HTMLElement {
     if (this.shadowRoot) {
       this.shadowRoot.innerHTML = html()
     }
-    this.chartElement = this.shadowRoot?.querySelector('.circle-chart')
+    this.chartElement = this.shadowRoot.querySelector('.circle-chart')
   }
 })

--- a/src/client/js/components/circle-chart.js
+++ b/src/client/js/components/circle-chart.js
@@ -126,12 +126,17 @@ const styles = `
 </style>
 `
 
+/**
+ * @param {number} total
+ * @param {number} value
+ * @returns number
+ */
 const calcPercentage = (total, value) => {
   if (!total) {
     return 0
   }
 
-  return parseFloat((value / total).toFixed(3, 10))
+  return parseFloat((value / total).toFixed(3))
 }
 
 const html = () => `
@@ -140,6 +145,17 @@ const html = () => `
 `
 
 customElements.define('circle-chart', class extends HTMLElement {
+  /** @type {Array<{ key: string; name: string; color: string; count: number; }> | null} */
+  data
+  /** @type {HTMLElement | null | undefined} */
+  chartElement
+  /** @type {string} */
+  showPercentFor
+  /** @type {string} */
+  title
+  /** @type {SVGSVGElement | null} */
+  svg
+
   static get observedAttributes () {
     return [
       'data',
@@ -164,6 +180,11 @@ customElements.define('circle-chart', class extends HTMLElement {
     this.render()
   }
 
+  /**
+   * @param {string} name
+   * @param {string} oldValue
+   * @param {string} newValue
+   */
   attributeChangedCallback (name, oldValue, newValue) {
     if (newValue === 'undefined' || newValue === oldValue) {
       return
@@ -181,14 +202,16 @@ customElements.define('circle-chart', class extends HTMLElement {
         this.title = newValue
         break
       default:
-        console.warning(`Unhandled attribute: ${name}`)
+        console.warn(`Unhandled attribute: ${name}`)
     }
   }
 
   composeCircles () {
     let sliceOffset = 0
+    /** @type {string[]} */
+    const init = []
     return `
-      ${this.data.reduce((acc, curr) => {
+      ${this.data?.reduce((acc, curr) => {
         const percentage = calcPercentage(this.total, curr.count)
         const innerRadius = this.showPercentFor !== '' ? 0.85 : 0
         const strokeLength = CHART_CIRCUMFERENCE * percentage
@@ -205,7 +228,7 @@ customElements.define('circle-chart', class extends HTMLElement {
         sliceOffset += percentage
 
         return acc
-      }, []).join('')}
+      }, init).join('')}
     `
   }
 
@@ -214,14 +237,14 @@ customElements.define('circle-chart', class extends HTMLElement {
       ${this.title !== ''
         ? `<strong class='circle-chart-title'>${this.title}</strong>`
         : ''}
-      ${this.data.map(({ name, color }) => (
+      ${this.data?.map(({ name, color }) => (
         `<label class='circle-chart-label' style='--color: ${color}'>${name}</label>`
       )).join('')}
     `
   }
 
   createCircleLabel () {
-    const relevantItem = this.data.find(d => d.key === this.showPercentFor)
+    const relevantItem = this.data?.find(d => d.key === this.showPercentFor)
     if (!relevantItem) {
       return ''
     }
@@ -255,11 +278,15 @@ customElements.define('circle-chart', class extends HTMLElement {
     this.labels.innerHTML = this.createChartLabels()
 
     // Add chart elements to DOM
-    this.chartElement.append(this.svg)
-    this.chartElement.append(this.labels)
+    this.chartElement?.append(this.svg)
+    this.chartElement?.append(this.labels)
   }
 
   updateChart () {
+    if (!this.svg || !this.labels) {
+      return
+    }
+
     this.svg.innerHTML = `
       ${this.composeCircles()}
       ${this.createCircleLabel()}
@@ -278,7 +305,7 @@ customElements.define('circle-chart', class extends HTMLElement {
 
     this.total = this.data.reduce((acc, curr) => acc + curr.count, 0)
 
-    this.chartElement.classList.add('updating')
+    this.chartElement?.classList.add('updating')
     this.updateTimeout = setTimeout(() => {
       if (!this.svg) {
         this.createChart()
@@ -286,12 +313,14 @@ customElements.define('circle-chart', class extends HTMLElement {
         this.updateChart()
       }
 
-      this.chartElement.classList.remove('updating')
+      this.chartElement?.classList.remove('updating')
     }, this.svg ? CHART_UPDATE_DURATION : 0)
   }
 
   render () {
-    this.shadowRoot.innerHTML = html()
-    this.chartElement = this.shadowRoot.querySelector('.circle-chart')
+    if (this.shadowRoot) {
+      this.shadowRoot.innerHTML = html()
+    }
+    this.chartElement = this.shadowRoot?.querySelector('.circle-chart')
   }
 })

--- a/src/client/js/components/custom-select.js
+++ b/src/client/js/components/custom-select.js
@@ -62,7 +62,6 @@ customElements.define('custom-select', class extends HTMLElement {
   constructor () {
     super()
     this.attachShadow({ mode: 'open' })
-    // @ts-ignore: this.shadowRoot exists, as per this.attachShadow above
     this.shadowRoot.innerHTML = html
     // @ts-ignore: We know that this will not return null
     this.select = this.shadowRoot.querySelector('select')
@@ -109,7 +108,6 @@ customElements.define('custom-select', class extends HTMLElement {
 
     temp.className = 'hidden'
     temp.append(selectedOption.cloneNode(true))
-    // @ts-ignore: this.shadowRoot exists, as per this.attachShadow above
     this.shadowRoot.append(temp)
 
     // let’s wait for the next tick to make sure that the dimensions of temp are available

--- a/src/client/js/components/custom-select.js
+++ b/src/client/js/components/custom-select.js
@@ -64,7 +64,7 @@ customElements.define('custom-select', class extends HTMLElement {
     this.attachShadow({ mode: 'open' })
     // @ts-ignore: this.shadowRoot exists, as per this.attachShadow above
     this.shadowRoot.innerHTML = html
-    // @ts-ignore We know that this will not return null:
+    // @ts-ignore: We know that this will not return null
     this.select = this.shadowRoot.querySelector('select')
     this.options = this.querySelectorAll('option')
 

--- a/src/client/js/components/custom-select.js
+++ b/src/client/js/components/custom-select.js
@@ -56,17 +56,22 @@ const html = `
 `
 
 customElements.define('custom-select', class extends HTMLElement {
+  /** @type {HTMLSelectElement} */
+  select
+
   constructor () {
     super()
     this.attachShadow({ mode: 'open' })
+    // @ts-ignore: this.shadowRoot exists, as per this.attachShadow above
     this.shadowRoot.innerHTML = html
+    // @ts-ignore We know that this will not return null:
     this.select = this.shadowRoot.querySelector('select')
     this.options = this.querySelectorAll('option')
 
     // move <option> elements into <select> (<slot> not permitted as <select> child)
     this.select.append(...this.options)
     this.setAttribute('value', this.select.value)
-    this.setAttribute('selected-index', this.select.selectedIndex)
+    this.setAttribute('selected-index', this.select.selectedIndex.toString())
   }
 
   get value () {
@@ -79,15 +84,18 @@ customElements.define('custom-select', class extends HTMLElement {
 
   connectedCallback () {
     this.matchOptionWidth()
-    this.select.addEventListener('change', this)
+    this.select?.addEventListener('change', this)
   }
 
+  /**
+   * @param {InputEvent & { target: HTMLSelectElement }} e
+   */
   handleEvent (e) {
     switch (e.type) {
       case 'change':
         this.matchOptionWidth()
         this.setAttribute('value', e.target.value)
-        this.setAttribute('selected-index', e.target.selectedIndex)
+        this.setAttribute('selected-index', e.target.selectedIndex.toString())
         this.dispatchEvent(new Event('change'))
         break
     }
@@ -95,11 +103,13 @@ customElements.define('custom-select', class extends HTMLElement {
 
   matchOptionWidth () {
     // update <select> width based on selected <option> (override fixed width based on largest <option>)
+    /** @type {HTMLSelectElement & { w?: number }} */
     const temp = document.createElement('select')
     const selectedOption = this.options[this.select.selectedIndex]
 
     temp.className = 'hidden'
     temp.append(selectedOption.cloneNode(true))
+    // @ts-ignore: this.shadowRoot exists, as per this.attachShadow above
     this.shadowRoot.append(temp)
 
     // let’s wait for the next tick to make sure that the dimensions of temp are available

--- a/src/client/js/components/toast-alert.js
+++ b/src/client/js/components/toast-alert.js
@@ -117,7 +117,7 @@ const html = `
 </output>
 `
 
-const ToastTypes = {
+const ToastTypes = /** @type {const} */ {
   Error: 'error',
   Success: 'success'
 }
@@ -126,6 +126,7 @@ customElements.define('toast-alert', class extends HTMLElement {
   constructor () {
     super()
     this.attachShadow({ mode: 'open' })
+    // @ts-ignore: this.shadowRoot exists, as per this.attachShadow above
     this.shadowRoot.innerHTML = html
   }
 
@@ -133,8 +134,9 @@ customElements.define('toast-alert', class extends HTMLElement {
     return this.getAttribute('ttl')
   }
 
+  /** @param {string | null} value */
   set ttl (value) {
-    this.setAttribute('ttl', value)
+    this.setAttribute('ttl', value ?? '')
     this.style.setProperty('--ttl', `${value}s`) // seconds before fade-out starts
   }
 
@@ -142,17 +144,19 @@ customElements.define('toast-alert', class extends HTMLElement {
     return this.getAttribute('type')
   }
 
+  /** @param {string | null} value */
   set type (value) {
-    const isValidType = Object.values(ToastTypes).includes(value)
+    const isValidType = typeof value === 'string' && Object.values(ToastTypes).includes(value)
     if (!isValidType) {
-      console.warning(`Unknown toast type ${value}.`)
+      console.warn(`Unknown toast type ${value}.`)
+      return
     }
 
     this.setAttribute('type', value)
   }
 
   connectedCallback () {
-    const toasts = Array.from(document.querySelectorAll('toast-alert')).reverse()
+    const toasts = /** @type {HTMLElement[]} */ (Array.from(document.querySelectorAll('toast-alert')).reverse())
 
     for (let i = 1, y = 0; i < toasts.length; i++) {
       // start at index 1 to push old toasts down with aggregated toast heights plus 10px gap
@@ -170,17 +174,19 @@ customElements.define('toast-alert', class extends HTMLElement {
       this.type = ToastTypes.Error
     }
 
+    // @ts-ignore: this.shadowRoot exists, as per this.attachShadow in the constructor
     this.shadowRoot.addEventListener('click', this)
     this.addEventListener('animationend', this)
   }
 
+  /** @param {Event} e */
   handleEvent (e) {
     switch (true) {
-      case e.target.matches('button'):
+      case e.target instanceof HTMLElement && e.target.matches('button'):
         this.remove()
         window.gtag('event', 'toast_alert', { action: 'dismiss' })
         break
-      case e.animationName === 'fade-out':
+      case e instanceof AnimationEvent && e.animationName === 'fade-out':
         this.remove()
         window.gtag('event', 'toast_alert', { action: 'faded' })
         break
@@ -188,6 +194,7 @@ customElements.define('toast-alert', class extends HTMLElement {
   }
 
   disconnectedCallback () {
+    // @ts-ignore: this.shadowRoot exists, as per this.attachShadow in the constructor
     this.shadowRoot.removeEventListener('click', this)
     this.removeEventListener('animationend', this)
   }

--- a/src/client/js/components/toast-alert.js
+++ b/src/client/js/components/toast-alert.js
@@ -126,7 +126,6 @@ customElements.define('toast-alert', class extends HTMLElement {
   constructor () {
     super()
     this.attachShadow({ mode: 'open' })
-    // @ts-ignore: this.shadowRoot exists, as per this.attachShadow above
     this.shadowRoot.innerHTML = html
   }
 
@@ -174,7 +173,6 @@ customElements.define('toast-alert', class extends HTMLElement {
       this.type = ToastTypes.Error
     }
 
-    // @ts-ignore: this.shadowRoot exists, as per this.attachShadow in the constructor
     this.shadowRoot.addEventListener('click', this)
     this.addEventListener('animationend', this)
   }
@@ -194,7 +192,6 @@ customElements.define('toast-alert', class extends HTMLElement {
   }
 
   disconnectedCallback () {
-    // @ts-ignore: this.shadowRoot exists, as per this.attachShadow in the constructor
     this.shadowRoot.removeEventListener('click', this)
     this.removeEventListener('animationend', this)
   }

--- a/src/controllers/settings.js
+++ b/src/controllers/settings.js
@@ -29,6 +29,7 @@ import { getTemplate } from '../views/emails/email-2022.js'
 import { verifyPartial } from '../views/emails/email-verify.js'
 
 async function settingsPage (req, res) {
+  /** @type {Array<import('../db/tables/email_addresses.js').EmailRow>} */
   const emails = await getUserEmails(req.session.user.id)
   // Add primary subscriber email to the list
   emails.push({

--- a/src/custom-types.d.ts
+++ b/src/custom-types.d.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+interface HTMLElement {
+  // We access this.shadowRoot in custom elements often, and we've almost always
+  // already called this.attachShadow({ mode: 'open' }). So, the default type
+  // that indicates that it might also be `null` generates a lot of noise for an
+  // error that we haven't run into yet. Thus, we override the default type to
+  // pretend that shadowRoot is always set.
+  shadowRoot: ShadowRoot;
+}

--- a/src/db/tables/email_addresses.js
+++ b/src/db/tables/email_addresses.js
@@ -198,6 +198,17 @@ async function _verifyNewEmail (emailHash) {
   return verifiedEmail
 }
 
+/**
+ * @typedef {object} EmailRow Email data, as returned from the database table `email_addresses`
+ * @property {string} email
+ * @property {string} sha1
+ * @property {boolean} verified
+ */
+
+/**
+ * @param {number} userId
+ * @returns {Promise<EmailRow[]>}
+ */
 async function getUserEmails (userId) {
   const userEmails = await knex('email_addresses')
     .where('subscriber_id', '=', userId)

--- a/src/utils/email.test.js
+++ b/src/utils/email.test.js
@@ -47,6 +47,8 @@ test.serial('EmailUtils.init with SMTP URL invokes nodemailer.createTransport', 
   const testSmtpUrl = 'smtps://test:test@test:1'
   const createTransport = {
     verify: td.func(),
+    // A mocked function can be empty:
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     sendMail: (mailoptions, callback) => {}
   }
 
@@ -77,6 +79,8 @@ test.serial('EmailUtils.sendEmail with recipient, subject, template, context cal
 
   const createTransport = {
     verify: td.func(),
+    // A mocked function can be empty:
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     use: () => {},
     sendMail: (_options, cb) => cb(null, 'sent'),
     transporter: { name: 'MockTransporter' }
@@ -111,6 +115,8 @@ test.serial('EmailUtils.sendEmail rejects with error', async t => {
 
   const createTransport = {
     verify: td.func(),
+    // A mocked function can be empty:
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     use: () => {},
     // eslint-disable-next-line n/no-callback-literal
     sendMail: (_options, cb) => cb('error', 'null'),

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -3,6 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 class UserInputError extends Error {
+  /**
+   * @param {[string?]} params
+   */
   constructor (...params) {
     super(...params)
     this.statusCode = 400
@@ -10,6 +13,9 @@ class UserInputError extends Error {
 }
 
 class UnauthorizedError extends Error {
+  /**
+   * @param {[string?]} params
+   */
   constructor (...params) {
     super(...params)
     this.statusCode = 403
@@ -17,6 +23,9 @@ class UnauthorizedError extends Error {
 }
 
 class MethodNotAllowedError extends Error {
+  /**
+   * @param {[string?]} params
+   */
   constructor (...params) {
     super(...params)
     this.statusCode = 405
@@ -24,6 +33,9 @@ class MethodNotAllowedError extends Error {
 }
 
 class RateLimitError extends Error {
+  /**
+   * @param {[string?]} params
+   */
   constructor (...params) {
     super(...params)
     this.statusCode = 429

--- a/src/utils/fluent.js
+++ b/src/utils/fluent.js
@@ -11,6 +11,7 @@ import AppConstants from '../app-constants.js'
 import { localStorage } from './local-storage.js'
 
 const supportedLocales = AppConstants.SUPPORTED_LOCALES?.split(',')
+/** @type {Record<string, FluentBundle>} */
 const fluentBundles = {}
 
 /**
@@ -30,7 +31,7 @@ async function initFluentBundles () {
 
         bundle.addResource(new FluentResource(str))
       }))
-    } catch (e) {
+    } catch (/** @type {any} */ e) {
       console.error('Could not read Fluent file:', e)
       throw new Error(e)
     }
@@ -46,7 +47,7 @@ async function initFluentBundles () {
 /**
  * Set the locale used for translations negotiated between requested and available
  *
- * @param {Array} requestedLocales - Locales requested by client.
+ * @param {string[]} requestedLocales - Locales requested by client.
  */
 function updateLocale (requestedLocales) {
   return negotiateLanguages(
@@ -75,7 +76,7 @@ function getRawMessage (id) {
 
   if (!bundle.hasMessage(id)) bundle = fluentBundles.en
 
-  if (bundle.hasMessage(id)) return bundle.getMessage(id).value
+  if (bundle.hasMessage(id)) return bundle.getMessage(id)?.value
 
   return id
 }
@@ -85,7 +86,7 @@ function getRawMessage (id) {
  * Defaults to en if message id not found in requested locale
  *
  * @param {string} id - The Fluent message id.
- * @param {object} args - key/value pairs corresponding to pattern in Fluent resource.
+ * @param {Record<string, import('@fluent/bundle').FluentVariable>} [args] - key/value pairs corresponding to pattern in Fluent resource.
  * @example
  * // Given FluentResource("hello = Hello, {$name}!")
  * getMessage (hello, {name: "Jane"})
@@ -101,8 +102,9 @@ function getMessage (id, args) {
  * Defaults to en if message id not found in requested locale
  *
  * @param {string} id - The Fluent message id.
- * @param {string{}} localePreferences
- * @param {object} args - key/value pairs corresponding to pattern in Fluent resource.
+ * @param {string[]} localePreferences
+ * @param {Record<string, import('@fluent/bundle').FluentVariable>} [args] - key/value pairs corresponding to pattern in Fluent resource.
+ * @returns {string}
  * @example
  * // Given FluentResource("hello = Hello, {$name}!")
  * getMessage (hello, {name: "Jane"})
@@ -113,11 +115,16 @@ function getMessageWithLocale (id, localePreferences, args) {
 
   if (!bundle.hasMessage(id)) bundle = fluentBundles.en
 
-  if (bundle.hasMessage(id)) return bundle.formatPattern(bundle.getMessage(id).value, args)
+  if (!bundle.hasMessage(id)) {
+    return id
+  }
 
-  return id
+  return bundle.formatPattern(bundle.getMessage(id)?.value ?? '', args)
 }
 
+/**
+ * @param {string} id
+ */
 function fluentError (id) {
   return new Error(getMessage(id))
 }

--- a/src/views/partials/add-email.js
+++ b/src/views/partials/add-email.js
@@ -4,6 +4,16 @@
 
 import { getMessage } from '../../utils/fluent.js'
 
+/**
+ * @typedef {object} PartialData
+ * @property {string} csrfToken
+ * @property {number} emailLimit
+ */
+
+/**
+ * @param {PartialData} data
+ * @returns string
+ */
 export const addEmail = data => `
 <header>
   <button class='close'></button>

--- a/src/views/partials/admin.js
+++ b/src/views/partials/admin.js
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const admin = data => `
+/**
+ * @param {unknown} _data
+ * @returns string
+ */
+export const admin = _data => `
 <section>
   <h1>Admin</h1>
 

--- a/src/views/partials/settings.js
+++ b/src/views/partials/settings.js
@@ -63,6 +63,11 @@ const createEmailList = (emails, breachCounts) => `
   </ul>
 `
 
+/**
+ * @param {string} csrfToken
+ * @param {{ isChecked: boolean; option: unknown; }} options
+ * @returns string
+ */
 const optionInput = (csrfToken, { isChecked, option }) => `
   <input
     ${isChecked ? 'checked' : ''}
@@ -74,6 +79,10 @@ const optionInput = (csrfToken, { isChecked, option }) => `
   >
 `
 
+/**
+ * @param {{ csrfToken: string; allEmailsToPrimary: boolean }} options
+ * @returns string
+ */
 const alertOptions = ({ csrfToken, allEmailsToPrimary }) => `
   <div class='settings-alert-options'>
     <label class='settings-radio-input'>
@@ -98,6 +107,16 @@ const alertOptions = ({ csrfToken, allEmailsToPrimary }) => `
   </div>
 `
 
+/**
+ * @typedef {object} PartialData
+ * @property {string} csrfToken
+ * @property {boolean} allEmailsToPrimary
+ */
+
+/**
+ * @param {PartialData} data
+ * @returns string
+ */
 export const settings = data => {
   const { allEmailsToPrimary, breachCounts, csrfToken, emails, limit } = data
 

--- a/src/views/partials/unsubscribe.js
+++ b/src/views/partials/unsubscribe.js
@@ -4,6 +4,15 @@
 
 import { getMessage } from '../../utils/fluent.js'
 
+/**
+ * @typedef {object} PartialData
+ * @property {string} csrfToken
+ */
+
+/**
+ * @param {PartialData} data
+ * @returns string
+ */
 const unsubscribe = data => `
   <section class="unsubscribe">
     <h1>${getMessage('unsub-headline')}</h1>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,109 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": [
+    "src/custom-types.d.ts",
     "src/client/js/components/**/*",
     "src/views/partials/add-email.js",
     "src/views/partials/admin.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "include": [
-    "src/utils/error.js",
+    "src/client/js/components/**/*",
+    "src/views/partials/add-email.js",
+    "src/views/partials/admin.js",
     // Replace the above with the following when our entire codebase has type annotations:
     // "src/**/*",
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
+  "include": [
+    "src/utils/error.js",
+    // Replace the above with the following when our entire codebase has type annotations:
+    // "src/**/*",
+  ],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
-
     /* Projects */
     // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
@@ -9,9 +13,8 @@
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -22,11 +25,10 @@
     // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
+    "moduleDetection": "force", /* Control what method is used to detect module-format JS files. */
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "module": "commonjs", /* Specify what module code is generated. */
+    "rootDir": "./src/", /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -42,12 +44,10 @@
     // "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
     /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    "allowJs": true, /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    "checkJs": true, /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
     /* Emit */
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
@@ -72,17 +72,15 @@
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -101,9 +99,8 @@
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   }
 }


### PR DESCRIPTION
This adds a CI check to verify the type annotations for the following files, as per the discussion in Slack and the eng meeting:

- `src/client/js/components/**/*`
- `src/views/partials/add-email.js`
- `src/views/partials/admin.js`

We can fix the type annotations for additional files as we go, and add them to `tsconfig.json` to get them checked. If you use VSCode or another editor that supports TypeScript, it'll also warn you inline if you introduce mistakes.

We could also add a separate `tsconfig.json` for local vs. in CI, where the local one covers all files in `src/` (and maybe allows implicit `any`s), but I imagine the number of red squigglies could get quite annoying quickly, so let's save that for a followup PR, maybe.