### PR TITLE
MNTOR-1834/add ga and anon flag

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -243,7 +243,7 @@ const customJestConfig = {
       statements: 0,
     },
     "src/app/functions/server/featureFlags.ts": {
-      branches: 90.9,
+      branches: 90,
       functions: 0,
       lines: 95.16,
       statements: 95.16,

--- a/src/app/(nextjs_migration)/components/client/FalseDoorBanner.tsx
+++ b/src/app/(nextjs_migration)/components/client/FalseDoorBanner.tsx
@@ -38,8 +38,23 @@ export const HandleFalseDoorTest = (props: HandleFalseDoorBanner) => {
     },
   });
 
-  const handleDismiss = () => {
+  const handleDismiss = (event?: Event) => {
     setCookie("falseDoorDismissed", "true", { path: "/" });
+
+    console.debug("event.target:", event?.target);
+    if (event && event.target && "id" in event.target) {
+      let action;
+      if (event?.target.id === "close-button") {
+        action = "dismissed";
+      } else {
+        action = "opened";
+      }
+      window.gtag("event", "clicked_false_door", {
+        action,
+        result: "success",
+        page_location: location.href,
+      });
+    }
   };
 
   useEffect(() => {
@@ -88,15 +103,21 @@ export const FalseDoorBanner = (props: FalseDoorBanner) => {
           {content}
         </div>
         <Link
+          id="open-button"
           className={styles.cta}
           target="_blank"
           href={props.link}
+          data-cta-id="false-door"
           onClick={props.onDismiss}
         >
           {l10n.getString("false-door-test-cta")}
         </Link>
       </div>
-      <button className={styles.dismiss} onClick={props.onDismiss}>
+      <button
+        id="close-button"
+        className={styles.dismiss}
+        onClick={props.onDismiss}
+      >
         <CloseBtn
           alt={l10n.getString("false-door-test-popup-close")}
           width="15"

--- a/src/app/functions/server/featureFlags.ts
+++ b/src/app/functions/server/featureFlags.ts
@@ -52,9 +52,9 @@ export async function isFlagEnabled(
     return false;
   }
 
-  if (!flag.allowList || !flag.allowList.length) {
+  if (!user) {
     return true;
-  } else if (user && flag.allowList?.includes(user.email)) {
+  } else if (flag.allowList?.includes(user.email)) {
     return true;
   } else {
     console.warn("User is not on the allow list for flag:", flag.name);


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1834


<!-- When adding a new feature: -->

# Description

A few small followups to the false door test:

- add GA - it's a little redundant but for completeness we'll fire the following events:
1. our existing `clicked_cta` event for CTAs
2. the automatic GA4 event for outbound clicks
3. a new `clicked_false_door` that shows whether the user clicked the outbound link or dismissed with X

I think (3) is the one we'll want to look at, (1) I included but it's a little odd because we don't have any other CTAs that behave like this (they are not dismiss-able). 

- after testing, I noticed that the flag is still not working correctly for anonymous (not authenticated) users, I corrected the flag code for this: if a `user` object is not passed then the allow list is not tested. 

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).