### PR TITLE
Typo in scan-email-address label on homepage

### DIFF
--- a/src/app/(nextjs_migration)/(guest)/page.tsx
+++ b/src/app/(nextjs_migration)/(guest)/page.tsx
@@ -25,7 +25,7 @@ export default async function Home() {
           <h1>{l10n.getString("exposure-landing-hero-heading")}</h1>
           <p>{l10n.getString("exposure-landing-hero-lead")}</p>
           <form hidden className="exposure-scan">
-            <label htmlFor="scan-email-adddress" className="visually-hidden">
+            <label htmlFor="scan-email-address" className="visually-hidden">
               {l10n.getString("exposure-landing-hero-email-label")}
             </label>
             <input


### PR DESCRIPTION
Found while testing the new Next.js code in dev/stage. Verified the error doesn't exist on prod currently, so looks like a regression from the migration.

```
Incorrect use of <label for=FORM_ELEMENT>
The label's for attribute doesn't match any element id. This might prevent the browser from correctly autofilling the form and accessibility tools from working correctly.
To fix this issue, make sure the label's for attribute references the correct id of a form field.
```

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-
Figma: 


<!-- When adding a new feature: -->

# Description



# Screenshot (if applicable)

Not applicable.

# How to test



# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
