### PR TITLE
MNTOR-2055 - Only show Fix button for active exposures

### DIFF
--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -272,6 +272,13 @@ export const ExposureCard = (props: ExposureCardProps) => {
       </span>
     );
   }
+
+  const letsFixItBtn = (
+    <span className={styles.fixItBtn}>
+      <Button variant={"primary"}>{l10n.getString("exposure-card-cta")}</Button>
+    </span>
+  );
+
   const exposureCard = (
     <div>
       <div className={styles.exposureCard}>
@@ -408,15 +415,13 @@ export const ExposureCard = (props: ExposureCardProps) => {
                 <ExposureCategoriesListElem />
               </dl>
             </div>
-            {featureFlagsEnabled.PremiumBrokerRemoval ? (
-              <span className={styles.fixItBtn}>
-                <Button variant={"primary"}>
-                  {l10n.getString("exposure-card-cta")}
-                </Button>
-              </span>
-            ) : (
-              ""
-            )}
+            {(isScanResult(props.exposureData) &&
+              featureFlagsEnabled.PremiumBrokerRemoval &&
+              props.exposureData.status === "new") ||
+            (!isScanResult(props.exposureData) &&
+              !props.exposureData.isResolved)
+              ? letsFixItBtn
+              : null}
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2055



<!-- When adding a new feature: -->

# Description
<img width="1408" alt="image" src="https://github.com/mozilla/blurts-server/assets/13066134/731d952e-55e3-4d35-b13a-4262f5d59cd4">
If exposure is fixed, don't show the CTA.




Not applicable.

# How to test



# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
