### PR TITLE
Add type for the onerep_profiles table

### DIFF
--- a/src/db/tables/onerep_profiles.ts
+++ b/src/db/tables/onerep_profiles.ts
@@ -5,6 +5,7 @@
 import initKnex from "knex";
 import knexConfig from "../knexfile.js";
 import { ProfileData } from "../../app/functions/server/onerep.js";
+import { parseIso8601Datetime } from "../../utils/parse.js";
 
 const knex = initKnex(knexConfig);
 
@@ -18,7 +19,11 @@ export async function setProfileDetails(
     last_name: profileData.last_name,
     city_name: profileData.addresses[0]["city"],
     state_code: profileData.addresses[0]["state"],
-    date_of_birth: profileData.birth_date,
+    // TODO: Validate input:
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    date_of_birth: parseIso8601Datetime(profileData.birth_date!)!,
+    // @ts-ignore knex.fn.now() results in it being set to a date,
+    // even if it's not typed as a JS date object:
     created_at: knex.fn.now(),
   });
 }

--- a/src/knex-tables.d.ts
+++ b/src/knex-tables.d.ts
@@ -4,6 +4,7 @@
 
 import { Knex } from "knex";
 import { ScanResult } from "./app/functions/server/onerep";
+import { StateAbbr } from "./utils/states";
 
 // See https://knexjs.org/guide/#typescript
 declare module "knex/types/tables" {
@@ -162,6 +163,26 @@ declare module "knex/types/tables" {
     "id" | "created_at" | "updated_at"
   >;
 
+  interface OnerepProfileRow {
+    id: number;
+    onerep_profile_id: null | SubscriberRow["onerep_profile_id"];
+    first_name: string;
+    last_name: string;
+    city_name: string;
+    state_code: StateAbbr;
+    date_of_birth: Date;
+    created_at: Date;
+    updated_at: Date;
+  }
+  type OnerepProfileOptionalColumns = Extract<
+    keyof OnerepProfileRow,
+    "onerep_profile_id"
+  >;
+  type OnerepProfileAutoInsertedColumns = Extract<
+    keyof OnerepProfileRow,
+    "id" | "created_at" | "updated_at"
+  >;
+
   interface Tables {
     feature_flags: Knex.CompositeTableType<
       FeatureFlagRow,
@@ -217,6 +238,19 @@ declare module "knex/types/tables" {
       // On updates, don't allow updating the ID and created date; all other fields are optional, except updated_at:
       Partial<Omit<OnerepScanRow, "id" | "created_at">> &
         Pick<OnerepScanRow, "updated_at">
+    >;
+
+    onerep_profiles: Knex.CompositeTableType<
+      OnerepProfileRow,
+      // On updates, auto-generated columns cannot be set, and nullable columns are optional:
+      Omit<
+        OnerepProfileRow,
+        OnerepProfileAutoInsertedColumns | OnerepProfileOptionalColumns
+      > &
+        Partial<Pick<OnerepProfileRow, OnerepProfileOptionalColumns>>,
+      // On updates, don't allow updating the ID and created date; all other fields are optional, except updated_at:
+      Partial<Omit<OnerepProfileRow, "id" | "created_at">> &
+        Pick<OnerepProfileRow, "updated_at">
     >;
   }
 }


### PR DESCRIPTION
This adds a type for the `onerep_profiles` table, based on https://github.com/mozilla/blurts-server/blob/main/src/db/migrations/20230703010356_add-onerep-profiles-table.js.