### PR TITLE
Make Next-Auth work with FxA

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -2,39 +2,71 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import NextAuth, { AuthOptions } from 'next-auth'
-import AppConstants from '../../../../appConstants.js'
+import NextAuth, { AuthOptions } from "next-auth";
+import AppConstants from "../../../../appConstants.js";
+
+interface FxaProfile {
+  email: string;
+  /** The value of the Accept-Language header when the user signed up for their Firefox Account */
+  locale: string;
+  amrValues: ["pwd", "email"];
+  twoFactorAuthentication: boolean;
+  metricsEnabled: boolean;
+  uid: string;
+  /** URL to an avatar image for the current user */
+  avatar: string;
+  avatarDefault: boolean;
+}
 
 export const authOptions: AuthOptions = {
   debug: true,
+  secret: process.env.NEXTAUTH_SECRET,
   providers: [
     {
       // As per https://mozilla.slack.com/archives/C4D36CAJW/p1683642497940629?thread_ts=1683642325.465929&cid=C4D36CAJW,
       // we should file a ticket against SVCSE with the `fxa` component to add
       // a redirect URL of /api/auth/callback/fxa for Firefox Monitor,
       // for every environment we deploy to:
-      id: 'fxa',
-      name: 'Firefox Accounts',
-      type: 'oauth',
+      id: "fxa",
+      name: "Firefox Accounts",
+      type: "oauth",
       authorization: {
         url: AppConstants.OAUTH_AUTHORIZATION_URI,
         params: {
-          scope: 'profile'
-        }
+          scope: "profile",
+          access_type: "offline",
+          action: "email",
+          prompt: "login",
+          max_age: 0,
+        },
       },
       token: AppConstants.OAUTH_TOKEN_URI,
-      userinfo: AppConstants.OAUTH_PROFILE_URI,
+      userinfo: {
+        request: async (context) => {
+          const response = await fetch(AppConstants.OAUTH_PROFILE_URI, {
+            headers: { Authorization: `Bearer ${context.tokens.access_token}` },
+          });
+          const userInfo = await response.json();
+          return userInfo;
+        },
+      },
       clientId: AppConstants.OAUTH_CLIENT_ID,
       clientSecret: AppConstants.OAUTH_CLIENT_SECRET,
-      profile: async (profile) => {
+      profile: async (profile: FxaProfile) => {
         return {
-          id: profile.sub
-        }
-      }
-    }
-  ]
-}
+          id: profile.uid,
+          email: profile.email,
+          avatar: profile.avatar,
+          avatarDefault: profile.avatarDefault,
+          twoFactorAuthentication: profile.twoFactorAuthentication,
+          metricsEnabled: profile.metricsEnabled,
+          locale: profile.locale,
+        };
+      },
+    },
+  ],
+};
 
-const handler = NextAuth(authOptions)
+const handler = NextAuth(authOptions);
 
-export { handler as GET, handler as POST }
+export { handler as GET, handler as POST };


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1624

Supercedes https://github.com/mozilla/blurts-server/pull/3051

<!-- When adding a new feature: -->

# Description

Finally managed to find the correct incantations to successfully authenticate against FxA using Next-Auth :tada: 

# How to test

Add the following two variables to your .env:

```
NEXTAUTH_URL=http://localhost:6060
NEXTAUTH_SECRET=<generate using `openssl rand -base64 32`>
```

You can then add <SignInButton/> to e.g. the landing page to kick off authentication.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
