### PR TITLE
Scale all fonts down one notch on small screens

### DIFF
--- a/src/app/tokens.scss
+++ b/src/app/tokens.scss
@@ -199,19 +199,36 @@ $layout-2xl: 192px;
 
 // Typeface
 // Title copy
-$text-title-lg: 700 56px / 56px var(--font-metropolis), sans-serif;
-$text-title-md: 700 48px / 48px var(--font-metropolis), sans-serif;
-$text-title-sm: 700 38px / 40px var(--font-metropolis), sans-serif;
-$text-title-xs: 700 28px / 30px var(--font-metropolis), sans-serif;
-$text-title-2xs: 700 24px / 26px var(--font-metropolis), sans-serif;
-$text-title-3xs: 700 18px / 20px var(--font-metropolis), sans-serif;
+// We use `svw`  (rather than just `vw`) to ensure that the fonts look good even
+// when the viewport is at its smallest (e.g. when scrollbars are visible).
+// In most cases they'll snap to one of the clamped values though, so it
+// doesn't matter too much.
+$text-title-lg: 700 clamp(48px, 4.4svw, 56px) / clamp(48px, 4.4svw, 56px)
+    var(--font-metropolis),
+  sans-serif;
+$text-title-md: 700 clamp(38px, 3.8svw, 48px) / clamp(40px, 3.8svw, 48px)
+    var(--font-metropolis),
+  sans-serif;
+$text-title-sm: 700 clamp(28px, 3svw, 38px) / clamp(30px, 3.16svw, 40px)
+    var(--font-metropolis),
+  sans-serif;
+$text-title-xs: 700 clamp(24px, 2.2svw, 28px) / clamp(26px, 2.4svw, 30px)
+    var(--font-metropolis),
+  sans-serif;
+$text-title-2xs: 700 clamp(20px, 1.6svw, 24px) / clamp(20px, 2svw, 26px)
+    var(--font-metropolis),
+  sans-serif;
+$text-title-3xs: 700 clamp(16px, 1.4svw, 18px) / 20px var(--font-metropolis),
+  sans-serif;
 
 // Body copy
-$text-body-xl: 400 21px / 32px var(--font-inter), sans-serif;
-$text-body-lg: 400 18px / 27px var(--font-inter), sans-serif;
-$text-body-md: 400 16px / 24px var(--font-inter), sans-serif;
-$text-body-sm: 400 14px / 21px var(--font-inter), sans-serif;
-$text-body-xs: 400 12px / 18px var(--font-inter), sans-serif;
+$text-body-xl: 400 clamp(18px, 1.7svw, 21px) / 1.5 var(--font-inter), sans-serif;
+$text-body-lg: 400 clamp(16px, 1.5svw, 18px) / 1.5 var(--font-inter), sans-serif;
+$text-body-md: 400 clamp(14px, 1.3svw, 16px) / 1.5 var(--font-inter), sans-serif;
+$text-body-sm: 400 clamp(12px, 1.14svw, 14px) / 1.5 var(--font-inter),
+  sans-serif;
+$text-body-xs: 400 clamp(10px, 0.975svw, 12px) / 1.5 var(--font-inter),
+  sans-serif;
 
 $tab-bar-height: 100px;
 


### PR DESCRIPTION
This was triggered by @codemist [pointing out that](https://github.com/mozilla/blurts-server/pull/3190#discussion_r1254675445) I was setting a media query to tone a header down a notch, which we probably want to do everywhere we use a header - which could get repetitive. So this PR instead incorporates that into the tokens. I'm not sure if this will always align with the designs, but it feels like a relatively safe thing to do, in the sense that it's probably fine overriding the designs if they don't align with this PR.

It sets all font tokens to have a size that's dependent on the viewport size, as determined by `svw`. In other words, it's dependent on the size of the viewport when all browser UI (scrollbars, etc.) is visible.

The `clamp()` functions have three arguments. The third argument, i.e. the font size/line height on the widest screens (e.g. laptops) are the same values that the tokens used to have. For the first argument, i.e. the font size/line height on the smallest screens (e.g. phones), I used the same values that the tokens one size below each token used to have. For the second argument, I eyeballed a value that roughly aligned with the font size changing in between mobile and desktop sizes. I made sure to preserve the font size- line height ratio for this.

So for example, we used to have these font sizes / line heights:

    $text-title-sm: 38px / 40px
    $text-title-xs: 28px / 30px

Therefore, the new font size for $text-title-sm is clamped between 28px (the `-xs` font size) and 38px (the `-sm` font size). 2.5svw appeared to result in an in-between font size on tablet-sized viewports.

And since `40px ÷ 38px ≈ 1.05`, I set the line-height to `3svw * 1.05 = 3.16svw`, clamped between 30px and 40px.

How to test: pick some text, apply the relevant token to its `font` style, and then start wiggling those viewports.