### PR TITLE
Store scan results in a separate table

### DIFF
--- a/src/apiMocks/mockData.ts
+++ b/src/apiMocks/mockData.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { faker } from "@faker-js/faker";
-import { ScanResult } from "../app/functions/server/onerep";
+import { OnerepScanResultRow } from "knex/types/tables";
 import {
   RemovalStatus,
   RemovalStatusMap,
@@ -24,8 +24,7 @@ import {
 const fakerSeed = 123;
 
 // This is a full list of scan results, all pages, and would normally be
-// stored in the `onerep_scan_results.onerep_scan_results` column
-// as `jsonb`.
+// stored in the `onerep_scan_results` table.
 export function mockedOneRepScanResults() {
   faker.seed(fakerSeed);
   return {
@@ -43,17 +42,20 @@ export type RandomScanOptions = Partial<{
  * Generates scan result with randomly-generated mock data.
  *
  * @param options
- * @returns {ScanResult} - A single scan result.
+ * @returns A single scan result.
  */
-export function createRandomScan(options: RandomScanOptions = {}): ScanResult {
+export function createRandomScan(
+  options: RandomScanOptions = {}
+): OnerepScanResultRow {
   faker.seed(options.fakerSeed);
   return {
     id: faker.number.int(),
-    profile_id: faker.number.int(),
+    onerep_scan_result_id: faker.number.int(),
+    onerep_scan_id: faker.number.int(),
     first_name: faker.person.firstName(),
     last_name: faker.person.lastName(),
     middle_name: faker.person.middleName(),
-    age: faker.number.int({ min: 14, max: 120 }).toString(),
+    age: faker.number.int({ min: 14, max: 120 }),
     status:
       options.status ??
       (faker.helpers.arrayElement(
@@ -71,11 +73,8 @@ export function createRandomScan(options: RandomScanOptions = {}): ScanResult {
     link: faker.internet.url(),
     data_broker: faker.internet.domainName(),
     data_broker_id: faker.number.int(),
-    created_at:
-      options.createdDate?.toISOString() ??
-      faker.date.recent({ days: 2 }).toISOString(),
-    updated_at: faker.date.recent({ days: 1 }).toISOString(),
-    url: faker.internet.url(),
+    created_at: options.createdDate ?? faker.date.recent({ days: 2 }),
+    updated_at: faker.date.recent({ days: 1 }),
   };
 }
 

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
@@ -4,8 +4,8 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { OnerepScanResultRow } from "knex/types/tables";
 import { View as DashboardEl } from "./View";
-import { ScanResult } from "../../../../../functions/server/onerep";
 import { Shell } from "../../../Shell";
 import { getEnL10nSync } from "../../../../../functions/server/mockL10n";
 import {
@@ -63,7 +63,7 @@ const BreachMockItem4: SubscriberBreach = createRandomBreach({
   ],
 });
 
-const scannedResultsArraySample: ScanResult[] = [
+const scannedResultsArraySample: OnerepScanResultRow[] = [
   createRandomScan({ status: "removed" }),
   createRandomScan({ status: "waiting_for_verification" }),
   createRandomScan({ status: "optout_in_progress" }),
@@ -71,7 +71,7 @@ const scannedResultsArraySample: ScanResult[] = [
   createRandomScan(),
 ];
 
-const scannedResolvedResultsArraySample: ScanResult[] = Array.from(
+const scannedResolvedResultsArraySample: OnerepScanResultRow[] = Array.from(
   { length: 5 },
   () => createRandomScan({ status: "removed" })
 );

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -7,6 +7,7 @@
 import { Key, useState } from "react";
 import Image from "next/image";
 import { Session } from "next-auth";
+import { OnerepScanResultRow } from "knex/types/tables";
 import styles from "./View.module.scss";
 import { Toolbar } from "../../../../../components/client/toolbar/Toolbar";
 import { BannerContent, DashboardTopBanner } from "./DashboardTopBanner";
@@ -20,7 +21,6 @@ import {
   ExposuresFilter,
   FilterState,
 } from "../../../../../components/client/ExposuresFilter";
-import { ScanResult } from "../../../../../functions/server/onerep";
 import { DashboardSummary } from "../../../../../functions/server/dashboard";
 import { getExposureStatus } from "../../../../../components/server/StatusPill";
 import { TabList } from "../../../../../components/client/TabList";
@@ -29,7 +29,6 @@ import { FeatureFlagsEnabled } from "../../../../../functions/server/featureFlag
 import { filterExposures } from "./filterExposures";
 import { SubscriberBreach } from "../../../../../../utils/subscriberBreaches";
 import { hasPremium } from "../../../../../functions/universal/user";
-import { parseIso8601Datetime } from "../../../../../../utils/parse";
 
 export type Props = {
   bannerData: DashboardSummary;
@@ -40,7 +39,7 @@ export type Props = {
   locale: string;
   user: Session["user"];
   userBreaches: SubscriberBreach[];
-  userScannedResults: ScanResult[];
+  userScannedResults: OnerepScanResultRow[];
   isEligibleForFreeScan: boolean;
   countryCode?: string;
   isAllFixed?: boolean;
@@ -70,22 +69,18 @@ export const View = (props: Props) => {
   const isActionNeededTab = selectedTab === "action-needed";
 
   const breachesDataArray = props.userBreaches.flat();
-  const scannedResultsDataArray =
-    // TODO: Add unit test when changing this code:
-    /* c8 ignore next */
-    props.userScannedResults.map((elem: ScanResult) => elem) || [];
 
   // Merge exposure cards
-  const combinedArray = [...breachesDataArray, ...scannedResultsDataArray];
+  const combinedArray = [...breachesDataArray, ...props.userScannedResults];
 
   // Sort in descending order
   const arraySortedByDate = combinedArray.sort((a, b) => {
     const dateA =
       (a as SubscriberBreach).addedDate ||
-      parseIso8601Datetime((a as ScanResult).created_at);
+      (a as OnerepScanResultRow).created_at;
     const dateB =
       (b as SubscriberBreach).addedDate ||
-      parseIso8601Datetime((b as ScanResult).created_at);
+      (b as OnerepScanResultRow).created_at;
 
     const timestampA = dateA.getTime();
     const timestampB = dateB.getTime();

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/FixView.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/FixView.tsx
@@ -7,6 +7,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { ReactNode } from "react";
+import { OnerepScanResultRow } from "knex/types/tables";
 import { FixNavigation } from "../../../../../../components/client/FixNavigation";
 import styles from "./fix.module.scss";
 import ImageArrowLeft from "./images/icon-arrow-left.svg";
@@ -18,13 +19,12 @@ import stepLeakedPasswordsIcon from "./images/step-counter-leaked-passwords.svg"
 import stepSecurityRecommendationsIcon from "./images/step-counter-security-recommendations.svg";
 import { usePathname } from "next/navigation";
 import { GuidedExperienceBreaches } from "../../../../../../functions/server/getUserBreaches";
-import { ScanResult } from "../../../../../../functions/server/onerep";
 import { useL10n } from "../../../../../../hooks/l10n";
 
 export type FixViewProps = {
   children: ReactNode;
   breaches: GuidedExperienceBreaches;
-  userScannedResults: ScanResult[];
+  userScannedResults: OnerepScanResultRow[];
 };
 
 export const FixView = (props: FixViewProps) => {

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/ManualRemoveView.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/ManualRemoveView.tsx
@@ -11,7 +11,7 @@ import {
   ClockIcon,
 } from "../../../../../../../../components/server/Icons";
 import { getOnerepProfileId } from "../../../../../../../../../db/tables/subscribers";
-import { getLatestOnerepScan } from "../../../../../../../../../db/tables/onerep_scans";
+import { getLatestOnerepScanResults } from "../../../../../../../../../db/tables/onerep_scans";
 import { authOptions } from "../../../../../../../../api/utils/auth";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
@@ -28,8 +28,8 @@ export default async function ManualRemoveView() {
   }
   const result = await getOnerepProfileId(session.user.subscriber.id);
   const profileId = result[0]["onerep_profile_id"] as number;
-  const scanResult = await getLatestOnerepScan(profileId);
-  const scanResultItems = scanResult?.onerep_scan_results?.data ?? [];
+  const scanResult = await getLatestOnerepScanResults(profileId);
+  const scanResultItems = scanResult.results;
   const subBreaches = await getSubscriberBreaches(session.user);
   const summary = dashboardSummary(scanResultItems, subBreaches);
 

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/view-data-brokers/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/view-data-brokers/page.tsx
@@ -7,7 +7,7 @@ import buttonStyles from "../../../../../../../../components/server/button.modul
 import styles from "../dataBrokerProfiles.module.scss";
 import { getL10n } from "../../../../../../../../functions/server/l10n";
 import { DataBrokerProfiles } from "../../../../../../../../components/client/DataBrokerProfiles";
-import { getLatestOnerepScan } from "../../../../../../../../../db/tables/onerep_scans";
+import { getLatestOnerepScanResults } from "../../../../../../../../../db/tables/onerep_scans";
 import { getServerSession } from "next-auth";
 import { authOptions } from "../../../../../../../../api/utils/auth";
 import { getOnerepProfileId } from "../../../../../../../../../db/tables/subscribers";
@@ -24,11 +24,10 @@ export default async function ViewDataBrokers() {
 
   const result = await getOnerepProfileId(session.user.subscriber.id);
   const profileId = result[0]["onerep_profile_id"] as number;
-  const scanResult = await getLatestOnerepScan(profileId);
-  const scanResultItems = scanResult?.onerep_scan_results?.data ?? [];
+  const latestScan = await getLatestOnerepScanResults(profileId);
 
   // TODO: Use api to set/query count
-  const countOfDataBrokerProfiles = scanResultItems.length;
+  const countOfDataBrokerProfiles = latestScan.results.length;
 
   return (
     <div>
@@ -52,7 +51,7 @@ export default async function ViewDataBrokers() {
           )}
           <AboutBrokersIcon />
         </h4>
-        <DataBrokerProfiles data={scanResultItems} />
+        <DataBrokerProfiles data={latestScan.results} />
       </div>
       <div className={styles.buttonsWrapper}>
         <Link

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/layout.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/layout.tsx
@@ -10,7 +10,7 @@ import { getGuidedExperienceBreaches } from "../../../../../../functions/univers
 import { redirect } from "next/navigation";
 import { ReactNode } from "react";
 import { FixView } from "./FixView";
-import { getLatestOnerepScan } from "../../../../../../../db/tables/onerep_scans";
+import { getLatestOnerepScanResults } from "../../../../../../../db/tables/onerep_scans";
 import { getOnerepProfileId } from "../../../../../../../db/tables/subscribers";
 import { canSubscribeToPremium } from "../../../../../../functions/universal/user";
 import { getCountryCode } from "../../../../../../functions/server/getCountryCode";
@@ -39,8 +39,8 @@ export default async function Layout({ children }: { children: ReactNode }) {
     return redirect("/redesign/user/welcome/");
   }
 
-  const scanResult = await getLatestOnerepScan(profileId);
-  const scanResultItems = scanResult?.onerep_scan_results?.data ?? [];
+  const scanResult = await getLatestOnerepScanResults(profileId);
+  const scanResultItems = scanResult.results;
 
   return (
     <FixView breaches={guidedExperience} userScannedResults={scanResultItems}>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
@@ -12,7 +12,7 @@ import { getCountryCode } from "../../../../../functions/server/getCountryCode";
 import { getSubscriberBreaches } from "../../../../../functions/server/getUserBreaches";
 import { getLocale } from "../../../../../functions/server/l10n";
 import { canSubscribeToPremium } from "../../../../../functions/universal/user";
-import { getLatestOnerepScan } from "../../../../../../db/tables/onerep_scans";
+import { getLatestOnerepScanResults } from "../../../../../../db/tables/onerep_scans";
 import { getOnerepProfileId } from "../../../../../../db/tables/subscribers";
 
 import { isFlagEnabled } from "../../../../../functions/server/featureFlags";
@@ -35,10 +35,9 @@ export default async function DashboardPage() {
     return redirect("/redesign/user/welcome/");
   }
 
-  const scanResult = await getLatestOnerepScan(profileId);
-  const scanResultItems = scanResult?.onerep_scan_results?.data ?? [];
+  const latestScan = await getLatestOnerepScanResults(profileId);
   const subBreaches = await getSubscriberBreaches(session.user);
-  const summary = dashboardSummary(scanResultItems, subBreaches);
+  const summary = dashboardSummary(latestScan.results, subBreaches);
   const locale = getLocale();
 
   const userIsEligibleForFreeScan = await isEligibleForFreeScan(
@@ -61,7 +60,7 @@ export default async function DashboardPage() {
       countryCode={countryCode}
       user={session.user}
       isEligibleForFreeScan={userIsEligibleForFreeScan}
-      userScannedResults={scanResultItems}
+      userScannedResults={latestScan.results}
       userBreaches={subBreaches}
       locale={locale}
       bannerData={summary}

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/subscribed/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/subscribed/page.tsx
@@ -12,7 +12,7 @@ import {
   optoutProfile,
 } from "../../../../../../functions/server/onerep";
 import {
-  getLatestOnerepScan,
+  getLatestOnerepScanResults,
   setOnerepScanResults,
 } from "../../../../../../../db/tables/onerep_scans";
 import { getCountryCode } from "../../../../../../functions/server/getCountryCode";
@@ -40,8 +40,8 @@ export default async function Subscribed() {
 
   const dev =
     process.env.NODE_ENV === "development" || process.env.APP_ENV === "heroku";
-  const latestScan = await getLatestOnerepScan(profileId);
-  if (!latestScan) {
+  const latestScan = await getLatestOnerepScanResults(profileId);
+  if (!latestScan.scan) {
     throw new Error("Must have performed manual scan");
   }
 
@@ -52,8 +52,8 @@ export default async function Subscribed() {
   if (dev) {
     await setOnerepScanResults(
       profileId,
-      latestScan.onerep_scan_id,
-      { data: scans },
+      latestScan.scan.onerep_scan_id,
+      scans,
       "initial"
     );
   }

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/subscribed/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/subscribed/page.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../../../../../functions/server/onerep";
 import {
   getLatestOnerepScanResults,
-  setOnerepScanResults,
+  addOnerepScanResults,
 } from "../../../../../../../db/tables/onerep_scans";
 import { getCountryCode } from "../../../../../../functions/server/getCountryCode";
 import { headers } from "next/headers";
@@ -50,7 +50,7 @@ export default async function Subscribed() {
   // In dev mode, record scans every time this page is reloaded.
   // The webhoook does this in production.
   if (dev) {
-    await setOnerepScanResults(
+    await addOnerepScanResults(
       profileId,
       latestScan.scan.onerep_scan_id,
       scans,

--- a/src/app/(proper_react)/redesign/(authenticated)/user/welcome/EnterInfo.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/welcome/EnterInfo.tsx
@@ -40,12 +40,12 @@ const createProfileAndStartScan = async (
     body: JSON.stringify(userInfo),
   });
 
-  const result = await response.json();
+  const result: WelcomeScanBody = await response.json();
   if (!result?.success) {
     throw new Error("Could not start scan");
   }
 
-  return result as WelcomeScanBody;
+  return result;
 };
 /* c8 ignore stop */
 

--- a/src/app/api/v1/onerep-events/route.ts
+++ b/src/app/api/v1/onerep-events/route.ts
@@ -83,14 +83,7 @@ export async function POST(req: NextRequest) {
     // The webhook just tells us which scan ID finished, we need to fetch the payload.
     const scanListFull = await getAllScanResults(profileId);
     // Store full list of results in the DB.
-    await setOnerepScanResults(
-      profileId,
-      scanId,
-      {
-        data: scanListFull,
-      },
-      reason
-    );
+    await setOnerepScanResults(profileId, scanId, scanListFull, reason);
 
     return NextResponse.json({ success: true }, { status: 200 });
   } catch (ex) {

--- a/src/app/api/v1/onerep-events/route.ts
+++ b/src/app/api/v1/onerep-events/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { captureException } from "@sentry/node";
 import crypto from "crypto";
 
-import { setOnerepScanResults } from "../../../../db/tables/onerep_scans";
+import { addOnerepScanResults } from "../../../../db/tables/onerep_scans";
 import { getAllScanResults, Scan } from "../../../functions/server/onerep";
 
 interface OnerepWebhookRequest {
@@ -83,7 +83,7 @@ export async function POST(req: NextRequest) {
     // The webhook just tells us which scan ID finished, we need to fetch the payload.
     const scanListFull = await getAllScanResults(profileId);
     // Store full list of results in the DB.
-    await setOnerepScanResults(profileId, scanId, scanListFull, reason);
+    await addOnerepScanResults(profileId, scanId, scanListFull, reason);
 
     return NextResponse.json({ success: true }, { status: 200 });
   } catch (ex) {

--- a/src/app/api/v1/user/welcome-scan/progress/route.ts
+++ b/src/app/api/v1/user/welcome-scan/progress/route.ts
@@ -13,7 +13,7 @@ import {
 } from "../../../../../../db/tables/subscribers";
 
 import {
-  getLatestOnerepScan,
+  getLatestOnerepScanResults,
   setOnerepScanResults,
 } from "../../../../../../db/tables/onerep_scans";
 import {
@@ -44,10 +44,10 @@ export async function GET(
         "onerep_profile_id"
       ] as number;
 
-      const latestScans = await getLatestOnerepScan(profileId);
-      const latestScanId = latestScans?.onerep_scan_id;
+      const latestScan = await getLatestOnerepScanResults(profileId);
+      const latestScanId = latestScan.scan?.onerep_scan_id;
 
-      if (latestScanId) {
+      if (typeof latestScanId !== "undefined") {
         const scan = await getScanDetails(profileId, latestScanId);
 
         // Store scan results only for development environments.
@@ -60,9 +60,7 @@ export async function GET(
           await setOnerepScanResults(
             profileId,
             scan.id,
-            {
-              data: allScanResults,
-            },
+            allScanResults,
             "manual"
           );
         }

--- a/src/app/api/v1/user/welcome-scan/progress/route.ts
+++ b/src/app/api/v1/user/welcome-scan/progress/route.ts
@@ -14,7 +14,7 @@ import {
 
 import {
   getLatestOnerepScanResults,
-  setOnerepScanResults,
+  addOnerepScanResults,
 } from "../../../../../../db/tables/onerep_scans";
 import {
   ListScanResultsResponse,
@@ -57,7 +57,7 @@ export async function GET(
           process.env.APP_ENV === "heroku"
         ) {
           const allScanResults = await getAllScanResults(profileId);
-          await setOnerepScanResults(
+          await addOnerepScanResults(
             profileId,
             scan.id,
             allScanResults,

--- a/src/app/api/v1/user/welcome-scan/result/route.ts
+++ b/src/app/api/v1/user/welcome-scan/result/route.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { getServerSession } from "next-auth";
+import { OnerepScanResultRow, OnerepScanRow } from "knex/types/tables";
 import { authOptions } from "../../../../utils/auth";
 import { NextResponse } from "next/server";
 
@@ -12,7 +13,14 @@ import {
   getSubscriberByEmail,
 } from "../../../../../../db/tables/subscribers";
 
-import { getLatestOnerepScan } from "../../../../../../db/tables/onerep_scans";
+import { getLatestOnerepScanResults } from "../../../../../../db/tables/onerep_scans";
+
+export type WelcomeScanResultResponse =
+  | {
+      success: true;
+      scan_results: { scan?: OnerepScanRow; results: OnerepScanResultRow[] };
+    }
+  | { success: false };
 
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -23,7 +31,7 @@ export async function GET() {
         "onerep_profile_id"
       ] as number;
 
-      const scanResults = await getLatestOnerepScan(profileId);
+      const scanResults = await getLatestOnerepScanResults(profileId);
       return NextResponse.json(
         { success: true, scan_results: scanResults },
         { status: 200 }

--- a/src/app/components/client/DataBrokerProfiles.tsx
+++ b/src/app/components/client/DataBrokerProfiles.tsx
@@ -9,10 +9,10 @@ import styles from "./DataBrokerProfiles.module.scss";
 import { useL10n } from "../../hooks/l10n";
 import IconChevronDown from "./assets/icon-chevron-down.svg";
 import { useState } from "react";
-import { ScanResult } from "../../functions/server/onerep";
+import { OnerepScanResultRow } from "knex/types/tables";
 
 export type Props = {
-  data: ScanResult[];
+  data: OnerepScanResultRow[];
 };
 
 export const DataBrokerProfiles = (props: Props) => {
@@ -54,7 +54,7 @@ export const DataBrokerProfiles = (props: Props) => {
 };
 
 export type DataBrokerProfileCardProps = {
-  data: ScanResult;
+  data: OnerepScanResultRow;
 };
 
 export const DataBrokerProfileCard = (props: DataBrokerProfileCardProps) => {

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -6,6 +6,7 @@
 
 import React, { useState } from "react";
 import Link from "next/link";
+import { OnerepScanResultRow } from "knex/types/tables";
 import styles from "./ExposureCard.module.scss";
 import { StatusPill } from "../server/StatusPill";
 import Image, { StaticImageData } from "next/image";
@@ -21,20 +22,18 @@ import {
 } from "../server/Icons";
 import { Button } from "../server/Button";
 import { useL10n } from "../../hooks/l10n";
-import { ScanResult } from "../../functions/server/onerep";
 import {
   DataClassEffected,
   SubscriberBreach,
 } from "../../../utils/subscriberBreaches";
-import { parseIso8601Datetime } from "../../../utils/parse";
 import { FallbackLogo } from "../server/BreachLogo";
 import { BreachDataClass, DataBrokerDataClass } from "./ExposureCardDataClass";
 
-export type Exposure = ScanResult | SubscriberBreach;
+export type Exposure = OnerepScanResultRow | SubscriberBreach;
 
 // Typeguard function
-export function isScanResult(obj: Exposure): obj is ScanResult {
-  return (obj as ScanResult).data_broker !== undefined; // only ScanResult has an instance of data_broker
+export function isScanResult(obj: Exposure): obj is OnerepScanResultRow {
+  return (obj as OnerepScanResultRow).data_broker !== undefined; // only ScanResult has an instance of data_broker
 }
 
 export type ExposureCardProps = {
@@ -54,7 +53,7 @@ export const ExposureCard = ({ exposureData, ...props }: ExposureCardProps) => {
 
 export type ScanResultCardProps = {
   exposureImg?: StaticImageData;
-  scanResult: ScanResult;
+  scanResult: OnerepScanResultRow;
   locale: string;
   isPremiumBrokerRemovalEnabled: boolean;
 };
@@ -181,11 +180,7 @@ const ScanResultCard = (props: ScanResultCardProps) => {
               {l10n.getString("exposure-card-date-found")}
             </dt>
             <dd className={styles.hideOnMobile}>
-              {dateFormatter.format(
-                // We should be able to result that OneRep's `created_at` property is a properly-formatted data string
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                parseIso8601Datetime(scanResult.created_at)!
-              )}
+              {dateFormatter.format(scanResult.created_at)}
             </dd>
             <dt className={styles.visuallyHidden}>
               {l10n.getString("exposure-card-label-status")}

--- a/src/app/components/client/ExposureCardDataClass.tsx
+++ b/src/app/components/client/ExposureCardDataClass.tsx
@@ -5,13 +5,13 @@
 "use client";
 
 import { ReactElement } from "react";
+import { OnerepScanResultRow } from "knex/types/tables";
 import styles from "./ExposureCard.module.scss";
 import { SubscriberBreach } from "../../../utils/subscriberBreaches";
 import { useL10n } from "../../hooks/l10n";
-import { ScanResult } from "../../functions/server/onerep";
 
 type DataBrokerDataClassProps = {
-  scanResultData: ScanResult;
+  scanResultData: OnerepScanResultRow;
   exposureCategoryLabel: string;
   num: number;
   icon: ReactElement;

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { OnerepScanResultRow } from "knex/types/tables";
 import { BreachDataTypes } from "../../../utils/breachResolution";
-import { ScanResult } from "./onerep";
 import { RemovalStatusMap } from "../universal/scanResult";
 import { SubscriberBreach } from "../../../utils/subscriberBreaches";
 
@@ -61,7 +61,7 @@ const exposureKeyMap: Record<string, string> = {
 };
 
 export function dashboardSummary(
-  scannedResults: ScanResult[],
+  scannedResults: OnerepScanResultRow[],
   subscriberBreaches: SubscriberBreach[]
 ): DashboardSummary {
   const summary: DashboardSummary = {

--- a/src/app/functions/server/onerep.ts
+++ b/src/app/functions/server/onerep.ts
@@ -10,7 +10,7 @@ import {
   ISO8601DateString,
 } from "../../../utils/parse.js";
 import { StateAbbr } from "../../../utils/states.js";
-import { getLatestOnerepScan } from "../../../db/tables/onerep_scans";
+import { getLatestOnerepScanResults } from "../../../db/tables/onerep_scans";
 import { isFlagEnabled } from "./featureFlags";
 import { RemovalStatus } from "../universal/scanResult.js";
 const log = mozlog("external.onerep");
@@ -51,6 +51,7 @@ export type ListScansResponse = {
 };
 export type ScanResult = {
   id: number;
+  scan_id: number;
   url: string;
   link: string;
   profile_id: number;
@@ -294,9 +295,9 @@ export async function isEligibleForFreeScan(
 
   const result = await getOnerepProfileId(user.subscriber.id);
   const profileId = result[0]["onerep_profile_id"] as number;
-  const scanResult = await getLatestOnerepScan(profileId);
+  const scanResult = await getLatestOnerepScanResults(profileId);
 
-  if (scanResult?.onerep_scan_results?.data?.length) {
+  if (scanResult.results.length) {
     console.warn("User has already used free scan");
     return false;
   }

--- a/src/db/migrations/20230907143204_add_onerep_scanresults_table.js
+++ b/src/db/migrations/20230907143204_add_onerep_scanresults_table.js
@@ -61,7 +61,10 @@ export async function up(knex) {
 
   if (scanResultRows.length > 0) {
     await knex("onerep_scan_results")
-      .insert(scanResultRows);
+      .insert(scanResultRows)
+      // On Heroku, we have multiple rows with the same `onerep_scan_id`:
+      .onConflict("onerep_scan_result_id")
+      .ignore();
   }
 
 

--- a/src/db/migrations/20230907143204_add_onerep_scanresults_table.js
+++ b/src/db/migrations/20230907143204_add_onerep_scanresults_table.js
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable("onerep_scans", table => {
+    table.unique("onerep_scan_id");
+  });
+
+  await knex.schema
+    .createTable("onerep_scan_results", table => {
+      table.increments("id").primary();
+      table.integer("onerep_scan_result_id").notNullable();
+      table.integer("onerep_scan_id").references("onerep_scans.onerep_scan_id").notNullable();
+      table.string("link").notNullable();
+      table.integer("age").nullable();
+      table.string("data_broker").notNullable();
+      table.integer("data_broker_id").notNullable();
+      table.jsonb("emails").notNullable();
+      table.jsonb("phones").notNullable();
+      table.jsonb("addresses").notNullable();
+      table.jsonb("relatives").notNullable();
+      table.string("first_name").notNullable();
+      table.string("middle_name").nullable();
+      table.string("last_name").notNullable();
+      table.string("status").notNullable();
+      table.timestamp("created_at").defaultTo(knex.fn.now());
+      table.timestamp("updated_at").defaultTo(knex.fn.now());
+      table.index("onerep_scan_id");
+      table.index("onerep_scan_result_id");
+    });
+
+  const scanRows = await knex("onerep_scans")
+    .select("id", "onerep_scan_id", "onerep_scan_results");
+
+  const scanResultRows = scanRows.map(scan => {
+    return scan.onerep_scan_results.data.map(scanResult => {
+      const rowToInsert = {
+        onerep_scan_result_id: scanResult.id,
+        onerep_scan_id: scan.onerep_scan_id,
+        link: scanResult.link,
+        age: typeof scanResult.age === "string" ? Number.parseInt(scanResult.age, 10) : null,
+        data_broker: scanResult.data_broker,
+        data_broker_id: scanResult.data_broker_id,
+        emails: JSON.stringify(scanResult.emails),
+        phones: JSON.stringify(scanResult.phones),
+        addresses: JSON.stringify(scanResult.addresses),
+        relatives: JSON.stringify(scanResult.relatives),
+        first_name: scanResult.first_name,
+        middle_name: scanResult.middle_name,
+        last_name: scanResult.last_name,
+        status: scanResult.status,
+      };
+      return rowToInsert
+    });
+  }).flat();
+
+  if (scanResultRows.length > 0) {
+    await knex("onerep_scan_results")
+      .insert(scanResultRows);
+  }
+
+
+  await knex.schema.alterTable("onerep_scans", table => {
+    table.dropColumn('onerep_scan_results');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable("onerep_scans", table => {
+    table.jsonb('onerep_scan_results');
+  });
+  await knex.schema.dropTable("onerep_scan_results")
+  await knex.schema.alterTable("onerep_scans", table => {
+    table.dropUnique("onerep_scan_id");
+  });
+}

--- a/src/db/tables/onerep_profiles.ts
+++ b/src/db/tables/onerep_profiles.ts
@@ -19,7 +19,7 @@ export async function setProfileDetails(
     last_name: profileData.last_name,
     city_name: profileData.addresses[0]["city"],
     state_code: profileData.addresses[0]["state"],
-    // TODO: Validate input:
+    // TODO: MNTOR-2157 Validate input:
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     date_of_birth: parseIso8601Datetime(profileData.birth_date!)!,
     // @ts-ignore knex.fn.now() results in it being set to a date,

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -55,7 +55,7 @@ async function setOnerepManualScan(
   });
 }
 
-async function setOnerepScanResults(
+async function addOnerepScanResults(
   onerepProfileId: number,
   onerepScanId: number,
   onerepScanResults: Array<ScanResult>,
@@ -118,6 +118,6 @@ export {
   getLatestOnerepScanResults,
   setOnerepProfileId,
   setOnerepManualScan,
-  setOnerepScanResults,
+  addOnerepScanResults,
   getScansCount,
 };

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -6,50 +6,27 @@ import initKnex from "knex";
 import knexConfig from "../knexfile.js";
 import { ScanResult, Scan } from "../../app/functions/server/onerep.js";
 import { Subscriber } from "../../app/(nextjs_migration)/(authenticated)/user/breaches/breaches.js";
+import { OnerepScanResultRow, OnerepScanRow } from "knex/types/tables";
 const knex = initKnex(knexConfig);
 
-async function getOnerepScanResults(
-  onerepProfileId: number,
-  onerepScanId: number
-): Promise<ScanResult[]> {
-  return (await knex("onerep_scans")
-    .select("onerep_scan_results")
-    .where("onerep_profile_id", onerepProfileId)
-    .andWhere("onerep_scan_id", onerepScanId)) as unknown as Promise<
-    ScanResult[]
-  >;
-}
-
-export interface GetLatestOnerepScanResult {
-  onerep_scan_id: number;
-  created_at: number;
-  updated_at: number;
-  onerep_scan_results: { data: ScanResult[] } | null;
-  onerep_scan_reason: string;
-}
-
-async function getLatestOnerepScan(
+async function getLatestOnerepScanResults(
   onerepProfileId: number
-): Promise<GetLatestOnerepScanResult | null> {
-  return (
-    await knex("onerep_scans")
-      .select(
-        "onerep_scan_id",
-        "created_at",
-        "updated_at",
-        "onerep_scan_results",
-        "onerep_scan_reason"
-      )
-      .where("onerep_profile_id", onerepProfileId)
-      .orderBy("created_at", "desc")
-      .limit(1)
-  )[0] as unknown as Promise<{
-    onerep_scan_id: number;
-    created_at: number;
-    updated_at: number;
-    onerep_scan_results: { data: ScanResult[] };
-    onerep_scan_reason: Scan["reason"];
-  }>;
+): Promise<{ scan: OnerepScanRow | null; results: OnerepScanResultRow[] }> {
+  const scan = await knex("onerep_scans")
+    .first()
+    .where("onerep_profile_id", onerepProfileId)
+    .orderBy("created_at", "desc");
+
+  const results =
+    typeof scan === "undefined"
+      ? []
+      : await knex("onerep_scan_results")
+          .select()
+          .where("onerep_scan_id", scan.onerep_scan_id);
+  return {
+    scan: scan ?? null,
+    results: results,
+  };
 }
 
 async function setOnerepProfileId(
@@ -81,32 +58,49 @@ async function setOnerepManualScan(
 async function setOnerepScanResults(
   onerepProfileId: number,
   onerepScanId: number,
-  onerepScanResults: object,
+  onerepScanResults: Array<ScanResult>,
   onerepScanReason: Scan["reason"]
 ) {
-  if (onerepScanReason === "manual") {
-    // Manual scans update an existing row.
-    await knex("onerep_scans")
-      .where("onerep_profile_id", onerepProfileId)
-      .andWhere("onerep_scan_id", onerepScanId)
-      .update({
-        onerep_scan_results: onerepScanResults as ScanResult,
+  await knex.transaction(async (transaction) => {
+    if (onerepScanReason === "manual") {
+      // Manual scans update an existing scan, replacing the previous results:
+      await transaction("onerep_scan_results")
+        .delete()
+        .where("onerep_scan_id", onerepScanId);
+    } else {
+      // Initial and Monitoring scans always create a new scan:
+      await transaction("onerep_scans").insert({
+        onerep_profile_id: onerepProfileId,
+        onerep_scan_id: onerepScanId,
+        onerep_scan_reason: onerepScanReason,
         // @ts-ignore knex.fn.now() results in it being set to a date,
         // even if it's not typed as a JS date object:
-        updated_at: knex.fn.now(),
+        created_at: knex.fn.now(),
       });
-  } else {
-    // Initial and Monitoring scans always create a new row.
-    await knex("onerep_scans").insert({
-      onerep_profile_id: onerepProfileId,
-      onerep_scan_id: onerepScanId,
-      onerep_scan_results: onerepScanResults as ScanResult,
-      onerep_scan_reason: onerepScanReason,
-      // @ts-ignore knex.fn.now() results in it being set to a date,
-      // even if it's not typed as a JS date object:
-      created_at: knex.fn.now(),
-    });
-  }
+    }
+
+    await transaction("onerep_scan_results").insert(
+      onerepScanResults.map((scanResult) => ({
+        onerep_scan_result_id: scanResult.id,
+        onerep_scan_id: scanResult.scan_id,
+        link: scanResult.link,
+        age:
+          typeof scanResult.age === "string"
+            ? Number.parseInt(scanResult.age, 10)
+            : undefined,
+        data_broker: scanResult.data_broker,
+        data_broker_id: scanResult.data_broker_id,
+        emails: JSON.stringify(scanResult.emails),
+        phones: JSON.stringify(scanResult.phones),
+        addresses: JSON.stringify(scanResult.addresses),
+        relatives: JSON.stringify(scanResult.relatives),
+        first_name: scanResult.first_name,
+        middle_name: scanResult.middle_name,
+        last_name: scanResult.last_name,
+        status: scanResult.status,
+      }))
+    );
+  });
 }
 
 async function getScansCount(
@@ -121,8 +115,7 @@ async function getScansCount(
 }
 
 export {
-  getLatestOnerepScan,
-  getOnerepScanResults,
+  getLatestOnerepScanResults,
   setOnerepProfileId,
   setOnerepManualScan,
   setOnerepScanResults,

--- a/src/knex-tables.d.ts
+++ b/src/knex-tables.d.ts
@@ -3,8 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Knex } from "knex";
-import { ScanResult, Scan } from "./app/functions/server/onerep";
+import { Scan } from "./app/functions/server/onerep";
 import { StateAbbr } from "./utils/states";
+import { RemovalStatus } from "./app/functions/universal/scanResult";
 
 // See https://knexjs.org/guide/#typescript
 declare module "knex/types/tables" {
@@ -149,7 +150,6 @@ declare module "knex/types/tables" {
     id: number;
     onerep_profile_id: number;
     onerep_scan_id: number;
-    onerep_scan_results: ScanResult;
     onerep_scan_reason: Scan["reason"];
     created_at: Date;
     updated_at: Date;
@@ -160,6 +160,43 @@ declare module "knex/types/tables" {
   >;
   type OnerepScanAutoInsertedColumns = Extract<
     keyof OnerepScanRow,
+    "id" | "created_at" | "updated_at"
+  >;
+
+  interface OnerepScanResultRow {
+    id: number;
+    onerep_scan_result_id: number;
+    onerep_scan_id: OnerepScanRow["onerep_scan_id"];
+    link: string;
+    age?: number;
+    data_broker: string;
+    data_broker_id: number;
+    emails: string[];
+    phones: string[];
+    addresses: Array<{
+      city: string;
+      state: StateAbbr;
+      street?: string;
+      zip?: string;
+    }>;
+    relatives: string[];
+    first_name: string;
+    middle_name?: string;
+    last_name: string;
+    status: RemovalStatus;
+    created_at: Date;
+    updated_at: Date;
+  }
+  type OnerepScanResultOptionalColumns = Extract<
+    keyof OnerepScanResultRow,
+    "middle_name"
+  >;
+  type OnerepScanResultSerializedColumns = Extract<
+    keyof OnerepScanResultRow,
+    "emails" | "phones" | "addresses" | "relatives"
+  >;
+  type OnerepScanResultAutoInsertedColumns = Extract<
+    keyof OnerepScanResultRow,
     "id" | "created_at" | "updated_at"
   >;
 
@@ -238,6 +275,23 @@ declare module "knex/types/tables" {
       // On updates, don't allow updating the ID and created date; all other fields are optional, except updated_at:
       Partial<Omit<OnerepScanRow, "id" | "created_at">> &
         Pick<OnerepScanRow, "updated_at">
+    >;
+
+    onerep_scan_results: Knex.CompositeTableType<
+      OnerepScanResultRow,
+      // On updates, auto-generated columns cannot be set, and nullable columns are optional:
+      Omit<
+        OnerepScanResultRow,
+        | OnerepScanResultAutoInsertedColumns
+        | OnerepScanResultOptionalColumns
+        | OnerepScanResultSerializedColumns
+      > &
+        Partial<Pick<OnerepScanResultRow, OnerepScanResultOptionalColumns>> &
+        Record<OnerepScanResultSerializedColumns, string>,
+      // On updates, don't allow updating the ID and created date; all other fields are optional, except updated_at:
+      Partial<Omit<OnerepScanResultRow, "id" | "created_at">> &
+        Pick<OnerepScanResultRow, "updated_at"> &
+        Record<OnerepScanResultSerializedColumns, string>
     >;
 
     onerep_profiles: Knex.CompositeTableType<


### PR DESCRIPTION
As discussed on Slack, this removes the scan results column that contains a JSON blob from the `onerep_scans` table, and instead creates a new `onerep_scan_results` table that holds the results - this will enable us to allow the user to resolve individual scan results from a scan. In a followup PR, I'll extend that table to add a boolean `manually_resolved` column, and an API to toggle that.

Note: this builds on https://github.com/mozilla/blurts-server/pull/3367 and https://github.com/mozilla/blurts-server/pull/3373, so merging those first should allow shrinking this PR a bit.