### PR TITLE
Also lint pendingTranslations in CI

### DIFF
--- a/.github/workflows/reference_linter.yaml
+++ b/.github/workflows/reference_linter.yaml
@@ -3,12 +3,14 @@ on:
   push:
     paths:
       - 'locales/en/**.ftl'
+      - 'pendingTranslations.ftl'
     branches:
       - main
       - localization
   pull_request:
     paths:
       - 'locales/en/**.ftl'
+      - 'pendingTranslations.ftl'
     branches:
       - main
       - localization
@@ -27,6 +29,9 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r .github/requirements.txt
-      - name: Lint reference
+      - name: Lint reference strings
         run: |
           moz-fluent-lint ./locales/en --config .github/linter_config.yml
+      - name: Lint pending strings
+        run: |
+          moz-fluent-lint ./ --config .github/linter_config.yml


### PR DESCRIPTION
This ensures that common issues with `.ftl` files are also highlighted by CI when they are present in `pendingTranslations.ftl`. (The job still only runs when the file is edited, so I can't set it as a merge condition - I can make it run always if we prefer that.)