### PR TITLE
MNTOR-1509 fix for broken GA JS on guest page

### DIFF
--- a/src/views/guestLayout.js
+++ b/src/views/guestLayout.js
@@ -42,7 +42,7 @@ const guestLayout = data => `
 
     <!-- Google tag (gtag.js) -->
     <script nonce='${data.nonce}'>
-      if (!navigator.doNotTrack || navigator.doNotTrack !== '1') {
+      if (navigator.doNotTrack !== '1') {
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -56,19 +56,19 @@ const guestLayout = data => `
           cookie_flags: "SameSite=None;Secure",
           debug_mode: ${Boolean(AppConstants.GA4_DEBUG_MODE)}
         });
-        window.gtag = gtag
 
         // Detect CTA clicks on public pages.
         document.querySelectorAll('[data-cta-id]').forEach(a =>
           a.addEventListener('click', e => {
             gtag('event', 'clicked_cta', { cta_id: a.dataset.ctaId })
-          })
-        )
+          }))
       } else {
         function gtag() {
           console.debug("Google Analytics disbled by DNT")
+        }
       }
-      </script>
+      window.gtag = gtag
+    </script>
     <!-- End Google tag (gtag.js) -->
 
   </head>

--- a/src/views/mainLayout.js
+++ b/src/views/mainLayout.js
@@ -42,7 +42,7 @@ const mainLayout = data => `
 
     <!-- Google tag (gtag.js) -->
     <script nonce='${data.nonce}'>
-      if (!navigator.doNotTrack || navigator.doNotTrack !== '1') {
+      if (navigator.doNotTrack !== '1') {
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -57,7 +57,7 @@ const mainLayout = data => `
           debug_mode: ${Boolean(AppConstants.GA4_DEBUG_MODE)}
         });
       } else {
-        function gtag() {q
+        function gtag() {
           console.debug("Google Analytics disbled by DNT")
         }
       }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1509
Figma: 


<!-- When adding a new feature: -->

# Description

Testing on dev, I noticed that the GA code in the guest layout was not working correctly. It's hard to test for syntax errors here, and it intentionally doesn't break the page so the e2e test doesn't catch it.

I think we should try to share more of this analytics code between the main and guest layout, maybe as a partial that they import? Anyway, for now this PR fixes up the script and also some small issues like a redundant DNT check.