### PR TITLE
Add a redirect from /security-tips for Next.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@
  /* eslint @typescript-eslint/no-var-requires: "off" */
 const { withSentryConfig } = require("@sentry/nextjs");
 
+/** @type {import('next').NextConfig} */
 const nextConfig = {
   async headers () {
     /** @type {import('next').NextConfig['headers']} */
@@ -95,6 +96,18 @@ const nextConfig = {
     }
 
     return headers
+  },
+  async redirects() {
+    return [
+      // We used to have a page with security tips;
+      // if folks get sent there via old lnks, redirect them to the most
+      // relevant page on SuMo:
+      {
+        source: '/security-tips',
+        destination: 'https://support.mozilla.org/kb/how-stay-safe-web',
+        permanent: false,
+      },
+    ];
   },
   webpack: (config, options) => {
     config.module.rules.push({


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1640
Figma:  N/A


<!-- When adding a new feature: -->

# Description

This adds the Next.js equivalent to https://github.com/mozilla/blurts-server/blob/83a32d11b4a95abbde24088fa9dcdcba2c5fc00a/src/routes/index.js#L42-L43

See also https://nextjs.org/docs/app/api-reference/next-config-js/redirects

# How to test

Start the Next.js server, go to `/security-tips`.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
