### PR TITLE
Update filter results when clearing search field

### DIFF
--- a/src/client/js/partials/allBreaches.js
+++ b/src/client/js/partials/allBreaches.js
@@ -8,7 +8,7 @@ let search, breachCards
 function init () {
   search = document.getElementById('breach-search')
   search.value = ''
-  search.addEventListener('keyup', filter)
+  search.addEventListener('input', filter)
   search.form.addEventListener('submit', filter)
   breachCards = allBreaches.querySelectorAll('.breach-card')
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1479
Figma: N/A


<!-- When adding a new feature: -->

# Description

On the public breach list, the search input that filters the list of breaches would respond to `keyup` events specifically, rather than anything that might change the input. Thus, if (e.g. in Chrome or Safari) a browser adds a "Clear input" icon to the field and the user clicks that, the field gets emptied, but the list of breaches are still narrowed down to the previous input.

# Screenshot (if applicable)

[Screencast from 2023-04-17 12-28-50.webm](https://user-images.githubusercontent.com/4251/232458914-04d835de-b2e4-4693-a50c-2c7168a0751e.webm)

# How to test

Visit `/breaches` in a Blink or WebKit browser, type something in the search field, then clear the field. The filter should get reset.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
