### PR TITLE
Use client-only component for email input

### DIFF
--- a/src/app/(nextjs_migration)/(guest)/page.tsx
+++ b/src/app/(nextjs_migration)/(guest)/page.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import Script from "next/script";
 import "../../../client/css/partials/landing.css";
 import { getL10n } from "../../functions/server/l10n";
+import ExposureScanInput from "../components/client/ExposureScanInput";
 
 import HeroImage from "../../../client/images/landing-hero@2x.webp";
 import LaptopImage from "../../../client/images/landing-laptop@2x.webp";
@@ -31,15 +32,11 @@ export default async function Home() {
             <label htmlFor="scan-email-address" className="visually-hidden">
               {l10n.getString("exposure-landing-hero-email-label")}
             </label>
-            <input
-              id="scan-email-address"
-              name="email"
-              type="email"
-              placeholder={l10n.getString(
-                "exposure-landing-hero-email-placeholder"
-              )}
-              required
-            />
+            {/* The DOM for this element is potentially modified by browser
+            extensions like for example Relay. This is causing a hydration
+            error. Even adding suppressHydrationWarning to the input does not
+            prevent the issues. */}
+            <ExposureScanInput />
             <button
               type="submit"
               className="button primary"

--- a/src/app/(nextjs_migration)/components/client/ExposureScanInput.tsx
+++ b/src/app/(nextjs_migration)/components/client/ExposureScanInput.tsx
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use client";
+
+import dynamic from "next/dynamic";
+import { useL10n } from "../../../hooks/l10n";
+
+const ExposureScanInput = () => {
+  const l10n = useL10n();
+
+  return (
+    <input
+      id="scan-email-address"
+      name="email"
+      type="email"
+      placeholder={l10n.getString("exposure-landing-hero-email-placeholder")}
+      required
+    />
+  );
+};
+
+export default dynamic(() => Promise.resolve(ExposureScanInput), {
+  ssr: false,
+});


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1863](https://mozilla-hub.atlassian.net/browse/MNTOR-1863)

<!-- When adding a new feature: -->

# Description

Browser extensions — in our test case the Relay browser extension — are potentially causing a React hydration error when manipulating the input. Strangely enough, adding `suppressHydrationWarning` to the input and/or the parent `<form>` does not prevent this from happening. One possible solution would be to only render the input client-side until we have a better solution.