### PR TITLE
fix: add locale filtering in addition to geo for false door test

### DIFF
--- a/src/app/(nextjs_migration)/layout.tsx
+++ b/src/app/(nextjs_migration)/layout.tsx
@@ -5,7 +5,7 @@
 import { ReactNode } from "react";
 import Script from "next/script";
 import { L10nProvider } from "../../contextProviders/localization";
-import { getL10nBundles } from "../functions/server/l10n";
+import { getL10nBundles, getLocale } from "../functions/server/l10n";
 import { HandleFalseDoorTest } from "./components/client/FalseDoorBanner";
 import { isFlagEnabled } from "../functions/server/featureFlags";
 import { getCountryCode } from "../functions/server/getCountryCode";
@@ -22,6 +22,7 @@ export default async function MigrationLayout({
   const countryCode = getCountryCode(headersList);
   const falseDoorFlag = await isFlagEnabled("FalseDoorTest");
   const waitlistLink = AppConstants.FALSE_DOOR_TEST_LINK_PHASE_ONE;
+  const locale = getLocale();
 
   return (
     <L10nProvider bundleSources={l10nBundles}>
@@ -36,9 +37,10 @@ export default async function MigrationLayout({
       />
       <Script type="module" src="/nextjs_migration/client/js/analytics.js" />
       {children}
-      {falseDoorFlag && waitlistLink && countryCode.toLowerCase() === "us" && (
-        <HandleFalseDoorTest link={waitlistLink} />
-      )}
+      {falseDoorFlag &&
+        waitlistLink &&
+        countryCode.toLowerCase() === "us" &&
+        locale === "en" && <HandleFalseDoorTest link={waitlistLink} />}
     </L10nProvider>
   );
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1834

<!-- When adding a new feature: -->

# Description

Filter by locale in addition to geo-location for false door test.

# How to test

Test with primary locale not set to en-* and geo-location not in US.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
