### PR TITLE
Make Storybook stories cover the full screen

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -12,4 +12,13 @@
      */
     font-family: Inter;
   }
+  /*
+    Make sure that stories set to render fullscreen (see
+    https://storybook.js.org/docs/react/configure/story-layout) also take up the
+    full height of the page. This is especially relevant for stories that
+    demonstrate full pages.
+   */
+  .sb-main-fullscreen #storybook-root {
+    height: 100%;
+  }
 </style>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -18,6 +18,7 @@ const AppDecorator: Exclude<Preview["decorators"], undefined>[0] = (
       <ReactAriaI18nProvider locale={getLocale(l10nBundles)}>
         <div
           className={`${inter.className} ${inter.variable} ${metropolis.variable}`}
+          style={{ height: "100%" }}
         >
           {storyFn()}
         </div>
@@ -35,6 +36,8 @@ const preview: Preview = {
         date: /Date$/,
       },
     },
+    // https://storybook.js.org/docs/react/configure/story-layout
+    layout: "fullscreen",
   },
   decorators: [AppDecorator],
 };


### PR DESCRIPTION
This is especially useful for stories that demonstrate full pages. Individual stories can still override this by setting

    parameters: { layout: "centered" }

or

    parameters: { layout: "padded" }

on a per-story basis. See
https://storybook.js.org/docs/react/configure/story-layout.

# How to test

Compare [the preview deployment](https://deploy-preview-3193--fx-monitor-storybook.netlify.app/iframe.html?args=&id=pages-dashboard--shell&viewMode=story) with [the one in `main`](https://fx-monitor-storybook.netlify.app/iframe.html?args=&id=pages-dashboard--shell&viewMode=story).