### PR TITLE
MNTOR-1166: Moving csrf to routing index

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -18,7 +18,6 @@ import '@sentry/tracing'
 import AppConstants from './app-constants.js'
 import { localStorage } from './utils/local-storage.js'
 import { errorHandler } from './middleware/error.js'
-import { doubleCsrfProtection } from './utils/csrf.js'
 import { initFluentBundles, updateLocale, getMessageWithLocale, getMessage } from './utils/fluent.js'
 import { loadBreachesIntoApp } from './utils/hibp.js'
 import { RateLimitError } from './utils/error.js'
@@ -175,7 +174,6 @@ app.use(noSearchEngineIndex)
 app.use(express.static(staticPath))
 app.use(express.json())
 app.use(cookieParser(AppConstants.COOKIE_SECRET))
-app.use(doubleCsrfProtection)
 
 const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -19,20 +19,21 @@ import { dialog } from '../controllers/dialog.js'
 import { landingPage } from '../controllers/landing.js'
 import { notFoundPage } from '../controllers/notFound.js'
 import { notFound } from '../middleware/error.js'
+import { doubleCsrfProtection } from '../utils/csrf.js'
 
 const router = express.Router()
 
 router.get('/', landingPage)
 router.get('*/dialog/:name', dialog)
 
-router.use('/', dockerFlowRoutes)
-router.use('/admin', adminRoutes)
+router.use('/', doubleCsrfProtection, dockerFlowRoutes)
+router.use('/admin', doubleCsrfProtection, adminRoutes)
 router.use('/api/v1/hibp/', hibpApiRoutes)
-router.use('/api/v1/user/', userApiRoutes)
-router.use('/oauth', authRoutes)
-router.use('/user', userRoutes)
-router.use('/breaches', breachesRoutes)
-router.use('/breach-details', breachDetailsRoutes)
+router.use('/api/v1/user/', doubleCsrfProtection, userApiRoutes)
+router.use('/oauth', doubleCsrfProtection, authRoutes)
+router.use('/user', doubleCsrfProtection, userRoutes)
+router.use('/breaches', doubleCsrfProtection, breachesRoutes)
+router.use('/breach-details', doubleCsrfProtection, breachDetailsRoutes)
 
 // Do not make the non-auth previews available on prod
 if (AppConstants.NODE_ENV !== 'production') {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1166


<!-- When adding a new feature: -->

# Description
We would want to skip CSRF for the breach callback URI for HIBP. The endpoint has API key auth requirement already


# Screenshot (if applicable)

Not applicable.

# How to test
* Follow the README to fake trigger a new breach
* The endpoint should be triggered
* An email should be sent to the email with the hash specified


# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
