### PR TITLE
Do not break if window.gtag is not available

### DIFF
--- a/public/nextjs_migration/client/js/dialog.js
+++ b/public/nextjs_migration/client/js/dialog.js
@@ -55,7 +55,7 @@ async function openDialog (path) {
     })
 
     if (!res.ok) throw new Error('Bad fetch response')
-    window.gtag('event', 'opened_closed_dialog', { action: 'open', result: 'success', page_location: location.href })
+    window.gtag?.('event', 'opened_closed_dialog', { action: 'open', result: 'success', page_location: location.href })
 
     const content = await res.text()
     dialogEl.insertAdjacentHTML('beforeend', content)
@@ -68,7 +68,7 @@ async function openDialog (path) {
     }
   } catch (e) {
     dialogEl.close()
-    window.gtag('event', 'opened_closed_dialog', { action: 'open', result: 'failed', page_location: location.href })
+    window.gtag?.('event', 'opened_closed_dialog', { action: 'open', result: 'failed', page_location: location.href })
     console.error(`Could not load dialog content for ${partialName}.`, e)
   }
 }


### PR DESCRIPTION
This may happen if e.g. AdBlocker Ultimate is installed. Unfortunately, I couldn't reproduce, so I don't know how to test, but QA (Robert) confirmed that this was fixed when I deployed it to dev (and that it broke there before I deployed).