### PR TITLE
Remove irrelevant warnings in tests

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -7,6 +7,7 @@ import { setProjectAnnotations } from "@storybook/react";
 import { toHaveNoViolations } from "jest-axe";
 import { expect } from "@jest/globals";
 import { defaultFallbackInView } from "react-intersection-observer";
+import failOnConsole from "jest-fail-on-console";
 
 import * as globalStorybookConfig from "./.storybook/preview";
 
@@ -15,6 +16,11 @@ setProjectAnnotations(
 );
 
 expect.extend(toHaveNoViolations);
+
+// Prevent logs from cluttering up actual problems in our tests:
+failOnConsole({
+  shouldFailOnWarn: true,
+});
 
 // See https://www.benmvp.com/blog/avoiding-react-act-warning-when-accessibility-testing-next-link-jest-axe/
 // If no `IntersectionObserver` exists, Next.js's <Link> will do a state update

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "jest": "^29.6.1",
         "jest-axe": "^7.0.1",
         "jest-environment-jsdom": "^29.5.0",
+        "jest-fail-on-console": "^3.1.1",
         "lint-staged": "^13.2.2",
         "node-mocks-http": "^1.12.1",
         "nodemon": "^2.0.20",
@@ -23861,6 +23862,46 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-fail-on-console": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-3.1.1.tgz",
+      "integrity": "sha512-g9HGhKcWOz8lHeZhLCXGg+RD/7upngiKkkBrHimsO/tGB0qi++QZffOgybjeI2bDW1qgdFiJJEG6t/WeTlfmOw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jest-get-type": {
@@ -50355,6 +50396,36 @@
             "@jest/types": "^29.6.1",
             "@types/node": "*",
             "jest-util": "^29.6.1"
+          }
+        }
+      }
+    },
+    "jest-fail-on-console": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-3.1.1.tgz",
+      "integrity": "sha512-g9HGhKcWOz8lHeZhLCXGg+RD/7upngiKkkBrHimsO/tGB0qi++QZffOgybjeI2bDW1qgdFiJJEG6t/WeTlfmOw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "jest": "^29.6.1",
     "jest-axe": "^7.0.1",
     "jest-environment-jsdom": "^29.5.0",
+    "jest-fail-on-console": "^3.1.1",
     "lint-staged": "^13.2.2",
     "node-mocks-http": "^1.12.1",
     "nodemon": "^2.0.20",

--- a/src/app/components/client/toolbar/UserMenu.test.tsx
+++ b/src/app/components/client/toolbar/UserMenu.test.tsx
@@ -64,6 +64,9 @@ it("checks if the user menu items are interactive", async () => {
   expect(settingsItem).toBeInTheDocument();
   const settingsItemWrapper = settingsItem.parentElement;
   const clickSettingsItemSpy = jest.spyOn(settingsItem, "click");
+  // Prevent the click from actually executing; otherwise we'll get a warning
+  // that JSDOM doesn't know how to mock switching from one page to another:
+  clickSettingsItemSpy.mockImplementationOnce(() => undefined);
   await user.click(settingsItemWrapper as HTMLElement);
   expect(clickSettingsItemSpy).toHaveBeenCalled();
 

--- a/src/app/components/client/toolbar/UserMenu.tsx
+++ b/src/app/components/client/toolbar/UserMenu.tsx
@@ -10,7 +10,13 @@ import Link from "next/link";
 import { Session } from "next-auth";
 import { signOut } from "next-auth/react";
 import { Item, useMenuTriggerState, useTreeState } from "react-stately";
-import { mergeProps, useMenuTrigger, useMenu, useMenuItem } from "react-aria";
+import {
+  mergeProps,
+  useMenuTrigger,
+  useMenu,
+  useMenuItem,
+  useButton,
+} from "react-aria";
 
 import type { AriaMenuOptions, AriaMenuTriggerProps } from "react-aria";
 import type { MenuTriggerProps, TreeState } from "react-stately";
@@ -148,10 +154,12 @@ function MenuTrigger(props: MenuTriggerComponentProps) {
 
   const mergedMenuProps = mergeProps(props, { ...menuProps, items });
 
+  const menuTiggerButton = useButton(menuTriggerProps, ref);
+
   return (
     <>
       <button
-        {...menuTriggerProps}
+        {...menuTiggerButton.buttonProps}
         ref={ref}
         className={styles.trigger}
         title={l10n.getString("user-menu-trigger-tooltip")}

--- a/src/app/functions/server/featureFlags.ts
+++ b/src/app/functions/server/featureFlags.ts
@@ -14,6 +14,15 @@ export type FeatureFlagsEnabled = {
   FalseDoorTest: boolean;
 };
 
+// This function is specifically meant to not execute in tests:
+/* c8 ignore next 6 */
+const warn: typeof console.warn = (...args) => {
+  if (process.env.NODE_ENV === "test") {
+    return;
+  }
+  console.warn(...args);
+};
+
 export async function isFlagEnabled(
   name: keyof FeatureFlagsEnabled,
   user?: Session["user"]
@@ -23,7 +32,7 @@ export async function isFlagEnabled(
   // TODO: Add unit test when changing this code:
   /* c8 ignore next 4 */
   if (!data) {
-    console.warn("Feature flag does not exist:", name);
+    warn("Feature flag does not exist:", name);
     return false;
   }
 
@@ -40,17 +49,17 @@ export async function isFlagEnabled(
   };
 
   if (flag.deletedAt) {
-    console.warn("Flag has been deleted:", flag.name);
+    warn("Flag has been deleted:", flag.name);
     return false;
   }
 
   if (flag.expiredAt) {
-    console.warn("Flag has expired:", flag.name);
+    warn("Flag has expired:", flag.name);
     return false;
   }
 
   if (!flag.isEnabled) {
-    console.warn("Flag is not enabled:", flag.name);
+    warn("Flag is not enabled:", flag.name);
     return false;
   }
 
@@ -59,7 +68,7 @@ export async function isFlagEnabled(
   } else if (flag.allowList?.includes(user.email)) {
     return true;
   } else {
-    console.warn("User is not on the allow list for flag:", flag.name);
+    warn("User is not on the allow list for flag:", flag.name);
     return false;
   }
 }

--- a/src/cloud-functions/index.js
+++ b/src/cloud-functions/index.js
@@ -143,10 +143,12 @@ async function notify(req, res) {
       .map((condition) => condition.logId)
       .join(", ");
 
-    console.info("Breach alert email was not sent.", {
-      name: breachAlert.Name,
-      reason: `The following conditions were not satisfied: ${conditionLogIds}.`,
-    });
+    if (process.env.NODE_ENV !== "test") {
+      console.info("Breach alert email was not sent.", {
+        name: breachAlert.Name,
+        reason: `The following conditions were not satisfied: ${conditionLogIds}.`,
+      });
+    }
 
     return res.status(200).json({
       info: "Breach loaded into database. Subscribers not notified.",


### PR DESCRIPTION
I'm not sure about this approach, but together with https://github.com/mozilla/blurts-server/pull/3340 and https://github.com/mozilla/blurts-server/pull/3341, this should ensure our console output when running tests is only related to code we're currently working on - happy to hear suggestions on other methods of achieving that.