### PR TITLE
fix: adjust locale filtering, do not fall back to en

### DIFF
--- a/src/app/(nextjs_migration)/layout.tsx
+++ b/src/app/(nextjs_migration)/layout.tsx
@@ -22,7 +22,14 @@ export default async function MigrationLayout({
   const countryCode = getCountryCode(headersList);
   const falseDoorFlag = await isFlagEnabled("FalseDoorTest");
   const waitlistLink = AppConstants.FALSE_DOOR_TEST_LINK_PHASE_ONE;
-  const locale = getLocale();
+  const acceptLanguage = headersList.get("Accept-Language");
+
+  let locale = "";
+  if (acceptLanguage) {
+    const acceptedLocales = acceptLanguage.split(",");
+    const primaryLocale = acceptedLocales[0];
+    locale = primaryLocale.split(";")[0];
+  }
 
   return (
     <L10nProvider bundleSources={l10nBundles}>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When adding a new feature: -->

# Description

This feature currently uses Fluent's `getLocale()` but that only happens to work when we have a localized version of the string (which we are reverting) - let's just look directly at the header.

# How to test

Check using different preferred (i.e. set first in the list) `Accept-Language` header in your browser.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
