### PR TITLE
Proposal: caching static generated assets

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -170,7 +170,16 @@ try {
 }
 
 app.use(noSearchEngineIndex)
-app.use(express.static(staticPath))
+app.use(express.static(staticPath, {
+  setHeaders: (res, path, stat) => {
+    if (path.substring(0, path.lastIndexOf('.')).endsWith('.hashed')) {
+      // Files with extensions like `.hashed.js` have a content hash in their
+      // file name, and hence will have a new filename if their content changes.
+      // Thus, it can be cached basically forever:
+      res.set('Cache-Control', 'max-age=31536000, immutable')
+    }
+  }
+}))
 app.use(express.json())
 app.use(cookieParser(AppConstants.COOKIE_SECRET))
 

--- a/src/utils/getAssetPath.js
+++ b/src/utils/getAssetPath.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { readFileSync } from 'fs'
+import { dirname, resolve } from 'path'
+import { fileURLToPath } from 'url'
+import AppConstants from '../appConstants.js'
+
+/** @type {Record<string, string>} */
+const assetPathMap = AppConstants.NODE_ENV === 'dev' ? {} : JSON.parse(readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../dist/meta.json'), 'utf-8'))
+
+/**
+ * @param {string} sourcePath
+ * @returns {string | undefined}
+ */
+export function getAssetPath (sourcePath) {
+  if (AppConstants.NODE_ENV === 'dev') {
+    return sourcePath
+  }
+
+  return assetPathMap['client' + sourcePath]?.replace('../dist', '')
+}

--- a/src/utils/getAssetPath.js
+++ b/src/utils/getAssetPath.js
@@ -5,17 +5,16 @@
 import { readFileSync } from 'fs'
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
-import AppConstants from '../appConstants.js'
 
 /** @type {Record<string, string>} */
-const assetPathMap = AppConstants.NODE_ENV === 'dev' ? {} : JSON.parse(readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../dist/meta.json'), 'utf-8'))
+const assetPathMap = process.env.npm_lifecycle_event === 'dev' ? {} : JSON.parse(readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../dist/meta.json'), 'utf-8'))
 
 /**
  * @param {string} sourcePath
  * @returns {string | undefined}
  */
 export function getAssetPath (sourcePath) {
-  if (AppConstants.NODE_ENV === 'dev') {
+  if (process.env.npm_lifecycle_event === 'dev') {
     return sourcePath
   }
 

--- a/src/views/dialogLayout.js
+++ b/src/views/dialogLayout.js
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { getAssetPath } from '../utils/getAssetPath.js'
+
 export const dialogLayout = data => `
-<link rel='stylesheet' href='/css/partials/${data.partial.name}.css' type='text/css'>
+<link rel='stylesheet' href='${getAssetPath(`/css/partials/${data.partial.name}.css`)}' type='text/css'>
 ${data.partial(data)}
 `

--- a/src/views/guestLayout.js
+++ b/src/views/guestLayout.js
@@ -4,6 +4,7 @@
 
 import AppConstants from '../appConstants.js'
 import { getMessage, getLocale } from '../utils/fluent.js'
+import { getAssetPath } from '../utils/getAssetPath.js'
 
 /**
  * @type {ViewPartial<GuestViewPartialData<any>>}
@@ -29,10 +30,10 @@ const guestLayout = data => `
     <meta property='og:url' content='${AppConstants.SERVER_URL}'>
     <meta property='og:image' content='${AppConstants.SERVER_URL}/images/og-image.webp'>
 
-    <link rel='preload' href='/fonts/Metropolis-Bold.woff2' as='font' type='font/woff2' crossorigin>
-    <link rel='preload' href='/fonts/Inter-Regular-latin.woff2' as='font' type='font/woff2' crossorigin>
-    <link rel='stylesheet' href='/css/index.css' type='text/css'>
-    <link rel='stylesheet' href='/css/partials/${data.partial.name}.css' type='text/css'>
+    <link rel='preload' href='${getAssetPath('/fonts/Metropolis-Bold.woff2')}' as='font' type='font/woff2' crossorigin>
+    <link rel='preload' href='${getAssetPath('/fonts/Inter-Regular-latin.woff2')}' as='font' type='font/woff2' crossorigin>
+    <link rel='stylesheet' href='${getAssetPath('/css/index.css')}' type='text/css'>
+    <link rel='stylesheet' href='${getAssetPath(`/css/partials/${data.partial.name}.css`)}' type='text/css'>
     <link rel='icon' href='/images/favicon-16.webp' sizes='16x16'>
     <link rel='icon' href='/images/favicon-32.webp' sizes='32x32'>
     <link rel='icon' href='/images/favicon-48.webp' sizes='48x48'>
@@ -41,7 +42,7 @@ const guestLayout = data => `
     <link rel='icon' href='/images/favicon-256.webp' sizes='256x256'>
     <link rel='apple-touch-icon' href='/images/apple-touch-icon.webp' sizes='180x180'>
 
-    <script src='/js/index.js' type='module'></script>
+    <script src='${getAssetPath('/js/index.js')}' type='module'></script>
 
     <noscript>
       <style>
@@ -51,7 +52,7 @@ const guestLayout = data => `
         }
       </style>
     </noscript>
-    ${data.skipPartialModule ? '' : `<script src='/js/partials/${data.partial.name}.js' type='module'></script>`}
+    ${data.skipPartialModule ? '' : `<script src='${getAssetPath(`/js/partials/${data.partial.name}.js`)}' type='module'></script>`}
   </head>
   <body>
     <header>

--- a/src/views/mainLayout.js
+++ b/src/views/mainLayout.js
@@ -4,6 +4,7 @@
 
 import AppConstants from '../appConstants.js'
 import { getMessage, getLocale } from '../utils/fluent.js'
+import { getAssetPath } from '../utils/getAssetPath.js'
 
 /**
  * @type {ViewPartial<MainViewPartialData<any>>}
@@ -29,10 +30,10 @@ const mainLayout = data => `
     <meta property='og:url' content='${AppConstants.SERVER_URL}'>
     <meta property='og:image' content='${AppConstants.SERVER_URL}/images/og-image.webp'>
 
-    <link rel='preload' href='/fonts/Metropolis-Bold.woff2' as='font' type='font/woff2' crossorigin>
-    <link rel='preload' href='/fonts/Inter-Regular-latin.woff2' as='font' type='font/woff2' crossorigin>
-    <link rel='stylesheet' href='/css/index.css' type='text/css'>
-    <link rel='stylesheet' href='/css/partials/${data.partial.name}.css' type='text/css'>
+    <link rel='preload' href='${getAssetPath('/fonts/Metropolis-Bold.woff2')}' as='font' type='font/woff2' crossorigin>
+    <link rel='preload' href='${getAssetPath('/fonts/Inter-Regular-latin.woff2')}' as='font' type='font/woff2' crossorigin>
+    <link rel='stylesheet' href='${getAssetPath('/css/index.css')}' type='text/css'>
+    <link rel='stylesheet' href='${getAssetPath(`/css/partials/${data.partial.name}.css`)}' type='text/css'>
     <link rel='icon' href='/images/favicon-16.webp' sizes='16x16'>
     <link rel='icon' href='/images/favicon-32.webp' sizes='32x32'>
     <link rel='icon' href='/images/favicon-48.webp' sizes='48x48'>
@@ -41,8 +42,8 @@ const mainLayout = data => `
     <link rel='icon' href='/images/favicon-256.webp' sizes='256x256'>
     <link rel='apple-touch-icon' href='/images/apple-touch-icon.webp' sizes='180x180'>
 
-    <script src='/js/index.js' type='module'></script>
-    ${data.skipPartialModule ? '' : `<script src='/js/partials/${data.partial.name}.js' type='module'></script>`}
+    <script src='${getAssetPath('/js/index.js')}' type='module'></script>
+    ${data.skipPartialModule ? '' : `<script src='${getAssetPath(`/js/partials/${data.partial.name}.js`)}' type='module'></script>`}
   </head>
   <body>
     <header>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "src/utils/log.js",
     "src/utils/states.js",
     "src/utils/parse.js",
+    "src/utils/getAssetPath.js",
     // Replace the above with the following when our entire codebase has type annotations:
     // "src/**/*",
   ],
@@ -40,7 +41,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     "moduleDetection": "force", /* Control what method is used to detect module-format JS files. */
     /* Modules */
-    "module": "commonjs", /* Specify what module code is generated. */
+    "module": "Node16", /* Specify what module code is generated. */
     "rootDir": "./src/", /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->
(Draft, so that we can discuss whether this is the right approach.)

# References: 
Jira: MNTOR-1552
Figma: N/A

This adds a hash of our client-side CSS and JS files to their filenames, and adds a function `getAssetPath` that returns that hashed file name given an original filename. I don't like how this requires us to remember to always use that function when referring to static assets, but I'm also not aware of a better way, as long as we're manually writing `<script>` and `<link>` tags.

Open questions:
- Do we want this? If not, what _do_ we want?
- ~~[How do we distinguish between built- and un-built environments?](https://mozilla.slack.com/archives/CEV7MGSQH/p1681999187269279) `NODE_ENV` still seems to be `dev` even when running `npm start`.~~ Fixed [using `npm_lifecycle_event`](https://mozilla.slack.com/archives/CEV7MGSQH/p1682006006342409?thread_ts=1681999187.269279&cid=CEV7MGSQH): a1d3a97b7
- How to deal with assets not handled by ESBuild, e.g. images?
- This still doesn't work; it looks like some script is referencing something under `/oath` and I'm not sure what yet, so I haven't been able to test the logged-in site yet.

So don't merge this, but do give input on the above :)