### PR TITLE
Add note on running Redis locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,9 @@ If you encounter issues with Heroku deploys, be sure to check your environment v
 _**TODO:** add full deploy process similar to Relay_
 
 _**TODO:** consider whether we can re-enable Heroku Review Apps_
+
+## Preserve sessions in local development
+
+Sessions by default are stored in-memory, which means that when the server restarts (e.g. because you made a code change), you will have to log in again.
+
+To avoid this hassle, you can install and run [Redis](https://redis.io/), which by default runs on `redis://localhost:6379`. Use that value for `REDIS_URL` in your `.env` file to preserve your sessions across server restarts.


### PR DESCRIPTION
Amri [pointed out](https://mozilla.slack.com/archives/C04BLQVN151/p1683645520098899?thread_ts=1683640128.490769&cid=C04BLQVN151) that setting up Redis will preserve sessions across session restarts, which I figured was worth documenting.