### PR TITLE
MNTOR-1385 - request subscription scope, as some of our RPs are not yet allowed

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -59,7 +59,7 @@ export const authOptions: AuthOptions = {
       authorization: {
         url: AppConstants.OAUTH_AUTHORIZATION_URI,
         params: {
-          scope: "profile",
+          scope: "profile https://identity.mozilla.com/account/subscriptions",
           access_type: "offline",
           action: "email",
           prompt: "login",


### PR DESCRIPTION
Request subscription scope when authenticating, as some of our RPs are not yet allowed.
This will fail early vs. just silently not working.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1385

<!-- When adding a new feature: -->

# How to test

Whether or not this works depends on the configuration of the environment on the FxA side, on investigating with SRE we found several client IDs registered for Fxa staging, most of which we are no longer using on the Monitor team.

SRE is adding the scope to our existing client IDs now, and we will work separately to deprecate any unused client IDs so there isn't confusing in the future. Additionally, SRE will enable this for production before we ship this feature (which is behind a flag).

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
