### PR TITLE
fix: use NEXT_PUBLIC_ prefix for APP_ENV in front-end code

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -3,6 +3,7 @@
 NODE_ENV=development
 # local, heroku, stage, production
 APP_ENV=local
+NEXT_PUBLIC_APP_ENV=local
 SERVER_URL=http://localhost:6060
 PORT=6060
 LOGOS_ORIGIN=

--- a/src/app/(proper_react)/redesign/(authenticated)/user/welcome/FindExposures.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/welcome/FindExposures.tsx
@@ -71,7 +71,7 @@ export const FindExposures = ({
       // the result if finished.
       if (
         (process.env.NODE_ENV === "development" ||
-          process.env.APP_ENV === "heroku") &&
+          process.env.NEXT_PUBLIC_APP_ENV === "heroku") &&
         !checkingScanProgress &&
         !scanFinished
       ) {


### PR DESCRIPTION
# Description

NextJS special-cases `process.env.NODE_ENV` for front-end code, all other variables such as `APP_ENV` must use the `NEXT_PUBLIC_` prefix.

# How to test

Scan (using polling method) should now work on Heroku.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
