### PR TITLE
Add routes for exposure scan signup and overview

### DIFF
--- a/src/controllers/exposure-scan.js
+++ b/src/controllers/exposure-scan.js
@@ -16,7 +16,7 @@ const exposureScanPage = (req, res, next) => {
   }
 
   /**
-   * @type {ViewPartialData<import('../views/partials/exposure-scan.js').PartialParameters>}
+   * @type {GuestViewPartialData<import('../views/partials/exposure-scan.js').PartialParameters>}
    */
   const data = {
     partial: exposureScan,

--- a/src/controllers/exposures.js
+++ b/src/controllers/exposures.js
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { mainLayout } from '../views/mainLayout.js'
+import { generateToken } from '../utils/csrf.js'
+import { exposuresSetup } from '../views/partials/exposures-setup.js'
+import { exposuresList } from '../views/partials/exposures-list.js'
+
+/**
+ * @type {import('express').RequestHandler}
+ */
+async function exposuresPage (req, res) {
+  const showDashboard = await hasSetUpExposureScanning(req.user)
+
+  if (!showDashboard) {
+    /**
+     * @type {MainViewPartialData<import('../views/partials/exposures-setup').PartialParameters>}
+     */
+    const data = {
+      partial: exposuresSetup,
+      csrfToken: generateToken(res, req),
+      nonce: res.locals.nonce,
+      fxaProfile: req.user?.fxa_profile_json
+    }
+    res.send(mainLayout(data))
+    return
+  }
+
+  /**
+   * @type {MainViewPartialData<import('../views/partials/exposures-list').PartialParameters>}
+   */
+  const data = {
+    partial: exposuresList,
+    csrfToken: generateToken(res, req),
+    nonce: res.locals.nonce,
+    fxaProfile: req.user?.fxa_profile_json
+  }
+
+  res.send(mainLayout(data))
+}
+
+/**
+ * @param {import('express').Request['user']} user
+ * @returns {Promise<boolean>} Whether the user has set up exposure scanning already
+ */
+async function hasSetUpExposureScanning (user) {
+  // TODO: Once the back-end supports storing a user's exposure scan data,
+  //       check whether it has been entered:
+  return false
+}
+
+export { exposuresPage }

--- a/src/custom-types.d.ts
+++ b/src/custom-types.d.ts
@@ -13,8 +13,23 @@ interface HTMLElement {
 
 // This lint rule does not apply to type definitions:
 // eslint-disable-next-line no-unused-vars
-type ViewPartial<ViewPartialParams = object> = (data: ViewPartialParams) => string;
-type ViewPartialData<ViewPartialParams = object> = {
-    partial: ViewPartial<ViewPartialParams>,
-    nonce: string
+type ViewPartial<ViewPartialParams = object> = (data: ViewPartialParams & { partial: { name: string } }) => string;
+type GuestViewPartialData<ViewPartialParams = object> = {
+    partial: ViewPartial<ViewPartialParams>;
+    nonce: string;
   } & ViewPartialParams;
+type MainViewPartialData<ViewPartialParams = object> = {
+    fxaProfile: NonNullable<import('express').Request['user']>['fxa_profile_json'];
+  } & GuestViewPartialData<ViewPartialParams>;
+
+declare namespace Express {
+  export interface Request {
+    user?: {
+      // TODO: Finish the type definition of the user object
+      fxa_profile_json?: {
+        avatar: string;
+        email: string;
+      }
+    };
+  }
+}

--- a/src/custom-types.d.ts
+++ b/src/custom-types.d.ts
@@ -22,14 +22,27 @@ type MainViewPartialData<ViewPartialParams = object> = {
     fxaProfile: NonNullable<import('express').Request['user']>['fxa_profile_json'];
   } & GuestViewPartialData<ViewPartialParams>;
 
+/**
+ * See https://github.com/mozilla/fxa/blob/564949dfc69f0f675ebb4e5f267282c2546a5767/packages/fxa-profile-server/lib/routes/profile.js#L63-L77
+ */
+type FxaProfile = {
+  email?: string;
+  uid?: string;
+  avatar?: string;
+  avatarDefault?: boolean;
+  displayName?: string;
+  locale?: string;
+  amrValues?: string[];
+  twoFactorAuthentication?: boolean;
+  subscriptions?: string[];
+  metricsEnabled?: boolean;
+  sub?: string;
+}
 declare namespace Express {
   export interface Request {
     user?: {
       // TODO: Finish the type definition of the user object
-      fxa_profile_json?: {
-        avatar: string;
-        email: string;
-      }
+      fxa_profile_json?: FxaProfile;
     };
   }
 }

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -10,6 +10,7 @@ import { requireSessionUser } from '../middleware/auth.js'
 import { logout } from '../controllers/auth.js'
 // import { dashboardPage } from '../controllers/dashboard.js'
 import { breachesPage } from '../controllers/breaches.js'
+import { exposuresPage } from '../controllers/exposures.js'
 import { dataRemovalPage } from '../controllers/data-removal.js'
 import { settingsPage } from '../controllers/settings.js'
 import {
@@ -30,6 +31,9 @@ router.get('/dashboard', (req, res) => res.redirect(302, '/user/breaches'))
 
 // data breaches detail page
 router.get('/breaches', requireSessionUser, breachesPage)
+
+// data exposures detail page
+router.get('/exposures', requireSessionUser, exposuresPage)
 
 // data removal page
 router.get('/data-removal', requireSessionUser, dataRemovalPage)

--- a/src/views/guestLayout.js
+++ b/src/views/guestLayout.js
@@ -6,9 +6,7 @@ import AppConstants from '../app-constants.js'
 import { getMessage, getLocale } from '../utils/fluent.js'
 
 /**
- * @template {object} PartialParameters
- * @param {ViewPartialData<PartialParameters>} data
- * @returns {string}
+ * @type {ViewPartial<GuestViewPartialData<any>>}
  */
 const guestLayout = data => `
 <!doctype html>

--- a/src/views/mainLayout.js
+++ b/src/views/mainLayout.js
@@ -5,6 +5,9 @@
 import AppConstants from '../app-constants.js'
 import { getMessage, getLocale } from '../utils/fluent.js'
 
+/**
+ * @type {ViewPartial<MainViewPartialData<any>>}
+ */
 const mainLayout = data => `
 <!doctype html>
 <html lang=${getLocale()}>
@@ -126,6 +129,9 @@ const mainLayout = data => `
 </html>
 `
 
+/**
+ * @type {ViewPartial<MainViewPartialData>}
+ */
 const userMenu = data => `
 <div class='user-menu-wrapper' tabindex='-1'>
   <button

--- a/src/views/partials/exposures-list.js
+++ b/src/views/partials/exposures-list.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @typedef {object} PartialParameters
+ * @property {string} csrfToken
+ */
+
+/**
+ * @type {ViewPartial<PartialParameters>}
+ */
+export const exposuresList = data => `
+  This page will show the user's exposures dashboard, when they have already set up exposure scanning.
+`

--- a/src/views/partials/exposures-setup.js
+++ b/src/views/partials/exposures-setup.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @typedef {object} PartialParameters
+ * @property {string} csrfToken
+ */
+
+/**
+ * @type {ViewPartial<PartialParameters>}
+ */
+export const exposuresSetup = data => `
+ This page will allow the user to enter their information to do a scan for public data exposures.
+`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,10 @@
     "src/views/partials/add-email.js",
     "src/views/partials/admin.js",
     "src/views/partials/exposure-scan.js",
+    "src/views/partials/exposures-setup.js",
+    "src/views/partials/exposures-list.js",
     "src/controllers/exposure-scan.js",
+    "src/controllers/exposures.js",
     "src/utils/emailAddress.js",
     // Replace the above with the following when our entire codebase has type annotations:
     // "src/**/*",


### PR DESCRIPTION
This should make it easier to work on both in parallel while minimising conflicts.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1544
Figma: https://www.figma.com/file/iJFOikscJeplRBOuKOtYEW/Onboarding?node-id=297%3A26021&t=AExoU4tTaoOmlEt9-4


<!-- When adding a new feature: -->

# Description

This adds a `/user/exposures` route, which should eventually show the exposure scan signup if the user hasn't gone through that signup before, and shows the exposures dashboard otherwise.

Note that I added all files to the `tsconfig.json`; if you need help with defining type definitions, either let me know, or remove the file you're working on from `tsconfig.json`. (Try it out by running `npm run lint:ts` in the project root.)

The new route isn't linked to, so it should not block production deployments.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/231453983-91bc6f8e-6716-4c00-ba61-77e6f3726df6.png)

![image](https://user-images.githubusercontent.com/4251/231455206-2e868ab6-a082-4d3a-9722-6ab96b5ea7b3.png)

# How to test

Visit `/user/exposures`. You should be prompted to log in, and see the partial for exposure signup if you are logged in. You can flip a boolean in code to see the exposure dashboard partial.
