### PR TITLE
MNTOR-1773/move sentry error handler earlier in startup

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -43,6 +43,13 @@ Sentry.init({
   }
 })
 
+// sentry error handler
+app.use(Sentry.Handlers.errorHandler({
+  shouldHandleError (error) {
+    if (error instanceof RateLimitError) return true
+  }
+}))
+
 // Determine from where to serve client code/assets:
 // Build script is triggered for `npm start` and assets are served from /dist.
 // Build script is NOT run for `npm run dev`, assets are served from /src, and nodemon restarts server without build (faster dev).
@@ -185,13 +192,6 @@ app.use('/api', apiLimiter)
 
 // routing
 app.use('/', indexRouter)
-
-// sentry error handler
-app.use(Sentry.Handlers.errorHandler({
-  shouldHandleError (error) {
-    if (error instanceof TooManyRequestsError) return true
-  }
-}))
 
 // app error handler
 app.use(errorHandler)


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1773

<!-- When adding a new feature: -->

# Description

We saw some exceptions and error messages that indicated that exceptions were not being loaded into app local storage, but we only actually got Sentry exceptions (with stack traces etc) from the settings code trying to read it.

This is because the Sentry error handler is loaded (as Express middleware) pretty late in startup, this PR moves it to load as early as possible.

EDIT: see also https://github.com/mozilla/blurts-server/pull/3088#issuecomment-1569539983 - the function that is throwing the exception we want is actually swallowing the exception and throwing a more generic message, but we want that stack trace! I've added a commit to address this as well.

# How to test

I did a positive test by making sure that the app functions correctly and passes tests, and a negative test by modifying `app.js` to throw an exception in startup right after the Sentry middleware is loaded, and confirmed that it appears in the `dev` environment in Sentry.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
