### PR TITLE
MNTOR-1915 - use APP_ENV to differentiate environments per NextJS recommendation

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,5 +1,8 @@
-# dev, heroku, stage, production
-NODE_ENV=dev
+# https://nextjs.org/docs/messages/non-standard-node-env
+# development, production, test
+NODE_ENV=development
+# local, heroku, stage, production
+APP_ENV=local
 SERVER_URL=http://localhost:6060
 PORT=6060
 LOGOS_ORIGIN=

--- a/esbuild.js
+++ b/esbuild.js
@@ -28,8 +28,8 @@ esbuild.build({
   external: ['*.webp', '*.svg'],
   outdir: 'dist',
   format: 'esm',
-  minify: AppConstants.NODE_ENV !== 'dev',
-  sourcemap: AppConstants.NODE_ENV !== 'dev',
+  minify: AppConstants.NODE_ENV !== 'development',
+  sourcemap: AppConstants.NODE_ENV !== 'development',
   splitting: false, // see note below
   treeShaking: true,
   platform: 'neutral',

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -9,12 +9,11 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
+  environment: process.env.NEXT_PUBLIC_APP_ENV,
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: ["development", "heroku"].includes(process.env.NODE_ENV)
-    ? 1.0
-    : 0.1,
+  tracesSampleRate: ["development"].includes(process.env.NODE_ENV) ? 1.0 : 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -9,6 +9,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
+  environment: process.env.APP_ENV,
   dsn: process.env.SENTRY_DSN,
 
   // Adjust this value in production, or use tracesSampler for greater control

--- a/src/app.js
+++ b/src/app.js
@@ -24,12 +24,12 @@ import { noSearchEngineIndex } from './middleware/noSearchEngineIndex.js'
 import { RateLimitError } from './utils/error.js'
 
 const app = express()
-const isDev = AppConstants.NODE_ENV === 'dev'
+const isDev = AppConstants.NODE_ENV === 'development'
 
 // init sentry
 Sentry.init({
   dsn: AppConstants.SENTRY_DSN,
-  environment: AppConstants.NODE_ENV,
+  environment: AppConstants.APP_ENV,
   debug: isDev,
   beforeSend (event, hint) {
     if (!hint.originalException.locales || hint.originalException.locales[0] === 'en') return event // return if no localization or localization is in english

--- a/src/app/api/v1/user/welcome-scan/progress/route.ts
+++ b/src/app/api/v1/user/welcome-scan/progress/route.ts
@@ -53,7 +53,8 @@ export async function GET(
         // Store scan results only for development environments.
         if (
           scan.status === "finished" &&
-          process.env.NODE_ENV === "development"
+          (process.env.NODE_ENV === "development" ||
+            process.env.APP_ENV === "heroku")
         ) {
           const allScanResults = await getAllScanResults(profileId);
           await setOnerepScanResults(profileId, scan.id, {

--- a/src/appConstants.js
+++ b/src/appConstants.js
@@ -8,6 +8,7 @@ dotenv.config()
 
 const requiredEnvVars = [
   'ADMINS',
+  'APP_ENV',
   'COOKIE_SECRET',
   'CSRF_SECRET',
   'DATABASE_URL',
@@ -65,8 +66,7 @@ const optionalEnvVars = [
 /** @type {Record<string, string>} */
 const AppConstants = { }
 
-// @ts-ignore TS thinks NODE_ENV can't be "heroku". Shut up TS, you're drunk!
-if (!process.env.SERVER_URL && (process.env.NODE_ENV) === 'heroku') {
+if (!process.env.SERVER_URL && (process.env.APP_ENV) === 'heroku') {
   process.env.SERVER_URL = `https://${process.env.HEROKU_APP_NAME}.herokuapp.com`
 }
 

--- a/src/db/knexfile.js
+++ b/src/db/knexfile.js
@@ -8,9 +8,9 @@
 import pgConnectionStr from 'pg-connection-string'
 
 import AppConstants from '../appConstants.js'
-const { DATABASE_URL, NODE_ENV } = AppConstants
+const { DATABASE_URL, APP_ENV, NODE_ENV } = AppConstants
 const connectionObj = pgConnectionStr.parse(DATABASE_URL)
-if (NODE_ENV === 'heroku') {
+if (APP_ENV === 'heroku') {
   // @ts-ignore TODO: Check if this typing error is correct, or if the types are wrong?
   connectionObj.ssl = { rejectUnauthorized: false }
 }

--- a/src/middleware/error.js
+++ b/src/middleware/error.js
@@ -41,7 +41,7 @@ function errorHandler (err, req, res, next) {
     success: false,
     status: errStatus,
     message: process.env.NODE_ENV !== 'production' ? errMsg : 'Something went wrong', // hide error message when in production
-    stack: process.env.NODE_ENV === 'dev' ? err.stack : {} // hide stack when not in dev
+    stack: process.env.NODE_ENV === 'development' ? err.stack : {} // hide stack when not in dev
   })
 }
 

--- a/src/middleware/noSearchEngineIndex.js
+++ b/src/middleware/noSearchEngineIndex.js
@@ -4,9 +4,9 @@
 
 import AppConstants from '../appConstants.js'
 
-const { NODE_ENV } = AppConstants
-const noindexEnvs = ['dev', 'heroku', 'stage']
-const noSearchEngineIndex = !noindexEnvs.includes(NODE_ENV)
+const { APP_ENV } = AppConstants
+const noindexEnvs = ['local', 'heroku', 'stage']
+const noSearchEngineIndex = !noindexEnvs.includes(APP_ENV)
   ? (_req, _res, next) => next()
   : (_req, res, next) => {
       res.header('X-Robots-Tag', 'noindex')

--- a/src/utils/dockerflow.js
+++ b/src/utils/dockerflow.js
@@ -29,7 +29,7 @@ if (!fs.existsSync(versionJsonPath)) {
 }
 
 export function vers() {
-  if (AppConstants.NODE_ENV === "heroku") {
+  if (AppConstants.APP_ENV === "heroku") {
     /* eslint-disable no-process-env */
     return {
       commit: process.env.HEROKU_SLUG_COMMIT,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1915

<!-- When adding a new feature: -->

# Description

Use `NODE_ENV` and `APP_ENV` per https://nextjs.org/docs/messages/non-standard-node-env

# How to test

Everything should function as before, but we should take extra care to test that Sentry handles this correctly.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
