### PR TITLE
Replace chart.js by a manually generated SVG

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@types/node": "^20.1.1",
         "@types/react": "^18.2.6",
         "@types/react-dom": "^18.2.4",
-        "chart.js": "^4.3.0",
         "client-oauth2": "^4.3.3",
         "csrf-csrf": "^2.2.2",
         "dotenv": "^16.0.3",
@@ -37,7 +36,6 @@
         "patch-package": "^7.0.0",
         "pg": "^8.9.0",
         "react": "^18.2.0",
-        "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
         "uuid": "^9.0.0"
       },
@@ -3118,11 +3116,6 @@
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "dev": true
-    },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
-      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@mdx-js/react": {
       "version": "2.3.0",
@@ -9274,17 +9267,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chart.js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.3.0.tgz",
-      "integrity": "sha512-ynG0E79xGfMaV2xAHdbhwiPLczxnNNnasrmPEXriXsPJGjmhOBYzFVEsB65w2qMDz+CaBJJuJD0inE/ab/h36g==",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=7"
       }
     },
     "node_modules/chokidar": {
@@ -18539,15 +18521,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-chartjs-2": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
-      "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
-      "peerDependencies": {
-        "chart.js": "^4.1.1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-colorful": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
@@ -24706,11 +24679,6 @@
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "dev": true
     },
-    "@kurkle/color": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
-      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
-    },
     "@mdx-js/react": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.3.0.tgz",
@@ -29268,14 +29236,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
       "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
       "dev": true
-    },
-    "chart.js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.3.0.tgz",
-      "integrity": "sha512-ynG0E79xGfMaV2xAHdbhwiPLczxnNNnasrmPEXriXsPJGjmhOBYzFVEsB65w2qMDz+CaBJJuJD0inE/ab/h36g==",
-      "requires": {
-        "@kurkle/color": "^0.3.0"
-      }
     },
     "chokidar": {
       "version": "3.5.3",
@@ -36143,12 +36103,6 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
-    },
-    "react-chartjs-2": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
-      "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
-      "requires": {}
     },
     "react-colorful": {
       "version": "5.6.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@types/node": "^20.1.1",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
-    "chart.js": "^4.3.0",
     "client-oauth2": "^4.3.3",
     "csrf-csrf": "^2.2.2",
     "dotenv": "^16.0.3",
@@ -75,7 +74,6 @@
     "patch-package": "^7.0.0",
     "pg": "^8.9.0",
     "react": "^18.2.0",
-    "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
     "uuid": "^9.0.0"
   },

--- a/pendingTranslations.ftl
+++ b/pendingTranslations.ftl
@@ -17,3 +17,8 @@ footer-external-link-faq-tooltip = Frequently asked questions
 # Variables:
 #   $nr (number) - Total number of exposures found for the user
 exposure-chart-heading = <nr>{ $nr }</nr> <label>exposures</label>
+exposure-chart-legend-heading-type = Exposure
+exposure-chart-legend-heading-nr = Number
+# Variables:
+#   $nr (number) - Number of a particular type of exposure found for the user
+exposure-chart-legend-value-nr = { $nr }x

--- a/pendingTranslations.ftl
+++ b/pendingTranslations.ftl
@@ -11,3 +11,9 @@ main-nav-link-faq-tooltip = Frequently asked questions
 
 footer-external-link-faq-label = FAQs
 footer-external-link-faq-tooltip = Frequently asked questions
+
+# The number inside <nr> will be displayed in a large font,
+# the label inside <label> will be shown underneath, in a smaller font.
+# Variables:
+#   $nr (number) - Total number of exposures found for the user
+exposure-chart-heading = <nr>{ $nr }</nr> <label>exposures</label>

--- a/src/app/components/client/Chart.module.scss
+++ b/src/app/components/client/Chart.module.scss
@@ -1,51 +1,5 @@
 @import "../../tokens";
 
-.gutter {
-  stroke: $color-white;
-}
-
-.slice {
-  // We start at 2, because element 1 is .gutter
-  &:nth-child(2) {
-    stroke: $color-purple-90;
-  }
-  &:nth-child(3) {
-    stroke: $color-purple-80;
-  }
-  &:nth-child(4) {
-    stroke: $color-purple-70;
-  }
-  &:nth-child(5) {
-    stroke: $color-purple-60;
-  }
-  &:nth-child(6) {
-    stroke: $color-purple-50;
-  }
-  &:nth-child(7) {
-    stroke: $color-purple-40;
-  }
-  &:nth-child(8) {
-    stroke: $color-purple-30;
-  }
-  &:nth-child(9) {
-    stroke: $color-purple-20;
-  }
-  &:nth-child(10) {
-    stroke: $color-purple-10;
-  }
-  &:nth-child(11) {
-    stroke: $color-purple-05;
-  }
-}
-
-.headingNr {
-  font-family: var(--font-inter);
-  font-weight: 600;
-}
-.headingLabel {
-  font-family: var(--font-inter);
-}
-
 .chartContainer {
   width: $content-sm;
   text-align: center;
@@ -58,3 +12,194 @@
     font-style: italic;
   }
 }
+
+.gutter {
+  stroke: $color-white;
+}
+
+.chartAndLegendWrapper {
+  display: flex;
+  gap: $spacing-2xl;
+  min-width: $content-xs;
+
+  .chart {
+    flex: 1 0 $content-sm;
+
+    .headingNr {
+      font-family: var(--font-inter);
+      font-weight: 600;
+    }
+    .headingLabel {
+      font-family: var(--font-inter);
+    }
+
+    .slice {
+      @media (prefers-reduced-motion: no-preference) {
+        transition: stroke-dashoffset 1s ease;
+      }
+      // The --sliceLength custom property is set in the element's props
+      stroke-dashoffset: var(--sliceLength);
+    }
+  }
+
+  .legend {
+    flex: 0 0 $content-xs;
+    height: auto;
+    display: flex;
+    align-items: center;
+
+    thead {
+      // These styles are taken from
+      // https://react-spectrum.adobe.com/react-aria/VisuallyHidden.html
+      border: 0;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      height: 1px;
+      margin: 0 -1px -1px 0;
+      overflow: hidden;
+      padding: 0;
+      position: absolute;
+      width: 1px;
+      white-space: nowrap;
+    }
+
+    tbody tr {
+      text-align: start;
+      color: $color-grey-40;
+      font: $text-body-xs;
+
+      td {
+        padding-inline: $spacing-xs;
+      }
+
+      svg {
+        width: 15px;
+        height: 15px;
+      }
+    }
+  }
+}
+
+/* stylelint-disable no-descending-specificity */
+// We start at 2, because element 1 is .gutter
+.slice:nth-child(2) {
+  stroke: $color-purple-90;
+}
+.legend tbody tr:nth-child(1) {
+  .chartAndLegendWrapper:has(.slice:nth-child(2):hover) & {
+    color: $color-purple-90;
+  }
+
+  rect {
+    fill: $color-purple-90;
+  }
+}
+.slice:nth-child(3) {
+  stroke: $color-purple-80;
+}
+.legend tbody tr:nth-child(2) {
+  .chartAndLegendWrapper:has(.slice:nth-child(3):hover) & {
+    color: $color-purple-80;
+  }
+
+  rect {
+    fill: $color-purple-80;
+  }
+}
+.slice:nth-child(4) {
+  stroke: $color-purple-70;
+}
+.legend tbody tr:nth-child(3) {
+  .chartAndLegendWrapper:has(.slice:nth-child(4):hover) & {
+    color: $color-purple-70;
+  }
+
+  rect {
+    fill: $color-purple-70;
+  }
+}
+.slice:nth-child(5) {
+  stroke: $color-purple-60;
+}
+.legend tbody tr:nth-child(4) {
+  .chartAndLegendWrapper:has(.slice:nth-child(5):hover) & {
+    color: $color-purple-60;
+  }
+
+  rect {
+    fill: $color-purple-60;
+  }
+}
+.slice:nth-child(6) {
+  stroke: $color-purple-50;
+}
+.legend tbody tr:nth-child(5) {
+  .chartAndLegendWrapper:has(.slice:nth-child(6):hover) & {
+    color: $color-purple-50;
+  }
+
+  rect {
+    fill: $color-purple-50;
+  }
+}
+.slice:nth-child(7) {
+  stroke: $color-purple-40;
+}
+.legend tbody tr:nth-child(6) {
+  .chartAndLegendWrapper:has(.slice:nth-child(7):hover) & {
+    color: $color-purple-40;
+  }
+
+  rect {
+    fill: $color-purple-40;
+  }
+}
+.slice:nth-child(8) {
+  stroke: $color-purple-30;
+}
+.legend tbody tr:nth-child(7) {
+  .chartAndLegendWrapper:has(.slice:nth-child(8):hover) & {
+    color: $color-purple-30;
+  }
+
+  rect {
+    fill: $color-purple-30;
+  }
+}
+.slice:nth-child(9) {
+  stroke: $color-purple-20;
+}
+.legend tbody tr:nth-child(8) {
+  .chartAndLegendWrapper:has(.slice:nth-child(9):hover) & {
+    color: $color-purple-20;
+  }
+
+  rect {
+    fill: $color-purple-20;
+  }
+}
+.slice:nth-child(10) {
+  stroke: $color-purple-10;
+}
+.legend tbody tr:nth-child(9) {
+  .chartAndLegendWrapper:has(.slice:nth-child(10):hover) & {
+    color: $color-purple-10;
+  }
+
+  rect {
+    fill: $color-purple-10;
+  }
+}
+.slice:nth-child(11) {
+  stroke: $color-purple-05;
+}
+.legend tbody tr:nth-child(10) {
+  .chartAndLegendWrapper:has(.slice:nth-child(11):hover) & {
+    color: $color-purple-05;
+  }
+
+  rect {
+    fill: $color-purple-05;
+  }
+}
+/* stylelint-enable no-descending-specificity */

--- a/src/app/components/client/Chart.module.scss
+++ b/src/app/components/client/Chart.module.scss
@@ -1,5 +1,51 @@
 @import "../../tokens";
 
+.gutter {
+  stroke: $color-white;
+}
+
+.slice {
+  // We start at 2, because element 1 is .gutter
+  &:nth-child(2) {
+    stroke: $color-purple-90;
+  }
+  &:nth-child(3) {
+    stroke: $color-purple-80;
+  }
+  &:nth-child(4) {
+    stroke: $color-purple-70;
+  }
+  &:nth-child(5) {
+    stroke: $color-purple-60;
+  }
+  &:nth-child(6) {
+    stroke: $color-purple-50;
+  }
+  &:nth-child(7) {
+    stroke: $color-purple-40;
+  }
+  &:nth-child(8) {
+    stroke: $color-purple-30;
+  }
+  &:nth-child(9) {
+    stroke: $color-purple-20;
+  }
+  &:nth-child(10) {
+    stroke: $color-purple-10;
+  }
+  &:nth-child(11) {
+    stroke: $color-purple-05;
+  }
+}
+
+.headingNr {
+  font-family: var(--font-inter);
+  font-weight: 600;
+}
+.headingLabel {
+  font-family: var(--font-inter);
+}
+
 .chartContainer {
   width: $content-sm;
   text-align: center;
@@ -7,10 +53,8 @@
   flex-direction: column;
   align-items: center;
 
-  p {
+  figcaption {
     font: $text-body-xs;
     font-style: italic;
   }
 }
-
-

--- a/src/app/components/client/Chart.tsx
+++ b/src/app/components/client/Chart.tsx
@@ -2,79 +2,112 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- "use client";
+"use client";
 
- import { Chart as ChartJS, ArcElement, Tooltip, Legend, ChartOptions, Chart } from 'chart.js';
-import { Doughnut } from "react-chartjs-2";
-import styles from "./Chart.module.scss"
+import { Fragment, ReactNode } from "react";
+import { useL10n } from "../../hooks/l10n";
+import styles from "./Chart.module.scss";
 
 export type Props = {
-  labels: string[];
-  data: number[];
-  backgroundColors: string[];
+  data: Array<[string, number]>;
   totalExposures: number;
 };
 export const DoughnutChart = (props: Props) => {
-  const sumOfFixedExposures = props.data.reduce((total, num) => total + num, 0);
+  const l10n = useL10n();
+  const sumOfFixedExposures = props.data.reduce(
+    (total, [_label, num]) => total + num,
+    0
+  );
+  const percentages = props.data.map(([label, num]) => {
+    return [label, num / sumOfFixedExposures] as const;
+  });
 
-  // Draw stats in the center of doughnut chart
-  const textCenter = {
-    id: 'textCenter',
-    beforeDatasetsDraw(chart: any) {
-      const { ctx } = chart;
-      const xCoor = chart.getDatasetMeta(0).data[0].x;
-      const yCoor = chart.getDatasetMeta(0).data[0].y;
-      ctx.save();
+  const diameter = 100;
+  const ringWidth = 15;
+  const radius = (diameter - ringWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const sliceBorderWidth = 0;
+  const headingNumberSize = diameter / 8;
+  const headingLabelSize = headingNumberSize / 2;
+  const headingGap = 4;
 
-      ctx.font = '700 28px / 40px var(--font-metropolis), sans-serif';
-      ctx.fillStyle = 'black';
-      ctx.textAlign = 'center';
-      ctx.fillText(`${sumOfFixedExposures}`, xCoor, yCoor);
+  const slices = percentages.map(([label, percent], index) => {
+    const percentOffset = percentages
+      .slice(0, index)
+      .reduce((offset, [_label, num]) => offset + num, 0);
 
-      ctx.font = '400 14px / 21px var(--font-inter), sans-serif';
-      ctx.textAlign = 'center';
-      ctx.fillText("fixed", xCoor, yCoor + 20);
-    }
-  };
+    return (
+      <circle
+        key={label}
+        cx={diameter / 2}
+        cy={diameter / 2}
+        r={radius}
+        className={styles.slice}
+        fill="none"
+        strokeWidth={ringWidth}
+        strokeDasharray={`${circumference} ${circumference}`}
+        // Length of the slice
+        strokeDashoffset={circumference * (1 - percent) + sliceBorderWidth}
+        // Rotate it to not overlap the other slices
+        transform={`rotate(${-90 + 360 * percentOffset} ${diameter / 2} ${
+          diameter / 2
+        })`}
+      />
+    );
+  });
 
-
-  ChartJS.register(ArcElement, Tooltip, Legend, textCenter);
-
-  const data = {
-    labels: props.labels,
-    datasets: [
-      {
-        data: props.data,
-        backgroundColor: props.backgroundColors,
-      },
-    ],
-  };
-
-  const options: ChartOptions<'doughnut'> = {
-    plugins: {
-      legend: {
-        position: 'right',
-        align: 'center',
-        labels: {
-          usePointStyle: true,
-          // Add count next to each legend item
-          generateLabels: (chart: any) => {
-            const datasets = chart.data.datasets;
-            return datasets[0].data.map((data: any, i: number) => ({
-              text: `${chart.data.labels[i]} ${data}`,
-              fillStyle: datasets[0].backgroundColor[i],
-              index: i
-          }))},
-        },
-      },
-      [textCenter.id]: textCenter,
-    },
-  };
-  
   return (
-  <div className={styles.chartContainer}>
-    <Doughnut className={styles.doughnutChart} data={data} options={options} />
-    <p>This chart shows the total number of exposures that are fixed ({sumOfFixedExposures} out of {props.totalExposures}).</p>
-  </div>
+    <figure className={styles.chartContainer}>
+      <svg
+        // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role#svg_and_roleimg
+        role="img"
+        aria-label={l10n
+          .getString("exposure-chart-heading", {
+            nr: sumOfFixedExposures,
+          })
+          .replace("<nr>", "")
+          .replace("</nr>", "")
+          .replace("<label>", "")
+          .replace("</label>", "")}
+        viewBox={`0 0 ${diameter} ${diameter}`}
+      >
+        <circle
+          cx={diameter / 2}
+          cy={diameter / 2}
+          r={radius}
+          fill="none"
+          strokeWidth={ringWidth}
+          className={styles.gutter}
+        />
+        {slices}
+        {l10n.getFragment("exposure-chart-heading", {
+          elems: {
+            nr: (
+              <text
+                className={styles.headingNr}
+                fontSize={headingNumberSize}
+                x={diameter / 2}
+                y={diameter / 2 - headingGap / 2}
+                textAnchor="middle"
+              />
+            ),
+            label: (
+              <text
+                className={styles.headingLabel}
+                fontSize={headingLabelSize}
+                x={diameter / 2}
+                y={diameter / 2 + headingLabelSize + headingGap / 2}
+                textAnchor="middle"
+              />
+            ),
+          },
+          vars: { nr: sumOfFixedExposures },
+        })}
+      </svg>
+      <figcaption>
+        This chart shows the total number of exposures that are fixed (
+        {sumOfFixedExposures} out of {props.totalExposures}).
+      </figcaption>
+    </figure>
   );
 };

--- a/src/app/components/client/Chart.tsx
+++ b/src/app/components/client/Chart.tsx
@@ -4,7 +4,7 @@
 
 "use client";
 
-import { Fragment, ReactNode } from "react";
+import { CSSProperties } from "react";
 import { useL10n } from "../../hooks/l10n";
 import styles from "./Chart.module.scss";
 
@@ -46,8 +46,11 @@ export const DoughnutChart = (props: Props) => {
         fill="none"
         strokeWidth={ringWidth}
         strokeDasharray={`${circumference} ${circumference}`}
-        // Length of the slice
-        strokeDashoffset={circumference * (1 - percent) + sliceBorderWidth}
+        style={
+          {
+            "--sliceLength": circumference * (1 - percent) + sliceBorderWidth,
+          } as CSSProperties
+        }
         // Rotate it to not overlap the other slices
         transform={`rotate(${-90 + 360 * percentOffset} ${diameter / 2} ${
           diameter / 2
@@ -58,52 +61,85 @@ export const DoughnutChart = (props: Props) => {
 
   return (
     <figure className={styles.chartContainer}>
-      <svg
-        // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role#svg_and_roleimg
-        role="img"
-        aria-label={l10n
-          .getString("exposure-chart-heading", {
-            nr: sumOfFixedExposures,
-          })
-          .replace("<nr>", "")
-          .replace("</nr>", "")
-          .replace("<label>", "")
-          .replace("</label>", "")}
-        viewBox={`0 0 ${diameter} ${diameter}`}
-      >
-        <circle
-          cx={diameter / 2}
-          cy={diameter / 2}
-          r={radius}
-          fill="none"
-          strokeWidth={ringWidth}
-          className={styles.gutter}
-        />
-        {slices}
-        {l10n.getFragment("exposure-chart-heading", {
-          elems: {
-            nr: (
-              <text
-                className={styles.headingNr}
-                fontSize={headingNumberSize}
-                x={diameter / 2}
-                y={diameter / 2 - headingGap / 2}
-                textAnchor="middle"
-              />
-            ),
-            label: (
-              <text
-                className={styles.headingLabel}
-                fontSize={headingLabelSize}
-                x={diameter / 2}
-                y={diameter / 2 + headingLabelSize + headingGap / 2}
-                textAnchor="middle"
-              />
-            ),
-          },
-          vars: { nr: sumOfFixedExposures },
-        })}
-      </svg>
+      <div className={styles.chartAndLegendWrapper}>
+        <svg
+          // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role#svg_and_roleimg
+          role="img"
+          aria-label={l10n
+            .getString("exposure-chart-heading", {
+              nr: sumOfFixedExposures,
+            })
+            .replace("<nr>", "")
+            .replace("</nr>", "")
+            .replace("<label>", "")
+            .replace("</label>", "")}
+          viewBox={`0 0 ${diameter} ${diameter}`}
+          className={styles.chart}
+        >
+          <circle
+            cx={diameter / 2}
+            cy={diameter / 2}
+            r={radius}
+            fill="none"
+            strokeWidth={ringWidth}
+            className={styles.gutter}
+          />
+          {slices}
+          {l10n.getFragment("exposure-chart-heading", {
+            elems: {
+              nr: (
+                <text
+                  className={styles.headingNr}
+                  fontSize={headingNumberSize}
+                  x={diameter / 2}
+                  y={diameter / 2 - headingGap / 2}
+                  textAnchor="middle"
+                />
+              ),
+              label: (
+                <text
+                  className={styles.headingLabel}
+                  fontSize={headingLabelSize}
+                  x={diameter / 2}
+                  y={diameter / 2 + headingLabelSize + headingGap / 2}
+                  textAnchor="middle"
+                />
+              ),
+            },
+            vars: { nr: sumOfFixedExposures },
+          })}
+        </svg>
+        <div className={styles.legend}>
+          <table>
+            <thead>
+              <tr>
+                {/* The first column contains the chart colour,
+                    which is irrelevant to screen readers. */}
+                <td aria-hidden={true} />
+                <th>{l10n.getString("exposure-chart-legend-heading-type")}</th>
+                <th>{l10n.getString("exposure-chart-legend-heading-nr")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {props.data.map(([label, num]) => (
+                <tr key={label}>
+                  <td aria-hidden={true}>
+                    <svg viewBox="0 0 10 10">
+                      <rect rx={2} width="10" height="10" />
+                    </svg>
+                  </td>
+                  <td>{label}</td>
+                  <td>
+                    {l10n.getString("exposure-chart-legend-value-nr", {
+                      nr: num,
+                    })}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
       <figcaption>
         This chart shows the total number of exposures that are fixed (
         {sumOfFixedExposures} out of {props.totalExposures}).

--- a/src/app/components/client/stories/Chart.stories.ts
+++ b/src/app/components/client/stories/Chart.stories.ts
@@ -6,8 +6,6 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { DoughnutChart } from "../Chart";
 
-import styles from "../Chart.module.scss"
-
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
 const meta: Meta<typeof DoughnutChart> = {
   title: "Charts",
@@ -16,26 +14,18 @@ const meta: Meta<typeof DoughnutChart> = {
 export default meta;
 type Story = StoryObj<typeof DoughnutChart>;
 
-// Organized from $color-purple-90 to $color-purple-20, refer to tokens.scss
-const purpleColors = ['#321c64', '#45278d', '#592acb', '#7542e5', '#9059ff', '#ab71ff', '#c689ff', '#cb9eff'];
-
 // Predicting that the data may result in this fashion
-const data: any[] = [
-  ['Home address', 11],
-  ['Family members', 12],
-  ['Contact Info', 1],
-  ['Full name', 5],
-  ['Other', 2]
+const data: Array<[string, number]> = [
+  ["Home address", 11],
+  ["Family members", 12],
+  ["Contact Info", 1],
+  ["Full name", 5],
+  ["Other", 2],
 ];
-
-const labels: string[] = data.map(([label]) => label);
-const numbers: number[] = data.map(([, number]) => number);
 
 export const FixedExposures: Story = {
   args: {
-    labels: labels,
-    data: numbers,
-    backgroundColors: purpleColors.slice(0, data.length),
+    data: data,
     totalExposures: 309,
   },
 };


### PR DESCRIPTION
This builds on https://github.com/mozilla/blurts-server/pull/3139 and thus targets that branch.

As proposed in [this comment](https://github.com/mozilla/blurts-server/pull/3139#pullrequestreview-1498164492), this replaces chart.js by a manually generated SVG. It looks a bit different, but avoids adding two more maintainers to our supply chain, shaves some bytes off our bundle size, and removes the weird behaviour that elements in the chart could be disabled.

Additionally, it sets an `aria-label` for the chart to communicate the total number of fixed exposures, and turns the legend into a table that communicates the same data as in the chart for screen readers.

I also had the chart colours determined by CSS based on the order of the exposures. The disadvantage is that we can't ensure that the same type of exposure gets the same colour every time, so we could change that to use explicit classes for the different types of exposures if we want.