### PR TITLE
Bugfixes for the filter menu

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -42,9 +42,9 @@ export const View = (props: Props) => {
   const l10n = useL10n();
 
   const initialFilterState: FilterState = {
-    exposureType: "",
-    dateFound: "",
-    status: "",
+    exposureType: "show-all-exposure-type",
+    dateFound: "show-all-date-found",
+    status: "show-all-status",
   };
   const [filters, setFilters] = useState<FilterState>(initialFilterState);
   const [selectedTab, setSelectedTab] = useState<Key>("action-needed");
@@ -176,13 +176,12 @@ export const View = (props: Props) => {
         ? "data-broker"
         : "data-breach";
       const isFilteredByExposureType =
-        filters.exposureType === "" ||
         filters.exposureType === "show-all-exposure-type" ||
         filters.exposureType === exposureType;
 
       // Filter by date
       let isFilteredByDate = true;
-      if (filters.dateFound !== "" && filters.dateFound !== "show-all-date") {
+      if (filters.dateFound !== "show-all-date-found") {
         const exposureDate = isScanResult(exposure)
           ? new Date(exposure.created_at)
           : exposure.AddedDate;
@@ -317,7 +316,10 @@ export const View = (props: Props) => {
           {isActionNeededTab ? <TabContentActionNeeded /> : <TabContentFixed />}
         </section>
         <div className={styles.exposuresFilterWrapper}>
-          <ExposuresFilter setFilterValues={setFilters} />
+          <ExposuresFilter
+            initialFilterValues={initialFilterState}
+            setFilterValues={setFilters}
+          />
         </div>
         {noUnresolvedExposures ? (
           <div className={styles.noExposures}>

--- a/src/app/components/client/ExposuresFilter.tsx
+++ b/src/app/components/client/ExposuresFilter.tsx
@@ -5,6 +5,7 @@
 import styles from "./ExposuresFilter.module.scss";
 import { CloseBtn, FilterIcon, QuestionMarkCircle } from "../server/Icons";
 import React, {
+  FormEventHandler,
   ReactElement,
   ReactNode,
   createContext,
@@ -100,12 +101,15 @@ export const ExposuresFilter = ({
     }));
   };
 
-  const handleSaveButtonClick = () => {
+  const handleSaveButtonClick: FormEventHandler = (event) => {
+    event.preventDefault();
+
     setFilterValues(filterState);
+    filterDialogState.close();
   };
 
   const ExposuresFilterContent = (
-    <>
+    <form onSubmit={handleSaveButtonClick}>
       <div className={styles.exposuresFilterRadioButtons}>
         <FilterRadioGroup
           type="exposure-type"
@@ -172,19 +176,21 @@ export const ExposuresFilter = ({
       </div>
       <div className={styles.filterControls}>
         <Button
+          type="button"
           small
           variant="secondary"
           onClick={() => setFilterState(initialFilterValues)}
         >
           {l10n.getString("dashboard-exposures-filter-reset")}
         </Button>
-        <Button small variant="primary" onClick={handleSaveButtonClick}>
+        <Button type="submit" small variant="primary">
           {l10n.getString("dashboard-exposures-filter-show-results")}
         </Button>
       </div>
       <button
         {...dismissButtonProps}
         ref={dismissButtonRef}
+        type="button"
         className={styles.dismissButton}
         onClick={() => {
           filterDialogState.close();
@@ -197,7 +203,7 @@ export const ExposuresFilter = ({
           height="14"
         />
       </button>
-    </>
+    </form>
   );
 
   return (

--- a/src/app/components/client/ExposuresFilter.tsx
+++ b/src/app/components/client/ExposuresFilter.tsx
@@ -14,10 +14,12 @@ import React, {
 } from "react";
 import Image from "next/image";
 import {
+  AriaDialogProps,
   AriaPopoverProps,
   AriaRadioProps,
   Overlay,
   useButton,
+  useDialog,
   useOverlayTrigger,
   usePopover,
   useRadio,
@@ -254,9 +256,11 @@ export const ExposuresFilter = ({
       {explainerDialogState.isOpen && explainerDialog}
       {filterDialogState.isOpen && (
         <Popover state={filterDialogState} triggerRef={filterBtnRef}>
-          <div className={styles.exposuresFilterWrapper} {...overlayProps}>
-            {ExposuresFilterContent}
-          </div>
+          <FilterDialog>
+            <div className={styles.exposuresFilterWrapper} {...overlayProps}>
+              {ExposuresFilterContent}
+            </div>
+          </FilterDialog>
         </Popover>
       )}
     </>
@@ -295,6 +299,20 @@ const Popover = (props: PopoverProps) => {
         </Overlay>
       )}
     </>
+  );
+};
+
+type FilterDialogProps = AriaDialogProps & {
+  children: ReactNode;
+};
+const FilterDialog = ({ children, ...otherProps }: FilterDialogProps) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const { dialogProps } = useDialog(otherProps, dialogRef);
+
+  return (
+    <div {...dialogProps} ref={dialogRef}>
+      {children}
+    </div>
   );
 };
 

--- a/src/app/components/client/ExposuresFilter.tsx
+++ b/src/app/components/client/ExposuresFilter.tsx
@@ -37,16 +37,20 @@ import CalendarIcon from "./assets/calendar.svg";
 import { ExposuresFilterExplainer } from "./ExposuresFilterExplainer";
 
 export type FilterState = {
-  exposureType: string;
-  dateFound: string;
-  status: string;
+  exposureType: "show-all-exposure-type" | "data-broker" | "data-breach";
+  dateFound: "show-all-date-found" | "seven-days" | "thirty-days" | "last-year";
+  status: "show-all-status" | "action-needed" | "in-progress" | "fixed";
 };
 
 type ExposuresFilterProps = {
+  initialFilterValues: FilterState;
   setFilterValues: React.Dispatch<React.SetStateAction<FilterState>>;
 };
 
-export const ExposuresFilter = ({ setFilterValues }: ExposuresFilterProps) => {
+export const ExposuresFilter = ({
+  initialFilterValues,
+  setFilterValues,
+}: ExposuresFilterProps) => {
   const l10n = useL10n();
 
   const [explainerDialog, setExplainerDialog] = useState<ReactElement>();
@@ -84,18 +88,8 @@ export const ExposuresFilter = ({ setFilterValues }: ExposuresFilterProps) => {
     dismissButtonRef
   ).buttonProps;
 
-  const emptyFilterState = {
-    exposureType: "",
-    dateFound: "",
-    status: "",
-  };
-
-  const [filterState, setFilterState] = useState<FilterState>(emptyFilterState);
-
-  const checkEmptyFilterState =
-    filterState.exposureType === "" &&
-    filterState.dateFound === "" &&
-    filterState.status === "";
+  const [filterState, setFilterState] =
+    useState<FilterState>(initialFilterValues);
 
   const handleRadioChange = (type: string, value: string) => {
     setFilterState((prevFilterState) => ({
@@ -176,19 +170,13 @@ export const ExposuresFilter = ({ setFilterValues }: ExposuresFilterProps) => {
       </div>
       <div className={styles.filterControls}>
         <Button
-          disabled={checkEmptyFilterState}
           small
           variant="secondary"
-          onClick={() => setFilterState(emptyFilterState)}
+          onClick={() => setFilterState(initialFilterValues)}
         >
           {l10n.getString("dashboard-exposures-filter-reset")}
         </Button>
-        <Button
-          disabled={checkEmptyFilterState}
-          small
-          variant="primary"
-          onClick={handleSaveButtonClick}
-        >
+        <Button small variant="primary" onClick={handleSaveButtonClick}>
           {l10n.getString("dashboard-exposures-filter-show-results")}
         </Button>
       </div>


### PR DESCRIPTION
(Note: this builds on https://github.com/mozilla/blurts-server/pull/3269.)

I've combined a couple of bugfixes in this PR - let me know if you'd prefer for me to submit them in separate PRs. Otherwise, it's probably easiest to review per commit.

What I did:

- dae58de065ca020e153bd0327e1c829f3ab2a3d1 Have React Aria handle change events for the radio buttons. I'm not sure if bugs followed from this, but at least it ensures we meet its expectations and removes a bunch of our code without losing functionality.
- d498f3e75f3fa1263d0f6e4b0a3a77932e9aa872 Only allow particular values of the filter form in the types. This uncovered one bug where the "Show all" option for dates wouldn't be respected (because it checked for `"show-all-date"` rather than `"show-all-date-found"`). I also made the "Show all" options preselected here.
- d43365262c3f2866d441a1f1e2aac3ad90ff8de9 Wrap the filter in a dialog, as listed as a requirement in [the `usePopover` docs](https://react-spectrum.adobe.com/react-aria/usePopover.html). This ensures that focus moves into the popover when opening it with the keyboard.
- 258cd9204301962bb107cd307aa22eb9b93e2934 Wrap the filter form inside a `<form>`, and move the submit handler to that form's `onSubmit` rather than the button's `onClick`. This appears to fix the issue with the form closing when selecting a filter option, and allows you to submit the form by pressing <kbd>Enter</kbd> with a radio button focused.