### PR TITLE
Proxy company icons

### DIFF
--- a/src/app/api/breach-icon/[breach-domain]/route.ts
+++ b/src/app/api/breach-icon/[breach-domain]/route.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { readFile } from "node:fs/promises";
+import { dirname, resolve as pathResolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { NextResponse } from "next/server";
+
+export async function GET(
+  request: Request,
+  context: { params: { "breach-domain": string } }
+) {
+  const logoPath = pathResolve(
+    dirname(fileURLToPath(import.meta.url)),
+    `../../../../../public/logo_cache/${context.params["breach-domain"]}.ico`
+  );
+  try {
+    const file = await readFile(logoPath);
+    return new NextResponse(file, {
+      headers: { "Content-Type": "image/x-icon" },
+    });
+  } catch (e) {
+    return new NextResponse(null, { status: 404 });
+  }
+}

--- a/src/app/functions/server/getBreaches.ts
+++ b/src/app/functions/server/getBreaches.ts
@@ -82,7 +82,10 @@ export async function getBreachIcons(breaches: Breach[]): Promise<LogoMap> {
           const logoFilename = breachDomain.toLowerCase() + ".ico";
           const logoPath = pathResolve(logoFolder, logoFilename);
           if (existingLogos.includes(logoFilename)) {
-            resolve([breachDomain, `/logo_cache/${logoFilename}`]);
+            resolve([
+              breachDomain,
+              `/api/breach-icon/${breachDomain.toLowerCase()}`,
+            ]);
             return;
           }
           get(
@@ -99,7 +102,7 @@ export async function getBreachIcons(breaches: Breach[]): Promise<LogoMap> {
                 file.close();
                 resolve([
                   breachDomain,
-                  `/logo_cache/${breachDomain.toLowerCase()}.ico`,
+                  `/api/breach-icon/${breachDomain.toLowerCase()}`,
                 ]);
               });
               file.on("error", (error) => reject(error));


### PR DESCRIPTION
Downloading them to public/ after the app is built doesn't result in the server serving them, so this adds an API that reads the icons from disk and serves them up. This is really a stopgap solution; we really want to get around to downloading them in a cron job and storing them on our CDN, but I don't know enough of our infrastructure at the moment to know how to do that.
