### PR TITLE
config: send more debug info from dev/heroku envs

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -12,17 +12,22 @@ Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
+  tracesSampleRate: ["development", "heroku"].includes(process.env.NODE_ENV)
+    ? 1.0
+    : 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: true,
+  debug: ["development", "heroku"].includes(process.env.NODE_ENV),
 
   replaysOnErrorSampleRate: 1.0,
 
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production
-  replaysSessionSampleRate:
-    process.env.NEXT_PUBLIC_NODE_ENV === "development" ? 1.0 : 0.1,
+  replaysSessionSampleRate: ["development", "heroku"].includes(
+    process.env.NODE_ENV
+  )
+    ? 1.0
+    : 0.1,
 
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -24,7 +24,7 @@ Sentry.init({
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production
   replaysSessionSampleRate: ["development", "heroku"].includes(
-    process.env.NODE_ENV
+    process.env.NEXT_PUBLIC_NODE_ENV
   )
     ? 1.0
     : 0.1,

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -24,7 +24,7 @@ Sentry.init({
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production
   replaysSessionSampleRate: ["development", "heroku"].includes(
-    process.env.NEXT_PUBLIC_NODE_ENV
+    process.env.NODE_ENV
   )
     ? 1.0
     : 0.1,
@@ -33,8 +33,8 @@ Sentry.init({
   integrations: [
     new Sentry.Replay({
       // Additional Replay configuration goes in here, for example:
-      maskAllText: process.env.NEXT_PUBLIC_NODE_ENV === "development",
-      blockAllMedia: process.env.NEXT_PUBLIC_NODE_ENV === "development",
+      maskAllText: process.env.NODE_ENV === "development",
+      blockAllMedia: process.env.NODE_ENV === "development",
     }),
   ],
 });

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -17,7 +17,7 @@ Sentry.init({
     : 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: ["development", "heroku"].includes(process.env.NODE_ENV),
+  debug: false,
 
   replaysOnErrorSampleRate: 1.0,
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -12,8 +12,10 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
 
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
+  tracesSampleRate: ["development", "heroku"].includes(process.env.NODE_ENV)
+    ? 1.0
+    : 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: process.env.NODE_ENV === "development",
+  debug: ["development", "heroku"].includes(process.env.NODE_ENV),
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -17,5 +17,5 @@ Sentry.init({
     : 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: ["development", "heroku"].includes(process.env.NODE_ENV),
+  debug: false,
 });


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When adding a new feature: -->

# Description

This is a small config change for the Heroku dev env to send in more performance and log debug data for Sentry. It causes Heroku (and local development, if enabled with the `SENTRY_DSN` and `NEXT_PUBLIC_SENTRY_DSN` env vars) to log to the console and also set the traces sample rate to 100%.

Production (and any other environments such as stage) will have the trace sample rate set to 1% and disabled debug logging.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).