### PR TITLE
Add a maximum width for email address

### DIFF
--- a/src/client/css/partials/exposureScan.css
+++ b/src/client/css/partials/exposureScan.css
@@ -43,6 +43,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: var(--gap);
+  width: var(--max-width-p);
   max-width: 100%;
 }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1547
Figma: N/A

<!-- When adding a new feature: -->

# Description

On large viewports, we don't want the hero content part to endlessly grow if the user's email address happens to be ridiculously long. This change limits it to a reasonable size that maintains readability for the regular content, and truncates the email address if it is wider than that.

# Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/4251/232488677-28cf6716-710b-4d3e-a74d-2d1c6a4bf79f.png)

Previously:

![image](https://user-images.githubusercontent.com/4251/232488855-a56eafbe-2225-4dc0-8490-4c71e1686330.png)

# How to test

Enter a very long email address to scan for.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
