### PR TITLE
Initial landing page loading enhancements

### DIFF
--- a/src/app/(nextjs_migration)/(authenticated)/user/layout.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/user/layout.tsx
@@ -38,6 +38,7 @@ const MainLayout = async (props: Props) => {
               width="213"
               height="33"
               alt={l10n.getString("brand-fx-monitor")}
+              priority
             />
           </a>
           <div className="nav-wrapper">

--- a/src/app/(nextjs_migration)/(guest)/layout.tsx
+++ b/src/app/(nextjs_migration)/(guest)/layout.tsx
@@ -28,6 +28,7 @@ const GuestLayout = (props: Props) => {
               width="213"
               height="33"
               alt={l10n.getString("brand-fx-monitor")}
+              priority
             />
           </a>
           <menu>

--- a/src/app/(nextjs_migration)/(guest)/page.tsx
+++ b/src/app/(nextjs_migration)/(guest)/page.tsx
@@ -18,8 +18,9 @@ export default async function Home() {
 
   return (
     <div data-partial="landing">
+      {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+      <script type="module" src="/nextjs_migration/client/js/transitionObserver.js" rel="preload"></script>
       <Script type="module" src="/nextjs_migration/client/js/transitionObserver.js" />
-      <Script type="module" src="/nextjs_migration/client/js/landing.js" />
       <section className="hero">
         <div>
           <h1>{l10n.getString("exposure-landing-hero-heading")}</h1>

--- a/src/app/(nextjs_migration)/(guest)/page.tsx
+++ b/src/app/(nextjs_migration)/(guest)/page.tsx
@@ -18,9 +18,8 @@ export default async function Home() {
 
   return (
     <div data-partial="landing">
-      {/* eslint-disable-next-line @next/next/no-sync-scripts */}
-      <script type="module" src="/nextjs_migration/client/js/transitionObserver.js" rel="preload"></script>
-      <Script type="module" src="/nextjs_migration/client/js/transitionObserver.js" />
+      <script type="module" src="/nextjs_migration/client/js/transitionObserver.js" async></script>
+      <Script type="module" src="/nextjs_migration/client/js/landing.js" />
       <section className="hero">
         <div>
           <h1>{l10n.getString("exposure-landing-hero-heading")}</h1>

--- a/src/app/(nextjs_migration)/(guest)/page.tsx
+++ b/src/app/(nextjs_migration)/(guest)/page.tsx
@@ -47,7 +47,7 @@ export default async function Home() {
           </form>
         </div>
         <figure>
-          <Image alt="" src={HeroImage} />
+          <Image alt="" src={HeroImage} priority />
         </figure>
       </section>
 

--- a/src/app/(nextjs_migration)/layout.tsx
+++ b/src/app/(nextjs_migration)/layout.tsx
@@ -15,7 +15,8 @@ export default async function MigrationLayout({
   const l10nBundles = getL10nBundles();
   return (
     <L10nProvider bundleSources={l10nBundles}>
-      <Script type="module" src="/nextjs_migration/client/js/resizeObserver.js" />
+      {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+      <script type="module" src="/nextjs_migration/client/js/resizeObserver.js" rel="preload" />
       <Script type="module" src="/nextjs_migration/client/js/analytics.js" />
       {children}
     </L10nProvider>

--- a/src/app/(nextjs_migration)/layout.tsx
+++ b/src/app/(nextjs_migration)/layout.tsx
@@ -15,8 +15,7 @@ export default async function MigrationLayout({
   const l10nBundles = getL10nBundles();
   return (
     <L10nProvider bundleSources={l10nBundles}>
-      {/* eslint-disable-next-line @next/next/no-sync-scripts */}
-      <script type="module" src="/nextjs_migration/client/js/resizeObserver.js" rel="preload" />
+      <script type="module" src="/nextjs_migration/client/js/resizeObserver.js" async />
       <Script type="module" src="/nextjs_migration/client/js/analytics.js" />
       {children}
     </L10nProvider>


### PR DESCRIPTION
# Description

I’ve noticed that there is a layout shift that happens pretty late with the `Next.js` version of the landing page in comparison to https://monitor.firefox.com/. The `Script` tag seems to not pre/async load `/nextjs_migration/client/js/resizeObserver.js` and ignores the attributes. One workaround would be to just add the scripts that we depend on for setting the layout correctly with HTML `script` tags.

# Screenshot

**Before**

https://github.com/mozilla/blurts-server/assets/13835474/6439fa7d-7c30-47f8-9d99-7d49905200f0

**After**

https://github.com/mozilla/blurts-server/assets/13835474/c6a97fe1-2e7e-4e59-8326-d8e4d800e1a1

# How to test

- Visit `/` and reload the page
- Compare page load with `main`
