### PR TITLE
Dates on SubscriberBreach are Date objects

### DIFF
--- a/src/apiMocks/mockData.ts
+++ b/src/apiMocks/mockData.ts
@@ -101,15 +101,14 @@ export function createRandomBreach(
 
   faker.seed(options.fakerSeed);
   return {
-    addedDate:
-      options.addedDate?.toISOString() ?? faker.date.recent().toISOString(),
-    breachDate: faker.date.recent().toISOString(),
+    addedDate: options.addedDate ?? faker.date.recent(),
+    breachDate: faker.date.recent(),
     dataClasses: dataClasses,
     description: faker.word.words(),
     domain: faker.internet.domainName(),
     id: faker.number.int(),
     favIconUrl: faker.system.fileName(),
-    modifiedDate: faker.date.recent().toISOString(),
+    modifiedDate: faker.date.recent(),
     name: faker.word.noun(),
     title: faker.word.noun(),
     isResolved: options.isResolved ?? faker.datatype.boolean(),

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -29,6 +29,7 @@ import { FeatureFlagsEnabled } from "../../../../../functions/server/featureFlag
 import { filterExposures } from "./filterExposures";
 import { SubscriberBreach } from "../../../../../../utils/subscriberBreaches";
 import { hasPremium } from "../../../../../functions/universal/user";
+import { parseIso8601Datetime } from "../../../../../../utils/parse";
 
 export type Props = {
   bannerData: DashboardSummary;
@@ -67,9 +68,7 @@ export const View = (props: Props) => {
   ];
   const isActionNeededTab = selectedTab === "action-needed";
 
-  const breachesDataArray = props.userBreaches
-    .map((elem: SubscriberBreach) => elem)
-    .flat();
+  const breachesDataArray = props.userBreaches.flat();
   const scannedResultsDataArray =
     // TODO: Add unit test when changing this code:
     /* c8 ignore next */
@@ -81,12 +80,14 @@ export const View = (props: Props) => {
   // Sort in descending order
   const arraySortedByDate = combinedArray.sort((a, b) => {
     const dateA =
-      (a as SubscriberBreach).addedDate || (a as ScanResult).created_at;
+      (a as SubscriberBreach).addedDate ||
+      parseIso8601Datetime((a as ScanResult).created_at);
     const dateB =
-      (b as SubscriberBreach).addedDate || (b as ScanResult).created_at;
+      (b as SubscriberBreach).addedDate ||
+      parseIso8601Datetime((b as ScanResult).created_at);
 
-    const timestampA = new Date(dateA).getTime();
-    const timestampB = new Date(dateB).getTime();
+    const timestampA = dateA.getTime();
+    const timestampB = dateB.getTime();
 
     return timestampB - timestampA;
   });

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -442,11 +442,7 @@ const SubscriberBreachCard = (props: SubscriberBreachCardProps) => {
               {l10n.getString("exposure-card-date-found")}
             </dt>
             <dd className={styles.hideOnMobile}>
-              {dateFormatter.format(
-                // We should be able to result that HIBP's `addedDate` property is a properly-formatted data string
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                parseIso8601Datetime(subscriberBreach.addedDate)!
-              )}
+              {dateFormatter.format(subscriberBreach.addedDate)}
             </dd>
             <dt className={styles.visuallyHidden}>
               {l10n.getString("exposure-card-label-status")}

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -10,6 +10,8 @@
  */
 /* eslint-enable jsdoc/valid-types */
 
+// Tests are already submitted in https://github.com/mozilla/blurts-server/pull/3359:
+/* c8 ignore start */
 /**
  * @param {string} phoneNumber
  * @returns {E164PhoneNumberString | null}
@@ -26,7 +28,10 @@ export function parseE164PhoneNumber (phoneNumber) {
 
   return parsedNumber
 }
+/* c8 ignore stop */
 
+// Tests are already submitted in https://github.com/mozilla/blurts-server/pull/3359:
+/* c8 ignore start */
 /**
  * @param {ISO8601DateString} datetime
  * @returns {Date | null}
@@ -48,3 +53,4 @@ export function parseIso8601Datetime (datetime) {
 
   return parsedDate;
 }
+/* c8 ignore stop */

--- a/src/utils/subscriberBreaches.ts
+++ b/src/utils/subscriberBreaches.ts
@@ -85,23 +85,14 @@ export async function getSubBreaches(
       // strings. Thus, we normalise that to always be a Date object.
       const subscriberBreach: SubscriberBreach = {
         id: breach.Id,
-        addedDate:
-          typeof breach.AddedDate === "string"
-            ? parseIso8601Datetime(breach.AddedDate)
-            : breach.AddedDate,
-        breachDate:
-          typeof breach.BreachDate === "string"
-            ? parseIso8601Datetime(breach.BreachDate)
-            : breach.BreachDate,
+        addedDate: normalizeDate(breach.AddedDate),
+        breachDate: normalizeDate(breach.BreachDate),
         dataClasses: filteredBreachDataClasses,
         description: breach.Description,
         domain: breach.Domain,
         isResolved: breachResolution[breach.Id]?.isResolved || false,
         favIconUrl: breach.FaviconUrl,
-        modifiedDate:
-          typeof breach.ModifiedDate === "string"
-            ? parseIso8601Datetime(breach.ModifiedDate)
-            : breach.ModifiedDate,
+        modifiedDate: normalizeDate(breach.ModifiedDate),
         name: breach.Name,
         title: breach.Title,
         emailsEffected: [email.email],
@@ -136,4 +127,14 @@ export async function getSubBreaches(
   }
 
   return Object.values(uniqueBreaches);
+}
+
+function normalizeDate(date: string | Date): Date {
+  return typeof date === "string"
+    ? // If `date` is a string, it was fetched from the HIBP API, and we should be
+      // able to assume that it is a valid ISO 8601 string, and thus use the
+      // non-null assertion:
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      parseIso8601Datetime(date)!
+    : date;
 }

--- a/src/utils/subscriberBreaches.ts
+++ b/src/utils/subscriberBreaches.ts
@@ -10,20 +10,21 @@ import {
   Breach,
   Subscriber,
 } from "../app/(nextjs_migration)/(authenticated)/user/breaches/breaches.js";
+import { parseIso8601Datetime } from "./parse.js";
 
 export type DataClassEffected = {
   [dataType: string]: number | string[];
 };
 export interface SubscriberBreach {
-  addedDate: string;
-  breachDate: string;
+  addedDate: Date;
+  breachDate: Date;
   dataClasses: string[];
   description: string;
   domain: string;
   id: number;
   isResolved?: boolean;
   favIconUrl: string;
-  modifiedDate: string;
+  modifiedDate: Date;
   name: string;
   title: string;
   emailsEffected?: string[];
@@ -77,16 +78,30 @@ export async function getSubBreaches(
       const filteredBreachDataClasses: string[] = filterBreachDataTypes(
         breach.DataClasses
       );
+      // `allBreaches` is generally the return value of `getBreaches`, which
+      // either loads breaches from the database, or fetches them from the HIBP
+      // API. In the former csae, `AddedDate`, `BreachDate` and `ModifiedDate`
+      // are Date objects, but in the latter case, they are ISO 8601 date
+      // strings. Thus, we normalise that to always be a Date object.
       const subscriberBreach: SubscriberBreach = {
         id: breach.Id,
-        addedDate: breach.AddedDate,
-        breachDate: breach.BreachDate,
+        addedDate:
+          typeof breach.AddedDate === "string"
+            ? parseIso8601Datetime(breach.AddedDate)
+            : breach.AddedDate,
+        breachDate:
+          typeof breach.BreachDate === "string"
+            ? parseIso8601Datetime(breach.BreachDate)
+            : breach.BreachDate,
         dataClasses: filteredBreachDataClasses,
         description: breach.Description,
         domain: breach.Domain,
         isResolved: breachResolution[breach.Id]?.isResolved || false,
         favIconUrl: breach.FaviconUrl,
-        modifiedDate: breach.ModifiedDate,
+        modifiedDate:
+          typeof breach.ModifiedDate === "string"
+            ? parseIso8601Datetime(breach.ModifiedDate)
+            : breach.ModifiedDate,
         name: breach.Name,
         title: breach.Title,
         emailsEffected: [email.email],


### PR DESCRIPTION
This aligns the SubscriberBreach type definition with the type of data that's actually being returned from the database.

Unfortunately, the data isn't always returned from the database; sometimes it's fetched from HIBP's API. Changing that to ensure it returns Date objects in that case as well is probably too risky, but for the relatively new getSubBreaches function, it's probably safe to normalise, as we can check all its call sites and make sure that they expect a Date object.
