### PR TITLE
Don't show error when everything was OK

### DIFF
--- a/src/client/js/partials/breaches.js
+++ b/src/client/js/partials/breaches.js
@@ -94,7 +94,7 @@ async function updateBreachStatus (input) {
       })
     })
 
-    if (res.ok) {
+    if (!res.ok) {
       throw new ClientError('We couldn’t search for the latest breaches. Please refresh or try again later.', {
         action: ErrorActionTypes.Toast
       })


### PR DESCRIPTION
Currently on stage, you get an error message when resolving a breach and no error occurred:

![image](https://github.com/mozilla/blurts-server/assets/4251/19c24f60-52a1-4f61-ab7a-55339dd65fb7)
