### PR TITLE
Port admin pages to Next.js

### DIFF
--- a/public/nextjs_migration/client/js/emailPreview.js
+++ b/public/nextjs_migration/client/js/emailPreview.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const emailsPartial = document.querySelector("[data-partial='emailPreview']")
+let emailPreviewForm
+let emailTemplateSelect
+
+function init () {
+  emailPreviewForm = document.querySelector('.js-email-preview-form')
+  emailTemplateSelect = emailsPartial.querySelector('.js-email custom-select')
+
+  emailPreviewForm?.addEventListener('submit', sendTestEmail)
+  emailTemplateSelect?.addEventListener('change', handleEvent)
+}
+
+function handleEvent (event) {
+  const templateSelectChanged = event.target.matches(
+    'custom-select[name="email-template"]'
+  )
+
+  if (templateSelectChanged) {
+    const templateValue = event.target.value
+    const currentPathname = window.location.pathname
+
+    const lastSlugIndex = currentPathname.lastIndexOf('/')
+    const pathFirstPart = currentPathname.substring(0, lastSlugIndex)
+    const pathSecondPart = currentPathname.substring(lastSlugIndex + 1)
+
+    const updatedPath = pathSecondPart !== 'emails'
+      ? `${pathFirstPart}/${templateValue}`
+      : `${currentPathname}/${templateValue}`
+
+    if (currentPathname !== updatedPath) {
+      window.location.replace(updatedPath)
+    }
+  }
+}
+
+async function sendTestEmail (event) {
+  event.preventDefault()
+  const selectedRecipient = event.target.querySelector(
+    'input[name="email-recipient-option"]:checked'
+  ).value
+
+  try {
+    const response = await fetch('/admin/send-test-email', {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      mode: 'same-origin',
+      method: 'POST',
+      body: JSON.stringify({
+        emailId: emailTemplateSelect.value,
+        recipient: selectedRecipient
+      })
+    })
+
+    if (response?.redirected) {
+      throw response.error
+    }
+
+    window.alert('Email sent!')
+  } catch (err) {
+    throw new Error(`Sending test email failed: ${err}`)
+  }
+}
+
+if (emailsPartial) init()

--- a/src/app/(nextjs_migration)/(authenticated)/admin/emails/[template]/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/admin/emails/[template]/page.tsx
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { redirect } from "next/navigation";
+import Script from "next/script";
+import { getServerSession } from "next-auth";
+import appConstants from "../../../../../../appConstants";
+import {
+  EmailTemplateType,
+  getMonthlyDummyData,
+  getNotificationDummyData,
+  getSignupReportDummyData,
+  getVerificationDummyData,
+} from "../../../../../../utils/email";
+import { getPreviewTemplate } from "../../../../../../views/emails/email2022";
+import { verifyPartial } from "../../../../../../views/emails/emailVerify";
+import { breachAlertEmailPartial } from "../../../../../../views/emails/emailBreachAlert";
+import { monthlyUnresolvedEmailPartial } from "../../../../../../views/emails/emailMonthlyUnresolved";
+import { signupReportEmailPartial } from "../../../../../../views/emails/emailSignupReport";
+import { authOptions } from "../../../../../api/auth/[...nextauth]/route";
+import { getL10n } from "../../../../../functions/server/l10n";
+import { ReactLocalization } from "@fluent/react";
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace JSX {
+    interface IntrinsicElements {
+      "custom-select": {
+        name: string;
+        dangerouslySetInnerHTML: { __html: string };
+      };
+    }
+  }
+}
+
+export default async function EmailTemplatePage(props: {
+  params: { template: string };
+}) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user.email) {
+    return redirect("/");
+  }
+
+  const admins = process.env.ADMINS?.split(",") ?? [];
+  // Note: ../layout.tsx currently hides this page for non-admins.
+  //       Not sure if we actually want to have this available to non-admins as well.
+  const isAdminPreview = admins.includes(session.user.email);
+  const chosenTemplate =
+    Object.values(EmailTemplateType).find((t) => t === props.params.template) ??
+    EmailTemplateType.Verification;
+  const l10n = getL10n();
+  const templates = getTemplatesData(l10n);
+  const selectedPreviewTemplate = templates[chosenTemplate].template;
+  const recipients = [session.user.email];
+  if (appConstants.EMAIL_TEST_RECIPIENT) {
+    recipients.push(appConstants.EMAIL_TEST_RECIPIENT);
+  }
+
+  return (
+    <div data-partial="emailPreview">
+      <Script src="/nextjs_migration/client/js/customSelect.js" />
+      <Script src="/nextjs_migration/client/js/emailPreview.js" />
+      <section className="email-preview js-email">
+        <h1>Email preview</h1>
+        <div className="email-preview-controls">
+          <custom-select
+            name="email-template"
+            dangerouslySetInnerHTML={{
+              __html: getPreviewOptions(chosenTemplate, templates),
+            }}
+          />
+          {isAdminPreview ? (
+            <form className="js-email-preview-form email-preview-form">
+              {getRecipientInputs(recipients)}
+              <button className="primary" type="submit">
+                Send test email
+              </button>
+            </form>
+          ) : null}
+        </div>
+        <hr className="monitor-gradient" />
+        <div dangerouslySetInnerHTML={{ __html: selectedPreviewTemplate }} />
+      </section>
+    </div>
+  );
+}
+
+function getTemplatesData(l10n: ReactLocalization) {
+  return {
+    [EmailTemplateType.Verification]: {
+      label: "Email verification",
+      template: getPreviewTemplate(
+        getVerificationDummyData(appConstants.EMAIL_TEST_RECIPIENT, l10n),
+        verifyPartial,
+        l10n
+      ),
+    },
+    [EmailTemplateType.Notification]: {
+      label: "Breach notification",
+      template: getPreviewTemplate(
+        getNotificationDummyData(appConstants.EMAIL_TEST_RECIPIENT, l10n),
+        breachAlertEmailPartial,
+        l10n
+      ),
+    },
+    [EmailTemplateType.Monthly]: {
+      label: "Monthly unresolved breaches",
+      template: getPreviewTemplate(
+        getMonthlyDummyData(appConstants.EMAIL_TEST_RECIPIENT, l10n),
+        monthlyUnresolvedEmailPartial,
+        l10n
+      ),
+    },
+    [EmailTemplateType.SignupReport]: {
+      label: "Signup report",
+      template: getPreviewTemplate(
+        getSignupReportDummyData(appConstants.EMAIL_TEST_RECIPIENT, l10n),
+        signupReportEmailPartial,
+        l10n
+      ),
+    },
+  };
+}
+
+// Transitioning from untyped JS:
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getPreviewOptions(currentTemplateKey: string, data: any) {
+  const optionsElements = Object.keys(data)
+    .map(
+      (templateKey) => `
+    <option
+      value='${templateKey}'
+      ${currentTemplateKey === templateKey ? "selected" : ""}
+    >
+      ${data[templateKey].label}
+    </option>
+  `
+    )
+    .join("");
+
+  return optionsElements;
+}
+
+// Transitioning from untyped JS:
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getRecipientInputs(recipients: any[]) {
+  const recipientInputElements = recipients.map((recipient, index) => {
+    return (
+      <label key={recipient}>
+        <input
+          name="email-recipient-option"
+          type="radio"
+          value={recipient}
+          checked={index === 0}
+        />
+        {recipient}
+      </label>
+    );
+  });
+
+  return <fieldset>{recipientInputElements}</fieldset>;
+}

--- a/src/app/(nextjs_migration)/(authenticated)/admin/emails/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/admin/emails/page.tsx
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { notFound, redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { EmailTemplateType } from "../../../../../utils/email";
+import { authOptions } from "../../../../api/auth/[...nextauth]/route";
+
+export default async function EmailRootPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user.email) {
+    return notFound();
+  }
+
+  const admins = process.env.ADMINS?.split(",") ?? [];
+  const isAdmin = admins.includes(session.user.email);
+
+  if (!isAdmin) {
+    return notFound();
+  }
+
+  return redirect("./emails/" + EmailTemplateType.Verification);
+}

--- a/src/app/(nextjs_migration)/(authenticated)/admin/layout.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/admin/layout.tsx
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ReactNode } from "react";
+import { getServerSession } from "next-auth";
+import { notFound } from "next/navigation";
+
+import "../../../../client/css/index.css";
+import { authOptions } from "../../../api/auth/[...nextauth]/route";
+export type Props = {
+  children: ReactNode;
+};
+
+const AdminLayout = async (props: Props) => {
+  const session = await getServerSession(authOptions);
+  const admins = process.env.ADMINS?.split(",") ?? [];
+  if (
+    !session ||
+    typeof session.user.email !== "string" ||
+    !admins.includes(session.user.email)
+  ) {
+    return notFound();
+  }
+
+  return <>{props.children}</>;
+};
+
+export default AdminLayout;

--- a/src/app/(nextjs_migration)/(authenticated)/admin/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/admin/page.tsx
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export default async function AdminPage() {
+  return (
+    <section>
+      <h1>Admin</h1>
+
+      <ul>
+        <li>
+          <a href="/admin/emails">Email preview</a>
+        </li>
+      </ul>
+    </section>
+  );
+}

--- a/src/app/(nextjs_migration)/(authenticated)/admin/send-test-email/route.ts
+++ b/src/app/(nextjs_migration)/(authenticated)/admin/send-test-email/route.ts
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { NextRequest, NextResponse } from "next/server";
+import AppConstants from "../../../../../appConstants.js";
+import {
+  EmailTemplateType,
+  getMonthlyDummyData,
+  getSignupReportDummyData,
+  getVerificationDummyData,
+  initEmail,
+  sendEmail,
+} from "../../../../../utils/email.js";
+import { getTemplate } from "../../../../../views/emails/email2022.js";
+import { getL10n } from "../../../../functions/server/l10n";
+import { verifyPartial } from "../../../../../views/emails/emailVerify.js";
+import { monthlyUnresolvedEmailPartial } from "../../../../../views/emails/emailMonthlyUnresolved.js";
+import { signupReportEmailPartial } from "../../../../../views/emails/emailSignupReport.js";
+
+export async function POST(req: NextRequest) {
+  const { emailId, recipient } = await req.json();
+  const l10n = getL10n();
+
+  switch (emailId) {
+    case EmailTemplateType.Verification: {
+      // Send test verification email
+      const emailTemplate = getTemplate(
+        getVerificationDummyData(recipient, l10n),
+        verifyPartial,
+        l10n
+      );
+      await initEmail(process.env.SMTP_URL);
+      await sendEmail(
+        recipient,
+        l10n.getString("email-subject-verify"),
+        emailTemplate
+      );
+      break;
+    }
+    case EmailTemplateType.Notification: {
+      // Send test breach notification email
+      await sendTestNotification(req, new NextResponse());
+      break;
+    }
+    case EmailTemplateType.Monthly: {
+      // Send test monthly unresolved breaches email
+      const emailTemplate = getTemplate(
+        getMonthlyDummyData(AppConstants.EMAIL_TEST_RECIPIENT, l10n),
+        monthlyUnresolvedEmailPartial,
+        l10n
+      );
+      await initEmail(process.env.SMTP_URL);
+      await sendEmail(
+        recipient,
+        l10n.getString("email-unresolved-heading"),
+        emailTemplate
+      );
+      break;
+    }
+    case EmailTemplateType.SignupReport: {
+      // Send test sign-up report email
+      const emailTemplate = getTemplate(
+        getSignupReportDummyData(AppConstants.EMAIL_TEST_RECIPIENT, l10n),
+        signupReportEmailPartial,
+        l10n
+      );
+      await initEmail(process.env.SMTP_URL);
+      await sendEmail(
+        recipient,
+        l10n.getString("email-subject-found-breaches"),
+        emailTemplate
+      );
+      break;
+    }
+    default: {
+      throw new Error(`No test email found for ${emailId}`);
+    }
+  }
+
+  console.info(`Sent test email: ${emailId}`);
+
+  // The notify function has its own response
+  if (emailId !== EmailTemplateType.Notification) {
+    return NextResponse.json(
+      { success: true, message: `Sent test ${emailId} email` },
+      { status: 200 }
+    );
+  }
+}
+
+async function sendTestNotification(req: NextRequest, res: NextResponse) {
+  // The test breach notification can be viewed in the public Mailinator inbox
+  // as documented in the README:
+  // https://github.com/mozilla/blurts-server#trigger-breach-alert-email
+  const breachNotificationData = {
+    breachName: "Adobe",
+    // Hash for dummy email `localmonitor20200827@mailinator.com`
+    hashPrefix: "365050",
+    hashSuffixes: ["53cbb89874fc738c0512daf12bc4d91765"],
+  };
+
+  const notifyReq = {
+    app: req.app,
+    body: {
+      ...req.body,
+      ...breachNotificationData,
+    },
+    token: AppConstants.HIBP_NOTIFY_TOKEN,
+  };
+
+  // TODO Disabled for now; not sure yet how to trigger this with the functionality
+  // moved to a Cloud Function.
+  // await notify(notifyReq, res);
+}

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -8,7 +8,7 @@ import { URL } from 'url'
 import mozlog from './log.js'
 import AppConstants from '../appConstants.js'
 import { MethodNotAllowedError } from '../utils/error.js'
-import { getMessage, fluentError } from '../utils/fluent.js'
+import { fluentError, getStringLookup } from '../utils/fluent.js'
 import { updateMonthlyEmailOptout } from '../db/tables/subscribers.js'
 
 const log = mozlog('email-utils')
@@ -218,77 +218,92 @@ const breachDummyLogo = new Map([
  * Dummy data for populating the breach notification email preview.
  *
  * @param {string} recipient
+ * @param l10n
  * @returns {object} Breach dummy data
  */
-const getNotificationDummyData = (recipient) => ({
-  breachData: {
-    Id: 1,
-    Name: 'Adobe',
-    Title: 'Adobe',
-    Domain: 'adobe.com',
-    BreachDate: '2013-01-01T22:00:00.000Z',
-    AddedDate: '2013-01-02T00:00:00.000Z',
-    ModifiedDate: '2023-01-01T00:00:00.000Z',
-    PwnCount: 123,
-    Description: 'Example description',
-    DataClasses: [
-      'email-addresses',
-      'password-hints',
-      'passwords',
-      'usernames'
-    ],
-    IsVerified: true,
-    IsFabricated: false,
-    IsSensitive: false,
-    IsRetired: false,
-    IsSpamList: false,
-    IsMalware: false
-  },
-  breachedEmail: recipient,
-  breachLogos: breachDummyLogo,
-  ctaHref: getEmailCtaHref('email-test-notification', 'dashboard-cta'),
-  heading: getMessage('email-spotted-new-breach'),
-  recipientEmail: recipient,
-  subscriberId: 123,
-  supportedLocales: ['en']
-})
+const getNotificationDummyData = (recipient, l10n) => {
+  const getMessage = getStringLookup(l10n);
+
+  return ({
+    breachData: {
+      Id: 1,
+      Name: 'Adobe',
+      Title: 'Adobe',
+      Domain: 'adobe.com',
+      BreachDate: '2013-01-01T22:00:00.000Z',
+      AddedDate: '2013-01-02T00:00:00.000Z',
+      ModifiedDate: '2023-01-01T00:00:00.000Z',
+      PwnCount: 123,
+      Description: 'Example description',
+      DataClasses: [
+        'email-addresses',
+        'password-hints',
+        'passwords',
+        'usernames'
+      ],
+      IsVerified: true,
+      IsFabricated: false,
+      IsSensitive: false,
+      IsRetired: false,
+      IsSpamList: false,
+      IsMalware: false
+    },
+    breachedEmail: recipient,
+    breachLogos: breachDummyLogo,
+    ctaHref: getEmailCtaHref('email-test-notification', 'dashboard-cta'),
+    heading: getMessage('email-spotted-new-breach'),
+    recipientEmail: recipient,
+    subscriberId: 123,
+    supportedLocales: ['en']
+  })
+}
 
 /**
  * Dummy data for populating the email verification preview
  *
  * @param {string} recipient
+ * @param l10n
  * @returns {object} Email verification dummy data
  */
-const getVerificationDummyData = (recipient) => ({
-  ctaHref: SERVER_URL,
-  heading: getMessage('email-verify-heading'),
-  recipientEmail: recipient,
-  subheading: getMessage('email-verify-subhead')
-})
+const getVerificationDummyData = (recipient, l10n) => {
+  const getMessage = getStringLookup(l10n);
+
+  return ({
+    ctaHref: SERVER_URL,
+    heading: getMessage('email-verify-heading'),
+    recipientEmail: recipient,
+    subheading: getMessage('email-verify-subhead')
+  })
+}
 
 /**
  * Dummy data for populating the monthly unresolved breaches email
  *
  * @param {string} recipient
+ * @param l10n
  * @returns {object} Monthly unresolved breaches dummy data
  */
-const getMonthlyDummyData = (recipient) => ({
-  breachedEmail: 'breached@email.com',
-  breachLogos: breachDummyLogo,
-  ctaHref: `${SERVER_URL}/user/breaches`,
-  heading: getMessage('email-unresolved-heading'),
-  monitoredEmails: {
-    count: 2
-  },
-  numBreaches: {
-    count: 3,
-    numResolved: 2,
-    numUnresolved: 1
-  },
-  recipientEmail: recipient,
-  subheading: getMessage('email-unresolved-subhead'),
-  unsubscribeUrl: `${SERVER_URL}/user/unsubscribe-monthly?token=token_123`
-})
+const getMonthlyDummyData = (recipient, l10n) => {
+  const getMessage = getStringLookup(l10n);
+
+  return ({
+    breachedEmail: 'breached@email.com',
+    breachLogos: breachDummyLogo,
+    ctaHref: `${SERVER_URL}/user/breaches`,
+    heading: getMessage('email-unresolved-heading'),
+    monitoredEmails: {
+      count: 2
+    },
+    numBreaches: {
+      count: 3,
+      numResolved: 2,
+      numUnresolved: 1
+    },
+    recipientEmail: recipient,
+    subheading: getMessage('email-unresolved-subhead'),
+    unsubscribeUrl: `${SERVER_URL}/user/unsubscribe-monthly?token=token_123`
+  })
+}
 
 /**
  * Dummy data for populating the signup report email
@@ -297,9 +312,10 @@ const getMonthlyDummyData = (recipient) => ({
  * @returns {object} Signup report email dummy data
  */
 
-const getSignupReportDummyData = (recipient) => {
+const getSignupReportDummyData = (recipient, l10n) => {
+  const getMessage = getStringLookup(l10n);
   const unsafeBreachesForEmail = [
-    getNotificationDummyData(recipient).breachData
+    getNotificationDummyData(recipient, l10n).breachData
   ]
   const breachesCount = unsafeBreachesForEmail.length
   const numPasswordsExposed = 1

--- a/src/views/emails/email2022.js
+++ b/src/views/emails/email2022.js
@@ -125,7 +125,7 @@ const emailFooter = (data, l10n) => {
   <tr class='footer'>
     <td style='${footerContainerStyle}'>
       ${data.unsubscribeUrl
-      ? `<p>${getUnsubscribeCopy(data)}</p>`
+      ? `<p>${getUnsubscribeCopy(data, l10n)}</p>`
       : ''}
       <p>
         ${getMessage('email-2022-hibp-attribution', {

--- a/src/views/emails/emailBreachAlert.js
+++ b/src/views/emails/emailBreachAlert.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { breachCardPartial } from './emailBreachCard.js'
-import { getMessage } from '../../utils/fluent.js'
+import { getStringLookup } from '../../utils/fluent.js'
 
 const breachAlertContainerStyle = `
   background: #f9f9fa;
@@ -21,8 +21,9 @@ const breachAlertCtaStyle = `
   padding: 12px 24px;
 `
 
-const breachAlertEmailPartial = data => {
+const breachAlertEmailPartial = (data, l10n) => {
   const { breachData, breachedEmail, breachLogos, ctaHref } = data
+  const getMessage = getStringLookup(l10n);
 
   return `
     <tr>
@@ -32,7 +33,7 @@ const breachAlertEmailPartial = data => {
             'email-address': `<strong>${breachedEmail}</strong>`
           })}
         </p>
-        ${breachCardPartial(breachData, breachLogos)}
+        ${breachCardPartial(breachData, breachLogos, l10n)}
         <a
           href='${ctaHref}'
           style='${breachAlertCtaStyle}'

--- a/src/views/emails/emailBreachCard.js
+++ b/src/views/emails/emailBreachCard.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getLocale, getMessage } from '../../utils/fluent.js'
+import { getLocale, getStringLookup } from '../../utils/fluent.js'
 import { formatDate } from '../../utils/formatDate.js'
 import { getBreachLogo } from '../../utils/breachLogo.js'
 
@@ -58,7 +58,8 @@ const breachAlertValueStyle = `
   padding-bottom: 15px;
 `
 
-const breachCardPartial = (breachData, breachLogos) => {
+const breachCardPartial = (breachData, breachLogos, l10n) => {
+  const getMessage = getStringLookup(l10n);
   const {
     AddedDate,
     DataClasses,

--- a/src/views/emails/emailMonthlyUnresolved.js
+++ b/src/views/emails/emailMonthlyUnresolved.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getMessage } from '../../utils/fluent.js'
+import { getMessage, getStringLookup } from '../../utils/fluent.js'
 
 const emailStyle = `
   color: black;
@@ -45,74 +45,78 @@ const ctaStyle = `
   padding: 12px 24px;
 `
 
-const monthlyUnresolvedEmailPartial = (data) => `
-  <tr>
-    <td style='${emailStyle}'>
-      <p>
-        ${getMessage('email-is-affected', {
-          'email-address': `<strong>${data.breachedEmail}</strong>`
-        })}
-      </p>
-      <p>
-        ${getMessage('email-more-detail')}
-      </p>
-    </td>
-  </tr>
-  <tr>
-    <td style='${containerStyle}'>
-      <p>
-        <strong>
-          ${getMessage('email-breach-status')}
-        </strong>
-      </p>
-      <table
-        border='0'
-        cellpadding='0'
-        cellspacing='0'
-        role='presentation'
-        style='${tableStyle}'
-      >
-        <tr>
-          <td style='${tableLabelStyle}'>
-            ${getMessage('email-monitored')}
-          </td>
-          <td style='${tableValueStyle}'>
-            ${data.monitoredEmails.count}
-          </td>
-        </tr>
-        <tr>
-          <td style='${tableLabelStyle}'>
-            ${getMessage('email-breach-total')}
-          </td>
-          <td style='${tableValueStyle}'>
-            ${data.numBreaches.count}
-          </td>
-        </tr>
-        <tr>
-          <td style='${tableLabelStyle}'>
-            ${getMessage('email-resolved')}
-          </td>
-          <td style='${tableValueStyle}'>
-            ${data.numBreaches.numResolved}
-          </td>
-        </tr>
-        <tr>
-          <td style='${tableLabelStyle}'>
-            ${getMessage('email-unresolved')}
-          </td>
-          <td style='${tableValueStyle}'>
-            ${data.numBreaches.numUnresolved}
-          </td>
-        </tr>
-      </table>
-      <a
-        href='${data.ctaHref}'
-        style='${ctaStyle}'
-      >
-        ${getMessage('email-resolve-cta')}
-      </a>
-    </td>
-  </tr>
+const monthlyUnresolvedEmailPartial = (data, l10n) => {
+  const getMessage = getStringLookup(l10n);
+
+  return `
+    <tr>
+      <td style='${emailStyle}'>
+        <p>
+          ${getMessage('email-is-affected', {
+      'email-address': `<strong>${data.breachedEmail}</strong>`
+    })}
+        </p>
+        <p>
+          ${getMessage('email-more-detail')}
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td style='${containerStyle}'>
+        <p>
+          <strong>
+            ${getMessage('email-breach-status')}
+          </strong>
+        </p>
+        <table
+          border='0'
+          cellpadding='0'
+          cellspacing='0'
+          role='presentation'
+          style='${tableStyle}'
+        >
+          <tr>
+            <td style='${tableLabelStyle}'>
+              ${getMessage('email-monitored')}
+            </td>
+            <td style='${tableValueStyle}'>
+              ${data.monitoredEmails.count}
+            </td>
+          </tr>
+          <tr>
+            <td style='${tableLabelStyle}'>
+              ${getMessage('email-breach-total')}
+            </td>
+            <td style='${tableValueStyle}'>
+              ${data.numBreaches.count}
+            </td>
+          </tr>
+          <tr>
+            <td style='${tableLabelStyle}'>
+              ${getMessage('email-resolved')}
+            </td>
+            <td style='${tableValueStyle}'>
+              ${data.numBreaches.numResolved}
+            </td>
+          </tr>
+          <tr>
+            <td style='${tableLabelStyle}'>
+              ${getMessage('email-unresolved')}
+            </td>
+            <td style='${tableValueStyle}'>
+              ${data.numBreaches.numUnresolved}
+            </td>
+          </tr>
+        </table>
+        <a
+          href='${data.ctaHref}'
+          style='${ctaStyle}'
+        >
+          ${getMessage('email-resolve-cta')}
+        </a>
+      </td>
+    </tr>
 `
+}
 
 export { monthlyUnresolvedEmailPartial }

--- a/src/views/emails/emailSignupReport.js
+++ b/src/views/emails/emailSignupReport.js
@@ -92,7 +92,7 @@ const signupReportEmailPartial = (data, l10n) => {
         ${
           unsafeBreachesForEmail?.length
             ? unsafeBreachesForEmail.map(unsafeBreach => (
-                breachCardPartial(unsafeBreach, breachLogos)
+                breachCardPartial(unsafeBreach, breachLogos, l10n)
               )).join('')
             : ''
         }

--- a/src/views/emails/emailVerify.js
+++ b/src/views/emails/emailVerify.js
@@ -22,25 +22,26 @@ const ctaStyle = `
 
 const verifyPartial = (data, l10n) => {
   const getMessage = getStringLookup(l10n);
+
   return `
-  <tr>
-    <td style='${containerStyle}'>
-      <p>
-        ${getMessage('email-verify-simply-click')}
-      </p>
-      <a
-        href='${data.ctaHref}'
-        style='${ctaStyle}'
-      >
-        ${getMessage('verify-email-cta')}
-      </a>
-      <p>
-        <strong>
-          ${getMessage('email-link-expires')}
-        </strong>
-      </p>
-    </td>
-  </tr>
-`
+    <tr>
+      <td style='${containerStyle}'>
+        <p>
+          ${getMessage('email-verify-simply-click')}
+        </p>
+        <a
+          href='${data.ctaHref}'
+          style='${ctaStyle}'
+        >
+          ${getMessage('verify-email-cta')}
+        </a>
+        <p>
+          <strong>
+            ${getMessage('email-link-expires')}
+          </strong>
+        </p>
+      </td>
+    </tr>
+  `
 }
 export { verifyPartial }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1639
Figma: N/A


<!-- When adding a new feature: -->

# Description

This recreated the admin page. Note that the Notification email doesn't work yet, because I don't know how to trigger the Cloud Function. Guidance appreciated :)

# How to test

Visit `/admin` while logged in to an account that is listed in the `ADMINS` environment variable.