### PR TITLE
Remove breach-only exposure cards array

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -64,37 +64,6 @@ export const View = (props: Props) => {
     return new Date(isoString);
   };
 
-  // Only breaches exposure cards
-  const breachExposureCards = props.userBreaches.breachesData.verifiedEmails
-    .map((verifiedEmail) => {
-      const breachCardsForThisEmail = verifiedEmail.breaches.map(
-        (breach, breachId) => {
-          return (
-            <li
-              key={`${verifiedEmail.email}_${breach.Id.toString()}_${breachId}`}
-              className={styles.exposureListItem}
-            >
-              <ExposureCard
-                exposureData={breach}
-                exposureName={breach.Name}
-                fromEmail={verifiedEmail.email}
-                exposureDetailsLink={""} //TODO: Find out what link to add in a breach card
-                dateFound={breach.AddedDate}
-                statusPillType="needAction"
-                locale={props.locale}
-                color={getRandomLightNebulaColor(breach.Name)}
-              />
-            </li>
-          );
-        }
-      );
-      // Technically a JSX.Element can be `any`, but we know it's not.
-      // (At least, I *think* that's why this rule triggers.)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return breachCardsForThisEmail;
-    })
-    .flat();
-
   const breachesDataArray = props.userBreaches.breachesData.verifiedEmails.map(
     (elem: BundledVerifiedEmails) => elem.breaches
   );
@@ -249,7 +218,7 @@ export const View = (props: Props) => {
             exposureData={exposure}
             exposureName={exposure.Title}
             fromEmail={email}
-            exposureDetailsLink=""
+            exposureDetailsLink={`/breach-details/${exposure.Name}`}
             dateFound={exposure.AddedDate}
             statusPillType={status}
             locale={props.locale}
@@ -329,9 +298,7 @@ export const View = (props: Props) => {
             </strong>
           </div>
         ) : (
-          <ul className={styles.exposureList}>
-            {isScanResultItemsEmpty ? breachExposureCards : exposureCardElems}
-          </ul>
+          <ul className={styles.exposureList}>{exposureCardElems}</ul>
         )}
       </div>
     </div>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->



<!-- When adding a new feature: -->

# Description

This eliminates the unnecessary `breachesDataArray` that remained from a debug session. The redundancy arises from the consolidation of `combinedArray`, which already combines both breach and broker data.

# Screenshot (if applicable)





# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
