### PR TITLE
Store new users in the database

### DIFF
--- a/src/app/(nextjs_migration)/(authenticated)/user/breaches/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/user/breaches/page.tsx
@@ -61,7 +61,10 @@ export default async function UserBreaches() {
   const l10n = getL10n();
 
   const userBreachesData: UserBreaches = await getUserBreaches({
-    user: session?.user,
+    // `(authenticated)/layout.tsx` ensures that `session` is not undefined,
+    // so the type assertion should be safe:
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    user: session!.user,
   });
 
   function createBreachRows({ breachesData, breachLogos }: UserBreaches) {

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -5,6 +5,23 @@
 import NextAuth, { AuthOptions } from "next-auth";
 import mozlog from "../../../../utils/log.js";
 import AppConstants from "../../../../appConstants.js";
+import {
+  getSubscriberByEmail,
+  updateFxAData,
+} from "../../../../db/tables/subscribers.js";
+import { addSubscriber } from "../../../../db/tables/emailAddresses.js";
+import { getBreaches } from "../../../functions/server/getBreaches";
+import { getBreachIcons } from "../../../functions/server/getBreaches";
+import { getBreachesForEmail } from "../../../../utils/hibp.js";
+import { getSha1 } from "../../../../utils/fxa.js";
+import {
+  getEmailCtaHref,
+  initEmail,
+  sendEmail,
+} from "../../../../utils/email.js";
+import { getTemplate } from "../../../../views/emails/email2022.js";
+import { signupReportEmailPartial } from "../../../../views/emails/emailSignupReport.js";
+import { getL10n } from "../../../functions/server/l10n";
 
 const log = mozlog("controllers.auth");
 
@@ -24,6 +41,9 @@ interface FxaProfile {
 export const authOptions: AuthOptions = {
   debug: true,
   secret: process.env.NEXTAUTH_SECRET,
+  session: {
+    strategy: "jwt",
+  },
   providers: [
     {
       // As per https://mozilla.slack.com/archives/C4D36CAJW/p1683642497940629?thread_ts=1683642325.465929&cid=C4D36CAJW,
@@ -55,7 +75,9 @@ export const authOptions: AuthOptions = {
       },
       clientId: AppConstants.OAUTH_CLIENT_ID,
       clientSecret: AppConstants.OAUTH_CLIENT_SECRET,
+      // Parse data returned by FxA's /userinfo/
       profile: async (profile: FxaProfile) => {
+        log.debug("fxa-confirmed-profile-data", profile);
         return {
           id: profile.uid,
           email: profile.email,
@@ -71,20 +93,97 @@ export const authOptions: AuthOptions = {
   callbacks: {
     async jwt({ token, account, profile, trigger }) {
       if (profile) {
-        token.locale = profile.locale;
-        token.twoFactorAuthentication = profile.twoFactorAuthentication;
-        token.metricsEnabled = profile.metricsEnabled;
-        token.avatar = profile.avatar;
-        token.avatarDefault = profile.avatarDefault;
+        token.fxa = {
+          locale: profile.locale,
+          twoFactorAuthentication: profile.twoFactorAuthentication,
+          metricsEnabled: profile.metricsEnabled,
+          avatar: profile.avatar,
+          avatarDefault: profile.avatarDefault,
+        };
+      }
+      if (account) {
+        // We're signing in with FxA; store user in database if not present yet.
+        log.debug("fxa-confirmed-fxaUser", account);
+
+        // Note: we could create an [Adapter](https://next-auth.js.org/tutorials/creating-a-database-adapter)
+        //       to store the user in the database, but by doing it in the callback,
+        //       we can also store FxA account data. We also don't have to worry
+        //       about model mismatches (i.e. Next-Auth expecting one User to have
+        //       multiple Accounts at multiple providers).
+        const email = profile?.email;
+        const existingUser = await getSubscriberByEmail(email);
+
+        if (existingUser) {
+          token.subscriber = existingUser;
+          if (account.access_token && account.refresh_token) {
+            await updateFxAData(
+              existingUser,
+              account.access_token,
+              account.refresh_token,
+              JSON.stringify(profile)
+            );
+          }
+        }
+        if (!existingUser && email) {
+          const verifiedSubscriber = await addSubscriber(
+            email,
+            profile.locale,
+            account.access_token,
+            account.refresh_token,
+            JSON.stringify(profile)
+          );
+          token.subscriber = verifiedSubscriber;
+
+          const allBreaches = await getBreaches();
+          const unsafeBreachesForEmail = await getBreachesForEmail(
+            getSha1(email),
+            allBreaches,
+            true
+          );
+
+          // Send report email
+          const utmCampaignId = "report";
+          const l10n = getL10n();
+          const subject = unsafeBreachesForEmail?.length
+            ? l10n.getString("email-subject-found-breaches")
+            : l10n.getString("email-subject-no-breaches");
+
+          const breachLogos = await getBreachIcons(allBreaches);
+          const data = {
+            breachedEmail: email,
+            breachLogos: breachLogos,
+            ctaHref: getEmailCtaHref(utmCampaignId, "dashboard-cta"),
+            heading: "email-breach-summary",
+            recipientEmail: email,
+            subscriberId: verifiedSubscriber,
+            unsafeBreachesForEmail,
+            utmCampaign: utmCampaignId,
+          };
+          const emailTemplate = getTemplate(
+            data,
+            signupReportEmailPartial,
+            l10n
+          );
+
+          await initEmail(process.env.SMTP_URL);
+          await sendEmail(data.recipientEmail, subject, emailTemplate);
+        }
       }
       return token;
     },
     async session({ session, token }) {
-      session.user.locale = token.locale;
-      session.user.twoFactorAuthentication = token.twoFactorAuthentication;
-      session.user.metricsEnabled = token.metricsEnabled;
-      session.user.avatar = token.avatar;
-      session.user.avatarDefault = token.avatarDefault;
+      if (token.fxa) {
+        session.user.fxa = {
+          locale: token.fxa.locale,
+          twoFactorAuthentication: token.fxa.twoFactorAuthentication,
+          metricsEnabled: token.fxa.metricsEnabled,
+          avatar: token.fxa.avatar,
+          avatarDefault: token.fxa.avatarDefault,
+        };
+      }
+      if (token.subscriber) {
+        session.user.subscriber = token.subscriber;
+      }
       return session;
     },
   },

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -10,8 +10,10 @@ import {
   updateFxAData,
 } from "../../../../db/tables/subscribers.js";
 import { addSubscriber } from "../../../../db/tables/emailAddresses.js";
-import { getBreaches } from "../../../functions/server/getBreaches";
-import { getBreachIcons } from "../../../functions/server/getBreaches";
+import {
+  getBreaches,
+  getBreachIcons,
+} from "../../../functions/server/getBreaches";
 import { getBreachesForEmail } from "../../../../utils/hibp.js";
 import { getSha1 } from "../../../../utils/fxa.js";
 import {

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -103,7 +103,7 @@ export const authOptions: AuthOptions = {
           avatarDefault: profile.avatarDefault,
         };
       }
-      if (account) {
+      if (account && profile) {
         // We're signing in with FxA; store user in database if not present yet.
         log.debug("fxa-confirmed-fxaUser", account);
 
@@ -112,7 +112,7 @@ export const authOptions: AuthOptions = {
         //       we can also store FxA account data. We also don't have to worry
         //       about model mismatches (i.e. Next-Auth expecting one User to have
         //       multiple Accounts at multiple providers).
-        const email = profile?.email;
+        const email = profile.email;
         const existingUser = await getSubscriberByEmail(email);
 
         if (existingUser) {

--- a/src/app/functions/server/getUserBreaches.ts
+++ b/src/app/functions/server/getUserBreaches.ts
@@ -3,13 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { cookies } from "next/headers";
+import { Session } from "next-auth";
 
 import { getBreaches, getBreachIcons } from "./getBreaches";
 import { appendBreachResolutionChecklist } from "./breachResolution";
 import { getSubscriberByEmail } from "../../../../src/db/tables/subscribers.js";
 import { getAllEmailsAndBreaches } from "../../../../src/utils/breaches.js";
 
-export async function getUserBreaches({ user }) {
+export async function getUserBreaches({ user }: { user: Session["user"] }) {
   const subscriber = await getSubscriberByEmail(user.email);
   const allBreaches = await getBreaches();
   const breachesData = await getAllEmailsAndBreaches(subscriber, allBreaches);

--- a/src/app/transitionTypes.ts
+++ b/src/app/transitionTypes.ts
@@ -5,3 +5,43 @@
 // Type definitions in this file are used to incomplete (or just plain `any`);
 // however, they give us a single place to find all references to the same type,
 // making it easier to add proper type definitions down the road.
+
+/** Data about the user from the `subscribers` database table */
+export type Subscriber = {
+  id: number;
+  primary_sha1: string;
+  primary_email: string;
+  primary_verification_token: string;
+  primary_verified: boolean;
+  created_at: Date;
+  updated_at: Date;
+  fx_newsletter: boolean;
+  signup_language: string;
+  fxa_refresh_token: string;
+  fxa_access_token: string;
+  fxa_profile_json: object;
+  fxa_uid: string;
+  // TODO: Find unknown type
+  breaches_last_shown: null | unknown;
+  all_emails_to_primary: boolean;
+  // TODO: Find unknown type
+  breaches_resolved: null | unknown;
+  // TODO: Find unknown type
+  waitlists_joined: null | unknown;
+  // TODO: Find unknown type
+  breach_stats: null | unknown;
+  // TODO: Find unknown type
+  monthly_email_at: null | unknown;
+  // TODO: Find unknown type
+  monthly_email_optout: null | unknown;
+  // TODO: Find unknown type
+  breach_resolution: null | unknown;
+  // TODO: Find unknown type
+  db_migration_1: null | unknown;
+  // TODO: Find unknown type
+  db_migration_2: null | unknown;
+  // TODO: Find unknown type
+  onerep_profile_id: null | unknown;
+  // TODO: Find unknown type
+  email_addresses: unknown[];
+};

--- a/src/db/tables/emailAddresses.js
+++ b/src/db/tables/emailAddresses.js
@@ -154,7 +154,7 @@ async function _addEmailHash (sha1, email, signupLanguage, verified = false) {
  * @param {string} fxaAccessToken from Firefox Account Oauth
  * @param {string} fxaRefreshToken from Firefox Account Oauth
  * @param {string} fxaProfileData from Firefox Account
- * @returns {object} subscriber knex object added to DB
+ * @returns {Promise<import('../../app/transitionTypes.js').Subscriber>} subscriber knex object added to DB
  */
 async function addSubscriber (email, signupLanguage, fxaAccessToken = null, fxaRefreshToken = null, fxaProfileData = null) {
   console.log({ email })

--- a/src/next-auth.d.ts
+++ b/src/next-auth.d.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import NextAuth, { DefaultSession } from "next-auth";
-import { JWT } from "next-auth/jwt";
+import { DefaultSession } from "next-auth";
+import { Subscriber } from "./app/transitionTypes";
 
 declare module "next-auth" {
   /** The OAuth profile extracted from Firefox Accounts */
@@ -19,16 +19,19 @@ declare module "next-auth" {
     avatarDefault: boolean;
   }
 
-  /** The OAuth profile extracted from Firefox Accounts */
+  /** Session data available after deserialising the JWT */
   interface Session {
     user: {
-      /** The value of the Accept-Language header when the user signed up for their Firefox Account */
-      locale: string;
-      twoFactorAuthentication: boolean;
-      metricsEnabled: boolean;
-      /** URL to an avatar image for the current user */
-      avatar: string;
-      avatarDefault: boolean;
+      fxa?: {
+        /** The value of the Accept-Language header when the user signed up for their Firefox Account */
+        locale: string;
+        twoFactorAuthentication: boolean;
+        metricsEnabled: boolean;
+        /** URL to an avatar image for the current user */
+        avatar: string;
+        avatarDefault: boolean;
+      };
+      subscriber?: Subscriber;
     } & DefaultSession["user"];
   }
 }
@@ -36,12 +39,15 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
   /** Returned by the `jwt` callback and `getToken`, when using JWT sessions */
   interface JWT {
-    /** The value of the Accept-Language header when the user signed up for their Firefox Account */
-    locale: string;
-    twoFactorAuthentication: boolean;
-    metricsEnabled: boolean;
-    /** URL to an avatar image for the current user */
-    avatar: string;
-    avatarDefault: boolean;
+    fxa?: {
+      /** The value of the Accept-Language header when the user signed up for their Firefox Account */
+      locale: string;
+      twoFactorAuthentication: boolean;
+      metricsEnabled: boolean;
+      /** URL to an avatar image for the current user */
+      avatar: string;
+      avatarDefault: boolean;
+    };
+    subscriber?: Subscriber;
   }
 }

--- a/src/utils/fluent.js
+++ b/src/utils/fluent.js
@@ -91,9 +91,32 @@ function getRawMessage (id) {
  * // Given FluentResource("hello = Hello, {$name}!")
  * getMessage (hello, {name: "Jane"})
  * // Returns "Hello, Jane!"
+ * @deprecated Use [[getL10n]]; to ease the transition, see [[getStringLookup]].
  */
 function getMessage (id, args) {
   return getMessageWithLocale(id, getLocale(), args)
+}
+
+/**
+ * Get a function that localises a string
+ *
+ * This is a transition function to make it easy to port code that still uses
+ * [[getMessage]] to the Next.js setup. If you're calling that code from a place
+ * that has a FluentLocalization object (i.e. code reachable from a Next.js
+ * requests, where its `headers` function is available and which can therefore
+ * obtain it by calling [[getL10n]]), it will use that; otherwise it will fall
+ * back to the existing `getMessage`.
+ *
+ * @param {import('@fluent/react').ReactLocalization | undefined} l10n A FluentLocalization object, if available.
+ * @returns {typeof getMessage} A function equivalent to [[getMessage]], but it'll use the FluentLocalization object if given one.
+ */
+function getStringLookup(l10n) {
+  if (l10n) {
+    return (id, vars) => {
+      return l10n.getString(id, vars)
+    };
+  }
+  return getMessage;
 }
 
 /**
@@ -129,4 +152,4 @@ function fluentError (id) {
   return new Error(getMessage(id))
 }
 
-export { initFluentBundles, updateLocale, getLocale, getMessage, getMessageWithLocale, getRawMessage, fluentError }
+export { initFluentBundles, updateLocale, getLocale, getMessage, getMessageWithLocale, getStringLookup, getRawMessage, fluentError }

--- a/src/utils/fluent.js
+++ b/src/utils/fluent.js
@@ -92,6 +92,7 @@ function getRawMessage (id) {
  * getMessage (hello, {name: "Jane"})
  * // Returns "Hello, Jane!"
  * @deprecated Use [[getL10n]]; to ease the transition, see [[getStringLookup]].
+ * @todo Delete this function, and replace calls to it with calls to ReactLocalization.getString
  */
 function getMessage (id, args) {
   return getMessageWithLocale(id, getLocale(), args)

--- a/src/views/emails/email2022.js
+++ b/src/views/emails/email2022.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import AppConstants from '../../appConstants.js'
-import { getMessage } from '../../utils/fluent.js'
+import { getStringLookup } from '../../utils/fluent.js'
 
 const companyAddress = '2 Harrison St. #175, San Francisco, California 94105 USA'
 const links = (data) => ({
@@ -65,48 +65,51 @@ const footerImageStyle = `
   margin: 24px auto 0;
 `
 
-const emailHeader = (data) => `
-  <tr class='logo'>
-    <td height='100'></td>
-  </tr>
-  <tr class='header'>
-    <td>
-      <table
-        border='0'
-        cellpadding='0'
-        cellspacing='0'
-        role='presentation'
-        style='${headerTableStyle}'
-      >
-        <tr>
-          <td>
-            <h1>
-              ${getMessage(data.heading)}
-            </h1>
-            ${data.subhead !== ''
-              ? `<p>${getMessage(data.subhead)}</p>`
-              : ''
-            }
-          </td>
-          <td
-            class='header-image'
-            style='${headerImageContainerStyle}'
-          >
-            <img
-              alt=''
-              height='331'
-              src='${images.header}'
-              style='${headerImageStyle}'
-              width='476'
+const emailHeader = (data, l10n) => {
+  const getMessage = getStringLookup(l10n);
+  return `
+    <tr class='logo'>
+      <td height='100'></td>
+    </tr>
+    <tr class='header'>
+      <td>
+        <table
+          border='0'
+          cellpadding='0'
+          cellspacing='0'
+          role='presentation'
+          style='${headerTableStyle}'
+        >
+          <tr>
+            <td>
+              <h1>
+                ${getMessage(data.heading)}
+              </h1>
+              ${data.subhead !== ''
+        ? `<p>${getMessage(data.subhead)}</p>`
+        : ''}
+            </td>
+            <td
+              class='header-image'
+              style='${headerImageContainerStyle}'
             >
-          </td>
-        </tr>
-      </table>
-    </td>
-  </tr>
-`
+              <img
+                alt=''
+                height='331'
+                src='${images.header}'
+                style='${headerImageStyle}'
+                width='476'
+              >
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  `
+}
 
-function getUnsubscribeCopy (data) {
+function getUnsubscribeCopy (data, l10n) {
+  const getMessage = getStringLookup(l10n);
   const unsubLink = `<a href='${data.unsubscribeUrl}'>${getMessage('email-unsub-link')}</a>`
   const faqLink = `<a href='${links(data).faq}'>${getMessage('frequently-asked-questions')}</a>`
 
@@ -116,18 +119,18 @@ function getUnsubscribeCopy (data) {
   })
 }
 
-const emailFooter = (data) => `
+const emailFooter = (data, l10n) => {
+  const getMessage = getStringLookup(l10n);
+  return `
   <tr class='footer'>
     <td style='${footerContainerStyle}'>
-      ${
-        data.unsubscribeUrl
-          ? `<p>${getUnsubscribeCopy(data)}</p>`
-          : ''
-      }
+      ${data.unsubscribeUrl
+      ? `<p>${getUnsubscribeCopy(data)}</p>`
+      : ''}
       <p>
         ${getMessage('email-2022-hibp-attribution', {
-          'hibp-link-attr': `href='${links(data).hibp}' rel='noopener'`
-        })}
+        'hibp-link-attr': `href='${links(data).hibp}' rel='noopener'`
+      })}
       </p>
       <img
         alt='${getMessage('mozilla')}'
@@ -150,6 +153,7 @@ const emailFooter = (data) => `
     </td>
   </tr>
 `
+}
 
 const getStyles = () => `
   <style>
@@ -250,7 +254,7 @@ const getStyles = () => `
   </style>
 `
 
-const getEmailContent = (data, partial) => {
+const getEmailContent = (data, partial, l10n) => {
   return `
     <table
       border='0'
@@ -263,19 +267,20 @@ const getEmailContent = (data, partial) => {
       ${emailHeader({
         heading: data.heading,
         subhead: data.subheading ?? ''
-      })}
-      ${partial(data)}
-      ${emailFooter(data)}
+      }, l10n)}
+      ${partial(data, l10n)}
+      ${emailFooter(data, l10n)}
     </table>
   `
 }
 
-const getPreviewTemplate = (data, partial) => `
+const getPreviewTemplate = (data, partial, l10n) => `
   ${getStyles()}
-  ${getEmailContent(data, partial)}
+  ${getEmailContent(data, partial, l10n)}
 `
 
-const getTemplate = (data, partial) => {
+const getTemplate = (data, partial, l10n) => {
+  const getMessage = getStringLookup(l10n);
   return `
     <!doctype html>
     <html>
@@ -291,7 +296,7 @@ const getTemplate = (data, partial) => {
       </head>
 
       <body class='email-body' style='${bodyStyle}'>
-        ${getEmailContent(data, partial)}
+        ${getEmailContent(data, partial, l10n)}
       </body>
     </html>
   `

--- a/src/views/emails/emailSignupReport.js
+++ b/src/views/emails/emailSignupReport.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { breachCardPartial } from './emailBreachCard.js'
-import { getMessage } from '../../utils/fluent.js'
+import { getStringLookup } from '../../utils/fluent.js'
 
 const emailStyle = `
   color: black;
@@ -44,7 +44,8 @@ const ctaStyle = `
   padding: 12px 24px;
 `
 
-const signupReportEmailPartial = data => {
+const signupReportEmailPartial = (data, l10n) => {
+  const getMessage = getStringLookup(l10n);
   const {
     breachedEmail,
     breachLogos,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1774 and MNTOR-1775
Figma: N/A

<!-- When adding a new feature: -->

# Description

This does a couple of things:
- It adds a `getStringLookup` API to ease the transition from old Fluent functions (which depend on the user's locale being stored in AsyncLocalStorage). It will behave the same as the old getMessage() when called as-is, but when passed an instance of ReactLocalization (which we have access to in Next.js routes), it will retrieve the localised string from that.
- It updates the code that sends the breach check email on first sign-in to pass an instance of ReactLocalization.
- It splits session data and JWT properties to separate data provided to use by FxA from data we store in our own database.
- It checks if the user that signs in is already known in our database, and if not, it adds them. It does so using mostly the same code as in /src/controllers/auth.js's `confirmed` function.

This should enable fixing https://github.com/mozilla/blurts-server/pull/3095#pullrequestreview-1458583304.

# How to test

Sign in with a user you have not signed in before. There should be no errors, and you should receive a welcome email. Additionally, user data (in particular, their ID in the database) should now be available on the session object.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - This is primarily code with side effects (DB calls, email sending), so very hard to unit test.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage. N/A
