### PR TITLE
Up test coverage threshold for future code to 100%

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -1,0 +1,29 @@
+# How to get to 100% test coverage
+
+We have set up a very strict test coverage threshold: 100% branch coverage. How can you achieve that?
+
+The first thing to realise is: we don't actually have 100% coverage. Not all code needs unit tests, however, we want it to be a conscious choice not to test a particular code branch. Thus, we make liberal use of [ignore comments](https://github.com/istanbuljs/v8-to-istanbul/blob/fca5e6a9e6ef38a9cdc3a178d5a6cf9ef82e6cab/README.md#ignoring-uncovered-lines), but those should be accompanied by a comment explaining why that code is OK to ignore. And maybe this is all too much of a hassle, and we disable these thresholds again.
+
+## The coverage report
+
+One very important tool in your toolchain is the coverage report. After running `npm test` locally, you'll be able to find a graphical coverage report inside `/coverage/lcov-report/index.html`. Open that in a web browser, and you'll be able to see which code paths you forgot to cover in a test. Or alternatively, which code paths should be marked with an ignore comment.
+
+## How to write tests for UI
+
+For tests concerning the UI in particular, you can get the most bang for your buck by simulating user actions, resisting the urge to drop down to the component level and mocking out individual props. [Think integration tests, not unit tests](https://kentcdodds.com/blog/write-tests), in so far as there's a clear distinction in the first place. Make your tests [reason about the UI like users do](https://testing-library.com/docs/queries/about#priority) (for example, by finding a button with a particular label to click on, rather than the fifth child of an element with class name `navigation`).
+
+Both of those measures ensure we won't have to update a whole bunch of unit tests unless we actually meaningfully change the behaviour for users, while still verifying the behaviour of a whole slew of components in one go.
+
+## When is it OK not to add a test?
+
+What follows is a list of some reasons not to write a unit test - your ignore comments can refer to these reasons. However, this list is not exhaustive! If you come across another valid reason not to test a bit of code, feel free to add that to this list and then reference it in your code.
+
+### Mock-heavy
+
+If most of the code under test would be interacting with mocks, writing the test would be a lot of work, would require lots of maintenance to keep the mocks up-to-date, while not being very likely to actually catch bugs. This is particularly likely for code that has lots of side effects, e.g. because it executes database queries or sends HTTP requests.
+
+Feel free to mark such code as skipped for coverage. However, do consider extracting code that is side-effect-free into a separate, testable, function. For example, if you have code that sends an HTTP request, then parses the response, that parsing code can be extracted into a separate function that takes the response body and converts it into parsed data.
+
+### Trivial
+
+Some code is exceptionally trivial, such that it is unlikely to contain bugs. When you're in the habit of writing unit tests, it might still be easy enough to set up a quick unit test because why not, but sometimes the effort probably won't pay off.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -37,9 +37,14 @@ const customJestConfig = {
   coverageDirectory: "coverage",
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  coveragePathIgnorePatterns: [
+    "/node_modules/",
+    "<rootDir>/src/db/knexfile.js",
+    // Old, pre-Next.js code assumed to be working:
+    "<rootDir>/src/appConstants.js",
+    "<rootDir>/src/views/",
+    "<rootDir>/src/middleware/",
+  ],
 
   // Indicates which provider should be used to instrument code for coverage
   coverageProvider: "v8",
@@ -53,7 +58,191 @@ const customJestConfig = {
   // ],
 
   // An object that configures minimum threshold enforcement for coverage results
-  // coverageThreshold: undefined,
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+    // The following thresholds are set while transitioning to stronger unit
+    // test discipline; future code should only increase coverage and, ideally,
+    // remove these exceptions by getting the coverage to 100%, or individually
+    // skipping code for coverage as appropriate, with a comment describing why.
+    // See https://github.com/istanbuljs/v8-to-istanbul/blob/fca5e6a9e6ef38a9cdc3a178d5a6cf9ef82e6cab/README.md#ignoring-uncovered-lines
+    "src/apiMocks/mockData.ts": {
+      branches: 85,
+      functions: 50,
+      lines: 50,
+      statements: 90,
+    },
+    "src/app/(proper_react)/redesign/MobileShell.tsx": {
+      branches: 50,
+      functions: 50,
+      lines: 94,
+      statements: 94,
+    },
+    "src/app/(proper_react)/redesign/PageLink.tsx": {
+      branches: 60,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+    "src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner.tsx":
+      {
+        branches: 80,
+        functions: 83,
+        lines: 98,
+        statements: 98,
+      },
+    "src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx": {
+      branches: 80,
+      functions: 71,
+      lines: 87,
+      statements: 87,
+    },
+    "src/app/(proper_react)/redesign/(authenticated)/user/welcome/EnterInfo.tsx":
+      {
+        branches: 100,
+        functions: 40,
+        lines: 89,
+        statements: 89,
+      },
+    "src/app/(proper_react)/redesign/(authenticated)/user/welcome/FindExposures.tsx":
+      {
+        branches: 70,
+        functions: 100,
+        lines: 74,
+        statements: 74,
+      },
+    "src/app/(proper_react)/redesign/(authenticated)/user/welcome/GetStarted.tsx":
+      {
+        branches: 100,
+        functions: 50,
+        lines: 100,
+        statements: 100,
+      },
+    "src/app/(proper_react)/redesign/(authenticated)/user/welcome/View.tsx": {
+      branches: 95,
+      functions: 50,
+      lines: 99,
+      statements: 99,
+    },
+    "src/app/components/client/Chart.tsx": {
+      branches: 100,
+      functions: 25,
+      lines: 100,
+      statements: 100,
+    },
+    "src/app/components/client/ComboBox.tsx": {
+      branches: 83,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+    "src/app/components/client/ExposureCard.tsx": {
+      branches: 73,
+      functions: 75,
+      lines: 79,
+      statements: 79,
+    },
+    "src/app/components/client/ExposuresFilter.tsx": {
+      branches: 50,
+      functions: 5,
+      lines: 71,
+      statements: 71,
+    },
+    "src/app/components/client/ExposuresFilterExplainer.tsx": {
+      branches: 100,
+      functions: 0,
+      lines: 16,
+      statements: 16,
+    },
+    "src/app/components/client/InputField.tsx": {
+      branches: 83,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+    "src/app/components/client/ListBox.tsx": {
+      branches: 100,
+      functions: 0,
+      lines: 40,
+      statements: 40,
+    },
+    "src/app/components/client/LocationAutocompleteInput.tsx": {
+      branches: 62,
+      functions: 50,
+      lines: 74,
+      statements: 74,
+    },
+    "src/app/components/client/Popover.tsx": {
+      branches: 100,
+      functions: 0,
+      lines: 45,
+      statements: 45,
+    },
+    "src/app/components/client/ProgressCard.tsx": {
+      branches: 100,
+      functions: 0,
+      lines: 18,
+      statements: 18,
+    },
+    "src/app/components/client/dialog/Dialog.tsx": {
+      branches: 50,
+      functions: 50,
+      lines: 79,
+      statements: 79,
+    },
+    "src/app/components/client/toolbar/AppPicker.tsx": {
+      branches: 75,
+      functions: 37,
+      lines: 72,
+      statements: 72,
+    },
+    "src/app/components/server/Icons.tsx": {
+      branches: 90,
+      functions: 66,
+      lines: 68,
+      statements: 68,
+    },
+    "src/app/components/server/StatusPill.tsx": {
+      branches: 50,
+      functions: 100,
+      lines: 83,
+      statements: 83,
+    },
+    "src/app/functions/server/mockL10n.ts": {
+      branches: 91,
+      functions: 71,
+      lines: 92,
+      statements: 92,
+    },
+    "src/app/functions/universal/user.ts": {
+      branches: 100,
+      functions: 25,
+      lines: 68,
+      statements: 68,
+    },
+    "src/cloud-functions/index.js": {
+      branches: 63,
+      functions: 66,
+      lines: 60,
+      statements: 60,
+    },
+    "src/utils/*.js": {
+      branches: 19,
+      functions: 0,
+      lines: 0,
+      statements: 14,
+    },
+    "src/db/tables/*.js": {
+      branches: 0,
+      functions: 0,
+      lines: 0,
+      statements: 0,
+    },
+  },
 
   // A path to a custom dependency extractor
   // dependencyExtractor: undefined,

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner.tsx
@@ -56,6 +56,8 @@ export const DashboardTopBanner = (props: DashboardTopBannerProps) => {
       ),
       cta: {
         content: l10n.getString("dashboard-top-banner-protect-your-data-cta"),
+        // Ignored for test coverage; to be replaced by a link:
+        /* c8 ignore next 4 */
         onClick: () => {
           window.location.href =
             "/redesign/user/dashboard/fix/data-broker-profiles/view-data-brokers";
@@ -91,6 +93,8 @@ export const DashboardTopBanner = (props: DashboardTopBannerProps) => {
       ),
       cta: {
         content: l10n.getString("dashboard-top-banner-no-exposures-found-cta"),
+        // Ignored for test coverage; to be implemented:
+        /* c8 ignore next 3 */
         onClick: () => {
           // do something
         },
@@ -110,6 +114,8 @@ export const DashboardTopBanner = (props: DashboardTopBannerProps) => {
         content: l10n.getString(
           "dashboard-top-banner-lets-keep-protecting-cta"
         ),
+        // Ignored for test coverage; to be implemented:
+        /* c8 ignore next 3 */
         onClick: () => {
           // do something
         },
@@ -129,6 +135,8 @@ export const DashboardTopBanner = (props: DashboardTopBannerProps) => {
         content: l10n.getString(
           "dashboard-top-banner-your-data-is-protected-cta"
         ),
+        // Ignored for test coverage; to be implemented:
+        /* c8 ignore next 3 */
         onClick: () => {
           props?.ctaCallback?.();
         },

--- a/src/app/components/client/toolbar/UserMenu.tsx
+++ b/src/app/components/client/toolbar/UserMenu.tsx
@@ -13,11 +13,15 @@ export type Props = {
 
 export const UserMenu = (props: Props) => {
   // Placeholder to enable login/logout until we create an actual menu
+  // Ignored for test coverage; to be implemented:
+  /* c8 ignore next 3 */
   if (!props.user) {
     return <button onClick={() => void signIn("fxa")}>Sign in</button>;
   }
 
   return (
+    // Ignored for test coverage; to be implemented:
+    /* c8 ignore next */
     <button onClick={() => void signOut({ callbackUrl: "/" })}>Sign out</button>
   );
 };

--- a/src/app/components/server/Button.tsx
+++ b/src/app/components/server/Button.tsx
@@ -29,9 +29,15 @@ export const Button = (props: Props & HTMLAttributes<HTMLButtonElement>) => {
   const classes = [
     styles.button,
     styles[variant],
+    // Ignored for test coverage; not used in tested pages yet:
+    /* c8 ignore next */
     destructive && styles.destructive,
     small && styles.small,
+    // Ignored for test coverage; not used in tested pages yet:
+    /* c8 ignore next */
     isLoading && styles.isLoading,
+    // Ignored for test coverage; not used in tested pages yet:
+    /* c8 ignore next */
     disabled && styles.disabled,
   ]
     .filter(Boolean)

--- a/src/app/functions/client/gaEvent.ts
+++ b/src/app/functions/client/gaEvent.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/* c8 ignore next 8 */
 export function gaEvent(_params: {
   category: string;
   action: string;

--- a/src/app/functions/server/getCountryCode.ts
+++ b/src/app/functions/server/getCountryCode.ts
@@ -19,9 +19,9 @@ export function getCountryCode(
   const acceptLanguage = headers.get("Accept-Language");
   if (acceptLanguage) {
     const acceptedLocales = acceptLanguage.split(",");
-    const primaryLocale = acceptedLocales[0] ?? "";
+    const primaryLocale = acceptedLocales[0];
     const [locale, _weight] = primaryLocale.split(";");
-    const [_language, country] = (locale ?? "").split("-");
+    const [_language, country] = locale.split("-");
     if (country) {
       return country.toLowerCase();
     }

--- a/src/app/functions/server/mockL10n.ts
+++ b/src/app/functions/server/mockL10n.ts
@@ -15,11 +15,15 @@ import type { LocaleData } from "./l10n";
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 export function getEnL10nBundlesSync(): LocaleData[] {
+  // Ignored for test coverage, since tests don't run in a Webpack context:
+  /* c8 ignore next 2 */
   return process.env.STORYBOOK === "true"
     ? getEnL10nBundlesInWebpackContext()
     : getEnL10nBundlesInNodeContext();
 }
 
+// Ignored for test coverage, since tests don't run in a Webpack context:
+/* c8 ignore start */
 export function getEnL10nBundlesInWebpackContext(): LocaleData[] {
   const referenceStringsContext: { keys: () => string[] } & ((
     path: string
@@ -57,6 +61,7 @@ export function getEnL10nBundlesInWebpackContext(): LocaleData[] {
     },
   ];
 }
+/* c8 ignore stop */
 
 export function getEnL10nBundlesInNodeContext(): LocaleData[] {
   const {

--- a/src/app/hooks/useElementWidth.ts
+++ b/src/app/hooks/useElementWidth.ts
@@ -4,6 +4,8 @@
 
 import { RefObject, useEffect, useState } from "react";
 
+// Ignored for test coverage, as tests would be too mock-heavy to be useful:
+/* c8 ignore start */
 const useElementWidthImp = (ref: RefObject<HTMLElement> | undefined) => {
   const [width, setWidth] = useState<number>(0);
 
@@ -22,3 +24,4 @@ export const useElementWidth =
   typeof window === "undefined" || typeof window.matchMedia !== "function"
     ? () => 0
     : useElementWidthImp;
+/* c8 ignore stop */

--- a/src/contextProviders/localization.tsx
+++ b/src/contextProviders/localization.tsx
@@ -31,6 +31,9 @@ export const L10nProvider = (props: {
   // To enable server-side rendering, all tags are converted to plain text nodes.
   // They will be upgraded to regular HTML elements in the browser:
   const parseMarkup: MarkupParser | undefined =
+    // Ignored for test coverage, since `document` is mocked (and thus defined)
+    // in unit tests:
+    /* c8 ignore next 7 */
     typeof document === "undefined"
       ? (str: string) => [
           {


### PR DESCRIPTION
All future code that is inside a file that gets executed as part of a test, test coverage should be 100%. I have added exceptions for existing files under test that do not reach this threshold; ideally those exceptions get removed over time.

We will probably want to have a conversation about which code does not need unit tests; those can either be added to the `coveragePathIgnorePatterns` property in `jest.config.cjs` if those reasons apply to an entire file; otherwise, specific lines of code can be ignored using specific comments as described in https://github.com/istanbuljs/v8-to-istanbul/blob/fca5e6a9e6ef38a9cdc3a178d5a6cf9ef82e6cab/README.md#ignoring-uncovered-lines

I have already applied a couple of such comments to existing code. For example, `useElementWidth` heavily interacts with `window` to keep a state variable up-to-date with an element's size; testing that would involve extensively mocking resize events. Test failures would be more likely to be caused by problems in the test than by actual bugs in the code, so writing a test for that is probably not worth it.

This is a proposal, and even if we merge this, we can adjust course later if it turns out not to work well for us.