### PR TITLE
Fix issue where Relay icon was outside of email input

### DIFF
--- a/src/client/css/partials/landing.css
+++ b/src/client/css/partials/landing.css
@@ -34,8 +34,15 @@
   gap: var(--padding-md);
 }
 
+.hero form.exposure-scan .fx-relay-email-input-wrapper {
+  /* note: visual fix for the Relay add-on injected icon */
+  max-width: 80%;
+  position: relative;
+  overflow: hidden;  
+}
+
 .hero form.exposure-scan input[type='email'] {
-  width: 80%;
+  width: 100%;
   padding: var(--padding-sm) var(--padding-md);
   border-radius: var(--border-radius);
   border: 1px solid var(--gray-30);


### PR DESCRIPTION
## Summary

When a user with the Relay add-on installed visits the homepage, the injected Relay icon is outside of the email input.

### References: 
Jira: https://mozilla-hub.atlassian.net/browse/MNTOR-1592

## How to test

- Test in Firefox browser
- Install [Relay add-on](https://addons.mozilla.org/en-US/firefox/addon/private-relay/) and log into Relay
- Open homepage
- **Expected:** The Relay icon should be inside the email input form

## Checklist (Definition of Done)
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
- [x] ~Localization strings (if needed) have been added.~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.~
- [x] ~Jira ticket has been updated (if needed) to match changes made during the development process.~

## Screenshot (if applicable)

![image](https://user-images.githubusercontent.com/2692333/236236309-0440e14f-c6bd-47a4-b0ea-b7d8d6ef8d65.png)

