### PR TITLE
Add UTM params to floating banner link

### DIFF
--- a/src/utils/utmParams.js
+++ b/src/utils/utmParams.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @param {{ linkUrl: string; utmParams: { [key: string]: string; }; }} options
+ * @returns {string} url
+ */
+export function appendUtmParams ({ linkUrl, utmParams }) {
+  const url = new URL(linkUrl)
+
+  for (const param in utmParams) {
+    url.searchParams.append(param, utmParams[param])
+  }
+  return url.href
+}

--- a/src/views/partials/floatingBanner.js
+++ b/src/views/partials/floatingBanner.js
@@ -4,16 +4,26 @@
 
 import AppConstants from '../../appConstants.js'
 import { getMessage } from '../../utils/fluent.js'
+import { appendUtmParams } from '../../utils/utmParams.js'
 
 /**
  * @param {{ pathname: string; }} options
- * @returns { string } banner
+ * @returns {string} banner
  */
 export const getFloatingBanner = ({ pathname }) => {
   const pageHasFloatingBanner = AppConstants.FLOATING_BANNER_PAGES?.split(',').includes(pathname)
   if (!pageHasFloatingBanner) {
     return ''
   }
+
+  const linkHref = appendUtmParams({
+    linkUrl: AppConstants.FLOATING_BANNER_LINK,
+    utmParams: {
+      utm_source: 'fx-monitor',
+      utm_medium: 'mozilla-websites',
+      utm_content: `${AppConstants.FLOATING_BANNER_TYPE}_${pathname}`
+    }
+  })
 
   return `
     <link rel='stylesheet' href='/css/partials/floatingBanner.css' type='text/css'>
@@ -22,7 +32,7 @@ export const getFloatingBanner = ({ pathname }) => {
       <img class='floating-banner-image' src='/images/banner-icon.svg' alt='' />
       <p class='floating-banner-content'>${getMessage('floating-banner-text')}</p>
       <div class='floating-banner-buttons'>
-        <a href='${AppConstants.FLOATING_BANNER_LINK}' target='_blank' class='button primary'>${getMessage('floating-banner-link-label')}</a>
+        <a href='${linkHref}' target='_blank' class='button primary'>${getMessage('floating-banner-link-label')}</a>
         <button class='floating-banner-dismiss secondary'>${getMessage('floating-banner-dismiss-button-label')}</button>
       </div>
     </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "src/utils/emailAddress.js",
     "src/utils/log.js",
     "src/utils/states.js",
-    "src/utils/parse.js"
+    "src/utils/parse.js",
+    "src/utils/utmParams.js"
     // Replace the above with the following when our entire codebase has type annotations:
     // "src/**/*",
   ],


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1664](https://mozilla-hub.atlassian.net/browse/MNTOR-1664)

<!-- When adding a new feature: -->

# Description

Follow up for https://github.com/mozilla/blurts-server/pull/3067: We are adding UTM params to the floating banner link.

# How to test

1. Set the following `.env` variables:
```
FLOATING_BANNER_DELAY=5000
FLOATING_BANNER_LINK='https://www.mozilla.org/newsletter/security-and-privacy/'
FLOATING_BANNER_TYPE='newsletterSignupBanner'
FLOATING_BANNER_PAGES='/breaches,/user/breaches'
```
2. The Banner should be shown after a delay of `5000 ms` when navigating to `/breaches` or `/user/breaches`.
3. The sign-up link should have the UTM parameters appended to it.
4. After following the sign-up link or dismissing the banner once a user should not see the banner again.
