### PR TITLE
fix: scan result may be empty

### DIFF
--- a/src/app/functions/server/onerep.ts
+++ b/src/app/functions/server/onerep.ts
@@ -269,7 +269,7 @@ export async function isEligible() {
   const profileId = result[0]["onerep_profile_id"] as number;
   const scanResult = await getLatestOnerepScan(profileId);
 
-  if (scanResult.onerep_scan_results.data.length) {
+  if (scanResult?.onerep_scan_results?.data?.length) {
     const latestScanDate = new Date(scanResult["created_at"]);
     const lastMonth = new Date();
     lastMonth.setMonth(lastMonth.getMonth() - 1);

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -24,8 +24,8 @@ async function getLatestOnerepScan(onerepProfileId: number): Promise<{
   onerep_scan_id: number;
   created_at: number;
   updated_at: number;
-  onerep_scan_results: { data: ScanResult[] };
-}> {
+  onerep_scan_results: { data: ScanResult[] } | null;
+} | null> {
   return (
     await knex("onerep_scans")
       .select(


### PR DESCRIPTION
# Description

When testing this feature with a new account, I noticed that it depends on the scan result being non-null (which will not be the case for users that haven't performed a scan yet).

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
