### PR TITLE
Fix HIBP link in verification email

### DIFF
--- a/src/views/emails/email2022.js
+++ b/src/views/emails/email2022.js
@@ -142,7 +142,12 @@ const emailFooter = (data, l10n) => {
       <p>
         ${getMessage('email-2022-hibp-attribution', {
         'hibp-link-attr': `href='${links(data).hibp}' rel='noopener'`
-      })}
+      })
+      // The following are special characters inserted by Fluent,
+      // which break the link when inserted into the tag.
+      ?.replaceAll("⁩", "")
+      .replaceAll("⁨", "")
+      }
       </p>
       <img
         alt='${getMessage('mozilla')}'


### PR DESCRIPTION
Since this is the same fix as in https://github.com/mozilla/blurts-server/pull/3134/commits/add1e8ecf889fbc819b6c86ac34496fdc7cec876, I figured I'd quickly apply it here too.

# References: 
Jira: MNTOR-1858