### PR TITLE
Add Postgres.app option on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the "what" and "why" of data breach alerts.
 ### Requirements
 
 * [Volta](https://volta.sh/) (installs the correct version of Node and npm)
-* [Postgres](https://www.postgresql.org/) | Note: If you're on a Mac, download the [Postgres.app](https://postgresapp.com/) instead. 
+* [Postgres](https://www.postgresql.org/) | Note: On a Mac, we recommend downloading the [Postgres.app](https://postgresapp.com/) instead. 
 
 ### Code style
 


### PR DESCRIPTION


<!-- When adding a new feature: -->

# Description

This adds an option to install PostgreSQL through the [Postgres.app ](https://postgresapp.com/)for macOS users during the set up.
> Postgres.app is a full-featured PostgreSQL installation packaged as a standard Mac app

