### PR TITLE
A couple of small fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "next dev --port=6060",
     "build": "next build",
-    "start": "next start",
+    "start": "next start --port=6060",
     "lint": "stylelint '**/*.scss' && prettier --check './src' && next lint",
     "test": "NODE_OPTIONS=--loader=testdouble c8 ava",
     "e2e": "playwright test src/e2e/",

--- a/src/app/(nextjs_migration)/(guest)/breach-details/[breachName]/page.tsx
+++ b/src/app/(nextjs_migration)/(guest)/breach-details/[breachName]/page.tsx
@@ -157,10 +157,17 @@ export default async function BreachDetail(props: {
           <p
             className="breach-detail-attribution"
             dangerouslySetInnerHTML={{
-              __html: l10n.getString("email-2022-hibp-attribution", {
-                "hibp-link-attr":
-                  'href="https://haveibeenpwned.com/" target="_blank"',
-              }),
+              __html: l10n
+                .getString("email-2022-hibp-attribution", {
+                  "hibp-link-attr":
+                    'href="https://haveibeenpwned.com/" target="_blank"',
+                })
+                // The following are special characters inserted by Fluent,
+                // which break the link when inserted into the tag.
+                // (For future strings, we can just `getElement` to properly insert
+                // tags into localised strings.)
+                .replaceAll("⁩", "")
+                .replaceAll("⁨", ""),
             }}
           />
         </div>

--- a/src/client/css/partials/breaches.css
+++ b/src/client/css/partials/breaches.css
@@ -218,7 +218,8 @@
   display: none;
 }
 
-.breach-row .breach-company .breach-logo {
+.breach-row .breach-company .breach-logo,
+.breach-row .breach-company img {
   height: 1.5rem;
   display: inline-block;
   vertical-align: bottom;


### PR DESCRIPTION
This fixes a couple of small things:

- Makes the HIBP link on the breach detail page clickable again ([example of bug](https://stage.firefoxmonitor.nonprod.cloudops.mozgcp.net/breach-details/JDGroup))
- Starts the built server on port 6060 as well (which aligns with the redirect URLs configured for FxA)
- Makes sure the breach icons are also vertically aligned on the dashboard, by applying styles that were no longer applied by using the new icon component.