### PR TITLE
Include python for Heroku and CircleCI builders

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,7 @@ jobs:
             - run: npm run build-glean
             - run: npm run lint
     deploy:
-        docker:
-            - image: docker:stable-git
-              auth:
-                username: $DOCKER_USER
-                password: $DOCKER_PASS
+        executor: node_with_python
         working_directory: /dockerflow
         steps:
             - checkout
@@ -122,7 +118,7 @@ jobs:
         # is based on:
         # https://github.com/CircleCI-Public/heroku-orb/blob/master/src/jobs/deploy-via-git.yml
         # https://github.com/CircleCI-Public/heroku-orb/blob/master/src/commands/deploy-via-git.yml
-        executor: heroku/default
+        executor: python/default
         parameters:
             app-name:
                 description: "The name of the Heroku App"


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2022


<!-- When adding a new feature: -->

# Description

Glean requires python3 at build time, ensure that it is present for both Heroku and Docker builders.
