### PR TITLE
Fix adddress typo in landing partial

### DIFF
--- a/src/views/partials/landing.js
+++ b/src/views/partials/landing.js
@@ -10,7 +10,7 @@ export const landing = () => `
     <h1>${getMessage('exposure-landing-hero-heading')}</h1>
     <p>${getMessage('exposure-landing-hero-lead')}</p>
     <form hidden class="exposure-scan">
-      <label for="scan-email-adddress" class="visually-hidden">
+      <label for="scan-email-address" class="visually-hidden">
         ${getMessage('exposure-landing-hero-email-label')}
       </label>
       <input


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-
Figma: 


<!-- When adding a new feature: -->

# Description

Noticed while trying to lint some HTML on staging.

```sh
git grep -En "scan-email-ad{2,3}ress" src | cat

src/views/partials/landing.js:13:      <label for="scan-email-adddress" class="visually-hidden">
src/views/partials/landing.js:17:        id="scan-email-address"
```

```txt
Error: The value of the for attribute of the label element must be the ID of a non-hidden form control.

From line 62, column 7; to line 62, column 63

n">↩      <label for="scan-email-adddress" class="visually-hidden">↩     
```


# Screenshot (if applicable)

Not applicable.

# How to test



# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
