### PR TITLE
Do not prompt ineligible users to start a scan

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
@@ -180,6 +180,7 @@ export const DashboardWithScan: Story = {
         user={mockSession.user}
         userBreaches={breachItemArraySample}
         userScannedResults={scannedResultsArraySample}
+        isEligibleForFreeScan={false}
         locale={"en"}
         bannerData={dashboardSummaryWithScan}
         featureFlagsEnabled={{
@@ -192,6 +193,7 @@ export const DashboardWithScan: Story = {
 };
 
 export const DashboardWithScanUserFromUs: Story = {
+  name: "Dashboard with scan, user from US",
   render: () => (
     <Shell l10n={getEnL10nSync()} session={mockSession}>
       <DashboardEl
@@ -199,6 +201,7 @@ export const DashboardWithScanUserFromUs: Story = {
         user={mockSession.user}
         userBreaches={breachItemArraySample}
         userScannedResults={scannedResultsArraySample}
+        isEligibleForFreeScan={true}
         locale={"en"}
         bannerData={dashboardSummaryWithScan}
         featureFlagsEnabled={{
@@ -211,12 +214,34 @@ export const DashboardWithScanUserFromUs: Story = {
 };
 
 export const DashboardWithoutScan: Story = {
+  name: "Dashboard without scan",
   render: () => (
     <Shell l10n={getEnL10nSync()} session={mockSession}>
       <DashboardEl
         user={mockSession.user}
         userBreaches={breachItemArraySample}
         userScannedResults={[]}
+        isEligibleForFreeScan={false}
+        locale={"en"}
+        bannerData={dashboardSummaryNoScan}
+        featureFlagsEnabled={{
+          FreeBrokerScan: true,
+          PremiumBrokerRemoval: true,
+        }}
+      />
+    </Shell>
+  ),
+};
+
+export const DashboardWithoutScanUserFromUs: Story = {
+  name: "Dashboard without scan, user from US",
+  render: () => (
+    <Shell l10n={getEnL10nSync()} session={mockSession}>
+      <DashboardEl
+        user={{ email: "example@example.com" }}
+        userBreaches={breachItemArraySample}
+        userScannedResults={[]}
+        isEligibleForFreeScan={true}
         locale={"en"}
         bannerData={dashboardSummaryNoScan}
         featureFlagsEnabled={{
@@ -235,6 +260,7 @@ export const DashboardEmptyListState: Story = {
         user={mockSession.user}
         userBreaches={breachItemArraySample}
         userScannedResults={[]}
+        isEligibleForFreeScan={true}
         locale={"en"}
         bannerData={dashboardSummaryNoScan}
         featureFlagsEnabled={{
@@ -254,6 +280,7 @@ export const DashboardFreeUser: Story = {
         user={{ email: "example@example.com" }}
         userBreaches={breachItemArraySample}
         userScannedResults={scannedResultsArraySample}
+        isEligibleForFreeScan={true}
         locale={"en"}
         bannerData={dashboardSummaryWithScan}
         featureFlagsEnabled={{
@@ -276,6 +303,7 @@ export const DashboardPremiumUser: Story = {
         user={userWithPremiumSubscription}
         userBreaches={breachItemArraySample}
         userScannedResults={scannedResultsArraySample}
+        isEligibleForFreeScan={true}
         locale={"en"}
         bannerData={dashboardSummaryWithScan}
         featureFlagsEnabled={{
@@ -295,6 +323,7 @@ export const DashboardNoSession: Story = {
         user={{ email: "example@example.com" }}
         userBreaches={breachItemArraySample}
         userScannedResults={scannedResultsArraySample}
+        isEligibleForFreeScan={false}
         locale={"en"}
         bannerData={dashboardSummaryWithScan}
         featureFlagsEnabled={{

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
@@ -11,6 +11,7 @@ import Meta, {
   DashboardWithScan,
   DashboardWithScanUserFromUs,
   DashboardWithoutScan,
+  DashboardWithoutScanUserFromUs,
   DashboardFreeUser,
   DashboardPremiumUser,
   DashboardNoSession,
@@ -34,7 +35,7 @@ it("passes the axe accessibility test suite 2", async () => {
 });
 
 it("passes the axe accessibility test suite 3", async () => {
-  const ComposedDashboard = composeStory(DashboardWithoutScan, Meta);
+  const ComposedDashboard = composeStory(DashboardWithoutScanUserFromUs, Meta);
   const { container } = render(<ComposedDashboard />);
   expect(await axe(container)).toHaveNoViolations();
 });
@@ -47,9 +48,25 @@ it("shows the “let’s fix it” banner content", () => {
   expect(letsFixItBannerContent).toBeInTheDocument();
 });
 
+it("shows the 'Start a free scan' CTA to free US-based users who haven't performed a scan yet", () => {
+  const ComposedDashboard = composeStory(DashboardWithoutScanUserFromUs, Meta);
+  render(<ComposedDashboard />);
+
+  const freeScanCta = screen.getByRole("link", { name: "Start a free scan" });
+  expect(freeScanCta).toBeInTheDocument();
+});
+
+it("does not show the 'Start a free scan' CTA for non-US users", () => {
+  const ComposedDashboard = composeStory(DashboardWithoutScan, Meta);
+  render(<ComposedDashboard />);
+
+  const freeScanCta = screen.queryByRole("link", { name: "Start a free scan" });
+  expect(freeScanCta).not.toBeInTheDocument();
+});
+
 it("switches between tab panels", async () => {
   const user = userEvent.setup();
-  const ComposedDashboard = composeStory(DashboardWithoutScan, Meta);
+  const ComposedDashboard = composeStory(DashboardWithoutScanUserFromUs, Meta);
   render(<ComposedDashboard />);
 
   const tabActionNeededTrigger = screen.getByRole("tab", {

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner.tsx
@@ -23,6 +23,7 @@ export type DashboardTopBannerProps = {
   content: BannerContent;
   bannerData: DashboardSummary;
   hasRunScan: boolean;
+  isEligibleForFreeScan: boolean;
   type: TabType;
   ctaCallback?: () => void;
 };
@@ -209,7 +210,11 @@ export const DashboardTopBanner = (props: DashboardTopBannerProps) => {
           )}
         </div>
         <div className={styles.chart}>
-          <Chart hasRunScan={props.hasRunScan} data={chartData} />
+          <Chart
+            hasRunScan={props.hasRunScan}
+            data={chartData}
+            isEligibleForFreeScan={props.isEligibleForFreeScan}
+          />
         </div>
       </div>
     </>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -40,6 +40,7 @@ export type Props = {
   user: Session["user"];
   userBreaches: SubscriberBreach[];
   userScannedResults: ScanResult[];
+  isEligibleForFreeScan: boolean;
   countryCode?: string;
 };
 
@@ -110,6 +111,8 @@ export const View = (props: Props) => {
       }
     }
 
+    // TODO: Add unit test when changing this code:
+    /* c8 ignore next */
     return exposure.isResolved ? "fixed" : "needAction";
   };
 
@@ -235,6 +238,7 @@ export const View = (props: Props) => {
           content={contentType}
           type={selectedTab as TabType}
           hasRunScan={!isScanResultItemsEmpty}
+          isEligibleForFreeScan={props.isEligibleForFreeScan}
           // TODO: Add unit test when changing this code:
           /* c8 ignore next 3 */
           ctaCallback={() => {

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
@@ -19,6 +19,7 @@ import { getLatestOnerepScan } from "../../../../../../db/tables/onerep_scans";
 import { getOnerepProfileId } from "../../../../../../db/tables/subscribers";
 
 import { isFlagEnabled } from "../../../../../functions/server/featureFlags";
+import { isEligibleForFreeScan } from "../../../../../functions/server/onerep";
 export default async function DashboardPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user?.subscriber?.id) {
@@ -45,6 +46,11 @@ export default async function DashboardPage() {
   console.log(JSON.stringify(guidedBreaches));
   const locale = getLocale();
 
+  const userIsEligibleForFreeScan = await isEligibleForFreeScan(
+    session.user,
+    countryCode
+  );
+
   const FreeBrokerScan = await isFlagEnabled("FreeBrokerScan", session.user);
   const PremiumBrokerRemoval = await isFlagEnabled(
     "PremiumBrokerRemoval",
@@ -56,6 +62,7 @@ export default async function DashboardPage() {
     <View
       countryCode={countryCode}
       user={session.user}
+      isEligibleForFreeScan={userIsEligibleForFreeScan}
       userScannedResults={scanResultItems}
       userBreaches={subBreaches}
       locale={locale}

--- a/src/app/components/client/Chart.tsx
+++ b/src/app/components/client/Chart.tsx
@@ -191,7 +191,7 @@ export const DoughnutChart = (props: Props) => {
                 ))}
               </tbody>
             </table>
-            {!props.hasRunScan && props.isEligibleForFreeScan ? prompt : null}
+            {!props.hasRunScan && props.isEligibleForFreeScan && prompt}
           </div>
         </div>
         <figcaption>

--- a/src/app/components/client/Chart.tsx
+++ b/src/app/components/client/Chart.tsx
@@ -20,6 +20,7 @@ import Link from "next/link";
 export type Props = {
   data: Array<[string, number]>;
   hasRunScan: boolean;
+  isEligibleForFreeScan: boolean;
 };
 
 export const DoughnutChart = (props: Props) => {
@@ -190,7 +191,7 @@ export const DoughnutChart = (props: Props) => {
                 ))}
               </tbody>
             </table>
-            {!props.hasRunScan ? prompt : null}
+            {!props.hasRunScan && props.isEligibleForFreeScan ? prompt : null}
           </div>
         </div>
         <figcaption>

--- a/src/app/components/client/stories/Chart.stories.ts
+++ b/src/app/components/client/stories/Chart.stories.ts
@@ -26,5 +26,7 @@ const data: Array<[string, number]> = [
 export const FixedExposures: Story = {
   args: {
     data: data,
+    isEligibleForFreeScan: true,
+    hasRunScan: true,
   },
 };


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2119
Figma: N/A


<!-- When adding a new feature: -->

# Description

The chart would prompt users who hadn't run a scan yet to start a free scan - even those who unfortunately cannot. This fixes that.

# Screenshot (if applicable)

![image](https://github.com/mozilla/blurts-server/assets/4251/3f82a356-8584-43cf-aa93-62e4472e92ac)

# How to test

Set your language to something other than `en-US`, then visit the dashboard with a free user who has not run a scan yet. On `main`, you see the above prompt; in this branch, you shouldn't.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
