### PR TITLE
Fix path to version.json

### DIFF
--- a/src/controllers/dockerflow.js
+++ b/src/controllers/dockerflow.js
@@ -8,7 +8,7 @@
  import AppConstants from '../appConstants.js'
  import packageJson from '../../package.json';
 
- const versionJsonPath = path.join(__dirname, 'version.json')
+ const versionJsonPath = path.join(__dirname, '../../version.json')
  
  // If the version.json file already exists (e.g., created by circle + docker),
  // don't need to generate it


### PR DESCRIPTION
I noticed that https://stage.firefoxmonitor.nonprod.cloudops.mozgcp.net/__version__ currently shows the fallback data:

https://github.com/mozilla/blurts-server/blob/dd9c4b3529bfe90058587ed8724af0b3e31aab21/src/controllers/dockerflow.js#L28-L32

Presumably, that's because it's not looking in the right location for the `version.json`.