### PR TITLE
MNTOR-1509 - re-implement DNT check so it works with Safari

### DIFF
--- a/src/views/guestLayout.js
+++ b/src/views/guestLayout.js
@@ -42,28 +42,32 @@ const guestLayout = data => `
 
     <!-- Google tag (gtag.js) -->
     <script nonce='${data.nonce}'>
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtag/js?id='+i+dl;var n=d.querySelector('[nonce]');
-      n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','${AppConstants.GA4_MEASUREMENT_ID}');
-      function gtag(){dataLayer.push(arguments);}
-      ${AppConstants.GA4_DEBUG_MODE
-        ? `gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}', { 'debug_mode': true })`
-        : ''}
-      gtag('js', new Date());
-      gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}',
-        { cookie_domain: window.location.hostname, cookie_flags: "SameSite=None;Secure" }
-      );
-      window.gtag = gtag
+      if (!navigator.doNotTrack || navigator.doNotTrack !== '1') {
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtag/js?id='+i+dl;var n=d.querySelector('[nonce]');
+        n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','${AppConstants.GA4_MEASUREMENT_ID}');
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}', {
+          cookie_domain: window.location.hostname,
+          cookie_flags: "SameSite=None;Secure",
+          debug_mode: ${Boolean(AppConstants.GA4_DEBUG_MODE)}
+        });
+        window.gtag = gtag
 
-      // Detect CTA clicks on public pages.
-      document.querySelectorAll('[data-cta-id]').forEach(a =>
-        a.addEventListener('click', e => {
-          gtag('event', 'clicked_cta', { cta_id: a.dataset.ctaId })
-        })
-      )
+        // Detect CTA clicks on public pages.
+        document.querySelectorAll('[data-cta-id]').forEach(a =>
+          a.addEventListener('click', e => {
+            gtag('event', 'clicked_cta', { cta_id: a.dataset.ctaId })
+          })
+        )
+      } else {
+        function gtag() {
+          console.debug("Google Analytics disbled by DNT")
+      }
       </script>
     <!-- End Google tag (gtag.js) -->
 

--- a/src/views/mainLayout.js
+++ b/src/views/mainLayout.js
@@ -42,20 +42,25 @@ const mainLayout = data => `
 
     <!-- Google tag (gtag.js) -->
     <script nonce='${data.nonce}'>
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtag/js?id='+i+dl;var n=d.querySelector('[nonce]');
-      n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','${AppConstants.GA4_MEASUREMENT_ID}');
-      function gtag(){dataLayer.push(arguments);}
-      ${AppConstants.GA4_DEBUG_MODE
-        ? `gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}', { 'debug_mode': true })`
-        : ''}
-      gtag('js', new Date());
-      gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}',
-        { cookie_domain: window.location.hostname, cookie_flags: "SameSite=None;Secure" }
-      );
+      if (!navigator.doNotTrack || navigator.doNotTrack !== '1') {
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtag/js?id='+i+dl;var n=d.querySelector('[nonce]');
+        n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','${AppConstants.GA4_MEASUREMENT_ID}');
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '${AppConstants.GA4_MEASUREMENT_ID}', {
+          cookie_domain: window.location.hostname,
+          cookie_flags: "SameSite=None;Secure",
+          debug_mode: ${Boolean(AppConstants.GA4_DEBUG_MODE)}
+        });
+      } else {
+        function gtag() {q
+          console.debug("Google Analytics disbled by DNT")
+        }
+      }
       window.gtag = gtag
     </script>
     <!-- End Google tag (gtag.js) -->


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1509


<!-- When adding a new feature: -->

# Description

The Do Not Track (DNT) header is deprecated and not implemented in all browsers (notably Safari), but until we have a better opt-out mechanism we should keep this in place to be consistent with other Mozilla sites.