### PR TITLE
Fix MNTOR-1598 - Add wrapper to input form on homepage breach scan

### DIFF
--- a/src/client/css/partials/landing.css
+++ b/src/client/css/partials/landing.css
@@ -34,8 +34,9 @@
   gap: var(--padding-md);
 }
 
-.hero form.exposure-scan .fx-relay-email-input-wrapper {
+.hero form.exposure-scan .exposure-scan-email-input {
   /* note: visual fix for the Relay add-on injected icon */
+  width: 100%;
   max-width: 80%;
   position: relative;
   overflow: hidden;  

--- a/src/views/partials/landing.js
+++ b/src/views/partials/landing.js
@@ -10,16 +10,18 @@ export const landing = () => `
     <h1>${getMessage('exposure-landing-hero-heading')}</h1>
     <p>${getMessage('exposure-landing-hero-lead')}</p>
     <form hidden class="exposure-scan">
-      <label for="scan-email-address" class="visually-hidden">
-        ${getMessage('exposure-landing-hero-email-label')}
-      </label>
-      <input
-        id="scan-email-address"
-        name="email"
-        type="email"
-        placeholder="${getMessage('exposure-landing-hero-email-placeholder')}"
-        required
-      />
+      <div class="exposure-scan-email-input">
+        <label for="scan-email-address" class="visually-hidden">
+          ${getMessage('exposure-landing-hero-email-label')}
+        </label>
+        <input
+          id="scan-email-address"
+          name="email"
+          type="email"
+          placeholder="${getMessage('exposure-landing-hero-email-placeholder')}"
+          required
+        />
+      </div>
       <button
         type="submit"
         class='button primary'


### PR DESCRIPTION
## Summary 

This PR solves a few extra issues that pop-up from solving [MNTOR-1592](https://mozilla-hub.atlassian.net/browse/MNTOR-1592)

See #3020 for more context

### References: 
Jira: [MNTOR-1598](https://mozilla-hub.atlassian.net/browse/MNTOR-1598)
Jira: [MNTOR-1600](https://mozilla-hub.atlassian.net/browse/MNTOR-1600)
Figma: N/A

## Testing

- Test in Firefox browser
- Install [Relay add-on](https://addons.mozilla.org/en-US/firefox/addon/private-relay/) and log into Relay
- Open homepage
- **Expected:** The Relay icon should be inside the email input form

## Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.

## Screenshot (if applicable)