### PR TITLE
Remove deprecated stylelint string-quotes rule

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -22,7 +22,6 @@
           "custom-elements"
         ]
       }
-    ],
-    "string-quotes": "single"
+    ]
   }
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-
Figma: 


<!-- When adding a new feature: -->

# Description

Removes the `The "string-quotes" rule is deprecated.` deprecation warning when running <kbd>npm run lint:css</kbd>.

```diff
npm run lint:css

# monitor@1.0.0 lint:css
# stylelint src/client/css/

-Deprecation warnings:
- - The "string-quotes" rule is deprecated.

src/client/css/nav.css
 78:1  ⚠  Expected selector "nav .callouts a" to come before selector "nav.site-nav a:not(.current):hover"  no-descending-specificity

src/client/css/partials/breachDetail.css
 259:1  ⚠  Expected selector ".breach-detail-recommendation dd a" to come before selector ".breach-detail-attribution a:hover"  no-descending-specificity

src/client/css/partials/breaches.css
 300:1  ⚠  Expected selector ".zero-state p" to come before selector ".breaches-table details > article p:first-of-type"             no-descending-specificity
 300:1  ⚠  Expected selector ".zero-state p" to come before selector ".breaches-table details .resolve-list-item input:checked + p"  no-descending-specificity

4 problems (0 errors, 4 warnings)
```


# Screenshot (if applicable)

Not applicable.

# How to test



# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
