### PR TITLE
Allow all <Image> sources to be loaded in our CSP

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -59,11 +59,16 @@ const nextConfig = {
               `connect-src 'self' ${
                 process.env.NODE_ENV === "development" ? "webpack://*" : ""
               } https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.ingest.sentry.io`,
-              `img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com https://firefoxusercontent.com https://mozillausercontent.com https://monitor.cdn.mozilla.net ${
-                process.env.FXA_ENABLED
-                  ? new URL(process.env.OAUTH_PROFILE_URI).origin
-                  : ""
-              }`,
+              `img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com https://firefoxusercontent.com https://mozillausercontent.com https://monitor.cdn.mozilla.net ${nextConfig.images.remotePatterns
+                .map(
+                  (pattern) =>
+                    `${
+                      pattern.protocol ?? "https"
+                    }://${pattern.hostname.replace("**", "*")}${
+                      pattern.port ? `:${pattern.port}` : ""
+                    }`
+                )
+                .join(" ")}`,
               "child-src 'self'",
               "style-src 'self' 'unsafe-inline'",
               "font-src 'self'",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1853
Figma: N/A


<!-- When adding a new feature: -->

# Description

Profile images got blocked by our Content Security Policy:

> Content Security Policy: The page’s settings blocked the loading of a resource at https://profile.stage.mozaws.net/v1/avatar/v (“img-src”).

They were already allowlisted [via `<Image>`'s `remotePatterns`](https://nextjs.org/docs/app/api-reference/components/image#remotepatterns), but those weren't necessarily added to our Content Security Policy.

Supersedes #3150.

# How to test

Run `npm run build; npm start`, then verify that the profile image (or its placeholder) does get loaded.