### PR TITLE
Set the base path for metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ReactNode } from "react";
+import { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { getServerSession } from "next-auth";
@@ -14,11 +15,15 @@ import { metropolis } from "./fonts/Metropolis/metropolis";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
-export async function generateMetadata() {
+export async function generateMetadata(): Promise<Metadata> {
   const l10n = getL10n();
   return {
     title: l10n.getString("brand-fx-monitor"),
     description: l10n.getString("meta-desc-2"),
+    metadataBase:
+      typeof process.env.SERVER_URL === "string"
+        ? new URL(process.env.SERVER_URL)
+        : undefined,
     twitter: {
       card: "summary_large_image",
       title: l10n.getString("brand-fx-monitor"),


### PR DESCRIPTION
This ensures that relative URLs (such as those in
`openGraph.images`) resolve to the correct URL, and thus fixes the problem called out by @pdehaan in https://github.com/mozilla/blurts-server/pull/3134#issuecomment-1593770158.

We should be able to properly test this on stage, but it does give confidence that a warning about this got removed from the build log, and that [the docs say](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase):

> The field's relative path will be composed with metadataBase to form a fully qualified URL.
If not configured, metadataBase is automatically populated with a [default value](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#default-value).

It should also apply for all other pages:

> metadataBase is typically set in root app/layout.js to apply to URL-based metadata fields across all routes.