### PR TITLE
Restore serving logos in the free scan API

### DIFF
--- a/src/app/api/v1/scan/route.ts
+++ b/src/app/api/v1/scan/route.ts
@@ -8,6 +8,7 @@ import { getBreaches } from "../../../functions/server/getBreaches";
 import { getBreachesForEmail } from "../../../../utils/hibp";
 import { getSha1 } from "../../../../utils/fxa";
 import { getL10n } from "../../../functions/server/l10n";
+import { getBreachLogo } from "../../../../utils/breachLogo";
 
 export async function POST(request: Request) {
   const body = await request.json();
@@ -54,6 +55,9 @@ export async function POST(request: Request) {
       dataClassStrings: breaches.map((breach) =>
         breach.DataClasses.map((dataClass: string) => l10n.getString(dataClass))
       ),
+      // This is sent in the API response because we can't call `getBreachLogo`
+      // client side, where it would expose AppConstants:
+      logos: breaches.map((breach) => getBreachLogo(breach)),
     };
     return NextResponse.json(successResponse);
   } catch (e) {

--- a/src/utils/breachLogo.js
+++ b/src/utils/breachLogo.js
@@ -7,8 +7,8 @@
  * @returns {string} HTML for a breach logo (either an `img`, or a `span.breach-logo` containing the breached company's first letter)
  */
 export function getBreachLogo (breach) {
-  if (breach.LogoPath) {
-    return `<img src='${breach.LogoPath}' alt='' loading="lazy" class='breach-logo' height='32' />`
+  if (breach.FaviconUrl) {
+    return `<img src='${breach.FaviconUrl}' alt='' loading="lazy" class='breach-logo' height='32' />`
   }
 
   // Add CSS variable and a dedicated class for the logo placeholder


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1883
Figma: N/A


<!-- When adding a new feature: -->

# Description

This partially reverts 3311fea; the UI still expects the API to send the HTML for each breach's icon, and even though that HTML is no longer generated from a logo map, it's still needed.

# Screenshot (if applicable)

![image](https://github.com/mozilla/blurts-server/assets/4251/179d7a1c-c824-4664-bce5-59b070488f40)

# How to test

Enter an email address that has breaches (e.g. `test@mailinator.com`), and verify that the breaches are shown. ([Stage](https://stage.firefoxmonitor.nonprod.cloudops.mozgcp.net/scan#email=test%40mailinator.com) currently shows an error because accessing `response.logos` throws.)
