### PR TITLE
Fix warnings about unknown `onPress` attribute

### DIFF
--- a/src/app/components/client/ExposuresFilter.tsx
+++ b/src/app/components/client/ExposuresFilter.tsx
@@ -186,6 +186,12 @@ export const ExposuresFilter = ({
     </form>
   );
 
+  const exposureTypeExplainerTriggerRef = useRef<HTMLButtonElement>(null);
+  const exposureTypeExplainerTriggerProps = useButton(
+    explainerDialogTrigger.triggerProps,
+    exposureTypeExplainerTriggerRef
+  ).buttonProps;
+
   return (
     <>
       <div className={styles.filterHeaderWrapper}>
@@ -209,8 +215,9 @@ export const ExposuresFilter = ({
           <li className={styles.hideOnMobile}>
             {l10n.getString("dashboard-exposures-filter-exposure-type")}
             <button
+              ref={exposureTypeExplainerTriggerRef}
               aria-label={l10n.getString("modal-open-alt")}
-              {...explainerDialogTrigger.triggerProps}
+              {...exposureTypeExplainerTriggerProps}
               onClick={() => openExplainerDialog("exposure")}
             >
               <QuestionMarkCircle

--- a/src/app/components/client/ProgressCard.tsx
+++ b/src/app/components/client/ProgressCard.tsx
@@ -4,10 +4,10 @@
 
 "use client";
 
-import { CSSProperties } from "react";
+import { CSSProperties, useRef } from "react";
 import Image from "next/image";
 import { useOverlayTriggerState } from "react-stately";
-import { useOverlayTrigger } from "react-aria";
+import { useButton, useOverlayTrigger } from "react-aria";
 import styles from "./ProgressCard.module.scss";
 import { ModalOverlay } from "./dialog/ModalOverlay";
 import { Dialog } from "./dialog/Dialog";
@@ -107,13 +107,20 @@ export const ProgressCard = (props: Props) => {
     </div>
   );
 
+  const explainerDialogTriggerRef = useRef<HTMLButtonElement>(null);
+  const explainerDialogTriggerProps = useButton(
+    explainerDialogTrigger.triggerProps,
+    explainerDialogTriggerRef
+  ).buttonProps;
+
   return (
     <div className={styles.progressCard}>
       <div className={styles.header}>
         {l10n.getString("progress-card-heres-what-we-fixed-headline")}
         <button
           aria-label={l10n.getString("modal-open-alt")}
-          {...explainerDialogTrigger.triggerProps}
+          ref={explainerDialogTriggerRef}
+          {...explainerDialogTriggerProps}
           onClick={() => explainerDialogState.open()}
         >
           <QuestionMarkCircle alt="" width="15" height="15" />


### PR DESCRIPTION
These warnings would show up in tests, and I think also in the browser console. In essence, the fix is that `triggerProps` returns an `onPress` property, which is an option for `useButton`, but can't be passed directly to a `<button>`. Thus, the fix is to use `useButton` for `<button>`s.