### PR TITLE
Fix warnings about wrapping tests in act()

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -77,13 +77,13 @@ const customJestConfig = {
       statements: 90,
     },
     "src/app/(proper_react)/redesign/MobileShell.tsx": {
-      branches: 50,
+      branches: 25,
       functions: 50,
       lines: 94,
       statements: 94,
     },
     "src/app/(proper_react)/redesign/PageLink.tsx": {
-      branches: 60,
+      branches: 33,
       functions: 100,
       lines: 100,
       statements: 100,
@@ -345,7 +345,14 @@ const customJestConfig = {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  setupFilesAfterEnv: [
+    "<rootDir>/jest.setup.ts",
+    // See https://www.benmvp.com/blog/avoiding-react-act-warning-when-accessibility-testing-next-link-jest-axe/
+    // Mocks the IntersectionObserver API, which is used by Next.js's <Link>.
+    // This prevents warnings about wrapping tests in act() for components that
+    // include <Link>s.
+    "react-intersection-observer/test-utils",
+  ],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -6,6 +6,7 @@ import "@testing-library/jest-dom";
 import { setProjectAnnotations } from "@storybook/react";
 import { toHaveNoViolations } from "jest-axe";
 import { expect } from "@jest/globals";
+import { defaultFallbackInView } from "react-intersection-observer";
 
 import * as globalStorybookConfig from "./.storybook/preview";
 
@@ -14,3 +15,13 @@ setProjectAnnotations(
 );
 
 expect.extend(toHaveNoViolations);
+
+// See https://www.benmvp.com/blog/avoiding-react-act-warning-when-accessibility-testing-next-link-jest-axe/
+// If no `IntersectionObserver` exists, Next.js's <Link> will do a state update
+// immediately after rendering, causing warnings about wrapping tests in act().
+global.IntersectionObserver = jest.fn();
+// Then in jest.config.cjs, we add an actual mock for the IntersectionObserver
+// API in `setupFilesAfterEnv`. When a <Link> scrolls into view, Next.js will
+// attempt to preload the target, causing another rerender that would cause a
+// warning about wrapping tests in act(). Thus, we tell it it's not in view.
+defaultFallbackInView(false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "node-mocks-http": "^1.12.1",
         "nodemon": "^2.0.20",
         "prettier": "2.8.8",
+        "react-intersection-observer": "^9.5.2",
         "sass": "^1.62.1",
         "storybook": "^7.0.18",
         "stylelint": "^15.6.0",
@@ -28384,6 +28385,15 @@
         "react": "^16.8.4 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-intersection-observer": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.5.2.tgz",
+      "integrity": "sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -53688,6 +53698,13 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-6.0.2.tgz",
       "integrity": "sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "react-intersection-observer": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.5.2.tgz",
+      "integrity": "sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "node-mocks-http": "^1.12.1",
     "nodemon": "^2.0.20",
     "prettier": "2.8.8",
+    "react-intersection-observer": "^9.5.2",
     "sass": "^1.62.1",
     "storybook": "^7.0.18",
     "stylelint": "^15.6.0",


### PR DESCRIPTION
This removes a whole bunch of warnings regarding wrapping tests in `act()`, which occurred for every component that included a `<Link>`. With big thanks to @benmvp for sharing the cause of the error and how to fix it: https://www.benmvp.com/blog/avoiding-react-act-warning-when-accessibility-testing-next-link-jest-axe/

This does add `react-intersection-observer` as a dependency, but I expect that we'll be using that at some point anyway (we're also using that in Relay), and it's a `devDependency` for now.

# How to test

Run `npm test`; a whole bunch of warnings should be gone.