### PR TITLE
Add locales-pending folder to CODEOWNERS for l10n

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,5 +1,6 @@
 # flod as main contact for string changes
 locales/en/*.ftl @flodolo
+locales-pending/*.ftl @flodolo
 
 # svcops helps us review db changes
 db/migrations/* @mozilla/svcops


### PR DESCRIPTION
Given the amount of content landing in `locales-pending`, it's better to have review early than to slow things down later, if we decide to expose it for localization.