### PR TITLE
Group related Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,41 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      eslint:
+        patterns:
+          - "@typescript-eslint/*"
+          - "eslint"
+          - "eslint-*"
+        exclude-patterns:
+          - "eslint-config-next"
+      jest:
+        patterns:
+          - "babel-jest"
+          - "jest"
+          - "jest-environment-jsdom"
+      testing-library:
+        patterns:
+          - "@testing-library/dom"
+          - "@testing-library/react"
+          - "@testing-library/user-event"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-test-renderer"
+      sentry:
+        patterns:
+          - "@sentry/*"
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+        exclude-patterns:
+          - "eslint-config-next"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
This should hopefully cut down on some of the noise of ESLint updates, and ensure that packages that break unless they are updated together are actually updated together.

See https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
