### PR TITLE
Fix media query not working on Safari

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,6 +3,7 @@
     "stylelint-config-standard"
   ],
   "rules": {
+    "media-feature-range-notation": null,
     "alpha-value-notation": "number",
     "import-notation": "string",
     "no-descending-specificity": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     "eslint.enable": true,
     "eslint.format.enable": true,
     "editor.tabSize": 2,
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false,
     "editor.formatOnSaveMode": "modificationsIfAvailable",
     "eslint.validate": [
         "javascript"

--- a/src/client/css/partials/floatingBanner.css
+++ b/src/client/css/partials/floatingBanner.css
@@ -61,7 +61,7 @@
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-@media (width <= 600px) {
+@media (max-width: 600px) {
   .floating-banner {
     padding: var(--padding-sm) 10vw var(--padding-sm) 2.5vw;
   }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1819
Figma: N/A


<!-- When adding a new feature: -->

# Description

Safari on iOS <16.4, which is still widely used (e.g. by the iPhone 13), doesn't support them.

The max-width media query was rewritten to the range syntax by our format-on-save setting, so I also disabled that.

# How to test

Visit the dashboard using a browser that doesn't support [range syntax](https://caniuse.com/css-media-range-syntax) for media queries, such as Safari before 16.4. Wait until the banner from https://github.com/mozilla/blurts-server/pull/3067 appears, and check that the buttons are stacked on a small screen.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. N/A, visual change
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
