### PR TITLE
MNTOR-2103 - pass subscriber ID correctly to getOnerepProfileId function

### DIFF
--- a/src/app/api/v1/fxa-rp-events/route.ts
+++ b/src/app/api/v1/fxa-rp-events/route.ts
@@ -236,7 +236,7 @@ export async function POST(request: NextRequest) {
         });
 
         // get profile id
-        const result = await getOnerepProfileId(subscriber);
+        const result = await getOnerepProfileId(subscriber.id);
         const oneRepProfileId = result?.[0]?.["onerep_profile_id"] as number;
 
         if (


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2103


<!-- When adding a new feature: -->

# Description

This is a partial fix for MNTOR-2103, I think it will fix the immediate issue but the acceptance criteria also includes investigating:
1. if unit tests could've caught this
2. why it didn't show up in Sentry (just Heroku logs)

# How to test

Heroku is currently throwing errors and not consuming the FxA queue, after we land this patch it should start working again.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
