### PR TITLE
Re-enable analytic events

### DIFF
--- a/public/nextjs_migration/client/js/analytics.js
+++ b/public/nextjs_migration/client/js/analytics.js
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const bodyDataset = document.body.dataset
+
+async function init({ debugMode, ga4MeasurementId }) {
+  if (navigator.doNotTrack === '1') {
+    window.gtag = function () {
+      console.debug('Analytics disabled by DNT')
+    }
+    window.gtag()
+  } else {
+    await import(`https://www.googletagmanager.com/gtag/js?id=${ga4MeasurementId}`)
+
+    window.dataLayer = window.dataLayer || []
+
+    window.gtag = function () {
+      window.dataLayer.push(arguments)
+    }
+    window.gtag('js', new Date())
+    window.gtag('config', ga4MeasurementId, {
+      cookie_domain: window.location.hostname,
+      cookie_flags: 'SameSite=None;Secure',
+      debug_mode: debugMode
+    })
+
+    // Instrument CTA clicks for analytics.
+    document.querySelectorAll('[data-cta-id]').forEach(cta =>
+      cta.addEventListener('click', () => window.gtag('event', 'clicked_cta', { cta_id: cta.dataset.ctaId })))
+  }
+}
+
+if (bodyDataset) {
+  const analyticsConfig = Object.freeze({
+    debugMode: bodyDataset.nodeEnv !== 'production',
+    ga4MeasurementId: bodyDataset.ga4MeasurementId || 'G-CXG8K4KW4P'
+  })
+  
+  init(analyticsConfig)
+}

--- a/public/nextjs_migration/client/js/breaches.js
+++ b/public/nextjs_migration/client/js/breaches.js
@@ -58,12 +58,11 @@ function handleEvent (e) {
       break
     case e.target.matches('.resolve-list-item [type="checkbox"]'):
       updateBreachStatus(e.target)
-      // TODO: Re-enable gtag events
-      // window.gtag('event', 'resolved_breach_item', {
-      //   action: e.target.checked ? 'resolved' : 'unresolved',
-      //   page_location: location.href,
-      //   data_class: e.target.value
-      // })
+      window.gtag('event', 'resolved_breach_item', {
+        action: e.target.checked ? 'resolved' : 'unresolved',
+        page_location: location.href,
+        data_class: e.target.value
+      })
       break
     case e.type === 'email-added':
       state.emailCount = e.detail.newEmailCount

--- a/public/nextjs_migration/client/js/userMenu.js
+++ b/public/nextjs_migration/client/js/userMenu.js
@@ -32,8 +32,7 @@ function handleMenuButton () {
     userMenuWrapper.addEventListener('blur', (event) => handleBlur(event, handleMenuButton))
     userMenuWrapper.focus()
 
-    // TODO: Re-enable gtag events
-    // window.gtag('event', 'opened_closed_user_menu', { action: 'open' })
+    window.gtag('event', 'opened_closed_user_menu', { action: 'open' })
   } else {
     // Hide popover
     userMenuPopover.setAttribute('aria-expanded', false)
@@ -41,7 +40,7 @@ function handleMenuButton () {
 
     userMenuButton.focus()
 
-    // window.gtag('event', 'opened_closed_user_menu', { action: 'close' })
+    window.gtag('event', 'opened_closed_user_menu', { action: 'close' })
   }
 }
 

--- a/src/app/(nextjs_migration)/layout.tsx
+++ b/src/app/(nextjs_migration)/layout.tsx
@@ -16,6 +16,7 @@ export default async function MigrationLayout({
   return (
     <L10nProvider bundleSources={l10nBundles}>
       <Script src="/nextjs_migration/client/js/resizeObserver.js" />
+      <Script src="/nextjs_migration/client/js/analytics.js" />
       {children}
     </L10nProvider>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,13 @@ export default async function RootLayout({
 
   return (
     <html lang={currentLocale}>
-      <body className={inter.className}>
+      <body
+        className={inter.className}
+        // DO NOT ADD SECRETS HERE: The following data attributes expose
+        // variables that are being used in the public analytics scripts
+        data-ga4-measurement-id={process.env.GA4_MEASUREMENT_ID}
+        data-node-env={process.env.NODE_ENV}
+      >
         <SessionProvider session={session}>{children}</SessionProvider>
       </body>
     </html>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1643](https://mozilla-hub.atlassian.net/browse/MNTOR-1642)

<!-- When adding a new feature: -->

# Description

Re-enables analytics for the ported Next.js site.

# How to test

- Visit `/users/dashboard`
- Toggle the user menu
- `opened_closed_user_menu` event should be fired