### PR TITLE
MNTOR-1512 - backwards-compatibility with breach query

### DIFF
--- a/src/controllers/landing.js
+++ b/src/controllers/landing.js
@@ -11,6 +11,12 @@ function landingPage (req, res) {
     nonce: res.locals.nonce
   }
 
+  // Backward-compatibility with Monitor V1, for SEO.
+  if (req.query.breach) {
+    const breach = encodeURIComponent(req.query.breach)
+    return res.redirect(`/breach-details/${breach}`)
+  }
+
   res.send(guestLayout(data))
 }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1512


<!-- When adding a new feature: -->

# Description

Google Search is linking to Monitor as the top result for "monitor twitter breach" and it returnsa two links:
1. `/?breach=[...]` which is unhandled redirects to `/`
2. `/breach-details/[...]`which works as expected

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/61412/229680432-fe3d6d2d-ec55-4232-bc46-794abbb7ef74.png)

# How to test

## Steps to reproduce

### Expected:

URLs with `/?breach=[...]` redirect to `/breach-details/[...]` automatically.

### Actual:

URLs with `/?breach=[...]` redirect to `/`

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
