### PR TITLE
Fetch breach data and icons on heartbeat

### DIFF
--- a/src/app/[slug]/route.ts
+++ b/src/app/[slug]/route.ts
@@ -4,11 +4,17 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { vers } from "../../controllers/dockerflow.js";
+import { getBreaches, getBreachIcons } from "../functions/server/getBreaches";
 
 export async function GET(req: NextRequest) {
   // heartbeat route for dockerflow
   const slug = req.nextUrl.pathname;
   if (slug.includes("__heartbeat__") || slug.includes("__lbheartbeat__")) {
+    // Ensure breaches and their icons are loaded after app startup.
+    // Note: we do not `await` this Promise, to ensure we do not delay sending
+    //       the heartbeat response while we are still fetching the data.
+    // TODO: Replace with a cron job to fetch breach data and icons.
+    getBreaches().then(breaches => getBreachIcons(breaches));
     return NextResponse.json({ success: true, message: "OK" }, { status: 200 });
   }
 


### PR DESCRIPTION

# References: 
Jira: MNTOR-1838
Figma: N/A


<!-- When adding a new feature: -->

# Description

To ensure breach data and icons are available as soon as possible, this starts fetching them as soon as the __heartbeat__ endpoint receives a call. Note that they won't _delay_ that call; the Response is sent while the Promise callback is still pending. The icons and breach data shouldn't get refetched on _every_ heartbeat; new fetches are only started if there's no existing data.

This PR is just a proposal, but feel free to point out reasons this isn't a good idea.

# How to test

Delete `public/logo_cache` if it exists, then visit `/__heatbeat__/`. Verify that the response still comes in instantly.