### PR TITLE
Remove `buttonType` prop from <Button>

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner.tsx
@@ -65,7 +65,6 @@ export const DashboardTopBanner = (props: DashboardTopBannerProps) => {
       ),
       cta: (
         <Button
-          buttonType="link"
           href={
             "/redesign/user/dashboard/fix/data-broker-profiles/view-data-brokers"
           }

--- a/src/app/components/client/PremiumUpsellDialog.tsx
+++ b/src/app/components/client/PremiumUpsellDialog.tsx
@@ -133,7 +133,6 @@ function PremiumUpsellDialogContent() {
         </dd>
       </dl>
       <Button
-        buttonType="link"
         className={styles.productCta}
         href={premiumSubscriptionUrl}
         variant="primary"

--- a/src/app/components/server/Button.tsx
+++ b/src/app/components/server/Button.tsx
@@ -10,7 +10,6 @@ import { useButton } from "react-aria";
 export interface Props extends ComponentProps<"button"> {
   children: ReactNode;
   variant: "primary" | "secondary";
-  buttonType?: "button" | "link";
   className?: string;
   destructive?: boolean;
   disabled?: boolean;
@@ -25,7 +24,6 @@ export const Button = (
   const {
     children,
     variant,
-    buttonType,
     className,
     destructive,
     disabled,
@@ -56,7 +54,7 @@ export const Button = (
     .filter(Boolean)
     .join(" ");
 
-  return buttonType === "link" && href ? (
+  return typeof href === "string" ? (
     <Link href={href} className={classes}>
       {children}
     </Link>

--- a/src/app/components/server/stories/Button.stories.ts
+++ b/src/app/components/server/stories/Button.stories.ts
@@ -50,7 +50,6 @@ export const PrimaryLink: Story = {
   args: {
     variant: "primary",
     children: "Button",
-    buttonType: "link",
     href: "/",
   },
 };
@@ -59,7 +58,6 @@ export const SecondaryLink: Story = {
   args: {
     variant: "secondary",
     children: "Button",
-    buttonType: "link",
     href: "/",
   },
 };


### PR DESCRIPTION
If a button has a link target, it should always be a link, so no need for the caller to think about that explicitly.

One potential future improvement is to use an `<a>` if `href` doesn't start with `/`, but I'm not sure if we'll ever use `<Button>` for external links (maybe to FxA?).