### PR TITLE
Add API to manually mark scan results as resolved

### DIFF
--- a/src/apiMocks/mockData.ts
+++ b/src/apiMocks/mockData.ts
@@ -61,6 +61,7 @@ export function createRandomScan(
       (faker.helpers.arrayElement(
         Object.values(RemovalStatusMap)
       ) as RemovalStatus),
+    manually_resolved: faker.datatype.boolean(),
     addresses: Array.from({ length: 3 }, () => ({
       zip: faker.location.zipCode(),
       city: faker.location.city(),

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/subscribed/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/subscribed/page.tsx
@@ -20,7 +20,7 @@ import { headers } from "next/headers";
 
 export default async function Subscribed() {
   const session = await getServerSession(authOptions);
-  if (!session || !session.user || !session.user.subscriber) {
+  if (!session?.user?.subscriber) {
     throw new Error("No session");
   }
 

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/unsubscribed/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/unsubscribed/page.tsx
@@ -14,7 +14,7 @@ import { headers } from "next/headers";
 
 export default async function Unsubscribed() {
   const session = await getServerSession(authOptions);
-  if (!session || !session.user || !session.user.subscriber) {
+  if (!session?.user?.subscriber) {
     throw new Error("No session");
   }
 

--- a/src/app/api/v1/user/scan-result/[onerepScanResultId]/resolution/route.ts
+++ b/src/app/api/v1/user/scan-result/[onerepScanResultId]/resolution/route.ts
@@ -22,7 +22,7 @@ export async function POST(
   { params }: { params: { onerepScanResultId: string } }
 ): Promise<NextResponse<ResolveScanResultResponse>> {
   const session = await getServerSession(authOptions);
-  if (!session || !session.user || !session.user.subscriber) {
+  if (!session?.user?.subscriber) {
     return new NextResponse<ResolveScanResultResponse>(
       JSON.stringify({ success: false, message: "Unauthenticated" }),
       { status: 401 }

--- a/src/app/api/v1/user/scan-result/[onerepScanResultId]/resolution/route.ts
+++ b/src/app/api/v1/user/scan-result/[onerepScanResultId]/resolution/route.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+
+import { authOptions } from "../../../../../utils/auth";
+import {
+  isOnerepScanResultForSubscriber,
+  markOnerepScanResultAsResolved,
+} from "../../../../../../../db/tables/onerep_scans";
+
+export type ResolveScanResultResponse =
+  | {
+      success: true;
+    }
+  | { success: false; message: string };
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { onerepScanResultId: string } }
+): Promise<NextResponse<ResolveScanResultResponse>> {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user || !session.user.subscriber) {
+    return new NextResponse<ResolveScanResultResponse>(
+      JSON.stringify({ success: false, message: "Unauthenticated" }),
+      { status: 401 }
+    );
+  }
+
+  const scanResultId = Number.parseInt(params.onerepScanResultId, 10);
+  if (typeof scanResultId !== "number" || Number.isNaN(scanResultId)) {
+    return new NextResponse<ResolveScanResultResponse>(
+      JSON.stringify({ success: false, message: "Invalid scan result ID" }),
+      { status: 400 }
+    );
+  }
+
+  const isAllowedToResolve = await isOnerepScanResultForSubscriber({
+    onerepScanResultId: scanResultId,
+    subscriberId: session.user.subscriber.id,
+  });
+  if (!isAllowedToResolve) {
+    return new NextResponse<ResolveScanResultResponse>(
+      JSON.stringify({ success: false, message: "Invalid scan result ID" }),
+      { status: 403 }
+    );
+  }
+
+  try {
+    await markOnerepScanResultAsResolved(scanResultId);
+    return new NextResponse<ResolveScanResultResponse>(
+      JSON.stringify({ success: true }),
+      { status: 200 }
+    );
+  } catch (e) {
+    console.error(e);
+    return new NextResponse<ResolveScanResultResponse>(
+      JSON.stringify({
+        success: false,
+        message: "Something went wrong, please try again.",
+      }),
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/user/welcome-scan/create/route.ts
+++ b/src/app/api/v1/user/welcome-scan/create/route.ts
@@ -41,7 +41,7 @@ export async function POST(
   req: NextRequest
 ): Promise<NextResponse<WelcomeScanBody | unknown>> {
   const session = await getServerSession(authOptions);
-  if (!session || !session.user || !session.user.subscriber) {
+  if (!session?.user?.subscriber) {
     throw new Error("No session");
   }
 

--- a/src/db/migrations/20230908154315_add_manual_resolution_column.js
+++ b/src/db/migrations/20230908154315_add_manual_resolution_column.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  return knex.schema.alterTable("onerep_scan_results", table => {
+    table.boolean("manually_resolved").notNullable().defaultTo(false);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema.alterTable("onerep_scan_results", table => {
+    table.dropColumn("manually_resolved");
+  });
+}

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -103,6 +103,44 @@ async function addOnerepScanResults(
   });
 }
 
+async function isOnerepScanResultForSubscriber(params: {
+  onerepScanResultId: number;
+  subscriberId: number;
+}): Promise<boolean> {
+  const result = await knex("onerep_scan_results")
+    .innerJoin(
+      "onerep_scans",
+      "onerep_scan_results.onerep_scan_id",
+      "onerep_scans.onerep_scan_id"
+    )
+    .innerJoin(
+      "subscribers",
+      "onerep_scans.onerep_profile_id",
+      "subscribers.onerep_profile_id"
+    )
+    .where(
+      "onerep_scan_results.onerep_scan_result_id",
+      params.onerepScanResultId
+    )
+    .andWhere("subscribers.id", params.subscriberId)
+    .first("onerep_scan_result_id");
+
+  return typeof result?.onerep_scan_result_id === "number";
+}
+
+async function markOnerepScanResultAsResolved(
+  onerepScanResultId: number
+): Promise<void> {
+  await knex("onerep_scan_results")
+    .update({
+      manually_resolved: true,
+      // @ts-ignore knex.fn.now() results in it being set to a date,
+      // even if it's not typed as a JS date object:
+      updated_at: knex.fn.now(),
+    })
+    .where("onerep_scan_result_id", onerepScanResultId);
+}
+
 async function getScansCount(
   startDate: string,
   endDate: string,
@@ -120,4 +158,6 @@ export {
   setOnerepManualScan,
   addOnerepScanResults,
   getScansCount,
+  isOnerepScanResultForSubscriber,
+  markOnerepScanResultAsResolved,
 };

--- a/src/knex-tables.d.ts
+++ b/src/knex-tables.d.ts
@@ -184,12 +184,13 @@ declare module "knex/types/tables" {
     middle_name?: string;
     last_name: string;
     status: RemovalStatus;
+    manually_resolved: boolean;
     created_at: Date;
     updated_at: Date;
   }
   type OnerepScanResultOptionalColumns = Extract<
     keyof OnerepScanResultRow,
-    "middle_name"
+    "manually_resolved" | "middle_name"
   >;
   type OnerepScanResultSerializedColumns = Extract<
     keyof OnerepScanResultRow,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2117
Figma: N/A


<!-- When adding a new feature: -->

# Description

Note: this builds on https://github.com/mozilla/blurts-server/pull/3383.

This adds a boolean column `manually_resolved` to the table of scan results, and an API that allows the user to mark that as true.

# How to test

The client doesn't properly call it yet, but you can replace the `letsFixItBtn` inside `<ScanResultCard>` with the following, and then click the "Let's fix it" button on broker cards:

```jsx
  const letsFixItBtn = (
    <span className={styles.fixItBtn}>
      <Button variant={"primary"} onClick={(event) => {
        event.preventDefault();

        void fetch(
          `/api/v1/user/scan-result/${props.scanResult.onerep_scan_result_id}/resolution`,
          {
            method: "POST",
            credentials: "same-origin",
          }
        );
      }}>{l10n.getString("exposure-card-cta")}</Button>
    </span>
  );
```

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A (mostly DB and API code)
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege. - N/A
- [ ] All acceptance criteria are met. - N/A
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process. N/A
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage. N/A
