### PR TITLE
Add API to store data to scan for exposures

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -59,6 +59,9 @@ HIBP_THROTTLE_MAX_TRIES=5
 # Authorization token for HIBP to present to /hibp/notify endpoint
 HIBP_NOTIFY_TOKEN=unsafe-default-token-for-dev
 
+# OneRep API for exposure scanning
+ONEREP_API_KEY=
+
 # Firefox Remote Settings
 FX_REMOTE_SETTINGS_WRITER_SERVER=https://settings-writer.prod.mozaws.net/v1
 FX_REMOTE_SETTINGS_WRITER_USER=

--- a/db/migrations/20230413104243_add_onerep_profile_id.js
+++ b/db/migrations/20230413104243_add_onerep_profile_id.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.table('subscribers', (table) => {
+    table.integer('onerep_profile_id').nullable()
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.table('subscribers', (table) => {
+    table.dropColumn('onerep_profile_id')
+  })
+}

--- a/src/appConstants.js
+++ b/src/appConstants.js
@@ -32,6 +32,7 @@ const requiredEnvVars = [
   'OAUTH_CLIENT_SECRET',
   'OAUTH_PROFILE_URI',
   'OAUTH_TOKEN_URI',
+  'ONEREP_API_KEY',
   'REDIS_URL',
   'SENTRY_DSN',
   'SERVER_URL',

--- a/src/client/js/partials/exposuresSetup.js
+++ b/src/client/js/partials/exposuresSetup.js
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/** @type {HTMLDivElement} */
+// @ts-ignore: We guard against a null value by not calling init():
+const exposuresSetupPartial = document.querySelector("[data-partial='exposuresSetup']")
+
+if (exposuresSetupPartial) {
+  init()
+}
+
+async function init () {
+  const dataEl = /** @type {HTMLTemplateElement} */ (exposuresSetupPartial.querySelector('#data'))
+  const csrfToken = /** @type {string} */ (dataEl.dataset.csrfToken)
+
+  const mockButton = /** @type {HTMLButtonElement} */ (exposuresSetupPartial.querySelector('#storeMockData'))
+  mockButton.addEventListener('click', async () => {
+    await storeMockData(csrfToken)
+    document.location.reload()
+  })
+}
+
+/**
+ * @param {string} csrfToken
+ */
+async function storeMockData (csrfToken) {
+  /** @type {import('../../../external/onerep').ProfileData} */
+  const requestBody = {
+    city: 'Tulsa',
+    first_name: 'John',
+    last_name: 'Doe',
+    state: 'OK'
+  }
+
+  try {
+    const res = await fetch('/api/v1/user/exposures/', {
+      headers: {
+        'Content-Type': 'application/json',
+        'x-csrf-token': csrfToken,
+        Accept: 'application/json'
+      },
+      mode: 'same-origin',
+      method: 'POST',
+      body: JSON.stringify(requestBody)
+    })
+
+    if (!res.ok) {
+      throw new Error('Immediately caught to show an error message.')
+    }
+
+    /** @type {import("../../../controllers/request-breach-scan").RequestBreachScanResponse} */
+    const responseBody = await res.json()
+
+    if (!responseBody.success) {
+      throw new Error('Immediately caught to show an error message.')
+    }
+  } catch (e) {
+  }
+}

--- a/src/controllers/exposures.js
+++ b/src/controllers/exposures.js
@@ -6,12 +6,18 @@ import { mainLayout } from '../views/mainLayout.js'
 import { generateToken } from '../utils/csrf.js'
 import { exposuresSetup } from '../views/partials/exposuresSetup.js'
 import { exposuresList } from '../views/partials/exposuresList.js'
+import { listScanResults } from '../external/onerep.js'
 
 /**
  * @type {import('express').RequestHandler}
  */
-async function exposuresPage (req, res) {
-  const showDashboard = await hasSetUpExposureScanning(req.user)
+async function exposuresPage (req, res, next) {
+  if (!req.user) {
+    next()
+    return
+  }
+  const user = req.user
+  const showDashboard = hasSetUpExposureScanning(user)
 
   if (!showDashboard) {
     /**
@@ -21,12 +27,13 @@ async function exposuresPage (req, res) {
       partial: exposuresSetup,
       csrfToken: generateToken(res, req),
       nonce: res.locals.nonce,
-      fxaProfile: req.user?.fxa_profile_json
+      fxaProfile: user.fxa_profile_json
     }
     res.send(mainLayout(data))
     return
   }
 
+  const scanResults = await listScanResults(user.onerep_profile_id)
   /**
    * @type {MainViewPartialData<import('../views/partials/exposuresList').PartialParameters>}
    */
@@ -34,20 +41,19 @@ async function exposuresPage (req, res) {
     partial: exposuresList,
     csrfToken: generateToken(res, req),
     nonce: res.locals.nonce,
-    fxaProfile: req.user?.fxa_profile_json
+    fxaProfile: user.fxa_profile_json,
+    scanResults
   }
 
   res.send(mainLayout(data))
 }
 
 /**
- * @param {import('express').Request['user']} user
- * @returns {Promise<boolean>} Whether the user has set up exposure scanning already
+ * @param {NonNullable<import('express').Request['user']>} user
+ * @returns {user is import('express').Request['user'] & { onerep_profile_id: number }} Whether the user has set up exposure scanning already
  */
-async function hasSetUpExposureScanning (user) {
-  // TODO: Once the back-end supports storing a user's exposure scan data,
-  //       check whether it has been entered:
-  return false
+function hasSetUpExposureScanning (user) {
+  return typeof user.onerep_profile_id === 'number'
 }
 
 export { exposuresPage }

--- a/src/controllers/storeExposureScanData.js
+++ b/src/controllers/storeExposureScanData.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createProfile, createScan, parseExposureScanData } from '../external/onerep.js'
+import { setOnerepProfileId } from '../db/tables/subscribers.js'
+
+/**
+ * @typedef {{ success: false }} StoreExposureScanDataErrorResponse
+ * @typedef {{ success: true }} StoreExposureScanDataSuccessResponse
+ * @typedef {StoreExposureScanDataErrorResponse | StoreExposureScanDataSuccessResponse} StoreExposureScanDataResponse
+ */
+
+/** @type {import('express').RequestHandler<import('../external/onerep').ProfileData, StoreExposureScanDataResponse>} */
+async function storeExposureScanData (req, res, next) {
+  if (req.method !== 'POST' || !req.user) {
+    return next()
+  }
+  if (typeof req.user.onerep_profile_id === 'number') {
+    // Exposure scan data is already set for this user
+    res.status(409).send({ success: false })
+    return
+  }
+  const exposureScanInput = parseExposureScanData(req.body)
+  if (exposureScanInput === null) {
+    res.status(400).send({ success: false })
+    return
+  }
+
+  try {
+    const onerepProfileId = await createProfile(exposureScanInput)
+    await createScan(onerepProfileId)
+    await setOnerepProfileId(req.user, onerepProfileId)
+
+    /** @type {StoreExposureScanDataSuccessResponse} */
+    const successResponse = {
+      success: true
+    }
+    res.json(successResponse)
+    return
+  } catch (ex) {
+    res.status(500).send({ success: false })
+  }
+}
+
+export { storeExposureScanData }

--- a/src/custom-types.d.ts
+++ b/src/custom-types.d.ts
@@ -46,3 +46,16 @@ declare namespace Express {
     };
   }
 }
+
+declare module 'mozlog' {
+  type LogFunction = (_op: string, _details?: object) => void
+
+  type Options = {
+    app: string;
+    level: string;
+    fmt: string;
+  };
+  const defaultFunction: (_options: Options) => (_scope: string) => ({ debug: LogFunction, info: LogFunction, warn: LogFunction, error: LogFunction })
+
+  export default defaultFunction
+}

--- a/src/custom-types.d.ts
+++ b/src/custom-types.d.ts
@@ -40,7 +40,7 @@ type FxaProfile = {
 }
 declare namespace Express {
   export interface Request {
-    user?: {
+    user?: (import('./db/tables/subscribers_types').SubscriberRow) & {
       // TODO: Finish the type definition of the user object
       fxa_profile_json?: FxaProfile;
     };

--- a/src/db/tables/subscribers.js
+++ b/src/db/tables/subscribers.js
@@ -124,6 +124,18 @@ async function removeFxAData (subscriber) {
   return updatedSubscriber
 }
 
+/**
+ * @param {import('./subscribers_types').SubscriberRow} subscriber
+ * @param {number} onerepProfileId
+ */
+async function setOnerepProfileId (subscriber, onerepProfileId) {
+  await knex('subscribers')
+    .where('id', subscriber.id)
+    .update({
+      onerep_profile_id: onerepProfileId
+    })
+}
+
 async function setBreachesLastShownNow (subscriber) {
   // TODO: turn 2 db queries into a single query (also see #942)
   const nowDateTime = new Date()
@@ -314,6 +326,7 @@ export {
   updateFxAData,
   removeFxAData,
   updateFxAProfileData,
+  setOnerepProfileId,
   setBreachesLastShownNow,
   setAllEmailsToPrimary,
   setBreachesResolved,

--- a/src/db/tables/subscribers_types.d.ts
+++ b/src/db/tables/subscribers_types.d.ts
@@ -1,0 +1,10 @@
+// This file contains types for subscribers.js until it's fully typed
+
+export type SubscriberRow = {
+  id: number;
+  sha1: string;
+  email: string;
+  verification_token: string;
+  verified: boolean;
+  onerep_profile_id?: number;
+}

--- a/src/external/onerep.js
+++ b/src/external/onerep.js
@@ -1,0 +1,233 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import AppConstants from '../appConstants.js'
+import mozlog from '../utils/log.js'
+const log = mozlog('external.onerep')
+
+/**
+ * @param {string} path
+ * @param {Parameters<typeof fetch>[1]} [options]
+ */
+async function onerepFetch (path, options = {}) {
+  const url = 'https://api.onerep.com' + path
+  const headers = new Headers(options.headers)
+  headers.set('Authorization', `Basic ${Buffer.from(`${AppConstants.ONEREP_API_KEY}:`).toString('base64')}`)
+  return fetch(url, { ...options, headers })
+}
+
+/**
+ * @typedef {object} OneRepProfile
+ * @property {string} first_name
+ * @property {string} last_name
+ * @property {string} city
+ * @property {import('../utils/states').StateAbbr} state
+ * @property {import('../utils/parse.js').ISO8601DateString} [birth_date]
+ * @property {import('../utils/parse.js').E164PhoneNumberString} [phone_number]
+ */
+
+/**
+ * @param {OneRepProfile} profileData
+ * @returns {Promise<number>} Profile ID
+ */
+export async function createProfile (profileData) {
+  /**
+   * See https://docs.onerep.com/#operation/createProfile
+   *
+   * @type {any}
+   */
+  const requestBody = {
+    first_name: profileData.first_name,
+    last_name: profileData.last_name,
+    addresses: [
+      {
+        state: profileData.state,
+        city: profileData.city
+      }
+    ]
+  }
+  if (profileData.birth_date) {
+    requestBody.birth_date = profileData.birth_date
+  }
+  if (profileData.phone_number) {
+    requestBody.phone_numbers = [
+      { number: profileData.phone_number }
+    ]
+  }
+  const response = await onerepFetch('/profiles', {
+    method: 'POST',
+    body: JSON.stringify(requestBody)
+  })
+  if (!response.ok) {
+    log.info(`Failed to create OneRep profile: [${response.status}] [${response.statusText}]`)
+    throw new Error(`Failed to create OneRep profile: [${response.status}] [${response.statusText}]`)
+  }
+  /**
+   * See https://docs.onerep.com/#operation/createProfile
+   *
+   * @type {{
+   *   id: number,
+   *   status: 'active' | 'inactive',
+   *   created_at: import('../utils/parse.js').ISO8601DateString,
+   *   updated_at: import('../utils/parse.js').ISO8601DateString,
+   *   url: string,
+   * }}
+   */
+  const savedProfile = await response.json()
+  return savedProfile.id
+}
+
+/**
+ * @param {number} profileId
+ * @returns {Promise<void>}
+ */
+export async function activateProfile (profileId) {
+  /**
+   * See https://docs.onerep.com/#operation/activateProfile
+   *
+   * @type {any}
+   */
+  const response = await onerepFetch(`/profiles/${profileId}/activate`, {
+    method: 'PUT'
+  })
+  if (!response.ok) {
+    log.info(`Failed to activate OneRep profile: [${response.status}] [${response.statusText}]`)
+    throw new Error(`Failed to activate OneRep profile: [${response.status}] [${response.statusText}]`)
+  }
+}
+
+/**
+ * @param {number} profileId
+ * @returns {Promise<void>}
+ */
+export async function optoutProfile (profileId) {
+  /**
+   * See https://docs.onerep.com/#operation/optoutProfile
+   */
+  const response = await onerepFetch(`/profiles/${profileId}/optout`, {
+    method: 'POST'
+  })
+  if (!response.ok) {
+    log.info(`Failed to opt-out OneRep profile: [${response.status}] [${response.statusText}]`)
+    throw new Error(`Failed to opt-out OneRep profile: [${response.status}] [${response.statusText}]`)
+  }
+}
+
+/**
+ * @typedef {object} CreateScanResponse
+ * @property {number} id
+ * @property {number} profile_id
+ * @property {'in_progress'} status
+ * @property {'manual'} reason
+ * @property {import('../utils/parse.js').ISO8601DateString} created_at
+ * @property {import('../utils/parse.js').ISO8601DateString} updated_at
+ */
+
+/**
+ * @param {number} profileId
+ * @returns {Promise<CreateScanResponse>}
+ */
+export async function createScan (profileId) {
+  /**
+   * See https://docs.onerep.com/#operation/createScan
+   */
+  const response = await onerepFetch(`/profiles/${profileId}/scans`, {
+    method: 'POST'
+  })
+  if (!response.ok) {
+    log.info(`Failed to create a scan: [${response.status}] [${response.statusText}]`)
+    throw new Error(`Failed to create a scan: [${response.status}] [${response.statusText}]`)
+  }
+  return response.json()
+}
+
+/**
+ * @typedef {{ current_page: number; from: number; last_page: number; per_page: number; to: number; total: number; }} OneRepMeta
+ * @typedef {object} Scan
+ * @property {number} id
+ * @property {number} profile_id
+ * @property {'in_progress' | 'finished'} status
+ * @property {'initial' | 'monitoring' | 'manual'} reason
+ * @typedef {{ meta: OneRepMeta, data: Scan[] }} ListScansResponse
+ */
+
+/**
+ * @param {number} profileId
+ * @param {Partial<{ page: number; per_page: number }>} [options]
+ * @returns {Promise<ListScansResponse>}
+ */
+export async function listScans (profileId, options = {}) {
+  const queryParams = new URLSearchParams()
+  if (options.page) {
+    queryParams.set('page', options.page.toString())
+  }
+  if (options.per_page) {
+    queryParams.set('per_page', options.per_page.toString())
+  }
+  /**
+   * See https://docs.onerep.com/#operation/getScans
+   *
+   * @type {any}
+   */
+  const response = await onerepFetch(`/profiles/${profileId}/scans?` + queryParams.toString(), {
+    method: 'GET'
+  })
+  if (!response.ok) {
+    log.info(`Failed to fetch scans: [${response.status}] [${response.statusText}]`)
+    throw new Error(`Failed to fetch scans: [${response.status}] [${response.statusText}]`)
+  }
+  return response.json()
+}
+
+/**
+ * @typedef {object} ScanResult
+ * @property {number} id
+ * @property {number} profile_id
+ * @property {string} first_name
+ * @property {string} last_name
+ * @property {string} middle_name
+ * @property {`${number}`} age
+ * @property {Array<{ city: string; state: string; street: string; zip: string; }>} addresses
+ * @property {string[]} phones
+ * @property {string[]} emails
+ * @property {string} data_broker
+ * @property {import('../utils/parse.js').ISO8601DateString} created_at
+ * @property {import('../utils/parse.js').ISO8601DateString} updated_at
+ * @typedef {{ meta: OneRepMeta, data: ScanResult[] }} ListScanResultsResponse
+ */
+
+/**
+ * @typedef {'new' | 'optout_in_progress' | 'waiting_for_verification' | 'removed'} RemovalStatus
+ * @param {number} profileId
+ * @param {Partial<{ page: number; per_page: number; status: RemovalStatus }>} [options]
+ * @returns {Promise<ListScanResultsResponse>}
+ */
+export async function listScanResults (profileId, options = {}) {
+  const queryParams = new URLSearchParams({ 'profile_id[]': profileId.toString() })
+  if (options.page) {
+    queryParams.set('page', options.page.toString())
+  }
+  if (options.per_page) {
+    queryParams.set('per_page', options.per_page.toString())
+  }
+  if (options.status) {
+    const statuses = Array.isArray(options.status) ? options.status : [options.status]
+    statuses.forEach(status => {
+      queryParams.append('status[]', status)
+    })
+  }
+  /**
+   * See https://docs.onerep.com/#operation/getScanResults
+   *
+   * @type {any}
+   */
+  const response = await onerepFetch('/scan-results/?' + queryParams.toString(), {
+    method: 'GET'
+  })
+  if (!response.ok) {
+    log.info(`Failed to fetch scan results: [${response.status}] [${response.statusText}]`)
+    throw new Error(`Failed to fetch scan results: [${response.status}] [${response.statusText}]`)
+  }
+  return response.json()
+}

--- a/src/routes/api/v1/user.js
+++ b/src/routes/api/v1/user.js
@@ -16,12 +16,16 @@ import {
   verifyEmail,
   updateCommunicationOptions
 } from '../../../controllers/settings.js'
+import AppConstants from '../../../appConstants.js'
 
 const router = Router()
 // breaches
 router.put('/breaches', requireSessionUser, asyncMiddleware(putBreachResolution))
 router.get('/breaches', requireSessionUser, asyncMiddleware(getBreaches))
-router.post('/exposures', requireSessionUser, asyncMiddleware(storeExposureScanData))
+// Not ready yet, so don't expose in production:
+if (AppConstants.NODE_ENV === 'dev') {
+  router.post('/exposures', requireSessionUser, asyncMiddleware(storeExposureScanData))
+}
 router.post('/email', requireSessionUser, asyncMiddleware(addEmail))
 router.post('/resend-email', requireSessionUser, asyncMiddleware(resendEmail))
 router.post('/remove-email', requireSessionUser, asyncMiddleware(removeEmail))

--- a/src/routes/api/v1/user.js
+++ b/src/routes/api/v1/user.js
@@ -8,6 +8,7 @@ import { asyncMiddleware } from '../../../middleware/util.js'
 import { requireSessionUser } from '../../../middleware/auth.js'
 import { methodNotAllowed } from '../../../middleware/error.js'
 import { putBreachResolution, getBreaches } from '../../../controllers/breaches.js'
+import { storeExposureScanData } from '../../../controllers/storeExposureScanData.js'
 import {
   addEmail,
   resendEmail,
@@ -20,6 +21,7 @@ const router = Router()
 // breaches
 router.put('/breaches', requireSessionUser, asyncMiddleware(putBreachResolution))
 router.get('/breaches', requireSessionUser, asyncMiddleware(getBreaches))
+router.post('/exposures', requireSessionUser, asyncMiddleware(storeExposureScanData))
 router.post('/email', requireSessionUser, asyncMiddleware(addEmail))
 router.post('/resend-email', requireSessionUser, asyncMiddleware(resendEmail))
 router.post('/remove-email', requireSessionUser, asyncMiddleware(removeEmail))

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -18,6 +18,7 @@ import {
   unsubscribeMonthlyPage
 } from '../controllers/unsubscribe.js'
 import { unsubscribeFromEmails } from '../utils/email.js'
+import AppConstants from '../appConstants.js'
 
 const router = Router()
 const urlEncodedParser = bodyParser.urlencoded({ extended: false })
@@ -32,8 +33,11 @@ router.get('/dashboard', (req, res) => res.redirect(302, '/user/breaches'))
 // data breaches detail page
 router.get('/breaches', requireSessionUser, breachesPage)
 
-// data exposures detail page
-router.get('/exposures', requireSessionUser, exposuresPage)
+// Not ready yet, so don't expose in production:
+if (AppConstants.NODE_ENV === 'dev') {
+  // data exposures detail page
+  router.get('/exposures', requireSessionUser, exposuresPage)
+}
 
 // data removal page
 router.get('/data-removal', requireSessionUser, dataRemovalPage)

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @typedef {string} ISO8601DateString See https://en.wikipedia.org/wiki/ISO_8601
+ * @typedef {`+${string}`} E164PhoneNumberString See https://en.wikipedia.org/wiki/E.164
+ */
+
+/**
+ * @param {string} phoneNumber
+ * @returns {E164PhoneNumberString | null}
+ */
+export function parseE164PhoneNumber (phoneNumber) {
+  if (typeof phoneNumber !== 'string' || phoneNumber.length > 16 || !phoneNumber.startsWith('+')) {
+    return null
+  }
+
+  const parsedNumber = /** @type {E164PhoneNumberString} */ ('+' + Number.parseInt(phoneNumber.substring(1), 10).toString())
+  if (parsedNumber !== phoneNumber) {
+    return null
+  }
+
+  return parsedNumber
+}
+
+/**
+ * @param {ISO8601DateString} datetime
+ * @returns {Date | null}
+ */
+export function parseIso8601Datetime (datetime) {
+  if (typeof datetime !== 'string') {
+    return null
+  }
+
+  // Important caveat to keep in mind:
+  // > Support for ISO 8601 formats differs in that date-only strings
+  // > (e.g. "1970-01-01") are treated as UTC, not local.
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#parameters
+  try {
+    return new Date(datetime)
+  } catch (_e) {
+    return null
+  }
+}

--- a/src/utils/states.js
+++ b/src/utils/states.js
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @typedef {typeof usStates[keyof typeof usStates]} StateAbbr
+ */
+
+export const usStates = /** @type {const} */ (['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY', 'AS', 'GU', 'MP', 'PR', 'VI', 'UM', 'MH', 'FM', 'PW'])

--- a/src/views/partials/exposuresList.js
+++ b/src/views/partials/exposuresList.js
@@ -5,6 +5,7 @@
 /**
  * @typedef {object} PartialParameters
  * @property {string} csrfToken
+ * @property {import("../../external/onerep").ListScanResultsResponse} scanResults
  */
 
 /**
@@ -12,4 +13,5 @@
  */
 export const exposuresList = data => `
   This page will show the user's exposures dashboard, when they have already set up exposure scanning.
+  <pre>${JSON.stringify(data.scanResults, null, 2)}</pre>
 `

--- a/src/views/partials/exposuresSetup.js
+++ b/src/views/partials/exposuresSetup.js
@@ -11,5 +11,7 @@
  * @type {ViewPartial<PartialParameters>}
  */
 export const exposuresSetup = data => `
+<template id="data" data-csrf-token="${data.csrfToken}"></template>
  This page will allow the user to enter their information to do a scan for public data exposures.
+ <button id='storeMockData' class='primary'>Store mock data</button>
 `

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "src/controllers/exposures.js",
     "src/external/onerep.js",
     "src/utils/emailAddress.js",
+    "src/utils/log.js",
     "src/utils/states.js",
     "src/utils/parse.js",
     // Replace the above with the following when our entire codebase has type annotations:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,10 @@
     "src/views/partials/exposures-list.js",
     "src/controllers/exposure-scan.js",
     "src/controllers/exposures.js",
+    "src/external/onerep.js",
     "src/utils/emailAddress.js",
+    "src/utils/states.js",
+    "src/utils/parse.js",
     // Replace the above with the following when our entire codebase has type annotations:
     // "src/**/*",
   ],


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1543
Figma: https://www.figma.com/file/iJFOikscJeplRBOuKOtYEW/Onboarding?node-id=297%3A26021&t=AExoU4tTaoOmlEt9-4


<!-- When adding a new feature: -->

# Description

This adds an API at `/api/v1/user/exposures/` that allows passing in the data to scan for to find exposures. And adds a button at `/user/exposures` to send mock data to that API, to test it out.

# How to test

Make sure to run the migrations first and add the sandbox `ONEREP_API_KEY` to your env vars (ask me or Amri), then visit http://localhost:6060/user/exposures. Open your browser's network console before you click the button. After clicking it, your user should have a OneRep profile ID, and no longer be shown the button.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/). - Will fixup before merging.
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - The API layer is pretty thing, so not sure how much value it adds, but willing to give it a go if desired.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
