### PR TITLE
MNTOR-981: 

### DIFF
--- a/src/controllers/fxaRpEvents.js
+++ b/src/controllers/fxaRpEvents.js
@@ -114,8 +114,8 @@ const fxaRpEvents = async (req, res) => {
   }
 
   const subscriber = await getSubscriberByFxaUid(fxaUserId)
-  
-  // highly unlikely, though it is a possible edge case from QA tests. 
+
+  // highly unlikely, though it is a possible edge case from QA tests.
   // To reproduce, perform the following two actions in sequence very quickly in FxA settings portal:
   // 1. swap primary email and secondary email
   // 2. quickly follow step 1 with deleting the account


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-981


<!-- When adding a new feature: -->

# Description
Fixing an edge case caused by very quickly :
1) trigger a fxa profile change 
2) followed by deleting the same FxA account

The deletion event came to monitor first, we handled it, account is wiped from our DB, the profile change event hits monitor, monitor tries to fetch the record from the db, throwing an exception for not found.

In this PR, I've added the guard to silently absorb that exception, give FxA a 200 back and we will just record that in Sentry.


# Screenshot (if applicable)
<img width="571" alt="Screenshot 2023-05-25 at 11 09 43 AM" src="https://github.com/mozilla/blurts-server/assets/42494162/f3f016ed-5b74-4edb-a6ff-d81a757353a7">

Not applicable.

# How to test
Tested in heroku. Attempt to create the above race condition and see error message in sentry. Make sure the profile change event does not fail in grafana


# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
