### PR TITLE
Prevent merging unresolved conflicts

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -1,0 +1,17 @@
+name: No unresolved conflicts
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main, localization ]
+jobs:
+  detect-unresolved-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: List files with merge conflict markers
+        run: git --no-pager grep "<<<<<<<" ":(exclude).github/" || true
+      - name: Fail or succeed job if any files with merge conflict markers have been checked in
+        # Find lines containing "<<<<<<<", then count the number of lines.
+        # 0 matching lines results in exit code 0, i.e. success.
+        run: exit $(git grep "<<<<<<<" ":(exclude).github/" | wc --lines)


### PR DESCRIPTION
This adds a CI job that checks that there are no conflict markers checked in. Direct reason: I fixed some conflicts in https://github.com/mozilla/blurts-server/pull/3073, but [missed one](https://github.com/mozilla/blurts-server/commit/f307c8752e02ae41efa83626467ce0984659dad6).