### PR TITLE
Nextjs premerge

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -52,7 +52,8 @@ const nextConfig = {
               `script-src 'self' ${
                 process.env.NODE_ENV === "development"
                   ? "'unsafe-eval' 'unsafe-inline'"
-                  : ""
+                  : // See https://github.com/vercel/next.js/discussions/51039
+                    "'unsafe-inline'"
               } https://*.googletagmanager.com`,
               "script-src-attr 'none'",
               `connect-src 'self' ${
@@ -64,9 +65,7 @@ const nextConfig = {
                   : ""
               }`,
               "child-src 'self'",
-              `style-src 'self' ${
-                process.env.NODE_ENV === "development" ? "'unsafe-inline'" : ""
-              }`,
+              "style-src 'self' 'unsafe-inline'",
               "font-src 'self'",
               "form-action 'self'",
               "frame-ancestors 'self'",

--- a/src/app/(nextjs_migration)/(authenticated)/admin/emails/[template]/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/admin/emails/[template]/page.tsx
@@ -60,8 +60,8 @@ export default async function EmailTemplatePage(props: {
 
   return (
     <div data-partial="emailPreview">
-      <Script src="/nextjs_migration/client/js/customSelect.js" />
-      <Script src="/nextjs_migration/client/js/emailPreview.js" />
+      <Script type="module" src="/nextjs_migration/client/js/customSelect.js" />
+      <Script type="module" src="/nextjs_migration/client/js/emailPreview.js" />
       <section className="email-preview js-email">
         <h1>Email preview</h1>
         <div className="email-preview-controls">

--- a/src/app/(nextjs_migration)/(authenticated)/user/breaches/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/user/breaches/page.tsx
@@ -154,10 +154,10 @@ export default async function UserBreaches() {
 
   return (
     <>
-      <Script src="/nextjs_migration/client/js/customSelect.js" />
-      <Script src="/nextjs_migration/client/js/circleChart.js" />
-      <Script src="/nextjs_migration/client/js/breaches.js" />
-      <Script src="/nextjs_migration/client/js/dialog.js" />
+      <Script type="module" src="/nextjs_migration/client/js/customSelect.js" />
+      <Script type="module" src="/nextjs_migration/client/js/circleChart.js" />
+      <Script type="module" src="/nextjs_migration/client/js/breaches.js" />
+      <Script type="module" src="/nextjs_migration/client/js/dialog.js" />
       <main data-partial="breaches">
         <section>
           <header className="breaches-header">

--- a/src/app/(nextjs_migration)/(authenticated)/user/breaches/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/user/breaches/page.tsx
@@ -157,6 +157,7 @@ export default async function UserBreaches() {
       <Script src="/nextjs_migration/client/js/customSelect.js" />
       <Script src="/nextjs_migration/client/js/circleChart.js" />
       <Script src="/nextjs_migration/client/js/breaches.js" />
+      <Script src="/nextjs_migration/client/js/dialog.js" />
       <main data-partial="breaches">
         <section>
           <header className="breaches-header">

--- a/src/app/(nextjs_migration)/(authenticated)/user/breaches/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/user/breaches/page.tsx
@@ -5,19 +5,19 @@
 import Image from "next/image";
 import Script from "next/script";
 import { getServerSession } from "next-auth";
-import { Breach, CircleChartProps, UserBreaches } from "./breaches.d";
+import { CircleChartProps, UserBreaches } from "./breaches.d";
 
 import AppConstants from "../../../../../appConstants.js";
 import { getL10n } from "../../../../functions/server/l10n";
 import { getUserBreaches } from "../../../../functions/server/getUserBreaches";
 import { getLocale } from "../../../../../utils/fluent.js";
-import { getBreachLogo } from "../../../../../utils/breachLogo.js";
 import { authOptions } from "../../../../api/auth/[...nextauth]/route";
 
 import "../../../../../client/css/partials/breaches.css";
 import ImageIconEmail from "../../../../../client/images/icon-email.svg";
 import ImageBreachesNone from "../../../../../client/images/breaches-none.svg";
 import ImageBreachesAllResolved from "../../../../../client/images/breaches-all-resolved.svg";
+import { BreachLogo } from "../../../../components/server/BreachLogo";
 
 export async function generateMetadata() {
   const l10n = getL10n();
@@ -118,38 +118,36 @@ export default async function UserBreaches() {
           dataClasses: longList.format(dataClassesTranslated),
         });
 
-        const logo = getBreachLogo(breach, breachLogos);
-
-        return `
-         <details class='breach-row' data-status="${status}" data-email="${
-          account.email
-        }" data-classes="${dataClassesTranslated}" ${isHidden ? "hidden" : ""}>
-           <summary>
-             <span class='breach-company'>${logo} ${breach.Title}</span>
-             <span>${shortList.format(dataClassesTranslated)}</span>
-             <span>
-               <span class='resolution-badge is-resolved'>${l10n.getString(
-                 "column-status-badge-resolved"
-               )}</span>
-               <span class='resolution-badge is-active'>${l10n.getString(
-                 "column-status-badge-active"
-               )}</span>
-             </span>
-             <span>${shortDate.format(addedDate)}</span>
-           </summary>
-           <article>
-             <p>${description}</p>
-             <p><strong>${l10n.getString(
-               "breaches-resolve-heading"
-             )}</strong></p>
-             <ol class='resolve-list'>${createResolveSteps(breach)}</ol>
-           </article>
-         </details>
-         `;
+        return (
+          <details key={breach.Name + account.email} className='breach-row' data-status={status} data-email={account.email} data-classes={dataClassesTranslated} hidden={isHidden}>
+            <summary>
+              <span className='breach-company'><BreachLogo breach={breach} logos={breachLogos} /> {breach.Title}</span>
+              <span>{shortList.format(dataClassesTranslated)}</span>
+              <span>
+                <span className='resolution-badge is-resolved'>{l10n.getString(
+                  "column-status-badge-resolved"
+                )}</span>
+                <span className='resolution-badge is-active'>{l10n.getString(
+                  "column-status-badge-active"
+                )}</span>
+              </span>
+              <span>{shortDate.format(addedDate)}</span>
+            </summary>
+            <article>
+              <p>{description}</p>
+              <p><strong>{l10n.getString(
+                "breaches-resolve-heading"
+              )}</strong></p>
+              <ol className='resolve-list'
+                dangerouslySetInnerHTML={{ __html: createResolveSteps(breach) }}
+              />
+            </article>
+          </details>
+        );
       });
     });
 
-    return breachRowsHTML.join("");
+    return breachRowsHTML;
   }
 
   return (
@@ -234,11 +232,7 @@ export default async function UserBreaches() {
             <span></span>
             <span>{l10n.getString("column-detected")}</span>
           </header>
-          <div
-            dangerouslySetInnerHTML={{
-              __html: createBreachRows(userBreachesData),
-            }}
-          />
+          <div>{createBreachRows(userBreachesData)}</div>
 
           <template
             className="no-breaches"

--- a/src/app/(nextjs_migration)/(authenticated)/user/settings/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/user/settings/page.tsx
@@ -179,8 +179,8 @@ export default async function Settings() {
 
   return (
     <>
-      <Script src="/nextjs_migration/client/js/settings.js" />
-      <Script src="/nextjs_migration/client/js/dialog.js" />
+      <Script type="module" src="/nextjs_migration/client/js/settings.js" />
+      <Script type="module" src="/nextjs_migration/client/js/dialog.js" />
       <main data-partial="settings">
         <div className="settings js-settings">
           <h2 className="settings-title">

--- a/src/app/(nextjs_migration)/(guest)/breaches/page.tsx
+++ b/src/app/(nextjs_migration)/(guest)/breaches/page.tsx
@@ -39,7 +39,7 @@ export default async function PublicScan() {
 
   return (
     <div data-partial="allBreaches">
-      <Script src="/nextjs_migration/client/js/allBreaches.js" />
+      <Script type="module" src="/nextjs_migration/client/js/allBreaches.js" />
       <div id="breaches-loader" className="ab-bg breaches-loader"></div>
       <main>
         <div className="all-breaches-front-matter">

--- a/src/app/(nextjs_migration)/(guest)/page.tsx
+++ b/src/app/(nextjs_migration)/(guest)/page.tsx
@@ -18,8 +18,8 @@ export default async function Home() {
 
   return (
     <div data-partial="landing">
-      <Script src="/nextjs_migration/client/js/transitionObserver.js" />
-      <Script src="/nextjs_migration/client/js/landing.js" />
+      <Script type="module" src="/nextjs_migration/client/js/transitionObserver.js" />
+      <Script type="module" src="/nextjs_migration/client/js/landing.js" />
       <section className={styles.hero}>
         <div>
           <h1>{l10n.getString("exposure-landing-hero-heading")}</h1>

--- a/src/app/(nextjs_migration)/(guest)/scan/page.tsx
+++ b/src/app/(nextjs_migration)/(guest)/scan/page.tsx
@@ -21,7 +21,7 @@ export default function PublicScan() {
 
   return (
     <div data-partial="exposureScan">
-      <Script src="/nextjs_migration/client/js/scan.js" />
+      <Script type="module" src="/nextjs_migration/client/js/scan.js" />
       <div hidden id="data"></div>
       <div id="exposure-scan-loading">
         {l10n.getString("exposure-landing-result-loading")}

--- a/src/app/(nextjs_migration)/components/client/UserMenu.tsx
+++ b/src/app/(nextjs_migration)/components/client/UserMenu.tsx
@@ -28,7 +28,7 @@ export const UserMenu = ({ session, fxaSettingsUrl }: Props) => {
 
   return (
     <div className="user-menu-wrapper" tabIndex={-1}>
-      <Script src="/nextjs_migration/client/js/userMenu.js" />
+      <Script type="module" src="/nextjs_migration/client/js/userMenu.js" />
       <button
         aria-expanded="false"
         aria-haspopup="true"

--- a/src/app/(nextjs_migration)/components/client/UserMenu.tsx
+++ b/src/app/(nextjs_migration)/components/client/UserMenu.tsx
@@ -35,12 +35,13 @@ export const UserMenu = ({ session, fxaSettingsUrl }: Props) => {
         className="user-menu-button"
         title={l10n.getString("menu-button-title")}
       >
-        <Image
+        {/* The avatar is an SVG, which next/image doesn't process: https://nextjs.org/docs/pages/api-reference/components/image#dangerouslyallowsvg */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
           // The avatar should always be provided by FxA
           // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
           src={session.user?.fxa?.avatar!}
           alt={l10n.getString("menu-button-alt")}
-          width={46}
           height={46}
         />
       </button>

--- a/src/app/(nextjs_migration)/layout.tsx
+++ b/src/app/(nextjs_migration)/layout.tsx
@@ -15,8 +15,8 @@ export default async function MigrationLayout({
   const l10nBundles = getL10nBundles();
   return (
     <L10nProvider bundleSources={l10nBundles}>
-      <Script src="/nextjs_migration/client/js/resizeObserver.js" />
-      <Script src="/nextjs_migration/client/js/analytics.js" />
+      <Script type="module" src="/nextjs_migration/client/js/resizeObserver.js" />
+      <Script type="module" src="/nextjs_migration/client/js/analytics.js" />
       {children}
     </L10nProvider>
   );


### PR DESCRIPTION
A couple of changes that were necessary to make the built+deployed version work:

- Add `type="module"` to `<script>` tag for the ported client-side scripts. We already had this on the old website, and it gives each module its own scope - which is good, because there are overlapping identifiers in them (e.g. `init`).
- Fix the loading of the user's avatar - we used Next.js's `<Image>` component, but the avatar is an SVG, which it doesn't load.
- Use `<BreachLogo>` to display a company's logo on the dashboard as well. We already used it on the public breach pages as a replacement for the previous function that generated an HTML string.
- Allow Next.js's dynamically-injected scripts in our Content Security Policy.

This branch is currently deployed to Heroku, where you can see it in action.

Note that it builds on https://github.com/mozilla/blurts-server/pull/3112, so I set that as the PR target. As that gets merged, this PR's target should update to `nextjs` as well.