### PR TITLE
Don’t ignore script preloading

### DIFF
--- a/src/app/(nextjs_migration)/(authenticated)/user/breaches/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/user/breaches/page.tsx
@@ -124,16 +124,19 @@ export default async function UserBreaches() {
         type="module"
         src="/nextjs_migration/client/js/customSelect.js"
         rel="preload"
+        crossOrigin="anonymous"
       />
       <script
         type="module"
         src="/nextjs_migration/client/js/circleChart.js"
         rel="preload"
+        crossOrigin="anonymous"
       />
       <script
         type="module"
         src="/nextjs_migration/client/js/breaches.js"
         rel="preload"
+        crossOrigin="anonymous"
       />
       {/* eslint-enable @next/next/no-sync-scripts */}
       <Script type="module" src="/nextjs_migration/client/js/dialog.js" />

--- a/src/app/(nextjs_migration)/(guest)/page.tsx
+++ b/src/app/(nextjs_migration)/(guest)/page.tsx
@@ -18,9 +18,14 @@ export default async function Home() {
 
   return (
     <div data-partial="landing">
-      <Script
+      {/* These scripts predate the use of React and thus shouldn’t wait for
+      hydration to adjust the layout. */}
+      {/* eslint-disable @next/next/no-sync-scripts */}
+      <script
         type="module"
         src="/nextjs_migration/client/js/transitionObserver.js"
+        rel="preload"
+        crossOrigin="anonymous"
       />
       <Script type="module" src="/nextjs_migration/client/js/landing.js" />
       <section className="hero">

--- a/src/app/(nextjs_migration)/layout.tsx
+++ b/src/app/(nextjs_migration)/layout.tsx
@@ -22,6 +22,7 @@ export default async function MigrationLayout({
         type="module"
         src="/nextjs_migration/client/js/resizeObserver.js"
         rel="preload"
+        crossOrigin="anonymous"
       />
       <Script type="module" src="/nextjs_migration/client/js/analytics.js" />
       {children}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1863](https://mozilla-hub.atlassian.net/browse/MNTOR-1863)

<!-- When adding a new feature: -->

# Description

PR https://github.com/mozilla/blurts-server/pull/3137 made scripts load before hydration.  Even though they are not waiting for hydration to load they are still not being preloaded on `stage`. The console complains that the request credentials are not matching and adding `crossOrigin=anonymous` should resolve the issue:
```
A preload for 'https://stage.firefoxmonitor.nonprod.cloudops.mozgcp.net/nextjs_migration/client/js/resizeObserver.js' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.
```