### PR TITLE
MNTOR-1509 remove doNotTrack handling

### DIFF
--- a/src/views/guestLayout.js
+++ b/src/views/guestLayout.js
@@ -42,28 +42,23 @@ const guestLayout = data => `
 
     <!-- Google tag (gtag.js) -->
     <script nonce='${data.nonce}'>
-      if (navigator.doNotTrack !== '1') {
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtag/js?id='+i+dl;var n=d.querySelector('[nonce]');
-        n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','${AppConstants.GA4_MEASUREMENT_ID}');
-        function gtag(){dataLayer.push(arguments);}
-        ${AppConstants.GA4_DEBUG_MODE
-          ? `gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}', { 'debug_mode': true })`
-          : ''}
-        gtag('js', new Date());
-        gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}',
-          { cookie_domain: window.location.hostname, cookie_flags: "SameSite=None;Secure" }
-        );
-        window.gtag = gtag
-      } else {
-        function gtag() {
-          console.debug("Google Analytics disbled by DNT")
-        }
-        window.gtag = gtag
-      }
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtag/js?id='+i+dl;var n=d.querySelector('[nonce]');
+      n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','${AppConstants.GA4_MEASUREMENT_ID}');
+      function gtag(){dataLayer.push(arguments);}
+      ${AppConstants.GA4_DEBUG_MODE
+        ? `gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}', { 'debug_mode': true })`
+        : ''}
+      gtag('js', new Date());
+      gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}',
+        { cookie_domain: window.location.hostname, cookie_flags: "SameSite=None;Secure" }
+      );
+      window.gtag = gtag
+
+      // Detect CTA clicks on public pages.
       document.querySelectorAll('[data-cta-id]').forEach(a =>
         a.addEventListener('click', e => {
           gtag('event', 'clicked_cta', { cta_id: a.dataset.ctaId })

--- a/src/views/mainLayout.js
+++ b/src/views/mainLayout.js
@@ -42,28 +42,21 @@ const mainLayout = data => `
 
     <!-- Google tag (gtag.js) -->
     <script nonce='${data.nonce}'>
-      if (navigator.doNotTrack !== '1') {
-        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtag/js?id='+i+dl;var n=d.querySelector('[nonce]');
-        n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','${AppConstants.GA4_MEASUREMENT_ID}');
-        function gtag(){dataLayer.push(arguments);}
-        ${AppConstants.GA4_DEBUG_MODE
-          ? `gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}', { 'debug_mode': true })`
-          : ''}
-        gtag('js', new Date());
-        gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}',
-          { cookie_domain: window.location.hostname, cookie_flags: "SameSite=None;Secure" }
-        );
-        window.gtag = gtag
-      } else {
-        function gtag() {
-          console.debug("Google Analytics disbled by DNT")
-        }
-        window.gtag = gtag
-      }
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtag/js?id='+i+dl;var n=d.querySelector('[nonce]');
+      n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','${AppConstants.GA4_MEASUREMENT_ID}');
+      function gtag(){dataLayer.push(arguments);}
+      ${AppConstants.GA4_DEBUG_MODE
+        ? `gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}', { 'debug_mode': true })`
+        : ''}
+      gtag('js', new Date());
+      gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}',
+        { cookie_domain: window.location.hostname, cookie_flags: "SameSite=None;Secure" }
+      );
+      window.gtag = gtag
     </script>
     <!-- End Google tag (gtag.js) -->
   </head>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1509

<!-- When adding a new feature: -->

# Description

We are currently trying to read `navigator.doNotTrack`, but this is deprecated and not supported in Safari https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack - browsers seem to be moving away from DNT and towards using tracking protection in the client anyway.

I think we should just remove it for now.