### PR TITLE
Ensure tests can run in isolation

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -225,12 +225,12 @@ const customJestConfig = {
       statements: 68,
     },
     "src/cloud-functions/index.js": {
-      branches: 63,
+      branches: 60,
       functions: 66,
       lines: 60,
       statements: 60,
     },
-    "src/utils/*.{js,ts}": {
+    "src/utils/*.js": {
       branches: 19,
       functions: 0,
       lines: 0,
@@ -319,10 +319,10 @@ const customJestConfig = {
   // reporters: undefined,
 
   // Automatically reset mock state before every test
-  resetMocks: false,
+  resetMocks: true,
 
   // Reset the module registry before running each individual test
-  resetModules: false,
+  resetModules: true,
 
   // A path to a custom resolver
   // resolver: undefined,

--- a/src/utils/subscriberBreaches.ts
+++ b/src/utils/subscriberBreaches.ts
@@ -71,17 +71,7 @@ export async function getSubBreaches(
     );
 
     // breach resolution
-    const breachResolution = subscriber.breach_resolution
-      ? subscriber.breach_resolution[email.email]
-        ? subscriber.breach_resolution[email.email]
-        : // I think something's off with the code coverage measurement;
-          // AFAIK the next line does get hit. I don't think the line after that
-          // does, though, since `breach_resolution` is always defined.
-          // (i.e. I'm not sure why that check is there, and why one results in
-          // an empty array, and another in an empty object...)
-          /* c8 ignore next */
-          {}
-      : [];
+    const breachResolution = subscriber.breach_resolution?.[email.email] ?? {};
 
     for (const breach of foundBreaches) {
       const filteredBreachDataClasses: string[] = filterBreachDataTypes(

--- a/src/utils/subscriberBreaches.ts
+++ b/src/utils/subscriberBreaches.ts
@@ -74,7 +74,13 @@ export async function getSubBreaches(
     const breachResolution = subscriber.breach_resolution
       ? subscriber.breach_resolution[email.email]
         ? subscriber.breach_resolution[email.email]
-        : {}
+        : // I think something's off with the code coverage measurement;
+          // AFAIK the next line does get hit. I don't think the line after that
+          // does, though, since `breach_resolution` is always defined.
+          // (i.e. I'm not sure why that check is there, and why one results in
+          // an empty array, and another in an empty object...)
+          /* c8 ignore next */
+          {}
       : [];
 
     for (const breach of foundBreaches) {


### PR DESCRIPTION
The primary change here is to change `resetMocks` and `resetModules` to `true`, to ensure each unit test can run independently. To do so, I did have to update the tests from https://github.com/mozilla/blurts-server/pull/3304 to define the mocks each specific test depended on inside that test, rather than in a `beforeAll` call that set them up in the precise order that the tests had to run in as well.

I wasn't entirely sure from the test descriptions what behaviour they were verifying, so I updated the descriptions to specify what I _though_ they did. Let me know if they're wrong.