### PR TITLE
MNTOR-2022 fixup: revert unneeded Circle CI config changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
               auth:
                 username: $DOCKER_USER
                 password: $DOCKER_PASS
-    
+
     node_with_python:
         docker:
             - image: cimg/node:18.12.1
@@ -67,7 +67,11 @@ jobs:
             # Runs type checking:
             - run: npm run build
     deploy:
-        executor: node_with_python
+        docker:
+            - image: docker:stable-git
+              auth:
+                username: $DOCKER_USER
+                password: $DOCKER_PASS
         working_directory: /dockerflow
         steps:
             - checkout
@@ -121,7 +125,7 @@ jobs:
         # is based on:
         # https://github.com/CircleCI-Public/heroku-orb/blob/master/src/jobs/deploy-via-git.yml
         # https://github.com/CircleCI-Public/heroku-orb/blob/master/src/commands/deploy-via-git.yml
-        executor: python/default
+        executor: heroku/default
         parameters:
             app-name:
                 description: "The name of the Heroku App"


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2022
Figma: 


<!-- When adding a new feature: -->

# Description

When re-landing a5fe8c87ca4bc5111698c7804c6d56530bad649f, I accidentally re-introduced some changes to the Circle CI config that are no longer needed after testing on https://github.com/mozilla/blurts-server/pull/new/debug-deploy-with-glean

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
