### PR TITLE
Fixup exposure cards UI

### DIFF
--- a/locales-pending/premium.ftl
+++ b/locales-pending/premium.ftl
@@ -76,8 +76,8 @@ open-in-new-tab-alt = Open link in a new tab
 
 # Status Pill
 
-status-pill-action-needed = Action Needed
-status-pill-progress = In Progress
+status-pill-action-needed = Action needed
+status-pill-progress = In progress
 status-pill-fixed = Fixed
 
 # Exposure Card

--- a/locales-pending/premium.ftl
+++ b/locales-pending/premium.ftl
@@ -103,7 +103,7 @@ exposure-card-description-info-for-sale-part-two = Remove this profile to protec
 # $data_breach_date is the date of the data breach.
 exposure-card-description-data-breach-part-one = Your information was exposed in the <data_breach_link>{ $data_breach_company } data breach on { $data_breach_date }.</data_breach_link>
 exposure-card-description-data-breach-part-two = We’ll walk you through the steps to fix it.
-exposure-card-your-exposed-info = Your exposed info
+exposure-card-your-exposed-info = Your exposed info:
 exposure-card-exposure-type-data-broker = Info for sale
 exposure-card-exposure-type-data-breach = Data breach
 exposure-card-cta = Let’s fix it

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -273,20 +273,18 @@ function getRandomLightNebulaColor(name: string) {
     "#FFB4DB",
   ];
 
-  const charValue = name
-    .split("")
-    .map((letter) => letter.codePointAt(0))
-    .reduce((sum: number | undefined, codePoint) => {
-      if (sum !== undefined) {
-        return sum + codePoint!;
-      }
-      return codePoint;
-    }, 0);
+  const charValues = name.split("").map((letter) => letter.codePointAt(0));
 
-  if (charValue === undefined) {
+  const charSum = charValues.reduce((sum: number | undefined, codePoint) => {
+    if (codePoint === undefined) return sum;
+    if (sum === undefined) return codePoint;
+    return sum + codePoint;
+  }, undefined);
+
+  if (charSum === undefined) {
     return colors[0];
   }
 
-  const colorIndex = charValue % colors.length;
+  const colorIndex = charSum % colors.length;
   return colors[colorIndex];
 }

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -244,7 +244,7 @@ export const View = (props: Props) => {
 };
 
 // Same logic as breachLogo.js
-function getRandomLightNebulaColor(name: string): string {
+function getRandomLightNebulaColor(name: string) {
   const colors = [
     "#C689FF",
     "#D9BFFF",
@@ -276,11 +276,12 @@ function getRandomLightNebulaColor(name: string): string {
   const charValue = name
     .split("")
     .map((letter) => letter.codePointAt(0))
-    .reduce(
-      (sum: number | undefined, codePoint) =>
-        sum !== undefined ? sum + codePoint! : codePoint,
-      0
-    );
+    .reduce((sum: number | undefined, codePoint) => {
+      if (sum !== undefined) {
+        return sum + codePoint!;
+      }
+      return codePoint;
+    }, 0);
 
   if (charValue === undefined) {
     return colors[0];

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -6,7 +6,6 @@
 
 import { Session } from "next-auth";
 import styles from "./View.module.scss";
-import TwitterImage from "../../../../../components/client/assets/twitter-icon.png";
 import { Toolbar } from "../../../../../components/client/toolbar/Toolbar";
 import { DashboardTopBanner } from "./DashboardTopBanner";
 import { useL10n } from "../../../../../hooks/l10n";
@@ -69,6 +68,7 @@ export const View = (props: Props) => {
               dateFound={breach.AddedDate}
               statusPillType="needAction"
               locale={props.locale}
+              color={getRandomLightNebulaColor(breach.Name)}
             />
           </li>
         );
@@ -184,6 +184,7 @@ export const View = (props: Props) => {
                 dateFound={dateObject(exposure.created_at)}
                 statusPillType="needAction"
                 locale={props.locale}
+                color={getRandomLightNebulaColor(exposure.data_broker)}
               />
             </li>
           ) : (
@@ -197,6 +198,7 @@ export const View = (props: Props) => {
                 dateFound={exposure.AddedDate}
                 statusPillType="needAction"
                 locale={props.locale}
+                color={getRandomLightNebulaColor(exposure.Name)}
               />
             </li>
           )}
@@ -240,3 +242,53 @@ export const View = (props: Props) => {
     </div>
   );
 };
+
+// Same logic as breachLogo.js
+function getRandomLightNebulaColor(name: string): string {
+  const colors = [
+    "#C689FF",
+    "#D9BFFF",
+    "#AB71FF",
+    "#E7DFFF",
+    "#AB71FF",
+    "#3FE1B0",
+    "#54FFBD",
+    "#88FFD1",
+    "#B3FFE3",
+    "#D1FFEE",
+    "#F770FF",
+    "#F68FFF",
+    "#F6B8FF",
+    "#00B3F4",
+    "#00DDFF",
+    "#80EBFF",
+    "#FF8450",
+    "#FFA266",
+    "#FFB587",
+    "#FFD5B2",
+    "#FF848B",
+    "#FF9AA2",
+    "#FFBDC5",
+    "#FF8AC5",
+    "#FFB4DB",
+  ];
+
+  const charValue = name
+    .split("")
+    .map((letter) => letter.codePointAt(0))
+    .reduce(
+      (sum: number | undefined, codePoint) =>
+        sum !== undefined ? sum + codePoint! : codePoint,
+      0
+    );
+
+  if (charValue === undefined) {
+    // Handle the case where charValue is undefined.
+    // You may choose to return a default color or throw an error.
+    // For simplicity, let's return the first color from the array.
+    return colors[0];
+  }
+
+  const colorIndex = charValue % colors.length;
+  return colors[colorIndex];
+}

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -67,7 +67,7 @@ export const View = (props: Props) => {
               exposureName={breach.Name}
               exposureDetailsLink={""} //TODO: Find out what link to add in a breach card
               dateFound={breach.AddedDate}
-              statusPillType={"needAction"}
+              statusPillType="needAction"
               locale={props.locale}
             />
           </li>
@@ -170,7 +170,7 @@ export const View = (props: Props) => {
                 exposureName={exposure.data_broker}
                 exposureDetailsLink={exposure.link}
                 dateFound={dateObject(exposure.created_at)}
-                statusPillType={"needAction"}
+                statusPillType="needAction"
                 locale={props.locale}
               />
             </li>
@@ -183,7 +183,7 @@ export const View = (props: Props) => {
                 exposureName={exposure.Name}
                 exposureDetailsLink={""}
                 dateFound={exposure.AddedDate}
-                statusPillType={"needAction"}
+                statusPillType="needAction"
                 locale={props.locale}
               />
             </li>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -283,9 +283,6 @@ function getRandomLightNebulaColor(name: string): string {
     );
 
   if (charValue === undefined) {
-    // Handle the case where charValue is undefined.
-    // You may choose to return a default color or throw an error.
-    // For simplicity, let's return the first color from the array.
     return colors[0];
   }
 

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -65,6 +65,7 @@ export const View = (props: Props) => {
               exposureImg={TwitterImage}
               exposureData={breach}
               exposureName={breach.Name}
+              fromEmail={verifiedEmail.email}
               exposureDetailsLink={""} //TODO: Find out what link to add in a breach card
               dateFound={breach.AddedDate}
               statusPillType="needAction"
@@ -159,6 +160,19 @@ export const View = (props: Props) => {
 
   const exposureCardElems = filteredExposures.map(
     (exposure: ScanResult | HibpLikeDbBreach, index) => {
+      let email;
+      // Find the corresponding email for this exposure
+      if (!isScanResult(exposure)) {
+        props.userBreaches.breachesData.verifiedEmails.forEach(
+          (verifiedEmail) => {
+            if (
+              verifiedEmail.breaches.some((breach) => breach.Id === exposure.Id)
+            ) {
+              email = verifiedEmail.email;
+            }
+          }
+        );
+      }
       return (
         <>
           {isScanResult(exposure) ? (
@@ -181,6 +195,7 @@ export const View = (props: Props) => {
                 exposureImg={TwitterImage}
                 exposureData={exposure}
                 exposureName={exposure.Name}
+                fromEmail={email}
                 exposureDetailsLink={""}
                 dateFound={exposure.AddedDate}
                 statusPillType="needAction"

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -62,7 +62,6 @@ export const View = (props: Props) => {
             className={styles.exposureListItem}
           >
             <ExposureCard
-              exposureImg={TwitterImage}
               exposureData={breach}
               exposureName={breach.Name}
               fromEmail={verifiedEmail.email}
@@ -161,7 +160,7 @@ export const View = (props: Props) => {
   const exposureCardElems = filteredExposures.map(
     (exposure: ScanResult | HibpLikeDbBreach, index) => {
       let email;
-      // Find the corresponding email for this exposure
+      // Get the email assosciated with breach
       if (!isScanResult(exposure)) {
         props.userBreaches.breachesData.verifiedEmails.forEach(
           (verifiedEmail) => {
@@ -179,7 +178,6 @@ export const View = (props: Props) => {
             // Scanned result
             <li key={index} className={styles.exposureListItem}>
               <ExposureCard
-                exposureImg={TwitterImage}
                 exposureData={exposure}
                 exposureName={exposure.data_broker}
                 exposureDetailsLink={exposure.link}
@@ -192,7 +190,6 @@ export const View = (props: Props) => {
             // Breaches result
             <li key={index} className={styles.exposureListItem}>
               <ExposureCard
-                exposureImg={TwitterImage}
                 exposureData={exposure}
                 exposureName={exposure.Name}
                 fromEmail={email}

--- a/src/app/components/client/ExposureCard.module.scss
+++ b/src/app/components/client/ExposureCard.module.scss
@@ -53,15 +53,16 @@
         display: none;
       }
 
+      .exposureCompanyTitle {
+        font: $text-body-sm;
+        max-width: 120px;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+      }
+
       @media screen and (min-width: $screen-lg) {
         flex: 1 1 0%;
-
-        .exposureCompanyTitle {
-          max-width: 150px;
-          text-overflow: ellipsis;
-          overflow: hidden;
-          white-space: nowrap;
-        }
 
         &.hideOnMobile {
           display: block;
@@ -108,6 +109,22 @@
         display: flex;
         flex-direction: column;
         gap: $spacing-md;
+
+        @media screen and (min-width: $screen-lg) {
+          flex: 1 1 0;
+
+          .fixItBtn {
+            width: 150px;
+            flex: 1 1 0;
+          }
+        }
+
+        .exposedInfoTitle {
+          @media screen and (min-width: $screen-lg) {
+            align-self: center;
+            flex: 0 0 150px; // 150px is the width of categories title
+          }
+        }
       }
 
       @media screen and (min-width: $screen-lg) {
@@ -128,14 +145,20 @@
         margin-left: 0;
         padding-left: 0;
         display: grid;
-        grid-template-columns: repeat(2, 1fr);
-        grid-gap: $spacing-sm;
+        grid-template-columns: 1fr 1fr;
+        grid-row-gap: $spacing-sm;
+
+        @media screen and (min-width: $screen-sm) {
+          grid-template-columns: 1fr 1fr 1fr;
+        }
 
         @media screen and (min-width: $screen-lg) {
           display: flex;
           flex-direction: row;
           align-items: center;
           gap: $layout-xs;
+          flex-wrap: wrap;
+          justify-content: flex-start;
         }
 
         .detailsFoundItem {

--- a/src/app/components/client/ExposureCard.module.scss
+++ b/src/app/components/client/ExposureCard.module.scss
@@ -56,6 +56,13 @@
       @media screen and (min-width: $screen-lg) {
         flex: 1 1 0%;
 
+        .exposureCompanyTitle {
+          max-width: 150px;
+          text-overflow: ellipsis;
+          overflow: hidden;
+          white-space: nowrap;
+        }
+
         &.hideOnMobile {
           display: block;
         }

--- a/src/app/components/client/ExposureCard.module.scss
+++ b/src/app/components/client/ExposureCard.module.scss
@@ -66,7 +66,7 @@
 
       .exposureCompanyTitle {
         font: $text-body-sm;
-        max-width: 120px;
+        max-width: 200px;
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
@@ -75,14 +75,19 @@
       @media screen and (min-width: $screen-lg) {
         flex: 1 1 0%;
 
+        &.exposureImageWrapper {
+          flex: 0.2 0 $width-first-column-filter-bar;
+        }
+
         &.hideOnMobile {
           display: block;
         }
       }
 
-      .exposureImage {
-        max-width: 120px;
-        height: 100%;
+      .exposureImageWrapper {
+        .exposureImage {
+          height: 100%;
+        }
       }
     }
   }

--- a/src/app/components/client/ExposureCard.module.scss
+++ b/src/app/components/client/ExposureCard.module.scss
@@ -114,15 +114,19 @@
           flex: 1 1 0;
 
           .fixItBtn {
-            width: 150px;
-            flex: 1 1 0;
+            flex-shrink: 0;
           }
         }
 
         .exposedInfoTitle {
           @media screen and (min-width: $screen-lg) {
             align-self: center;
-            flex: 0 0 150px; // 150px is the width of categories title
+            flex: 0 0 90px; // fix width of categories title
+          }
+
+          @media screen and (min-width: $screen-xl) {
+            align-self: center;
+            flex: 0 0 150px;
           }
         }
       }

--- a/src/app/components/client/ExposureCard.module.scss
+++ b/src/app/components/client/ExposureCard.module.scss
@@ -45,6 +45,17 @@
     justify-content: space-between;
     height: 30px; // fixed height to standardize image/icon heights
 
+    .fallbackLogo {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 35px;
+      height: 35px;
+      border-radius: 50px;
+      color: black;
+      font: $text-title-3xs;
+    }
+
     dd {
       display: flex;
       align-items: center;

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -266,7 +266,7 @@ export const ExposureCard = (props: ExposureCardProps) => {
         <div className={styles.exposureHeader}>
           <dl className={styles.exposureHeaderList}>
             <dt className={styles.visuallyHidden}>
-              {l10n.getString("exposure-card-company-logo")}
+              {l10n.getString("exposure-card-label-company-logo")}
             </dt>
             <dd
               className={`${styles.hideOnMobile} ${styles.exposureImageWrapper}`}
@@ -283,7 +283,7 @@ export const ExposureCard = (props: ExposureCardProps) => {
               )}
             </dd>
             <dt className={styles.visuallyHidden}>
-              {l10n.getString("exposure-card-company")}
+              {l10n.getString("exposure-card-label-company")}
             </dt>
             <dd>
               <span className={styles.exposureCompanyTitle}>

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -269,7 +269,7 @@ export const ExposureCard = (props: ExposureCardProps) => {
               {l10n.getString("exposure-card-company-logo")}
             </dt>
             <dd
-              className={`${styles.exposureImageWrapper} ${styles.hideOnMobile}`}
+              className={`${styles.hideOnMobile} ${styles.exposureImageWrapper}`}
             >
               {/* While logo is not yet set, the fallback image is the first character of the exposure name */}
               {exposureImg ? (

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -4,7 +4,7 @@
 
 "use client";
 
-import React, { CSSProperties, ReactElement, useState } from "react";
+import React, { CSSProperties, ReactElement, useEffect, useState } from "react";
 import styles from "./ExposureCard.module.scss";
 import { StatusPill, StatusPillType } from "../server/StatusPill";
 import Image, { StaticImageData } from "next/image";
@@ -58,6 +58,7 @@ export type ExposureCardProps = {
   statusPillType: StatusPillType;
   locale: string;
   fromEmail?: string;
+  color: string;
 };
 
 type BreachExposureCategoryProps = {
@@ -80,10 +81,12 @@ export const ExposureCard = (props: ExposureCardProps) => {
     exposureDetailsLink,
     statusPillType,
     locale,
+    color,
   } = props;
 
   const l10n = useL10n();
   const [exposureCardExpanded, setExposureCardExpanded] = useState(false);
+
   const dateFormatter = new Intl.DateTimeFormat(locale, {
     // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#datestyle
     dateStyle: "medium",
@@ -251,7 +254,7 @@ export const ExposureCard = (props: ExposureCardProps) => {
     return (
       <span
         className={styles.fallbackLogo}
-        style={{ background: getRandomLightNebulaColor() } as CSSProperties}
+        style={{ background: props.color } as CSSProperties}
       >
         {firstLetter}
       </span>
@@ -377,7 +380,7 @@ export const ExposureCard = (props: ExposureCardProps) => {
                       height="13"
                     />
                   </span>
-                </a>{" "}
+                </a>
                 {l10n.getString(
                   "exposure-card-description-data-breach-part-two"
                 )}
@@ -406,36 +409,3 @@ export const ExposureCard = (props: ExposureCardProps) => {
 
   return exposureCard;
 };
-
-function getRandomLightNebulaColor() {
-  const colors = [
-    "#C689FF",
-    "#D9BFFF",
-    "#AB71FF",
-    "#E7DFFF",
-    "#AB71FF",
-    "#3FE1B0",
-    "#54FFBD",
-    "#88FFD1",
-    "#B3FFE3",
-    "#D1FFEE",
-    "#F770FF",
-    "#F68FFF",
-    "#F6B8FF",
-    "#00B3F4",
-    "#00DDFF",
-    "#80EBFF",
-    "#FF8450",
-    "#FFA266",
-    "#FFB587",
-    "#FFD5B2",
-    "#FF848B",
-    "#FF9AA2",
-    "#FFBDC5",
-    "#FF8AC5",
-    "#FFB4DB",
-  ];
-
-  const randomIndex = Math.floor(Math.random() * colors.length);
-  return colors[randomIndex];
-}

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -249,7 +249,7 @@ export const ExposureCard = (props: ExposureCardProps) => {
   };
 
   function fallbackLogo(exposureId: string) {
-    const firstLetter = exposureId[0].toUpperCase();
+    const firstLetter = exposureId?.[0]?.toUpperCase() || "";
 
     return (
       <span

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -215,8 +215,8 @@ export const ExposureCard = (props: ExposureCardProps) => {
         exposureCategoriesArray.push(
           <BreachExposureCategory
             key={item}
-            icon={<QuestionMarkCircle alt="" width="13" height="13" />}
-            exposureCategoryLabel={formatOtherBreachCategoriesLabel(item)} // Other exposure categories labels not localized for now
+            icon={<QuestionMarkCircle alt="" width="13" height="13" />} // default icon for categories without a unique one
+            exposureCategoryLabel={l10n.getString(item)} // categories are localized in data-classes.ftl
           />
         );
       }
@@ -370,9 +370,3 @@ export const ExposureCard = (props: ExposureCardProps) => {
 
   return exposureCard;
 };
-
-function formatOtherBreachCategoriesLabel(sentence: string): string {
-  return sentence
-    .replaceAll("-", " ")
-    .replace(/^[a-z]/, (i) => i.toUpperCase());
-}

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -390,7 +390,7 @@ export const ExposureCard = (props: ExposureCardProps) => {
           <div className={styles.exposedInfoContainer}>
             <div className={styles.exposedInfoWrapper}>
               <p className={styles.exposedInfoTitle}>
-                {l10n.getString("exposure-card-your-exposed-info")}:
+                {l10n.getString("exposure-card-your-exposed-info")}
               </p>
               <dl>
                 <ExposureCategoriesListElem />

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -4,7 +4,7 @@
 
 "use client";
 
-import React, { ReactElement, useState } from "react";
+import React, { CSSProperties, ReactElement, useState } from "react";
 import styles from "./ExposureCard.module.scss";
 import { StatusPill, StatusPillType } from "../server/StatusPill";
 import Image, { StaticImageData } from "next/image";
@@ -50,7 +50,7 @@ export function isScanResult(
 }
 
 export type ExposureCardProps = {
-  exposureImg: StaticImageData;
+  exposureImg?: StaticImageData;
   exposureName: string;
   exposureData: Exposure;
   exposureDetailsLink: string;
@@ -245,6 +245,18 @@ export const ExposureCard = (props: ExposureCardProps) => {
     return <>{listItems}</>;
   };
 
+  function fallbackLogo(exposureId: string) {
+    const firstLetter = exposureId[0].toUpperCase();
+
+    return (
+      <span
+        className={styles.fallbackLogo}
+        style={{ background: getRandomLightNebulaColor() } as CSSProperties}
+      >
+        {firstLetter}
+      </span>
+    );
+  }
   const exposureCard = (
     <div>
       <div className={styles.exposureCard}>
@@ -256,11 +268,16 @@ export const ExposureCard = (props: ExposureCardProps) => {
             <dd
               className={`${styles.exposureImageWrapper} ${styles.hideOnMobile}`}
             >
-              <Image
-                className={styles.exposureImage}
-                alt=""
-                src={exposureImg}
-              />
+              {/* While logo is not yet set, the fallback image is the first character of the exposure name */}
+              {exposureImg ? (
+                <Image
+                  className={styles.exposureImage}
+                  alt=""
+                  src={exposureImg}
+                />
+              ) : (
+                <>{fallbackLogo(props.exposureName)}</>
+              )}
             </dd>
             <dt className={styles.visuallyHidden}>
               {l10n.getString("exposure-card-company")}
@@ -389,3 +406,36 @@ export const ExposureCard = (props: ExposureCardProps) => {
 
   return exposureCard;
 };
+
+function getRandomLightNebulaColor() {
+  const colors = [
+    "#C689FF",
+    "#D9BFFF",
+    "#AB71FF",
+    "#E7DFFF",
+    "#AB71FF",
+    "#3FE1B0",
+    "#54FFBD",
+    "#88FFD1",
+    "#B3FFE3",
+    "#D1FFEE",
+    "#F770FF",
+    "#F68FFF",
+    "#F6B8FF",
+    "#00B3F4",
+    "#00DDFF",
+    "#80EBFF",
+    "#FF8450",
+    "#FFA266",
+    "#FFB587",
+    "#FFD5B2",
+    "#FF848B",
+    "#FF9AA2",
+    "#FFBDC5",
+    "#FF8AC5",
+    "#FFB4DB",
+  ];
+
+  const randomIndex = Math.floor(Math.random() * colors.length);
+  return colors[randomIndex];
+}

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -252,7 +252,11 @@ export const ExposureCard = (props: ExposureCardProps) => {
             <dt className={styles.visuallyHidden}>
               {l10n.getString("exposure-card-company")}
             </dt>
-            <dd>{exposureName}</dd>
+            <dd>
+              <span className={styles.exposureCompanyTitle}>
+                {exposureName}
+              </span>
+            </dd>
             <dt className={styles.visuallyHidden}>
               {l10n.getString("exposure-card-exposure-type")}
             </dt>

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -356,7 +356,9 @@ export const ExposureCard = (props: ExposureCardProps) => {
           )}
           <div className={styles.exposedInfoContainer}>
             <div className={styles.exposedInfoWrapper}>
-              <p>{l10n.getString("exposure-card-your-exposed-info")}:</p>
+              <p className={styles.exposedInfoTitle}>
+                {l10n.getString("exposure-card-your-exposed-info")}:
+              </p>
               <dl>
                 <ExposureCategoriesListElem />
               </dl>

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -57,11 +57,13 @@ export type ExposureCardProps = {
   dateFound: Date;
   statusPillType: StatusPillType;
   locale: string;
+  fromEmail?: string;
 };
 
 type BreachExposureCategoryProps = {
   exposureCategoryLabel: string;
   icon: ReactElement;
+  email: string;
 };
 
 type ScannedExposureCategoryProps = {
@@ -89,6 +91,8 @@ export const ExposureCard = (props: ExposureCardProps) => {
   const exposureCategoriesArray: React.ReactElement[] = [];
   const exposureItem = props.exposureData;
 
+  const verifiedEmailofBreach = props.fromEmail;
+
   const BreachExposureCategory = (props: BreachExposureCategoryProps) => {
     const description = l10n.getString("exposure-card-num-found", {
       exposure_num: 1, // We don't count categories for breaches.
@@ -100,7 +104,11 @@ export const ExposureCard = (props: ExposureCardProps) => {
           <span className={styles.exposureTypeIcon}>{props.icon}</span>
           {props.exposureCategoryLabel}
         </dt>
-        <dd>{description}</dd>
+        <dd>
+          {props.email === "email-addresses"
+            ? verifiedEmailofBreach
+            : description}
+        </dd>
       </div>
     );
   };
@@ -181,6 +189,7 @@ export const ExposureCard = (props: ExposureCardProps) => {
         exposureCategoriesArray.push(
           <BreachExposureCategory
             key={item}
+            email={item}
             icon={<EmailIcon alt="" width="13" height="13" />}
             exposureCategoryLabel={l10n.getString("exposure-card-email")}
           />
@@ -189,6 +198,7 @@ export const ExposureCard = (props: ExposureCardProps) => {
         exposureCategoriesArray.push(
           <BreachExposureCategory
             key={item}
+            email={item}
             icon={<PasswordIcon alt="" width="13" height="13" />}
             exposureCategoryLabel={l10n.getString("exposure-card-password")}
           />
@@ -197,6 +207,7 @@ export const ExposureCard = (props: ExposureCardProps) => {
         exposureCategoriesArray.push(
           <BreachExposureCategory
             key={item}
+            email={item}
             icon={<PhoneIcon alt="" width="13" height="13" />}
             exposureCategoryLabel={l10n.getString("exposure-card-phone-number")}
           />
@@ -205,6 +216,7 @@ export const ExposureCard = (props: ExposureCardProps) => {
         exposureCategoriesArray.push(
           <BreachExposureCategory
             key={item}
+            email={item}
             icon={<QuestionMarkCircle alt="" width="13" height="13" />}
             exposureCategoryLabel={l10n.getString("exposure-card-ip-address")}
           />
@@ -215,6 +227,7 @@ export const ExposureCard = (props: ExposureCardProps) => {
         exposureCategoriesArray.push(
           <BreachExposureCategory
             key={item}
+            email={item}
             icon={<QuestionMarkCircle alt="" width="13" height="13" />} // default icon for categories without a unique one
             exposureCategoryLabel={l10n.getString(item)} // categories are localized in data-classes.ftl
           />

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -4,7 +4,7 @@
 
 "use client";
 
-import React, { CSSProperties, ReactElement, useEffect, useState } from "react";
+import React, { CSSProperties, ReactElement, useState } from "react";
 import styles from "./ExposureCard.module.scss";
 import { StatusPill, StatusPillType } from "../server/StatusPill";
 import Image, { StaticImageData } from "next/image";
@@ -254,7 +254,7 @@ export const ExposureCard = (props: ExposureCardProps) => {
     return (
       <span
         className={styles.fallbackLogo}
-        style={{ background: props.color } as CSSProperties}
+        style={{ background: color } as CSSProperties}
       >
         {firstLetter}
       </span>

--- a/src/app/components/client/ExposuresFilter.module.scss
+++ b/src/app/components/client/ExposuresFilter.module.scss
@@ -51,6 +51,10 @@
       @media screen and (min-width: $screen-lg) {
         flex: 1 1 0%;
 
+        &.exposureImageWrapper {
+          flex: 0.2 0 $width-first-column-filter-bar;
+        }
+
         &.hideOnMobile {
           display: flex;
         }

--- a/src/app/components/client/ExposuresFilter.tsx
+++ b/src/app/components/client/ExposuresFilter.tsx
@@ -212,7 +212,7 @@ export const ExposuresFilter = ({ setFilterValues }: ExposuresFilterProps) => {
     <>
       <div className={styles.filterHeaderWrapper}>
         <ul className={styles.filterHeaderList}>
-          <li>
+          <li className={styles.exposureImageWrapper}>
             <button
               className={styles.filterBtn}
               ref={filterBtnRef}

--- a/src/app/components/server/StatusPill.module.scss
+++ b/src/app/components/server/StatusPill.module.scss
@@ -4,7 +4,11 @@
   font: $text-body-xs;
   font-weight: 600;
   display: inline-block;
-  min-width: 120px; // keep the width fixed
+  min-width: 90px; // keep the width fixed
+
+  @media screen and (min-width: $screen-md) {
+    min-width: 120px; // keep the width fixed
+  }
   text-align: center;
   padding: $spacing-sm 0;
   border-radius: $border-radius-sm;

--- a/src/app/tokens.scss
+++ b/src/app/tokens.scss
@@ -238,6 +238,7 @@ $text-body-xs: 400 clamp(10px, 0.975svw, 12px) / 1.5 var(--font-inter),
   sans-serif;
 
 $tab-bar-height: 100px;
+$width-first-column-filter-bar: 50px;
 
 @mixin visually-hidden {
   // These styles are taken from


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When adding a new feature: -->

# Description
This PR includes several enhancements based on feedback from both technical and design discussions. The changes are as follows:

1) Placeholder Fallback Logo: Added a logo using the initial letter of the exposure name when an actual logo is unavailable.
2) Multi-Row Data Types: The breach exposure card can now support two or more rows of data types.
3) Instead of displaying '1 found,' we now show the user's email associated with the breach, providing better context for users.


# Screenshot (if applicable)

<img width="1359" alt="image" src="https://github.com/mozilla/blurts-server/assets/13066134/d1796056-9b53-416e-870c-7e73abb23581">
<img width="1360" alt="image" src="https://github.com/mozilla/blurts-server/assets/13066134/6cd63626-60a0-4998-a59b-67d51323e9e3">


# How to test

After performing a scan, view these changes on `/redesign/user/dashboard`.




# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
