### PR TITLE
Redirect users following links to /security-tips

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -37,6 +37,8 @@ router.use('/oauth', doubleCsrfProtection, authRoutes)
 router.use('/user', doubleCsrfProtection, userRoutes)
 router.use('/breaches', doubleCsrfProtection, breachesRoutes)
 router.use('/breach-details', doubleCsrfProtection, breachDetailRoutes)
+// This page no longer exists, but other websites still link there:
+router.use('/security-tips', (req, res) => res.redirect(302, 'https://support.mozilla.org/kb/how-stay-safe-web'))
 router.use('/', doubleCsrfProtection, dockerFlowRoutes)
 
 // Do not make the non-auth previews available on prod


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1464
Figma:  N/A


<!-- When adding a new feature: -->

# Description

When users end up at `/security-tips` (e.g. by following old links from elsewhere), redirect them somewhere userful, rather than giving them a 404.

# How to test

Go to `/security-tips`.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
