### PR TITLE
Don’t freeze AppConstants for tests

### DIFF
--- a/src/appConstants.js
+++ b/src/appConstants.js
@@ -74,4 +74,6 @@ optionalEnvVars.forEach(key => {
   if (value) AppConstants[key] = value
 })
 
-export default Object.freeze(AppConstants)
+export default AppConstants.NODE_ENV === 'test'
+  ? AppConstants
+  : Object.freeze(AppConstants)


### PR DESCRIPTION
For testing features that are dependent on `env` variables it would be helpful to have a way to mock and change [AppConstants](https://github.com/mozilla/blurts-server/blob/main/src/appConstants.js) on the fly when running tests.

As a concrete example: This change would enable us to add more thorough tests to for the link block list we’ll introduce with PR #2961 and [was brought up](https://github.com/mozilla/blurts-server/pull/2961#discussion_r1170198870) by @Vinnl.