### PR TITLE
MNTOR-1948/record data broker resolution time

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/automatic-remove/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/automatic-remove/page.tsx
@@ -129,7 +129,10 @@ export default function AutomaticRemove() {
                     { price: "X.XX" }
                   )}
             </span>
-            <Button variant="primary">
+            <Button
+              variant="primary"
+              onClick={() => (window.location.href = "../../subscribed")} // TODO replace with final UI
+            >
               {selectedPlanIsYearly
                 ? l10n.getString(
                     "fix-flow-data-broker-profiles-automatic-remove-features-select-plan-yearly-button"

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/subscribed/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/subscribed/page.tsx
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getServerSession } from "next-auth";
+import { getOnerepProfileId } from "../../../../../../../db/tables/subscribers";
+import { authOptions } from "../../../../../../api/utils/auth";
+import {
+  activateProfile,
+  getAllScanResults,
+  isEligibleForPremium,
+  optoutProfile,
+} from "../../../../../../functions/server/onerep";
+import {
+  getLatestOnerepScan,
+  setOnerepScanResults,
+} from "../../../../../../../db/tables/onerep_scans";
+
+export default async function Subscribed() {
+  if (!(await isEligibleForPremium())) {
+    throw new Error("Not eligible for premium");
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user || !session.user.subscriber) {
+    throw new Error("No session");
+  }
+
+  const result = await getOnerepProfileId(session.user.subscriber.id);
+  const profileId = result[0]["onerep_profile_id"] as number;
+
+  try {
+    await activateProfile(profileId);
+    await optoutProfile(profileId);
+  } catch (ex) {
+    console.debug(ex); // TODO handle
+  }
+
+  const dev =
+    process.env.NODE_ENV === "development" || process.env.APP_ENV === "heroku";
+  const latestScan = await getLatestOnerepScan(profileId);
+  if (!latestScan) {
+    throw new Error("Must have performed manual scan");
+  }
+
+  const scans = await getAllScanResults(profileId);
+
+  // In dev mode, record scans every time this page is reloaded.
+  // The webhoook does this in production.
+  if (dev) {
+    await setOnerepScanResults(
+      profileId,
+      latestScan.onerep_scan_id,
+      { data: scans },
+      "initial"
+    );
+  }
+
+  return (
+    <div>
+      <div>
+        <h3>You are now subscribed</h3>
+        {dev ? (
+          <div>
+            <h3>Dev mode enabled</h3>
+            <p>Reload this page to update scan</p>
+            <pre>{JSON.stringify(scans, null, 2)}</pre>
+          </div>
+        ) : (
+          ""
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/unsubscribed/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/unsubscribed/page.tsx
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getServerSession } from "next-auth";
+import { getOnerepProfileId } from "../../../../../../../db/tables/subscribers";
+import { authOptions } from "../../../../../../api/utils/auth";
+import {
+  deactivateProfile,
+  isEligibleForPremium,
+} from "../../../../../../functions/server/onerep";
+
+export default async function Unsubscribed() {
+  if (!(await isEligibleForPremium())) {
+    throw new Error("Not eligible for premium");
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user || !session.user.subscriber) {
+    throw new Error("No session");
+  }
+
+  const result = await getOnerepProfileId(session.user.subscriber.id);
+  const profileId = result[0]["onerep_profile_id"] as number;
+
+  try {
+    await deactivateProfile(profileId);
+  } catch (ex) {
+    console.debug(ex); // TODO handle
+  }
+
+  return (
+    <div>
+      <div>
+        <h3>You are now unsubscribed</h3>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(proper_react)/redesign/(authenticated)/user/welcome/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/welcome/page.tsx
@@ -6,7 +6,7 @@ import { getServerSession } from "next-auth";
 import { SignInButton } from "../../../../../(nextjs_migration)/components/client/SignInButton";
 import { redirect } from "next/navigation";
 import {
-  isEligible,
+  isEligibleForFreeScan,
   ONEREP_DATA_BROKER_COUNT,
 } from "../../../../../functions/server/onerep";
 import { View } from "./View";
@@ -18,7 +18,7 @@ export default async function Onboarding() {
     return <SignInButton autoSignIn={true} />;
   }
 
-  const userIsEligible = await isEligible();
+  const userIsEligible = await isEligibleForFreeScan();
   if (!userIsEligible) {
     return redirect("/");
   }

--- a/src/app/api/v1/user/welcome-scan/create/route.ts
+++ b/src/app/api/v1/user/welcome-scan/create/route.ts
@@ -9,7 +9,7 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   createProfile,
   createScan,
-  isEligible,
+  isEligibleForFreeScan,
 } from "../../../../../functions/server/onerep";
 import type { ProfileData } from "../../../../../functions/server/onerep";
 import { meetsAgeRequirement } from "../../../../../functions/universal/user";
@@ -17,7 +17,7 @@ import AppConstants from "../../../../../../appConstants";
 import { getSubscriberByEmail } from "../../../../../../db/tables/subscribers";
 import {
   setOnerepProfileId,
-  setOnerepScan,
+  setOnerepManualScan,
 } from "../../../../../../db/tables/onerep_scans";
 import { setProfileDetails } from "../../../../../../db/tables/onerep_profiles";
 import { StateAbbr } from "../../../../../../utils/states";
@@ -40,7 +40,7 @@ export async function POST(
 ): Promise<NextResponse<WelcomeScanBody | unknown>> {
   const session = await getServerSession(authOptions);
 
-  const eligible = await isEligible();
+  const eligible = await isEligibleForFreeScan();
   if (!eligible) {
     throw new Error("User is not eligible for feature");
   }
@@ -83,7 +83,7 @@ export async function POST(
         // Start exposure scan
         const scan = await createScan(profileId);
         const scanId = scan.id;
-        await setOnerepScan(profileId, scanId);
+        await setOnerepManualScan(profileId, scanId);
 
         return NextResponse.json({ success: true }, { status: 200 });
       }

--- a/src/app/api/v1/user/welcome-scan/progress/route.ts
+++ b/src/app/api/v1/user/welcome-scan/progress/route.ts
@@ -52,14 +52,19 @@ export async function GET(
 
         // Store scan results only for development environments.
         if (
-          scan.status === "finished" &&
-          (process.env.NODE_ENV === "development" ||
-            process.env.APP_ENV === "heroku")
+          (scan.status === "finished" &&
+            process.env.NODE_ENV === "development") ||
+          process.env.APP_ENV === "heroku"
         ) {
           const allScanResults = await getAllScanResults(profileId);
-          await setOnerepScanResults(profileId, scan.id, {
-            data: allScanResults,
-          });
+          await setOnerepScanResults(
+            profileId,
+            scan.id,
+            {
+              data: allScanResults,
+            },
+            "manual"
+          );
         }
 
         return NextResponse.json(

--- a/src/db/migrations/20230811154502_add_onerep_scan_reason.js
+++ b/src/db/migrations/20230811154502_add_onerep_scan_reason.js
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export function up (knex) {
+  return knex.schema.table('onerep_scans', (table) => {
+    table.string('onerep_scan_reason')
+  })
+}
+
+export function down (knex) {
+  return knex.schema.table('onerep_scans', (table) => {
+    table.string('onerep_scan_reason')
+  })
+}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1948


<!-- When adding a new feature: -->

# Description

This uses a record-keeping approach in Postgres to store broker scans, so we can tell them apart. It works like this:

1. Free `manual` scan is created (one per user, creating 1 row)
2. The `manual` scan is updated when the webhook is received (updating the 1 existing row)
3. `initial` (happens on subscribe) and `monitoring` automated monthly scan creates 1 row each time the webhook is received

From my testing so far, the scan ID returned by (1) is used for the scans in (2), so we can't make `onerep_scan_id` unique. However that table has its own internal primary key, and each row stores so I think that's OK.

# How to test

In order to allow testing on dev/stage/prod and also accommodate local testing, I've implemented the following:

1. Basic `subscribe` and `unsubscribe` pages which activate profiles and initiate the opt-out/removal process
2. When in dev/heroku mode, the `subscribe` additionally page polls the server for the latest scan, and displays + stores the results in Postgres
3. When in non-dev/non-heroku mode, the `subscribe` does not poll the server (webhook should be used)

I'm working on adding better tests for the OneRep function, which is complicated by the fact that it uses the `next/headers` library but our Jest project uses `testEnvironment: "jsdom"`... I may just move the logic to a utility library - I think it will be too annoying to use if we require header to be passed into the (very simple) `onerepFetch()` function, which is simply a wrapper around `fetch`.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
