### PR TITLE
Fix bunched-up layout on iOS on the exposure scan

### DIFF
--- a/src/client/css/partials/exposureScan.css
+++ b/src/client/css/partials/exposureScan.css
@@ -84,7 +84,7 @@
   box-shadow: 0 2px 8px var(--gray-20);
   border-radius: calc(2 * var(--border-radius));
   text-decoration: none;
-  height: 100%;
+  height: auto;
 }
 
 #exposure-scan-results-none .exposure-scan-breach {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1545
Figma: N/A


<!-- When adding a new feature: -->

# Description

The layout looked all bunched up on iOS:

![image](https://user-images.githubusercontent.com/4251/232009169-ec535157-0d88-4980-a2cb-ded8e6c4b1b5.png)

This PR fixes that.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/232009223-39146ad7-43fa-4688-8d3e-5dacd6056f16.png)

# How to test

Do a scan from the landing page on iOS. Things shouldn't overlap.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
