### PR TITLE
Port unsubscribe-monthly page to Next.js

### DIFF
--- a/src/app/(nextjs_migration)/(guest)/user/unsubscribe-monthly/page.tsx
+++ b/src/app/(nextjs_migration)/(guest)/user/unsubscribe-monthly/page.tsx
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { redirect } from "next/navigation";
+import { updateMonthlyEmailOptout } from "../../../../../db/tables/subscribers";
+import { getL10n } from "../../../../functions/server/l10n";
+
+export default async function UnsubscribeMonthly(props: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  const token = props.searchParams.token;
+  if (typeof token !== "string") {
+    return redirect("/");
+  }
+  try {
+    await updateMonthlyEmailOptout(token);
+  } catch (error) {
+    console.log(error);
+    return redirect("/");
+  }
+  const l10n = getL10n();
+
+  return (
+    <div data-partial="unsubscribeMonthly">
+      <section className="unsubscribe">
+        <h1
+          dangerouslySetInnerHTML={{ __html: l10n.getString("unsub-headline") }}
+        />
+        <p>{l10n.getString("changes-saved")}</p>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1634
Figma: N/A


<!-- When adding a new feature: -->

# Description

Adds the page to unsubscribe from the monthly emails.

# How to test

Visit http://localhost:6060/user/unsubscribe-monthly?token=token_123&hash=hash_123. Also note how this is in the `(guest)` route group, even though it shares a path (`/user/`) with routes in the `(authenticated)` group - nevertheless, the authenticated dashboard still works.
