### PR TITLE
Attempt to fix image remotePatterns for stage and prod

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,11 +20,11 @@ const nextConfig = {
       },
       {
         protocol: "https",
-        hostname: "stage.firefoxmonitor.nonprod.cloudops.mozgcp.net",
+        hostname: "stage.firefoxmonitor.nonprod.cloudops.mozgcp.net/",
       },
       {
         protocol: "https",
-        hostname: "monitor.firefox.com",
+        hostname: "monitor.firefox.com/",
       },
       {
         protocol: "https",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1853](https://mozilla-hub.atlassian.net/browse/MNTOR-1853)


<!-- When adding a new feature: -->

# Description

I see the fallback placeholder for the profile image working on dev, but on stage, the network request is failing because of CSP reasons. This is just a guess: Let’s try to add a trailing `/` since the referer hostname might need an exact match.

# Screenshot

Profile placeholder
| dev | stage |
| --- | --- |
| <img width="80" alt="profile-dev" src="https://github.com/mozilla/blurts-server/assets/13835474/ad400a3e-938a-444c-a644-efca6764dd94"> | <img width="103" alt="profile-stage" src="https://github.com/mozilla/blurts-server/assets/13835474/d5ef5056-f8b8-41c6-892a-4f0898c2fca8"> |


# How to test

Only testable after the PR has been promoted to `stage`.
