### PR TITLE
MNTOR-2003 - fix: confirmation date-of-birth is off-by-one, set timezone explicitly

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/welcome/EnterInfo.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/welcome/EnterInfo.tsx
@@ -127,6 +127,7 @@ export const EnterInfo = ({ onScanStarted, onGoBack }: Props) => {
       value: dateOfBirth,
       displayValue: new Date(dateOfBirth).toLocaleDateString("en-US", {
         dateStyle: "medium",
+        timeZone: "UTC",
       }),
       errorMessage: l10n.getString(
         "onboarding-enter-details-input-error-message-generic"


### PR DESCRIPTION


<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2003


# Description

Fix: the confirmation screen for the date-of-birth in the free scan shows the previous day for me, it seems to be assuming UTC timezone. Passing "UTC" explicity to `toLocaleString()` seems to work.

# Screenshot (if applicable)

![image](https://github.com/mozilla/blurts-server/assets/61412/56dce980-83a8-41f6-816a-13669bc6ba71)

![image](https://github.com/mozilla/blurts-server/assets/61412/ad7d8218-b4d2-45de-b825-49f3e2be2824)

# How to test



# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
