### PR TITLE
Add helper function to test dashboard permutations

### DIFF
--- a/src/apiMocks/mockData.ts
+++ b/src/apiMocks/mockData.ts
@@ -61,6 +61,7 @@ export function createRandomScan(
       (faker.helpers.arrayElement(
         Object.values(RemovalStatusMap)
       ) as RemovalStatus),
+    manually_resolved: faker.datatype.boolean(),
     addresses: Array.from({ length: 3 }, () => ({
       zip: faker.location.zipCode(),
       city: faker.location.city(),

--- a/src/apiMocks/mockData.ts
+++ b/src/apiMocks/mockData.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { faker } from "@faker-js/faker";
-import { ScanResult } from "../app/functions/server/onerep";
+import { OnerepScanResultRow } from "knex/types/tables";
 import {
   RemovalStatus,
   RemovalStatusMap,
@@ -24,8 +24,7 @@ import {
 const fakerSeed = 123;
 
 // This is a full list of scan results, all pages, and would normally be
-// stored in the `onerep_scan_results.onerep_scan_results` column
-// as `jsonb`.
+// stored in the `onerep_scan_results` table.
 export function mockedOneRepScanResults() {
   faker.seed(fakerSeed);
   return {
@@ -43,17 +42,20 @@ export type RandomScanOptions = Partial<{
  * Generates scan result with randomly-generated mock data.
  *
  * @param options
- * @returns {ScanResult} - A single scan result.
+ * @returns A single scan result.
  */
-export function createRandomScan(options: RandomScanOptions = {}): ScanResult {
+export function createRandomScan(
+  options: RandomScanOptions = {}
+): OnerepScanResultRow {
   faker.seed(options.fakerSeed);
   return {
     id: faker.number.int(),
-    profile_id: faker.number.int(),
+    onerep_scan_result_id: faker.number.int(),
+    onerep_scan_id: faker.number.int(),
     first_name: faker.person.firstName(),
     last_name: faker.person.lastName(),
     middle_name: faker.person.middleName(),
-    age: faker.number.int({ min: 14, max: 120 }).toString(),
+    age: faker.number.int({ min: 14, max: 120 }),
     status:
       options.status ??
       (faker.helpers.arrayElement(
@@ -71,11 +73,8 @@ export function createRandomScan(options: RandomScanOptions = {}): ScanResult {
     link: faker.internet.url(),
     data_broker: faker.internet.domainName(),
     data_broker_id: faker.number.int(),
-    created_at:
-      options.createdDate?.toISOString() ??
-      faker.date.recent({ days: 2 }).toISOString(),
-    updated_at: faker.date.recent({ days: 1 }).toISOString(),
-    url: faker.internet.url(),
+    created_at: options.createdDate ?? faker.date.recent({ days: 2 }),
+    updated_at: faker.date.recent({ days: 1 }),
   };
 }
 

--- a/src/apiMocks/mockData.ts
+++ b/src/apiMocks/mockData.ts
@@ -127,7 +127,7 @@ export function createUserWithPremiumSubscription() {
       locale: "us",
       twoFactorAuthentication: false,
       metricsEnabled: false,
-      avatar: "",
+      avatar: "https://profile.stage.mozaws.net/v1/avatar/e",
       avatarDefault: true,
       subscriptions: ["monitor"],
     },

--- a/src/apiMocks/mockData.ts
+++ b/src/apiMocks/mockData.ts
@@ -28,14 +28,15 @@ const fakerSeed = 123;
 export function mockedOneRepScanResults() {
   faker.seed(fakerSeed);
   return {
-    data: Array.from({ length: 3 }, () => createRandomScan()),
+    data: Array.from({ length: 3 }, () => createRandomScanResult()),
   };
 }
 
-export type RandomScanOptions = Partial<{
+export type RandomScanResultOptions = Partial<{
   createdDate: Date;
   fakerSeed: number;
   status: RemovalStatus;
+  manually_resolved: boolean;
 }>;
 
 /**
@@ -44,8 +45,8 @@ export type RandomScanOptions = Partial<{
  * @param options
  * @returns A single scan result.
  */
-export function createRandomScan(
-  options: RandomScanOptions = {}
+export function createRandomScanResult(
+  options: RandomScanResultOptions = {}
 ): OnerepScanResultRow {
   faker.seed(options.fakerSeed);
   return {
@@ -61,7 +62,7 @@ export function createRandomScan(
       (faker.helpers.arrayElement(
         Object.values(RemovalStatusMap)
       ) as RemovalStatus),
-    manually_resolved: faker.datatype.boolean(),
+    manually_resolved: options.manually_resolved ?? faker.datatype.boolean(),
     addresses: Array.from({ length: 3 }, () => ({
       zip: faker.location.zipCode(),
       city: faker.location.city(),
@@ -100,11 +101,13 @@ export function createRandomBreach(
   );
 
   faker.seed(options.fakerSeed);
+  const isResolved = options.isResolved ?? faker.datatype.boolean();
   return {
     addedDate:
       options.addedDate?.toISOString() ?? faker.date.recent().toISOString(),
     breachDate: faker.date.recent().toISOString(),
     dataClasses: dataClasses,
+    resolvedDataClasses: isResolved ? dataClasses : [],
     description: faker.word.words(),
     domain: faker.internet.domainName(),
     id: faker.number.int(),
@@ -112,7 +115,7 @@ export function createRandomBreach(
     modifiedDate: faker.date.recent().toISOString(),
     name: faker.word.noun(),
     title: faker.word.noun(),
-    isResolved: options.isResolved ?? faker.datatype.boolean(),
+    isResolved: isResolved,
     dataClassesEffected: options.dataClassesEffected ?? [],
   };
 }

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
@@ -4,8 +4,8 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { OnerepScanResultRow } from "knex/types/tables";
 import { View as DashboardEl } from "./View";
-import { ScanResult } from "../../../../../functions/server/onerep";
 import { Shell } from "../../../Shell";
 import { getEnL10nSync } from "../../../../../functions/server/mockL10n";
 import {
@@ -63,7 +63,7 @@ const BreachMockItem4: SubscriberBreach = createRandomBreach({
   ],
 });
 
-const scannedResultsArraySample: ScanResult[] = [
+const scannedResultsArraySample: OnerepScanResultRow[] = [
   createRandomScan({ status: "removed" }),
   createRandomScan({ status: "waiting_for_verification" }),
   createRandomScan({ status: "optout_in_progress" }),
@@ -71,7 +71,7 @@ const scannedResultsArraySample: ScanResult[] = [
   createRandomScan(),
 ];
 
-const scannedResolvedResultsArraySample: ScanResult[] = Array.from(
+const scannedResolvedResultsArraySample: OnerepScanResultRow[] = Array.from(
   { length: 5 },
   () => createRandomScan({ status: "removed" })
 );

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
@@ -13,398 +13,381 @@ import {
   createRandomBreach,
   createUserWithPremiumSubscription,
 } from "../../../../../../apiMocks/mockData";
-import { DashboardSummary } from "../../../../../functions/server/dashboard";
 import { SubscriberBreach } from "../../../../../../utils/subscriberBreaches";
+import { LatestOnerepScanData } from "../../../../../../db/tables/onerep_scans";
 
-const meta: Meta<typeof DashboardEl> = {
+type DashboardWrapperProps = (
+  | {
+      countryCode: "us";
+      brokers: "no-scan" | "empty" | "unresolved" | "resolved";
+      premium: boolean;
+    }
+  | {
+      countryCode: "nl";
+    }
+) & { breaches: "empty" | "unresolved" | "resolved" };
+const DashboardWrapper = (props: DashboardWrapperProps) => {
+  const mockedResolvedBreach: SubscriberBreach = createRandomBreach({
+    dataClasses: ["email-addresses", "ip-addresses", "phone-numbers"],
+    addedDate: new Date("2023-06-18T14:48:00.000Z"),
+    dataClassesEffected: [
+      { "email-addresses": ["email1@gmail.com", "email2@gmail.com"] },
+      { "ip-addresses": 1 },
+      { "phone-numbers": 1 },
+      { passwords: 1 },
+    ],
+    isResolved: true,
+  });
+
+  const mockedUnresolvedBreach: SubscriberBreach = createRandomBreach({
+    dataClasses: ["email-addresses", "ip-addresses", "phone-numbers"],
+    addedDate: new Date("2023-06-18T14:48:00.000Z"),
+    dataClassesEffected: [
+      { "email-addresses": ["email1@gmail.com", "email2@gmail.com"] },
+      { "ip-addresses": 1 },
+    ],
+    isResolved: false,
+  });
+
+  let breaches: SubscriberBreach[] = [];
+  if (props.breaches === "resolved") {
+    breaches = [mockedResolvedBreach];
+  }
+  if (props.breaches === "unresolved") {
+    breaches = [mockedResolvedBreach, mockedUnresolvedBreach];
+  }
+
+  const mockedScan: OnerepScanRow = {
+    created_at: new Date(1998, 2, 31),
+    updated_at: new Date(1998, 2, 31),
+    id: 0,
+    onerep_profile_id: 0,
+    onerep_scan_id: 0,
+    onerep_scan_reason: "initial",
+  };
+
+  const mockedResolvedScanResults: OnerepScanResultRow[] = [
+    createRandomScanResult({ status: "removed" }),
+    createRandomScanResult({ status: "waiting_for_verification" }),
+    createRandomScanResult({ status: "optout_in_progress" }),
+  ];
+
+  const mockedUnresolvedScanResults: OnerepScanResultRow[] = [
+    ...mockedResolvedScanResults,
+    createRandomScanResult({ status: "new", manually_resolved: false }),
+    createRandomScanResult({ status: "new", manually_resolved: true }),
+  ];
+
+  const scanData: LatestOnerepScanData = { scan: null, results: [] };
+
+  if (props.countryCode === "us") {
+    if (props.brokers !== "no-scan") {
+      scanData.scan = mockedScan;
+
+      if (props.brokers === "resolved") {
+        scanData.results = mockedResolvedScanResults;
+      }
+      if (props.brokers === "unresolved") {
+        scanData.results = mockedUnresolvedScanResults;
+      }
+    }
+  }
+
+  const user =
+    props.countryCode === "us" && props.premium
+      ? createUserWithPremiumSubscription()
+      : { email: "example@example.com" };
+
+  const mockedSession = {
+    expires: new Date().toISOString(),
+    user: user,
+  };
+
+  return (
+    <Shell l10n={getEnL10nSync()} session={mockedSession}>
+      <DashboardEl
+        countryCode={props.countryCode}
+        user={user}
+        userBreaches={breaches}
+        userScanData={scanData}
+        isEligibleForFreeScan={props.countryCode === "us"}
+        locale={"en"}
+        featureFlagsEnabled={{
+          FreeBrokerScan: true,
+          PremiumBrokerRemoval: true,
+        }}
+      />
+    </Shell>
+  );
+};
+
+const meta: Meta<typeof DashboardWrapper> = {
   title: "Pages/Dashboard",
-  component: DashboardEl,
+  component: DashboardWrapper,
 };
 export default meta;
-type Story = StoryObj<typeof DashboardEl>;
+type Story = StoryObj<typeof DashboardWrapper>;
 
-const BreachMockItem1: SubscriberBreach = createRandomBreach({
-  dataClasses: ["email-addresses", "ip-addresses", "phone-numbers"],
-  addedDate: new Date("2023-06-18T14:48:00.000Z"),
-  dataClassesEffected: [
-    { "email-addresses": ["email1@gmail.com", "email2@gmail.com"] },
-    { "ip-addresses": 1 },
-    { "phone-numbers": 1 },
-    { passwords: 1 },
-  ],
-  isResolved: true,
-});
-
-const BreachMockItem2: SubscriberBreach = createRandomBreach({
-  dataClasses: ["email-addresses", "ip-addresses", "phone-numbers"],
-  addedDate: new Date("2023-06-18T14:48:00.000Z"),
-  dataClassesEffected: [
-    { "email-addresses": ["email1@gmail.com", "email2@gmail.com"] },
-    { "ip-addresses": 1 },
-  ],
-  isResolved: false,
-});
-
-const BreachMockItem3: SubscriberBreach = createRandomBreach({
-  dataClasses: ["email-addresses", "ip-addresses", "phone-numbers"],
-  addedDate: new Date("2023-06-18T14:48:00.000Z"),
-  dataClassesEffected: [
-    { "email-addresses": ["email1@gmail.com", "email2@gmail.com"] },
-    { "ip-addresses": 1 },
-  ],
-});
-
-const BreachMockItem4: SubscriberBreach = createRandomBreach({
-  dataClasses: ["email-addresses", "ip-addresses", "phone-numbers"],
-  addedDate: new Date("2023-06-18T14:48:00.000Z"),
-  dataClassesEffected: [
-    { "email-addresses": ["email1@gmail.com", "email2@gmail.com"] },
-    { "ip-addresses": 1 },
-  ],
-});
-
-const scanSample: OnerepScanRow = {
-  created_at: new Date(1998, 2, 31),
-  updated_at: new Date(1998, 2, 31),
-  id: 0,
-  onerep_profile_id: 0,
-  onerep_scan_id: 0,
-  onerep_scan_reason: "initial",
-};
-
-const scannedResultsArraySample: OnerepScanResultRow[] = [
-  createRandomScanResult({ status: "removed" }),
-  createRandomScanResult({ status: "waiting_for_verification" }),
-  createRandomScanResult({ status: "optout_in_progress" }),
-  createRandomScanResult({ status: "new", manually_resolved: false }),
-  createRandomScanResult({ status: "new", manually_resolved: true }),
-];
-
-const scannedResolvedResultsArraySample: OnerepScanResultRow[] = Array.from(
-  { length: 5 },
-  () => createRandomScanResult({ status: "removed" })
-);
-
-const breachItemArraySample: SubscriberBreach[] = [
-  BreachMockItem1,
-  BreachMockItem2,
-  BreachMockItem3,
-  BreachMockItem4,
-];
-
-const dashboardSummaryNoScan: DashboardSummary = {
-  dataBreachTotalNum: 20,
-  dataBreachFixedNum: 0,
-  dataBrokerFixedNum: 0,
-  dataBrokerInProgressNum: 0,
-  dataBrokerTotalNum: 0,
-  totalExposures: 51,
-  allExposures: {
-    emailAddresses: 30,
-    phoneNumbers: 19,
-    addresses: 0,
-    familyMembers: 0,
-    fullNames: 0,
-    socialSecurityNumbers: 2,
-    ipAddresses: 0,
-    passwords: 0,
-    creditCardNumbers: 0,
-    pins: 0,
-    securityQuestions: 0,
-    bankAccountNumbers: 0,
-  },
-  fixedExposures: {
-    emailAddresses: 0,
-    phoneNumbers: 0,
-    addresses: 0,
-    familyMembers: 0,
-    fullNames: 0,
-    socialSecurityNumbers: 0,
-    ipAddresses: 0,
-    passwords: 0,
-    creditCardNumbers: 0,
-    pins: 0,
-    securityQuestions: 0,
-    bankAccountNumbers: 0,
-  },
-  sanitizedExposures: [
-    { "email-addresses": 30 },
-    { "phone-numbers": 19 },
-    { "social-security-numbers": 2 },
-  ],
-  fixedSanitizedExposures: [],
-};
-
-const dashboardSummaryWithScan: DashboardSummary = {
-  dataBreachTotalNum: 88,
-  dataBrokerTotalNum: 217,
-  dataBreachFixedNum: 0,
-  dataBrokerFixedNum: 0,
-  dataBrokerInProgressNum: 0,
-  totalExposures: 1000,
-  allExposures: {
-    emailAddresses: 0,
-    phoneNumbers: 8,
-    addresses: 90,
-    familyMembers: 29,
-    fullNames: 98,
-    socialSecurityNumbers: 0,
-    ipAddresses: 0,
-    passwords: 0,
-    creditCardNumbers: 40,
-    pins: 0,
-    securityQuestions: 40,
-    bankAccountNumbers: 0,
-  },
-  sanitizedExposures: [
-    { "physical-addresses": 90 },
-    { "family-members-names": 29 },
-    { "full-name": 98 },
-    { "phone-numbers": 8 },
-    { "other-data-class": 80 },
-  ],
-  fixedExposures: {
-    emailAddresses: 0,
-    phoneNumbers: 0,
-    addresses: 0,
-    familyMembers: 0,
-    fullNames: 0,
-    socialSecurityNumbers: 0,
-    ipAddresses: 0,
-    passwords: 0,
-    creditCardNumbers: 0,
-    pins: 0,
-    securityQuestions: 0,
-    bankAccountNumbers: 0,
-  },
-  fixedSanitizedExposures: [],
-};
-
-const mockSession = {
-  expires: new Date().toISOString(),
-  user: { email: "example@example.com" },
-};
-
-export const DashboardWithScan: Story = {
-  render: () => (
-    <Shell l10n={getEnL10nSync()} session={mockSession}>
-      <DashboardEl
-        countryCode="nl"
-        user={mockSession.user}
-        userBreaches={breachItemArraySample}
-        userScanData={{ scan: scanSample, results: scannedResultsArraySample }}
-        isEligibleForFreeScan={false}
-        locale={"en"}
-        bannerData={dashboardSummaryWithScan}
-        featureFlagsEnabled={{
-          FreeBrokerScan: true,
-          PremiumBrokerRemoval: true,
-        }}
-      />
-    </Shell>
-  ),
-};
-
-export const DashboardWithScanUserFromUs: Story = {
-  name: "Dashboard with scan, user from US",
-  render: () => (
-    <Shell l10n={getEnL10nSync()} session={mockSession}>
-      <DashboardEl
-        countryCode="us"
-        user={mockSession.user}
-        userBreaches={breachItemArraySample}
-        userScanData={{ scan: scanSample, results: scannedResultsArraySample }}
-        isEligibleForFreeScan={true}
-        locale={"en"}
-        bannerData={dashboardSummaryWithScan}
-        featureFlagsEnabled={{
-          FreeBrokerScan: true,
-          PremiumBrokerRemoval: true,
-        }}
-      />
-    </Shell>
-  ),
-};
-
-export const DashboardWithoutScan: Story = {
-  name: "Dashboard without scan",
-  render: () => (
-    <Shell l10n={getEnL10nSync()} session={mockSession}>
-      <DashboardEl
-        countryCode="nl"
-        user={mockSession.user}
-        userBreaches={breachItemArraySample}
-        userScanData={{ scan: null, results: [] }}
-        isEligibleForFreeScan={false}
-        locale={"en"}
-        bannerData={dashboardSummaryNoScan}
-        featureFlagsEnabled={{
-          FreeBrokerScan: true,
-          PremiumBrokerRemoval: true,
-        }}
-      />
-    </Shell>
-  ),
-};
-
-export const DashboardWithoutScanUserFromUs: Story = {
-  name: "Dashboard without scan, user from US",
-  render: () => (
-    <Shell l10n={getEnL10nSync()} session={mockSession}>
-      <DashboardEl
-        countryCode="us"
-        user={{ email: "example@example.com" }}
-        userBreaches={breachItemArraySample}
-        userScanData={{ scan: null, results: [] }}
-        isEligibleForFreeScan={true}
-        locale={"en"}
-        bannerData={dashboardSummaryNoScan}
-        featureFlagsEnabled={{
-          FreeBrokerScan: true,
-          PremiumBrokerRemoval: true,
-        }}
-      />
-    </Shell>
-  ),
-};
-
-export const DashboardEmptyListState: Story = {
-  render: () => (
-    <Shell l10n={getEnL10nSync()} session={mockSession}>
-      <DashboardEl
-        countryCode="us"
-        user={mockSession.user}
-        userBreaches={breachItemArraySample}
-        userScanData={{ scan: null, results: [] }}
-        isEligibleForFreeScan={true}
-        locale={"en"}
-        bannerData={dashboardSummaryNoScan}
-        featureFlagsEnabled={{
-          FreeBrokerScan: true,
-          PremiumBrokerRemoval: true,
-        }}
-      />
-    </Shell>
-  ),
-};
-
-export const DashboardFreeUser: Story = {
-  render: () => (
-    <Shell l10n={getEnL10nSync()} session={mockSession}>
-      <DashboardEl
-        countryCode="us"
-        user={{ email: "example@example.com" }}
-        userBreaches={breachItemArraySample}
-        userScanData={{ scan: scanSample, results: scannedResultsArraySample }}
-        isEligibleForFreeScan={true}
-        locale={"en"}
-        bannerData={dashboardSummaryWithScan}
-        featureFlagsEnabled={{
-          FreeBrokerScan: true,
-          PremiumBrokerRemoval: true,
-        }}
-      />
-    </Shell>
-  ),
-};
-
-export const DashboardFreeUserAllResolved: Story = {
-  render: () => (
-    <Shell l10n={getEnL10nSync()} session={mockSession}>
-      <DashboardEl
-        countryCode="us"
-        user={{ email: "example@example.com" }}
-        userBreaches={[]}
-        userScanData={{
-          scan: scanSample,
-          results: scannedResolvedResultsArraySample,
-        }}
-        isEligibleForFreeScan={true}
-        locale={"en"}
-        bannerData={dashboardSummaryWithScan}
-        featureFlagsEnabled={{
-          FreeBrokerScan: true,
-          PremiumBrokerRemoval: true,
-        }}
-      />
-    </Shell>
-  ),
-};
-
-export const DashboardPremiumUser: Story = {
-  render: () => {
-    const userData = createUserWithPremiumSubscription();
-    return (
-      <Shell
-        l10n={getEnL10nSync()}
-        session={{ ...mockSession, user: userData }}
-      >
-        <DashboardEl
-          countryCode="us"
-          user={userData}
-          userBreaches={breachItemArraySample}
-          userScanData={{
-            scan: scanSample,
-            results: scannedResultsArraySample,
-          }}
-          isEligibleForFreeScan={true}
-          locale={"en"}
-          bannerData={dashboardSummaryWithScan}
-          featureFlagsEnabled={{
-            FreeBrokerScan: true,
-            PremiumBrokerRemoval: true,
-          }}
-        />
-      </Shell>
-    );
+export const DashboardNonUsNoBreaches: Story = {
+  name: "Non-US user, with 0 breaches",
+  args: {
+    countryCode: "nl",
+    breaches: "empty",
   },
 };
 
-export const DashboardPremiumUserAllResolved: Story = {
-  render: () => {
-    const userData = createUserWithPremiumSubscription();
-    return (
-      <Shell
-        l10n={getEnL10nSync()}
-        session={{ ...mockSession, user: userData }}
-      >
-        <DashboardEl
-          countryCode="us"
-          user={userData}
-          userBreaches={[]}
-          userScanData={{
-            scan: scanSample,
-            results: scannedResolvedResultsArraySample,
-          }}
-          isEligibleForFreeScan={true}
-          locale={"en"}
-          bannerData={dashboardSummaryWithScan}
-          featureFlagsEnabled={{
-            FreeBrokerScan: true,
-            PremiumBrokerRemoval: true,
-          }}
-        />
-      </Shell>
-    );
+export const DashboardNonUsUnresolvedBreaches: Story = {
+  name: "Non-US user, with unresolved breaches",
+  args: {
+    countryCode: "nl",
+    breaches: "unresolved",
   },
 };
 
-export const DashboardNoSession: Story = {
-  render: () => (
-    <Shell l10n={getEnL10nSync()} session={null}>
-      <DashboardEl
-        countryCode="us"
-        user={{ email: "example@example.com" }}
-        userBreaches={breachItemArraySample}
-        userScanData={{ scan: scanSample, results: scannedResultsArraySample }}
-        isEligibleForFreeScan={false}
-        locale={"en"}
-        bannerData={dashboardSummaryWithScan}
-        featureFlagsEnabled={{
-          FreeBrokerScan: true,
-          PremiumBrokerRemoval: true,
-        }}
-      />
-    </Shell>
-  ),
+export const DashboardNonUsResolvedBreaches: Story = {
+  name: "Non-US user, with all breaches resolved",
+  args: {
+    countryCode: "nl",
+    breaches: "resolved",
+  },
+};
+
+export const DashboardUsNoPremiumNoScanNoBreaches: Story = {
+  name: "US user, without Premium, without scan, with 0 breaches",
+  args: {
+    countryCode: "us",
+    premium: false,
+    breaches: "empty",
+    brokers: "no-scan",
+  },
+};
+
+export const DashboardUsNoPremiumNoScanUnresolvedBreaches: Story = {
+  name: "US user, without Premium, without scan, with unresolved breaches",
+  args: {
+    countryCode: "us",
+    premium: false,
+    breaches: "unresolved",
+    brokers: "no-scan",
+  },
+};
+
+export const DashboardUsNoPremiumNoScanResolvedBreaches: Story = {
+  name: "US user, without Premium, without scan, with all breaches resolved",
+  args: {
+    countryCode: "us",
+    premium: false,
+    breaches: "resolved",
+    brokers: "no-scan",
+  },
+};
+
+export const DashboardUsNoPremiumEmptyScanNoBreaches: Story = {
+  name: "US user, without Premium, with 0 scan results, with 0 breaches",
+  args: {
+    countryCode: "us",
+    premium: false,
+    breaches: "empty",
+    brokers: "empty",
+  },
+};
+
+export const DashboardUsNoPremiumEmptyScanUnresolvedBreaches: Story = {
+  name: "US user, without Premium, with 0 scan results, with unresolved breaches",
+  args: {
+    countryCode: "us",
+    premium: false,
+    breaches: "unresolved",
+    brokers: "empty",
+  },
+};
+
+export const DashboardUsNoPremiumEmptyScanResolvedBreaches: Story = {
+  name: "US user, without Premium, with 0 scan results, with all breaches resolved",
+  args: {
+    countryCode: "us",
+    premium: false,
+    breaches: "resolved",
+    brokers: "empty",
+  },
+};
+
+export const DashboardUsNoPremiumUnresolvedScanNoBreaches: Story = {
+  name: "US user, without Premium, with unresolved scan results, with 0 breaches",
+  args: {
+    countryCode: "us",
+    premium: false,
+    breaches: "empty",
+    brokers: "unresolved",
+  },
+};
+
+export const DashboardUsNoPremiumUnresolvedScanUnresolvedBreaches: Story = {
+  name: "US user, without Premium, with unresolved scan results, with unresolved breaches",
+  args: {
+    countryCode: "us",
+    premium: false,
+    breaches: "unresolved",
+    brokers: "unresolved",
+  },
+};
+
+export const DashboardUsNoPremiumUnresolvedScanResolvedBreaches: Story = {
+  name: "US user, without Premium, with unresolved scan results, with all breaches resolved",
+  args: {
+    countryCode: "us",
+    premium: false,
+    breaches: "resolved",
+    brokers: "unresolved",
+  },
+};
+
+export const DashboardUsNoPremiumResolvedScanNoBreaches: Story = {
+  name: "US user, without Premium, with all scan results resolved, with 0 breaches",
+  args: {
+    countryCode: "us",
+    premium: false,
+    breaches: "empty",
+    brokers: "resolved",
+  },
+};
+
+export const DashboardUsNoPremiumResolvedScanUnresolvedBreaches: Story = {
+  name: "US user, without Premium, with all scan results resolved, with unresolved breaches",
+  args: {
+    countryCode: "us",
+    premium: false,
+    breaches: "unresolved",
+    brokers: "resolved",
+  },
+};
+
+export const DashboardUsNoPremiumResolvedScanResolvedBreaches: Story = {
+  name: "US user, without Premium, with all scan results resolved, with all breaches resolved",
+  args: {
+    countryCode: "us",
+    premium: false,
+    breaches: "resolved",
+    brokers: "resolved",
+  },
+};
+
+export const DashboardUsPremiumNoScanNoBreaches: Story = {
+  name: "US user, with Premium, without scan, with 0 breaches",
+  args: {
+    countryCode: "us",
+    premium: true,
+    breaches: "empty",
+    brokers: "no-scan",
+  },
+};
+
+export const DashboardUsPremiumNoScanUnresolvedBreaches: Story = {
+  name: "US user, with Premium, without scan, with unresolved breaches",
+  args: {
+    countryCode: "us",
+    premium: true,
+    breaches: "unresolved",
+    brokers: "no-scan",
+  },
+};
+
+export const DashboardUsPremiumNoScanResolvedBreaches: Story = {
+  name: "US user, with Premium, without scan, with all breaches resolved",
+  args: {
+    countryCode: "us",
+    premium: true,
+    breaches: "resolved",
+    brokers: "no-scan",
+  },
+};
+
+export const DashboardUsPremiumEmptyScanNoBreaches: Story = {
+  name: "US user, with Premium, with 0 scan results, with 0 breaches",
+  args: {
+    countryCode: "us",
+    premium: true,
+    breaches: "empty",
+    brokers: "empty",
+  },
+};
+
+export const DashboardUsPremiumEmptyScanUnresolvedBreaches: Story = {
+  name: "US user, with Premium, with 0 scan results, with unresolved breaches",
+  args: {
+    countryCode: "us",
+    premium: true,
+    breaches: "unresolved",
+    brokers: "empty",
+  },
+};
+
+export const DashboardUsPremiumEmptyScanResolvedBreaches: Story = {
+  name: "US user, with Premium, with 0 scan results, with all breaches resolved",
+  args: {
+    countryCode: "us",
+    premium: true,
+    breaches: "resolved",
+    brokers: "empty",
+  },
+};
+
+export const DashboardUsPremiumUnresolvedScanNoBreaches: Story = {
+  name: "US user, with Premium, with unresolved scan results, with 0 breaches",
+  args: {
+    countryCode: "us",
+    premium: true,
+    breaches: "empty",
+    brokers: "unresolved",
+  },
+};
+
+export const DashboardUsPremiumUnresolvedScanUnresolvedBreaches: Story = {
+  name: "US user, with Premium, with unresolved scan results, with unresolved breaches",
+  args: {
+    countryCode: "us",
+    premium: true,
+    breaches: "unresolved",
+    brokers: "unresolved",
+  },
+};
+
+export const DashboardUsPremiumUnresolvedScanResolvedBreaches: Story = {
+  name: "US user, with Premium, with unresolved scan results, with all breaches resolved",
+  args: {
+    countryCode: "us",
+    premium: true,
+    breaches: "resolved",
+    brokers: "unresolved",
+  },
+};
+
+export const DashboardUsPremiumResolvedScanNoBreaches: Story = {
+  name: "US user, with Premium, with all scan results resolved, with 0 breaches",
+  args: {
+    countryCode: "us",
+    premium: true,
+    breaches: "empty",
+    brokers: "resolved",
+  },
+};
+
+export const DashboardUsPremiumResolvedScanUnresolvedBreaches: Story = {
+  name: "US user, with Premium, with all scan results resolved, with unresolved breaches",
+  args: {
+    countryCode: "us",
+    premium: true,
+    breaches: "unresolved",
+    brokers: "resolved",
+  },
+};
+
+export const DashboardUsPremiumResolvedScanResolvedBreaches: Story = {
+  name: "US user, with Premium, with all scan results resolved, with all breaches resolved",
+  args: {
+    countryCode: "us",
+    premium: true,
+    breaches: "resolved",
+    brokers: "resolved",
+  },
 };

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
@@ -16,16 +16,27 @@ import {
 import { SubscriberBreach } from "../../../../../../utils/subscriberBreaches";
 import { LatestOnerepScanData } from "../../../../../../db/tables/onerep_scans";
 
+const brokerOptions = {
+  "no-scan": "No scan started",
+  empty: "No scan results",
+  unresolved: "With unresolved scan results",
+  resolved: "All scan results resolved",
+};
+const breachOptions = {
+  empty: "No data breaches",
+  unresolved: "With unresolved data breaches",
+  resolved: "All data breaches resolved",
+};
 type DashboardWrapperProps = (
   | {
       countryCode: "us";
-      brokers: "no-scan" | "empty" | "unresolved" | "resolved";
+      brokers: keyof typeof brokerOptions;
       premium: boolean;
     }
   | {
       countryCode: "nl";
     }
-) & { breaches: "empty" | "unresolved" | "resolved" };
+) & { breaches: keyof typeof breachOptions };
 const DashboardWrapper = (props: DashboardWrapperProps) => {
   const mockedResolvedBreach: SubscriberBreach = createRandomBreach({
     dataClasses: ["email-addresses", "ip-addresses", "phone-numbers"],
@@ -124,6 +135,23 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
 const meta: Meta<typeof DashboardWrapper> = {
   title: "Pages/Dashboard",
   component: DashboardWrapper,
+  argTypes: {
+    brokers: {
+      options: Object.keys(brokerOptions),
+      description: "Scan results",
+      control: {
+        type: "radio",
+        labels: brokerOptions,
+      },
+    },
+    breaches: {
+      options: Object.keys(breachOptions),
+      control: {
+        type: "radio",
+        labels: breachOptions,
+      },
+    },
+  },
 };
 export default meta;
 type Story = StoryObj<typeof DashboardWrapper>;

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
@@ -16,13 +16,13 @@ import {
 import { SubscriberBreach } from "../../../../../../utils/subscriberBreaches";
 import { LatestOnerepScanData } from "../../../../../../db/tables/onerep_scans";
 
-const brokerOptions = {
+export const brokerOptions = {
   "no-scan": "No scan started",
   empty: "No scan results",
   unresolved: "With unresolved scan results",
   resolved: "All scan results resolved",
 };
-const breachOptions = {
+export const breachOptions = {
   empty: "No data breaches",
   unresolved: "With unresolved data breaches",
   resolved: "All data breaches resolved",

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
@@ -4,12 +4,12 @@
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { OnerepScanResultRow } from "knex/types/tables";
+import { OnerepScanResultRow, OnerepScanRow } from "knex/types/tables";
 import { View as DashboardEl } from "./View";
 import { Shell } from "../../../Shell";
 import { getEnL10nSync } from "../../../../../functions/server/mockL10n";
 import {
-  createRandomScan,
+  createRandomScanResult,
   createRandomBreach,
   createUserWithPremiumSubscription,
 } from "../../../../../../apiMocks/mockData";
@@ -63,17 +63,26 @@ const BreachMockItem4: SubscriberBreach = createRandomBreach({
   ],
 });
 
+const scanSample: OnerepScanRow = {
+  created_at: new Date(1998, 2, 31),
+  updated_at: new Date(1998, 2, 31),
+  id: 0,
+  onerep_profile_id: 0,
+  onerep_scan_id: 0,
+  onerep_scan_reason: "initial",
+};
+
 const scannedResultsArraySample: OnerepScanResultRow[] = [
-  createRandomScan({ status: "removed" }),
-  createRandomScan({ status: "waiting_for_verification" }),
-  createRandomScan({ status: "optout_in_progress" }),
-  createRandomScan({ status: "new" }),
-  createRandomScan(),
+  createRandomScanResult({ status: "removed" }),
+  createRandomScanResult({ status: "waiting_for_verification" }),
+  createRandomScanResult({ status: "optout_in_progress" }),
+  createRandomScanResult({ status: "new", manually_resolved: false }),
+  createRandomScanResult({ status: "new", manually_resolved: true }),
 ];
 
 const scannedResolvedResultsArraySample: OnerepScanResultRow[] = Array.from(
   { length: 5 },
-  () => createRandomScan({ status: "removed" })
+  () => createRandomScanResult({ status: "removed" })
 );
 
 const breachItemArraySample: SubscriberBreach[] = [
@@ -180,9 +189,10 @@ export const DashboardWithScan: Story = {
   render: () => (
     <Shell l10n={getEnL10nSync()} session={mockSession}>
       <DashboardEl
+        countryCode="nl"
         user={mockSession.user}
         userBreaches={breachItemArraySample}
-        userScannedResults={scannedResultsArraySample}
+        userScanData={{ scan: scanSample, results: scannedResultsArraySample }}
         isEligibleForFreeScan={false}
         locale={"en"}
         bannerData={dashboardSummaryWithScan}
@@ -203,7 +213,7 @@ export const DashboardWithScanUserFromUs: Story = {
         countryCode="us"
         user={mockSession.user}
         userBreaches={breachItemArraySample}
-        userScannedResults={scannedResultsArraySample}
+        userScanData={{ scan: scanSample, results: scannedResultsArraySample }}
         isEligibleForFreeScan={true}
         locale={"en"}
         bannerData={dashboardSummaryWithScan}
@@ -221,9 +231,10 @@ export const DashboardWithoutScan: Story = {
   render: () => (
     <Shell l10n={getEnL10nSync()} session={mockSession}>
       <DashboardEl
+        countryCode="nl"
         user={mockSession.user}
         userBreaches={breachItemArraySample}
-        userScannedResults={[]}
+        userScanData={{ scan: null, results: [] }}
         isEligibleForFreeScan={false}
         locale={"en"}
         bannerData={dashboardSummaryNoScan}
@@ -241,9 +252,10 @@ export const DashboardWithoutScanUserFromUs: Story = {
   render: () => (
     <Shell l10n={getEnL10nSync()} session={mockSession}>
       <DashboardEl
+        countryCode="us"
         user={{ email: "example@example.com" }}
         userBreaches={breachItemArraySample}
-        userScannedResults={[]}
+        userScanData={{ scan: null, results: [] }}
         isEligibleForFreeScan={true}
         locale={"en"}
         bannerData={dashboardSummaryNoScan}
@@ -260,9 +272,10 @@ export const DashboardEmptyListState: Story = {
   render: () => (
     <Shell l10n={getEnL10nSync()} session={mockSession}>
       <DashboardEl
+        countryCode="us"
         user={mockSession.user}
         userBreaches={breachItemArraySample}
-        userScannedResults={[]}
+        userScanData={{ scan: null, results: [] }}
         isEligibleForFreeScan={true}
         locale={"en"}
         bannerData={dashboardSummaryNoScan}
@@ -282,7 +295,7 @@ export const DashboardFreeUser: Story = {
         countryCode="us"
         user={{ email: "example@example.com" }}
         userBreaches={breachItemArraySample}
-        userScannedResults={scannedResultsArraySample}
+        userScanData={{ scan: scanSample, results: scannedResultsArraySample }}
         isEligibleForFreeScan={true}
         locale={"en"}
         bannerData={dashboardSummaryWithScan}
@@ -302,7 +315,10 @@ export const DashboardFreeUserAllResolved: Story = {
         countryCode="us"
         user={{ email: "example@example.com" }}
         userBreaches={[]}
-        userScannedResults={scannedResolvedResultsArraySample}
+        userScanData={{
+          scan: scanSample,
+          results: scannedResolvedResultsArraySample,
+        }}
         isEligibleForFreeScan={true}
         locale={"en"}
         bannerData={dashboardSummaryWithScan}
@@ -327,7 +343,39 @@ export const DashboardPremiumUser: Story = {
           countryCode="us"
           user={userData}
           userBreaches={breachItemArraySample}
-          userScannedResults={scannedResultsArraySample}
+          userScanData={{
+            scan: scanSample,
+            results: scannedResultsArraySample,
+          }}
+          isEligibleForFreeScan={true}
+          locale={"en"}
+          bannerData={dashboardSummaryWithScan}
+          featureFlagsEnabled={{
+            FreeBrokerScan: true,
+            PremiumBrokerRemoval: true,
+          }}
+        />
+      </Shell>
+    );
+  },
+};
+
+export const DashboardPremiumUserAllResolved: Story = {
+  render: () => {
+    const userData = createUserWithPremiumSubscription();
+    return (
+      <Shell
+        l10n={getEnL10nSync()}
+        session={{ ...mockSession, user: userData }}
+      >
+        <DashboardEl
+          countryCode="us"
+          user={userData}
+          userBreaches={[]}
+          userScanData={{
+            scan: scanSample,
+            results: scannedResolvedResultsArraySample,
+          }}
           isEligibleForFreeScan={true}
           locale={"en"}
           bannerData={dashboardSummaryWithScan}
@@ -348,7 +396,7 @@ export const DashboardNoSession: Story = {
         countryCode="us"
         user={{ email: "example@example.com" }}
         userBreaches={breachItemArraySample}
-        userScannedResults={scannedResultsArraySample}
+        userScanData={{ scan: scanSample, results: scannedResultsArraySample }}
         isEligibleForFreeScan={false}
         locale={"en"}
         bannerData={dashboardSummaryWithScan}

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
@@ -104,10 +104,10 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
     }
   }
 
-  const user =
-    props.countryCode === "us" && props.premium
-      ? createUserWithPremiumSubscription()
-      : { email: "example@example.com" };
+  const user = createUserWithPremiumSubscription();
+  if (props.countryCode !== "us" || !props.premium) {
+    user.fxa.subscriptions = [];
+  }
 
   const mockedSession = {
     expires: new Date().toISOString(),

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
@@ -16,6 +16,7 @@ import Meta, {
   DashboardPremiumUser,
   DashboardNoSession,
   DashboardFreeUserAllResolved,
+  DashboardPremiumUserAllResolved,
 } from "./Dashboard.stories";
 
 function enablePremium() {
@@ -226,4 +227,27 @@ it("shows returned free user who has resolved all tasks premium upsell and all f
   // click on cta
   await user.click(bannerPremiumCta[0]);
   expect(screen.getByRole("dialog")).toBeInTheDocument();
+});
+
+it("shows a returning Premium user who has resolved all tasks a CTA to check out what was fixed", async () => {
+  enablePremium();
+  const user = userEvent.setup();
+  const ComposedDashboard = composeStory(DashboardPremiumUserAllResolved, Meta);
+  render(<ComposedDashboard />);
+
+  // We show a CTA on desktop in the toolbar and in the mobile menu
+  const premiumBadges = screen.queryAllByText("Premium");
+  expect(premiumBadges.length).toBe(2);
+
+  // show banner CTA premium upgrade
+  const bannerPremiumCta = screen.queryAllByRole("button", {
+    name: "See what’s fixed",
+  });
+  expect(bannerPremiumCta.length).toBe(1);
+
+  // click on cta
+  await user.click(bannerPremiumCta[0]);
+
+  const fixedTab = screen.getByRole("tab", { name: "Fixed" });
+  expect(fixedTab).toHaveAttribute("aria-selected", "true");
 });

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
@@ -8,15 +8,13 @@ import userEvent from "@testing-library/user-event";
 import { composeStory } from "@storybook/react";
 import { axe } from "jest-axe";
 import Meta, {
-  DashboardWithScan,
-  DashboardWithScanUserFromUs,
-  DashboardWithoutScan,
-  DashboardWithoutScanUserFromUs,
-  DashboardFreeUser,
-  DashboardPremiumUser,
-  DashboardNoSession,
-  DashboardFreeUserAllResolved,
-  DashboardPremiumUserAllResolved,
+  DashboardNonUsNoBreaches,
+  DashboardUsNoPremiumNoScanNoBreaches,
+  DashboardUsNoPremiumResolvedScanResolvedBreaches,
+  DashboardUsNoPremiumUnresolvedScanNoBreaches,
+  DashboardUsNoPremiumUnresolvedScanUnresolvedBreaches,
+  DashboardUsPremiumNoScanNoBreaches,
+  DashboardUsPremiumResolvedScanResolvedBreaches,
 } from "./Dashboard.stories";
 
 function enablePremium() {
@@ -41,25 +39,34 @@ jest.mock("next/navigation", () => ({
 }));
 
 it("passes the axe accessibility test suite 1", async () => {
-  const ComposedDashboard = composeStory(DashboardWithScan, Meta);
+  const ComposedDashboard = composeStory(DashboardNonUsNoBreaches, Meta);
   const { container } = render(<ComposedDashboard />);
   expect(await axe(container)).toHaveNoViolations();
 });
 
 it("passes the axe accessibility test suite 2", async () => {
-  const ComposedDashboard = composeStory(DashboardWithScanUserFromUs, Meta);
+  const ComposedDashboard = composeStory(
+    DashboardUsNoPremiumUnresolvedScanUnresolvedBreaches,
+    Meta
+  );
   const { container } = render(<ComposedDashboard />);
   expect(await axe(container)).toHaveNoViolations();
 });
 
 it("passes the axe accessibility test suite 3", async () => {
-  const ComposedDashboard = composeStory(DashboardWithoutScanUserFromUs, Meta);
+  const ComposedDashboard = composeStory(
+    DashboardUsPremiumResolvedScanResolvedBreaches,
+    Meta
+  );
   const { container } = render(<ComposedDashboard />);
   expect(await axe(container)).toHaveNoViolations();
 });
 
 it("shows the “let’s fix it” banner content", () => {
-  const ComposedDashboard = composeStory(DashboardWithScanUserFromUs, Meta);
+  const ComposedDashboard = composeStory(
+    DashboardUsNoPremiumUnresolvedScanNoBreaches,
+    Meta
+  );
   render(<ComposedDashboard />);
 
   const letsFixItBannerContent = screen.getByText("Let’s protect your data");
@@ -67,7 +74,10 @@ it("shows the “let’s fix it” banner content", () => {
 });
 
 it("shows the 'Start a free scan' CTA to free US-based users who haven't performed a scan yet", () => {
-  const ComposedDashboard = composeStory(DashboardWithoutScanUserFromUs, Meta);
+  const ComposedDashboard = composeStory(
+    DashboardUsNoPremiumNoScanNoBreaches,
+    Meta
+  );
   render(<ComposedDashboard />);
 
   const freeScanCta = screen.getByRole("link", { name: "Start a free scan" });
@@ -75,7 +85,7 @@ it("shows the 'Start a free scan' CTA to free US-based users who haven't perform
 });
 
 it("does not show the 'Start a free scan' CTA for non-US users", () => {
-  const ComposedDashboard = composeStory(DashboardWithoutScan, Meta);
+  const ComposedDashboard = composeStory(DashboardNonUsNoBreaches, Meta);
   render(<ComposedDashboard />);
 
   const freeScanCta = screen.queryByRole("link", { name: "Start a free scan" });
@@ -84,7 +94,10 @@ it("does not show the 'Start a free scan' CTA for non-US users", () => {
 
 it("switches between tab panels", async () => {
   const user = userEvent.setup();
-  const ComposedDashboard = composeStory(DashboardWithoutScanUserFromUs, Meta);
+  const ComposedDashboard = composeStory(
+    DashboardUsNoPremiumNoScanNoBreaches,
+    Meta
+  );
   render(<ComposedDashboard />);
 
   const tabActionNeededTrigger = screen.getByRole("tab", {
@@ -103,7 +116,10 @@ it("switches between tab panels", async () => {
 
 it("shows the premium upgrade cta if the user is not a premium subscriber", () => {
   enablePremium();
-  const ComposedDashboard = composeStory(DashboardFreeUser, Meta);
+  const ComposedDashboard = composeStory(
+    DashboardUsNoPremiumNoScanNoBreaches,
+    Meta
+  );
   render(<ComposedDashboard />);
 
   // We show a CTA on desktop in the toolbar and in the mobile menu
@@ -116,7 +132,10 @@ it("shows the premium upgrade cta if the user is not a premium subscriber", () =
 it("opens and closes the premium upsell dialog", async () => {
   enablePremium();
   const user = userEvent.setup();
-  const ComposedDashboard = composeStory(DashboardFreeUser, Meta);
+  const ComposedDashboard = composeStory(
+    DashboardUsNoPremiumNoScanNoBreaches,
+    Meta
+  );
   render(<ComposedDashboard />);
 
   // We show a CTA on desktop in the toolbar and in the mobile menu
@@ -151,7 +170,10 @@ it("opens and closes the premium upsell dialog", async () => {
 it("toggles between the product offerings in the premium upsell dialog", async () => {
   enablePremium();
   const user = userEvent.setup();
-  const ComposedDashboard = composeStory(DashboardFreeUser, Meta);
+  const ComposedDashboard = composeStory(
+    DashboardUsNoPremiumNoScanNoBreaches,
+    Meta
+  );
   render(<ComposedDashboard />);
 
   // We show a CTA on desktop in the toolbar and in the mobile menu
@@ -186,7 +208,10 @@ it("toggles between the product offerings in the premium upsell dialog", async (
 
 it("shows the premium badge if the user is a premium subscriber", () => {
   enablePremium();
-  const ComposedDashboard = composeStory(DashboardPremiumUser, Meta);
+  const ComposedDashboard = composeStory(
+    DashboardUsPremiumNoScanNoBreaches,
+    Meta
+  );
   render(<ComposedDashboard />);
 
   // We show a CTA on desktop in the toolbar and in the mobile menu
@@ -194,22 +219,13 @@ it("shows the premium badge if the user is a premium subscriber", () => {
   expect(premiumBadges.length).toBe(2);
 });
 
-it("shows the premium upgrade cta if there is no user session", () => {
-  enablePremium();
-  const ComposedDashboard = composeStory(DashboardNoSession, Meta);
-  render(<ComposedDashboard />);
-
-  // We show a CTA on desktop in the toolbar and in the mobile menu
-  const premiumCtas = screen.queryAllByRole("button", {
-    name: "Upgrade to ⁨Premium⁩",
-  });
-  expect(premiumCtas.length).toBe(2);
-});
-
 it("shows returned free user who has resolved all tasks premium upsell and all fixed description", async () => {
   enablePremium();
   const user = userEvent.setup();
-  const ComposedDashboard = composeStory(DashboardFreeUserAllResolved, Meta);
+  const ComposedDashboard = composeStory(
+    DashboardUsNoPremiumResolvedScanResolvedBreaches,
+    Meta
+  );
   render(<ComposedDashboard />);
 
   // We show a CTA on desktop in the toolbar and in the mobile menu
@@ -232,7 +248,10 @@ it("shows returned free user who has resolved all tasks premium upsell and all f
 it("shows a returning Premium user who has resolved all tasks a CTA to check out what was fixed", async () => {
   enablePremium();
   const user = userEvent.setup();
-  const ComposedDashboard = composeStory(DashboardPremiumUserAllResolved, Meta);
+  const ComposedDashboard = composeStory(
+    DashboardUsPremiumResolvedScanResolvedBreaches,
+    Meta
+  );
   render(<ComposedDashboard />);
 
   // We show a CTA on desktop in the toolbar and in the mobile menu

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
@@ -15,6 +15,7 @@ import Meta, {
   DashboardUsNoPremiumUnresolvedScanUnresolvedBreaches,
   DashboardUsPremiumNoScanNoBreaches,
   DashboardUsPremiumResolvedScanResolvedBreaches,
+  DashboardUsPremiumResolvedScanUnresolvedBreaches,
 } from "./Dashboard.stories";
 
 function enablePremium() {
@@ -55,7 +56,7 @@ it("passes the axe accessibility test suite 2", async () => {
 
 it("passes the axe accessibility test suite 3", async () => {
   const ComposedDashboard = composeStory(
-    DashboardUsPremiumResolvedScanResolvedBreaches,
+    DashboardUsPremiumResolvedScanUnresolvedBreaches,
     Meta
   );
   const { container } = render(<ComposedDashboard />);

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner.tsx
@@ -9,8 +9,12 @@ import { useL10n } from "../../../../../hooks/l10n";
 import { DoughnutChart as Chart } from "../../../../../components/client/Chart";
 import { ProgressCard } from "../../../../../components/client/ProgressCard";
 import { DashboardSummary } from "../../../../../functions/server/dashboard";
-import { useRouter } from "next/navigation";
 import PremiumButton from "../../../../../components/client/PremiumButton";
+import {
+  InputData as StepDeterminationData,
+  getRelevantGuidedSteps,
+} from "../../../../../functions/server/getRelevantGuidedSteps";
+import { hasPremium } from "../../../../../functions/universal/user";
 
 export type BannerContent =
   | "LetsFixDataContent"
@@ -24,23 +28,18 @@ export type BannerContent =
 export type DashboardTopBannerProps = {
   content: BannerContent;
   bannerData: DashboardSummary;
+  stepDeterminationData: StepDeterminationData;
   hasRunScan: boolean;
   isEligibleForFreeScan: boolean;
   type: TabType;
-  ctaCallback?: () => void;
+  onShowFixed: () => void;
 };
 
 export const DashboardTopBanner = (props: DashboardTopBannerProps) => {
   const l10n = useL10n();
-  const router = useRouter();
 
-  const isFixedTab = props.type === "fixed";
-  const { totalExposures, dataBrokerFixedNum, dataBreachFixedNum } =
-    props.bannerData;
-
-  const chartDataKey = isFixedTab
-    ? "fixedSanitizedExposures"
-    : "sanitizedExposures";
+  const chartDataKey =
+    props.type === "fixed" ? "fixedSanitizedExposures" : "sanitizedExposures";
   const chartData: [string, number][] = props.bannerData[chartDataKey].map(
     (obj) => {
       const [key, value] = Object.entries(obj)[0];
@@ -48,189 +47,16 @@ export const DashboardTopBanner = (props: DashboardTopBannerProps) => {
     }
   );
 
-  const dataBrokerCount = parseInt(
-    process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
-    10
-  );
-
-  const contentData = {
-    LetsFixDataContent: {
-      headline: l10n.getString("dashboard-top-banner-protect-your-data-title"),
-      description: l10n.getString(
-        "dashboard-top-banner-protect-your-data-description",
-        {
-          data_breach_total_num: props.bannerData.dataBreachTotalNum,
-          data_broker_total_num: props.bannerData.dataBrokerTotalNum,
-        }
-      ),
-      cta: (
-        <Button
-          href={
-            "/redesign/user/dashboard/fix/data-broker-profiles/view-data-brokers"
-          }
-          small
-          variant="primary"
-        >
-          {l10n.getString("dashboard-top-banner-protect-your-data-cta")}
-        </Button>
-      ),
-      learnMore: null,
-    },
-    DataBrokerScanUpsellContent: {
-      headline: l10n.getString(
-        "dashboard-top-banner-monitor-protects-your-even-more-title"
-      ),
-      description: l10n.getString(
-        "dashboard-top-banner-monitor-protects-your-even-more-description",
-        {
-          data_broker_sites_total_num: dataBrokerCount,
-        }
-      ),
-      cta: (
-        <Button
-          // Ignored for test coverage; to be implemented:
-          /* c8 ignore next 3 */
-          onClick={() => {
-            router.push("/redesign/user/welcome");
-          }}
-          small
-          variant="primary"
-        >
-          {l10n.getString(
-            "dashboard-top-banner-monitor-protects-your-even-more-cta"
-          )}
-        </Button>
-      ),
-      learnMore: (
-        <a href="https://mozilla.org/products/monitor/how-it-works/">
-          {l10n.getString(
-            "dashboard-top-banner-monitor-protects-your-even-more-learn-more"
-          )}
-        </a>
-      ),
-    },
-    NoExposuresFoundContent: {
-      headline: l10n.getString("dashboard-top-banner-no-exposures-found-title"),
-      description: l10n.getString(
-        "dashboard-top-banner-no-exposures-found-description",
-        {
-          data_broker_sites_total_num: dataBrokerCount,
-        }
-      ),
-      cta: (
-        <Button
-          // Ignored for test coverage; to be implemented:
-          /* c8 ignore next 3 */
-          onClick={() => {
-            // do something
-          }}
-          small
-          variant="primary"
-        >
-          {l10n.getString("dashboard-top-banner-no-exposures-found-cta")}
-        </Button>
-      ),
-      learnMore: null,
-    },
-    ResumeBreachResolutionContent: {
-      headline: l10n.getString(
-        "dashboard-top-banner-lets-keep-protecting-title"
-      ),
-      description: l10n.getString(
-        "dashboard-top-banner-lets-keep-protecting-description",
-        {
-          remaining_exposures_total_num: totalExposures - dataBrokerFixedNum,
-        }
-      ),
-      cta: (
-        <Button
-          // Ignored for test coverage; to be implemented:
-          /* c8 ignore next 3 */
-          onClick={() => {
-            // do something
-          }}
-          small
-          variant="primary"
-        >
-          {l10n.getString("dashboard-top-banner-lets-keep-protecting-cta")}
-        </Button>
-      ),
-      learnMore: null,
-    },
-    YourDataIsProtectedContent: {
-      headline: l10n.getString(
-        "dashboard-top-banner-your-data-is-protected-title"
-      ),
-      description: l10n.getString(
-        "dashboard-top-banner-your-data-is-protected-description",
-        {
-          starting_exposure_total_num: totalExposures,
-        }
-      ),
-      cta: (
-        <Button
-          // Ignored for test coverage; to be implemented:
-          /* c8 ignore next 3 */
-          onClick={() => {
-            props?.ctaCallback?.();
-          }}
-          small
-          variant="primary"
-        >
-          {l10n.getString("dashboard-top-banner-your-data-is-protected-cta")}
-        </Button>
-      ),
-      learnMore: null,
-    },
-    YourDataIsProtectedAllFixedContent: {
-      headline: l10n.getString(
-        "dashboard-top-banner-your-data-is-protected-title"
-      ),
-      description: l10n.getString(
-        "dashboard-top-banner-your-data-is-protected-all-fixed-description",
-        {
-          starting_exposure_total_num: totalExposures,
-        }
-      ),
-      cta: (
-        <PremiumButton
-          label={"dashboard-top-banner-your-data-is-protected-all-fixed-cta"}
-        />
-      ),
-      learnMore: null,
-    },
-    NoContent: null,
-  };
-
-  const content = contentData[props.content];
-
   return (
     <>
       <div className={styles.container}>
         <div className={styles.explainerContentWrapper}>
-          {content && !isFixedTab && (
-            <div className={styles.explainerContent}>
-              <h3>{content.headline}</h3>
-              <p>{content.description}</p>
-              {
-                // TODO: Add unit test when changing this code:
-                /* c8 ignore next 4 */
-                content.cta ? (
-                  <span className={styles.cta}>{content.cta}</span>
-                ) : (
-                  ""
-                )
-              }
-              {content.learnMore ? <p>{content.learnMore}</p> : ""}
-            </div>
-          )}
-          {isFixedTab && (
-            <ProgressCard
-              resolvedByYou={dataBreachFixedNum}
-              autoRemoved={dataBrokerFixedNum}
-              totalNumExposures={totalExposures}
-            />
-          )}
+          <Content
+            bannerData={props.bannerData}
+            isOnFixedTab={props.type === "fixed"}
+            onShowFixed={props.onShowFixed}
+            stepDeterminationData={props.stepDeterminationData}
+          />
         </div>
         <div className={styles.chart}>
           <Chart
@@ -241,5 +67,222 @@ export const DashboardTopBanner = (props: DashboardTopBannerProps) => {
         </div>
       </div>
     </>
+  );
+};
+
+const Content = (props: {
+  stepDeterminationData: StepDeterminationData;
+  bannerData: DashboardSummary;
+  isOnFixedTab: boolean;
+  onShowFixed: () => void;
+}) => {
+  const l10n = useL10n();
+
+  if (props.isOnFixedTab) {
+    return (
+      <ProgressCard
+        resolvedByYou={props.bannerData.dataBreachFixedNum}
+        autoRemoved={props.bannerData.dataBrokerFixedNum}
+        totalNumExposures={props.bannerData.totalExposures}
+      />
+    );
+  }
+
+  const relevantGuidedStep = getRelevantGuidedSteps(
+    props.stepDeterminationData
+  ).current;
+
+  // There should be a relevant next step for every user (even if it's just
+  // going back to the dashbord), so we can't hit this line in tests (and
+  // shouldn't be able to in production either):
+  /* c8 ignore next 3 */
+  if (relevantGuidedStep === null) {
+    return null;
+  }
+
+  const dataBrokerCount = parseInt(
+    process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
+    10
+  );
+
+  if (relevantGuidedStep.id === "StartScan") {
+    // If the user hasn't run a data broker scan yet (and is able to),
+    // encourage them to run one:
+    return (
+      <div className={styles.explainerContent}>
+        <h3>
+          {l10n.getString(
+            "dashboard-top-banner-monitor-protects-your-even-more-title"
+          )}
+        </h3>
+        <p>
+          {l10n.getString(
+            "dashboard-top-banner-monitor-protects-your-even-more-description",
+            {
+              data_broker_sites_total_num: dataBrokerCount,
+            }
+          )}
+        </p>
+        <div className={styles.cta}>
+          <Button href={relevantGuidedStep.href} small variant="primary">
+            {l10n.getString(
+              "dashboard-top-banner-monitor-protects-your-even-more-cta"
+            )}
+          </Button>
+        </div>
+        <p>
+          <a href="https://mozilla.org/products/monitor/how-it-works/">
+            {l10n.getString(
+              "dashboard-top-banner-monitor-protects-your-even-more-learn-more"
+            )}
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  if (relevantGuidedStep.id === "ScanResult") {
+    if (
+      typeof props.stepDeterminationData.latestScanData?.results.length ===
+        "number" &&
+      props.stepDeterminationData.latestScanData.results.length > 0
+    ) {
+      // If the user has run a data broker scan, their data was found at a data
+      // broker, and they have not yet addressed that, encourage them to do that:
+      return (
+        <div className={styles.explainerContent}>
+          <h3>
+            {l10n.getString("dashboard-top-banner-protect-your-data-title")}
+          </h3>
+          <p>
+            {l10n.getString(
+              "dashboard-top-banner-protect-your-data-description",
+              {
+                data_breach_total_num: props.bannerData.dataBreachTotalNum,
+                data_broker_total_num: props.bannerData.dataBrokerTotalNum,
+              }
+            )}
+          </p>
+          <div className={styles.cta}>
+            <Button href={relevantGuidedStep.href} small variant="primary">
+              {l10n.getString("dashboard-top-banner-protect-your-data-cta")}
+            </Button>
+          </div>
+        </div>
+      );
+      // The V8 coverage reporter appears to get confused by the `ignore start`
+      // below, and think this closing bracket is ignored as well:
+      /* c8 ignore next 2 */
+    }
+
+    /* c8 ignore start */
+    // If the user has run a data broker scan, but their data was not found,
+    // congratulate them and encourage them to see their results.
+    // TODO: Check with PM - this state is currently never shown, because users
+    //       are directed to their data breaches if they have no unresolved data
+    //       brokers. Should we be keeping track of the user "acknowledging"
+    //       their scan results or something?
+    return (
+      <div className={styles.explainerContent}>
+        <h3>
+          {l10n.getString("dashboard-top-banner-no-exposures-found-title")}
+        </h3>
+        <p>
+          {l10n.getString(
+            "dashboard-top-banner-no-exposures-found-description",
+            {
+              data_broker_sites_total_num: dataBrokerCount,
+            }
+          )}
+        </p>
+        <div className={styles.cta}>
+          <Button href={relevantGuidedStep.href} small variant="primary">
+            {l10n.getString("dashboard-top-banner-no-exposures-found-cta")}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+  /* c8 ignore stop */
+
+  if (relevantGuidedStep.id === "Done") {
+    if (hasPremium(props.stepDeterminationData.user)) {
+      return (
+        <div className={styles.explainerContent}>
+          <h3>
+            {l10n.getString(
+              "dashboard-top-banner-your-data-is-protected-title"
+            )}
+          </h3>
+          <p>
+            {l10n.getString(
+              "dashboard-top-banner-your-data-is-protected-description",
+              {
+                starting_exposure_total_num: props.bannerData.totalExposures,
+              }
+            )}
+          </p>
+          <div className={styles.cta}>
+            <Button
+              onPress={() => {
+                props.onShowFixed();
+              }}
+              small
+              variant="primary"
+            >
+              {l10n.getString(
+                "dashboard-top-banner-your-data-is-protected-cta"
+              )}
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className={styles.explainerContent}>
+        <h3>
+          {l10n.getString("dashboard-top-banner-your-data-is-protected-title")}
+        </h3>
+        <p>
+          {l10n.getString(
+            "dashboard-top-banner-your-data-is-protected-all-fixed-description",
+            {
+              starting_exposure_total_num: props.bannerData.totalExposures,
+            }
+          )}
+        </p>
+        <div className={styles.cta}>
+          <PremiumButton
+            label={"dashboard-top-banner-your-data-is-protected-all-fixed-cta"}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // If the user was halfway through the resolution wizard,
+  // encourage them to pick up where they left off:
+  return (
+    <div className={styles.explainerContent}>
+      <h3>
+        {l10n.getString("dashboard-top-banner-lets-keep-protecting-title")}
+      </h3>
+      <p>
+        {l10n.getString(
+          "dashboard-top-banner-lets-keep-protecting-description",
+          {
+            remaining_exposures_total_num:
+              props.bannerData.totalExposures -
+              props.bannerData.dataBrokerFixedNum,
+          }
+        )}
+      </p>
+      <div className={styles.cta}>
+        <Button href={relevantGuidedStep.href} small variant="primary">
+          {l10n.getString("dashboard-top-banner-lets-keep-protecting-cta")}
+        </Button>
+      </div>
+    </div>
   );
 };

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -7,6 +7,7 @@
 import { Key, useState } from "react";
 import Image from "next/image";
 import { Session } from "next-auth";
+import { OnerepScanResultRow } from "knex/types/tables";
 import styles from "./View.module.scss";
 import { Toolbar } from "../../../../../components/client/toolbar/Toolbar";
 import { BannerContent, DashboardTopBanner } from "./DashboardTopBanner";
@@ -20,7 +21,6 @@ import {
   ExposuresFilter,
   FilterState,
 } from "../../../../../components/client/ExposuresFilter";
-import { ScanResult } from "../../../../../functions/server/onerep";
 import { DashboardSummary } from "../../../../../functions/server/dashboard";
 import { getExposureStatus } from "../../../../../components/server/StatusPill";
 import { TabList } from "../../../../../components/client/TabList";
@@ -39,7 +39,7 @@ export type Props = {
   locale: string;
   user: Session["user"];
   userBreaches: SubscriberBreach[];
-  userScannedResults: ScanResult[];
+  userScannedResults: OnerepScanResultRow[];
   isEligibleForFreeScan: boolean;
   countryCode?: string;
 };
@@ -70,20 +70,18 @@ export const View = (props: Props) => {
   const breachesDataArray = props.userBreaches
     .map((elem: SubscriberBreach) => elem)
     .flat();
-  const scannedResultsDataArray =
-    // TODO: Add unit test when changing this code:
-    /* c8 ignore next */
-    props.userScannedResults.map((elem: ScanResult) => elem) || [];
 
   // Merge exposure cards
-  const combinedArray = [...breachesDataArray, ...scannedResultsDataArray];
+  const combinedArray = [...breachesDataArray, ...props.userScannedResults];
 
   // Sort in descending order
   const arraySortedByDate = combinedArray.sort((a, b) => {
     const dateA =
-      (a as SubscriberBreach).addedDate || (a as ScanResult).created_at;
+      (a as SubscriberBreach).addedDate ||
+      (a as OnerepScanResultRow).created_at;
     const dateB =
-      (b as SubscriberBreach).addedDate || (b as ScanResult).created_at;
+      (b as SubscriberBreach).addedDate ||
+      (b as OnerepScanResultRow).created_at;
 
     const timestampA = new Date(dateA).getTime();
     const timestampB = new Date(dateB).getTime();

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -199,7 +199,7 @@ export const View = (props: Props) => {
         <TabList
           tabs={tabsData}
           onSelectionChange={(selectedKey) => setSelectedTab(selectedKey)}
-          defaultSelectedKey={selectedTab}
+          selectedKey={selectedTab}
         />
       </Toolbar>
       <div className={styles.dashboardContent}>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -21,7 +21,7 @@ import {
   ExposuresFilter,
   FilterState,
 } from "../../../../../components/client/ExposuresFilter";
-import { DashboardSummary } from "../../../../../functions/server/dashboard";
+import { getDashboardSummary } from "../../../../../functions/server/dashboard";
 import { getExposureStatus } from "../../../../../components/server/StatusPill";
 import { TabList } from "../../../../../components/client/TabList";
 import AllFixedLogo from "./images/dashboard-all-fixed.svg";
@@ -32,7 +32,6 @@ import { hasPremium } from "../../../../../functions/universal/user";
 import { LatestOnerepScanData } from "../../../../../../db/tables/onerep_scans";
 
 export type Props = {
-  bannerData: DashboardSummary;
   featureFlagsEnabled: Pick<
     FeatureFlagsEnabled,
     "FreeBrokerScan" | "PremiumBrokerRemoval"
@@ -120,7 +119,7 @@ export const View = (props: Props) => {
 
   const TabContentActionNeeded = () => {
     const { dataBreachTotalNum, dataBrokerTotalNum, totalExposures } =
-      props.bannerData;
+      getDashboardSummary(props.userScanData.results, props.userBreaches);
     return (
       <>
         <h2 className={styles.exposuresAreaHeadline}>
@@ -203,7 +202,10 @@ export const View = (props: Props) => {
       </Toolbar>
       <div className={styles.dashboardContent}>
         <DashboardTopBanner
-          bannerData={props.bannerData}
+          bannerData={getDashboardSummary(
+            props.userScanData.results,
+            props.userBreaches
+          )}
           stepDeterminationData={{
             countryCode: props.countryCode,
             latestScanData: props.userScanData,

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -29,6 +29,7 @@ import { FeatureFlagsEnabled } from "../../../../../functions/server/featureFlag
 import { filterExposures } from "./filterExposures";
 import { SubscriberBreach } from "../../../../../../utils/subscriberBreaches";
 import { hasPremium } from "../../../../../functions/universal/user";
+import { LatestOnerepScanData } from "../../../../../../db/tables/onerep_scans";
 
 export type Props = {
   bannerData: DashboardSummary;
@@ -39,9 +40,9 @@ export type Props = {
   locale: string;
   user: Session["user"];
   userBreaches: SubscriberBreach[];
-  userScannedResults: OnerepScanResultRow[];
+  userScanData: LatestOnerepScanData;
   isEligibleForFreeScan: boolean;
-  countryCode?: string;
+  countryCode: string;
 };
 
 export type TabType = "action-needed" | "fixed";
@@ -67,12 +68,10 @@ export const View = (props: Props) => {
   ];
   const isActionNeededTab = selectedTab === "action-needed";
 
-  const breachesDataArray = props.userBreaches
-    .map((elem: SubscriberBreach) => elem)
-    .flat();
+  const breachesDataArray = props.userBreaches.flat();
 
   // Merge exposure cards
-  const combinedArray = [...breachesDataArray, ...props.userScannedResults];
+  const combinedArray = [...breachesDataArray, ...props.userScanData.results];
 
   // Sort in descending order
   const arraySortedByDate = combinedArray.sort((a, b) => {
@@ -116,7 +115,7 @@ export const View = (props: Props) => {
       </li>
     );
   });
-  const isScanResultItemsEmpty = props.userScannedResults.length === 0;
+  const isScanResultItemsEmpty = props.userScanData.results.length === 0;
   const noUnresolvedExposures = exposureCardElems.length === 0;
 
   const TabContentActionNeeded = () => {
@@ -205,13 +204,17 @@ export const View = (props: Props) => {
       <div className={styles.dashboardContent}>
         <DashboardTopBanner
           bannerData={props.bannerData}
+          stepDeterminationData={{
+            countryCode: props.countryCode,
+            latestScanData: props.userScanData,
+            subscriberBreaches: props.userBreaches,
+            user: props.user,
+          }}
           content={contentType}
           type={selectedTab as TabType}
           hasRunScan={!isScanResultItemsEmpty}
           isEligibleForFreeScan={props.isEligibleForFreeScan}
-          // TODO: Add unit test when changing this code:
-          /* c8 ignore next 3 */
-          ctaCallback={() => {
+          onShowFixed={() => {
             setSelectedTab("fixed");
           }}
         />

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/filterExposures.test.ts
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/filterExposures.test.ts
@@ -5,7 +5,7 @@
 import { it, expect } from "@jest/globals";
 import {
   createRandomBreach,
-  createRandomScan,
+  createRandomScanResult,
 } from "../../../../../../apiMocks/mockData";
 import { filterExposures } from "./filterExposures";
 
@@ -29,19 +29,19 @@ const breachOld = createRandomBreach({
   addedDate: getDateDaysAgo(1000),
 });
 
-const scanResultThisWeek = createRandomScan({
+const scanResultThisWeek = createRandomScanResult({
   fakerSeed: 1234,
   createdDate: getDateDaysAgo(2),
 });
-const scanResultThisMonth = createRandomScan({
+const scanResultThisMonth = createRandomScanResult({
   fakerSeed: 1234,
   createdDate: getDateDaysAgo(10),
 });
-const scanResultThisYear = createRandomScan({
+const scanResultThisYear = createRandomScanResult({
   fakerSeed: 1234,
   createdDate: getDateDaysAgo(100),
 });
-const scanResultOld = createRandomScan({
+const scanResultOld = createRandomScanResult({
   fakerSeed: 1234,
   createdDate: getDateDaysAgo(1000),
 });

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/view-data-brokers/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/view-data-brokers/page.tsx
@@ -7,7 +7,7 @@ import buttonStyles from "../../../../../../../../components/server/button.modul
 import styles from "../dataBrokerProfiles.module.scss";
 import { getL10n } from "../../../../../../../../functions/server/l10n";
 import { DataBrokerProfiles } from "../../../../../../../../components/client/DataBrokerProfiles";
-import { getLatestOnerepScan } from "../../../../../../../../../db/tables/onerep_scans";
+import { getLatestOnerepScanResults } from "../../../../../../../../../db/tables/onerep_scans";
 import { getServerSession } from "next-auth";
 import { authOptions } from "../../../../../../../../api/utils/auth";
 import { getOnerepProfileId } from "../../../../../../../../../db/tables/subscribers";
@@ -24,11 +24,10 @@ export default async function ViewDataBrokers() {
 
   const result = await getOnerepProfileId(session.user.subscriber.id);
   const profileId = result[0]["onerep_profile_id"] as number;
-  const scanResult = await getLatestOnerepScan(profileId);
-  const scanResultItems = scanResult?.onerep_scan_results?.data ?? [];
+  const latestScan = await getLatestOnerepScanResults(profileId);
 
   // TODO: Use api to set/query count
-  const countOfDataBrokerProfiles = scanResultItems.length;
+  const countOfDataBrokerProfiles = latestScan.results.length;
 
   return (
     <div>
@@ -52,7 +51,7 @@ export default async function ViewDataBrokers() {
           )}
           <AboutBrokersIcon />
         </h4>
-        <DataBrokerProfiles data={scanResultItems} />
+        <DataBrokerProfiles data={latestScan.results} />
       </div>
       <div className={styles.buttonsWrapper}>
         <Link

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
@@ -12,7 +12,7 @@ import { getCountryCode } from "../../../../../functions/server/getCountryCode";
 import { getSubscriberBreaches } from "../../../../../functions/server/getUserBreaches";
 import { getLocale } from "../../../../../functions/server/l10n";
 import { canSubscribeToPremium } from "../../../../../functions/universal/user";
-import { getLatestOnerepScan } from "../../../../../../db/tables/onerep_scans";
+import { getLatestOnerepScanResults } from "../../../../../../db/tables/onerep_scans";
 import { getOnerepProfileId } from "../../../../../../db/tables/subscribers";
 
 import { isFlagEnabled } from "../../../../../functions/server/featureFlags";
@@ -35,10 +35,9 @@ export default async function DashboardPage() {
     return redirect("/redesign/user/welcome/");
   }
 
-  const scanResult = await getLatestOnerepScan(profileId);
-  const scanResultItems = scanResult?.onerep_scan_results?.data ?? [];
+  const latestScan = await getLatestOnerepScanResults(profileId);
   const subBreaches = await getSubscriberBreaches(session.user);
-  const summary = dashboardSummary(scanResultItems, subBreaches);
+  const summary = dashboardSummary(latestScan.results, subBreaches);
   const locale = getLocale();
 
   const userIsEligibleForFreeScan = await isEligibleForFreeScan(
@@ -58,7 +57,7 @@ export default async function DashboardPage() {
       countryCode={countryCode}
       user={session.user}
       isEligibleForFreeScan={userIsEligibleForFreeScan}
-      userScannedResults={scanResultItems}
+      userScannedResults={latestScan.results}
       userBreaches={subBreaches}
       locale={locale}
       bannerData={summary}

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
@@ -57,7 +57,7 @@ export default async function DashboardPage() {
       countryCode={countryCode}
       user={session.user}
       isEligibleForFreeScan={userIsEligibleForFreeScan}
-      userScannedResults={latestScan.results}
+      userScanData={latestScan}
       userBreaches={subBreaches}
       locale={locale}
       bannerData={summary}

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
@@ -7,7 +7,7 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { View } from "./View";
 import { authOptions } from "../../../../../api/utils/auth";
-import { dashboardSummary } from "../../../../../functions/server/dashboard";
+import { getDashboardSummary } from "../../../../../functions/server/dashboard";
 import { getCountryCode } from "../../../../../functions/server/getCountryCode";
 import { getSubscriberBreaches } from "../../../../../functions/server/getUserBreaches";
 import { getLocale } from "../../../../../functions/server/l10n";
@@ -37,7 +37,7 @@ export default async function DashboardPage() {
 
   const latestScan = await getLatestOnerepScanResults(profileId);
   const subBreaches = await getSubscriberBreaches(session.user);
-  const summary = dashboardSummary(latestScan.results, subBreaches);
+  const summary = getDashboardSummary(latestScan.results, subBreaches);
   const locale = getLocale();
 
   const userIsEligibleForFreeScan = await isEligibleForFreeScan(

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
@@ -7,7 +7,6 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { View } from "./View";
 import { authOptions } from "../../../../../api/utils/auth";
-import { getDashboardSummary } from "../../../../../functions/server/dashboard";
 import { getCountryCode } from "../../../../../functions/server/getCountryCode";
 import { getSubscriberBreaches } from "../../../../../functions/server/getUserBreaches";
 import { getLocale } from "../../../../../functions/server/l10n";
@@ -37,7 +36,6 @@ export default async function DashboardPage() {
 
   const latestScan = await getLatestOnerepScanResults(profileId);
   const subBreaches = await getSubscriberBreaches(session.user);
-  const summary = getDashboardSummary(latestScan.results, subBreaches);
   const locale = getLocale();
 
   const userIsEligibleForFreeScan = await isEligibleForFreeScan(
@@ -60,7 +58,6 @@ export default async function DashboardPage() {
       userScanData={latestScan}
       userBreaches={subBreaches}
       locale={locale}
-      bannerData={summary}
       featureFlagsEnabled={featureFlagsEnabled}
     />
   );

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/subscribed/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/subscribed/page.tsx
@@ -12,7 +12,7 @@ import {
   optoutProfile,
 } from "../../../../../../functions/server/onerep";
 import {
-  getLatestOnerepScan,
+  getLatestOnerepScanResults,
   setOnerepScanResults,
 } from "../../../../../../../db/tables/onerep_scans";
 import { getCountryCode } from "../../../../../../functions/server/getCountryCode";
@@ -40,8 +40,8 @@ export default async function Subscribed() {
 
   const dev =
     process.env.NODE_ENV === "development" || process.env.APP_ENV === "heroku";
-  const latestScan = await getLatestOnerepScan(profileId);
-  if (!latestScan) {
+  const latestScan = await getLatestOnerepScanResults(profileId);
+  if (!latestScan.scan) {
     throw new Error("Must have performed manual scan");
   }
 
@@ -52,8 +52,8 @@ export default async function Subscribed() {
   if (dev) {
     await setOnerepScanResults(
       profileId,
-      latestScan.onerep_scan_id,
-      { data: scans },
+      latestScan.scan.onerep_scan_id,
+      scans,
       "initial"
     );
   }

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/subscribed/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/subscribed/page.tsx
@@ -20,7 +20,7 @@ import { headers } from "next/headers";
 
 export default async function Subscribed() {
   const session = await getServerSession(authOptions);
-  if (!session || !session.user || !session.user.subscriber) {
+  if (!session?.user?.subscriber) {
     throw new Error("No session");
   }
 

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/unsubscribed/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/unsubscribed/page.tsx
@@ -14,7 +14,7 @@ import { headers } from "next/headers";
 
 export default async function Unsubscribed() {
   const session = await getServerSession(authOptions);
-  if (!session || !session.user || !session.user.subscriber) {
+  if (!session?.user?.subscriber) {
     throw new Error("No session");
   }
 

--- a/src/app/(proper_react)/redesign/(authenticated)/user/welcome/EnterInfo.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/welcome/EnterInfo.tsx
@@ -40,12 +40,12 @@ const createProfileAndStartScan = async (
     body: JSON.stringify(userInfo),
   });
 
-  const result = await response.json();
+  const result: WelcomeScanBody = await response.json();
   if (!result?.success) {
     throw new Error("Could not start scan");
   }
 
-  return result as WelcomeScanBody;
+  return result;
 };
 /* c8 ignore stop */
 

--- a/src/app/api/v1/onerep-events/route.ts
+++ b/src/app/api/v1/onerep-events/route.ts
@@ -83,14 +83,7 @@ export async function POST(req: NextRequest) {
     // The webhook just tells us which scan ID finished, we need to fetch the payload.
     const scanListFull = await getAllScanResults(profileId);
     // Store full list of results in the DB.
-    await setOnerepScanResults(
-      profileId,
-      scanId,
-      {
-        data: scanListFull,
-      },
-      reason
-    );
+    await setOnerepScanResults(profileId, scanId, scanListFull, reason);
 
     return NextResponse.json({ success: true }, { status: 200 });
   } catch (ex) {

--- a/src/app/api/v1/user/scan-result/[onerepScanResultId]/resolution/route.ts
+++ b/src/app/api/v1/user/scan-result/[onerepScanResultId]/resolution/route.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+
+import { authOptions } from "../../../../../utils/auth";
+import {
+  isOnerepScanResultForSubscriber,
+  markOnerepScanResultAsResolved,
+} from "../../../../../../../db/tables/onerep_scans";
+
+export type ResolveScanResultResponse =
+  | {
+      success: true;
+    }
+  | { success: false; message: string };
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { onerepScanResultId: string } }
+): Promise<NextResponse<ResolveScanResultResponse>> {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user || !session.user.subscriber) {
+    return new NextResponse<ResolveScanResultResponse>(
+      JSON.stringify({ success: false, message: "Unauthenticated" }),
+      { status: 401 }
+    );
+  }
+
+  const scanResultId = Number.parseInt(params.onerepScanResultId, 10);
+  if (typeof scanResultId !== "number" || Number.isNaN(scanResultId)) {
+    return new NextResponse<ResolveScanResultResponse>(
+      JSON.stringify({ success: false, message: "Invalid scan result ID" }),
+      { status: 400 }
+    );
+  }
+
+  const isAllowedToResolve = await isOnerepScanResultForSubscriber({
+    onerepScanResultId: scanResultId,
+    subscriberId: session.user.subscriber.id,
+  });
+  if (!isAllowedToResolve) {
+    return new NextResponse<ResolveScanResultResponse>(
+      JSON.stringify({ success: false, message: "Invalid scan result ID" }),
+      { status: 403 }
+    );
+  }
+
+  try {
+    await markOnerepScanResultAsResolved(scanResultId);
+    return new NextResponse<ResolveScanResultResponse>(
+      JSON.stringify({ success: true }),
+      { status: 200 }
+    );
+  } catch (e) {
+    return new NextResponse<ResolveScanResultResponse>(
+      JSON.stringify({
+        success: false,
+        message: "Something went wrong, please try again.",
+      }),
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/v1/user/scan-result/[onerepScanResultId]/resolution/route.ts
+++ b/src/app/api/v1/user/scan-result/[onerepScanResultId]/resolution/route.ts
@@ -22,7 +22,7 @@ export async function POST(
   { params }: { params: { onerepScanResultId: string } }
 ): Promise<NextResponse<ResolveScanResultResponse>> {
   const session = await getServerSession(authOptions);
-  if (!session || !session.user || !session.user.subscriber) {
+  if (!session?.user?.subscriber) {
     return new NextResponse<ResolveScanResultResponse>(
       JSON.stringify({ success: false, message: "Unauthenticated" }),
       { status: 401 }

--- a/src/app/api/v1/user/welcome-scan/create/route.ts
+++ b/src/app/api/v1/user/welcome-scan/create/route.ts
@@ -11,7 +11,7 @@ import {
   createScan,
   isEligibleForFreeScan,
 } from "../../../../../functions/server/onerep";
-import type { ProfileData } from "../../../../../functions/server/onerep";
+import type { CreateProfileRequest } from "../../../../../functions/server/onerep";
 import { meetsAgeRequirement } from "../../../../../functions/universal/user";
 import AppConstants from "../../../../../../appConstants";
 import { getSubscriberByEmail } from "../../../../../../db/tables/subscribers";
@@ -71,7 +71,7 @@ export async function POST(
   if (!meetsAgeRequirement(dateOfBirth)) {
     throw new Error(`User does not meet the age requirement: ${dateOfBirth}`);
   }
-  const profileData: ProfileData = {
+  const profileData: CreateProfileRequest = {
     first_name: firstName,
     last_name: lastName,
     addresses: [{ city, state }],

--- a/src/app/api/v1/user/welcome-scan/create/route.ts
+++ b/src/app/api/v1/user/welcome-scan/create/route.ts
@@ -41,7 +41,7 @@ export async function POST(
   req: NextRequest
 ): Promise<NextResponse<WelcomeScanBody | unknown>> {
   const session = await getServerSession(authOptions);
-  if (!session || !session.user || !session.user.subscriber) {
+  if (!session?.user?.subscriber) {
     throw new Error("No session");
   }
 

--- a/src/app/api/v1/user/welcome-scan/progress/route.ts
+++ b/src/app/api/v1/user/welcome-scan/progress/route.ts
@@ -13,7 +13,7 @@ import {
 } from "../../../../../../db/tables/subscribers";
 
 import {
-  getLatestOnerepScan,
+  getLatestOnerepScanResults,
   setOnerepScanResults,
 } from "../../../../../../db/tables/onerep_scans";
 import {
@@ -44,10 +44,10 @@ export async function GET(
         "onerep_profile_id"
       ] as number;
 
-      const latestScans = await getLatestOnerepScan(profileId);
-      const latestScanId = latestScans?.onerep_scan_id;
+      const latestScan = await getLatestOnerepScanResults(profileId);
+      const latestScanId = latestScan.scan?.onerep_scan_id;
 
-      if (latestScanId) {
+      if (typeof latestScanId !== "undefined") {
         const scan = await getScanDetails(profileId, latestScanId);
 
         // Store scan results only for development environments.
@@ -60,9 +60,7 @@ export async function GET(
           await setOnerepScanResults(
             profileId,
             scan.id,
-            {
-              data: allScanResults,
-            },
+            allScanResults,
             "manual"
           );
         }

--- a/src/app/api/v1/user/welcome-scan/result/route.ts
+++ b/src/app/api/v1/user/welcome-scan/result/route.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { getServerSession } from "next-auth";
+import { OnerepScanResultRow, OnerepScanRow } from "knex/types/tables";
 import { authOptions } from "../../../../utils/auth";
 import { NextResponse } from "next/server";
 
@@ -12,7 +13,14 @@ import {
   getSubscriberByEmail,
 } from "../../../../../../db/tables/subscribers";
 
-import { getLatestOnerepScan } from "../../../../../../db/tables/onerep_scans";
+import { getLatestOnerepScanResults } from "../../../../../../db/tables/onerep_scans";
+
+export type WelcomeScanResultResponse =
+  | {
+      success: true;
+      scan_results: { scan?: OnerepScanRow; results: OnerepScanResultRow[] };
+    }
+  | { success: false };
 
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -23,7 +31,7 @@ export async function GET() {
         "onerep_profile_id"
       ] as number;
 
-      const scanResults = await getLatestOnerepScan(profileId);
+      const scanResults = await getLatestOnerepScanResults(profileId);
       return NextResponse.json(
         { success: true, scan_results: scanResults },
         { status: 200 }

--- a/src/app/components/client/DataBrokerProfiles.tsx
+++ b/src/app/components/client/DataBrokerProfiles.tsx
@@ -9,10 +9,10 @@ import styles from "./DataBrokerProfiles.module.scss";
 import { useL10n } from "../../hooks/l10n";
 import IconChevronDown from "./assets/icon-chevron-down.svg";
 import { useState } from "react";
-import { ScanResult } from "../../functions/server/onerep";
+import { OnerepScanResultRow } from "knex/types/tables";
 
 export type Props = {
-  data: ScanResult[];
+  data: OnerepScanResultRow[];
 };
 
 export const DataBrokerProfiles = (props: Props) => {
@@ -54,7 +54,7 @@ export const DataBrokerProfiles = (props: Props) => {
 };
 
 export type DataBrokerProfileCardProps = {
-  data: ScanResult;
+  data: OnerepScanResultRow;
 };
 
 export const DataBrokerProfileCard = (props: DataBrokerProfileCardProps) => {

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -6,6 +6,7 @@
 
 import React, { ReactElement, useState } from "react";
 import Link from "next/link";
+import { OnerepScanResultRow } from "knex/types/tables";
 import styles from "./ExposureCard.module.scss";
 import { StatusPill } from "../server/StatusPill";
 import Image, { StaticImageData } from "next/image";
@@ -21,7 +22,6 @@ import {
 } from "../server/Icons";
 import { Button } from "../server/Button";
 import { useL10n } from "../../hooks/l10n";
-import { ScanResult } from "../../functions/server/onerep";
 import {
   DataClassEffected,
   SubscriberBreach,
@@ -29,11 +29,11 @@ import {
 import { parseIso8601Datetime } from "../../../utils/parse";
 import { FallbackLogo } from "../server/BreachLogo";
 
-export type Exposure = ScanResult | SubscriberBreach;
+export type Exposure = OnerepScanResultRow | SubscriberBreach;
 
 // Typeguard function
-export function isScanResult(obj: Exposure): obj is ScanResult {
-  return (obj as ScanResult).data_broker !== undefined; // only ScanResult has an instance of data_broker
+export function isScanResult(obj: Exposure): obj is OnerepScanResultRow {
+  return (obj as OnerepScanResultRow).data_broker !== undefined; // only ScanResult has an instance of data_broker
 }
 
 export type ExposureCardProps = {
@@ -60,7 +60,7 @@ export const ExposureCard = ({ exposureData, ...props }: ExposureCardProps) => {
 
 export type ScanResultCardProps = {
   exposureImg?: StaticImageData;
-  scanResult: ScanResult;
+  scanResult: OnerepScanResultRow;
   locale: string;
   isPremiumBrokerRemovalEnabled: boolean;
 };
@@ -202,11 +202,7 @@ const ScanResultCard = (props: ScanResultCardProps) => {
               {l10n.getString("exposure-card-date-found")}
             </dt>
             <dd className={styles.hideOnMobile}>
-              {dateFormatter.format(
-                // We should be able to result that OneRep's `created_at` property is a properly-formatted data string
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                parseIso8601Datetime(scanResult.created_at)!
-              )}
+              {dateFormatter.format(scanResult.created_at)}
             </dd>
             <dt className={styles.visuallyHidden}>
               {l10n.getString("exposure-card-label-status")}

--- a/src/app/components/client/TabList.tsx
+++ b/src/app/components/client/TabList.tsx
@@ -17,15 +17,13 @@ export type TabsProps =
   | TabListStateOptions<object>
   | AriaTabListOptions<object>;
 
-export interface TabListProps {
+export type TabListProps = TabsProps & {
   tabs: Array<{
     key: Key;
     name: string;
     content?: ReactNode;
   }>;
-  defaultSelectedKey?: Key;
-  onSelectionChange?: (key: Key) => void;
-}
+};
 
 export interface TabParams {
   item: {

--- a/src/app/components/client/stories/ExposureCard.stories.ts
+++ b/src/app/components/client/stories/ExposureCard.stories.ts
@@ -8,7 +8,7 @@ import FamilyTreeImage from "../assets/familytree.png";
 import TwitterImage from "../assets/twitter-icon.png";
 import {
   createRandomBreach,
-  createRandomScan,
+  createRandomScanResult,
 } from "../../../../apiMocks/mockData";
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
@@ -20,7 +20,7 @@ const meta: Meta<typeof ExposureCard> = {
 export default meta;
 type Story = StoryObj<typeof ExposureCard>;
 
-const ScanMockItem = createRandomScan();
+const ScanMockItem = createRandomScanResult();
 const BreachMockItem = createRandomBreach();
 
 export const DataBroker: Story = {

--- a/src/app/components/server/StatusPill.tsx
+++ b/src/app/components/server/StatusPill.tsx
@@ -51,6 +51,7 @@ export const getExposureStatus = (exposure: Exposure): StatusPillType => {
       case "removed":
         return "fixed";
       case "waiting_for_verification":
+      case "optout_in_progress":
         return "progress";
       default:
         return "needAction";

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { OnerepScanResultRow } from "knex/types/tables";
 import { BreachDataTypes } from "../../../utils/breachResolution";
-import { ScanResult } from "./onerep";
 import { RemovalStatusMap } from "../universal/scanResult";
 import { SubscriberBreach } from "../../../utils/subscriberBreaches";
 
@@ -61,7 +61,7 @@ const exposureKeyMap: Record<string, string> = {
 };
 
 export function dashboardSummary(
-  scannedResults: ScanResult[],
+  scannedResults: OnerepScanResultRow[],
   subscriberBreaches: SubscriberBreach[]
 ): DashboardSummary {
   const summary: DashboardSummary = {

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -60,7 +60,7 @@ const exposureKeyMap: Record<string, string> = {
   bankAccountNumbers: "bank-account-numbers",
 };
 
-export function dashboardSummary(
+export function getDashboardSummary(
   scannedResults: OnerepScanResultRow[],
   subscriberBreaches: SubscriberBreach[]
 ): DashboardSummary {

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -270,6 +270,5 @@ function sanitizeExposures(
     totalExposures
   );
   sanitizedExposures.push({ "other-data-class": other });
-  console.debug({ sanitizedExposures });
   return sanitizedExposures;
 }

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { OnerepScanResultRow } from "knex/types/tables";
-import { BreachDataTypes } from "../../../utils/breachResolution";
+import { BreachDataTypes } from "../universal/breach";
 import { RemovalStatusMap } from "../universal/scanResult";
 import { SubscriberBreach } from "../../../utils/subscriberBreaches";
 

--- a/src/app/functions/server/getRelevantGuidedSteps.ts
+++ b/src/app/functions/server/getRelevantGuidedSteps.ts
@@ -1,0 +1,241 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Session } from "next-auth";
+import { LatestOnerepScanData } from "../../../db/tables/onerep_scans";
+import { SubscriberBreach } from "../../../utils/subscriberBreaches";
+import { BreachDataTypes, HighRiskDataTypes } from "../universal/breach";
+
+export type InputData = {
+  user: Session["user"];
+  countryCode: string;
+  latestScanData: LatestOnerepScanData | null;
+  subscriberBreaches: SubscriberBreach[];
+};
+
+// Note: the order is important; it determines in which order the user will be
+//       guided through the pages.
+export const stepLinks = [
+  {
+    href: "/redesign/user/dashboard/fix/data-broker-profiles/start-free-scan",
+    id: "StartScan",
+  },
+  {
+    href: "/redesign/user/dashboard/fix/data-broker-profiles/view-data-brokers",
+    id: "ScanResult",
+  },
+  {
+    href: "/redesign/user/dashboard/fix/high-risk-data-breaches/social-security-number",
+    id: "HighRiskSsn",
+  },
+  {
+    href: "/redesign/user/dashboard/fix/high-risk-data-breaches/credit-card-number",
+    id: "HighRiskCreditCard",
+  },
+  {
+    href: "/redesign/user/dashboard/fix/high-risk-data-breaches/bank-account",
+    id: "HighRiskBankAccount",
+  },
+  {
+    href: "/redesign/user/dashboard/fix/high-risk-data-breaches/pin-number",
+    id: "HighRiskPin",
+  },
+  {
+    href: "/redesign/user/dashboard/fix/leaked-passwords/password",
+    id: "LeakedPasswordsPassword",
+  },
+  {
+    href: "/redesign/user/dashboard/fix/leaked-passwords/security-question",
+    id: "LeakedPasswordsSecurityQuestion",
+  },
+  {
+    href: "/redesign/user/dashboard/fix/security-recommendations/phone",
+    id: "SecurityTipsPhone",
+  },
+  {
+    href: "/redesign/user/dashboard/fix/security-recommendations/email",
+    id: "SecurityTipsEmail",
+  },
+  {
+    href: "/redesign/user/dashboard/fix/security-recommendations/ip",
+    id: "SecurityTipsIp",
+  },
+  {
+    href: "/redesign/user/dashboard",
+    id: "Done",
+  },
+] as const satisfies ReadonlyArray<{ href: string; id: string }>;
+
+export type StepLink = (typeof stepLinks)[number];
+
+export type OutputData = {
+  current: StepLink | null;
+  skipTarget: StepLink | null;
+};
+
+export function getRelevantGuidedSteps(
+  data: InputData,
+  stepsToSkip: Array<StepLink["id"]> = []
+): OutputData {
+  const current = getNextGuidedStep(data, stepsToSkip);
+
+  // There should be a relevant next step for every user (even if it's just
+  // going back to the dashbord), so we can't hit this line in tests (and
+  // shouldn't be able to in production either):
+  /* c8 ignore next 6 */
+  if (current === null) {
+    return {
+      current: null,
+      skipTarget: null,
+    };
+  }
+
+  const nextStepsToSkip = [...stepsToSkip];
+  nextStepsToSkip.push(current.id);
+  return {
+    current: current,
+    skipTarget: getNextGuidedStep(data, nextStepsToSkip),
+  };
+}
+
+function getNextGuidedStep(
+  data: InputData,
+  stepsToSkip: Array<StepLink["id"]> = []
+): StepLink | null {
+  // Resisting the urge to add a state machine... ^.^
+  const nextStep = stepLinks.find((stepLink) => {
+    return (
+      !stepsToSkip.includes(stepLink.id) &&
+      isEligibleFor(data, stepLink.id) &&
+      !hasCompleted(data, stepLink.id)
+    );
+  });
+
+  return nextStep ?? null;
+}
+
+function isEligibleFor(data: InputData, stepId: StepLink["id"]): boolean {
+  if (stepId === "StartScan") {
+    return data.countryCode === "us";
+  }
+
+  if (stepId === "ScanResult") {
+    return data.countryCode === "us";
+  }
+
+  if (stepId === "HighRiskSsn") {
+    // Our social security number-related mitigations aren't possible outside of the US:
+    return data.countryCode === "us";
+  }
+
+  if (
+    ["HighRiskCreditCard", "HighRiskBankAccount", "HighRiskPin"].includes(
+      stepId
+    )
+  ) {
+    // Anyone can view/resolve their high risk data breaches
+    return true;
+  }
+
+  if (
+    ["LeakedPasswordsPassword", "LeakedPasswordsSecurityQuestion"].includes(
+      stepId
+    )
+  ) {
+    // Anyone can view/resolve their high risk data breaches
+    return true;
+  }
+
+  if (
+    ["SecurityTipsPhone", "SecurityTipsEmail", "SecurityTipsIp"].includes(
+      stepId
+    )
+  ) {
+    // Anyone can view security tips
+    return true;
+  }
+
+  if (stepId === "Done") {
+    return true;
+    // All steps should have been covered by the above conditions:
+    /* c8 ignore next 4 */
+  }
+
+  return false as never;
+}
+
+function hasCompleted(data: InputData, stepId: StepLink["id"]): boolean {
+  if (stepId === "StartScan") {
+    return data.latestScanData?.scan !== null;
+  }
+
+  if (stepId === "ScanResult") {
+    return (
+      data.latestScanData !== null &&
+      Array.isArray(data.latestScanData?.results) &&
+      !data.latestScanData.results.some((scanResult) => {
+        return scanResult.status === "new" && !scanResult.manually_resolved;
+      })
+    );
+  }
+
+  function isResolved(
+    dataClass: (typeof BreachDataTypes)[keyof typeof BreachDataTypes]
+  ): boolean {
+    return !data.subscriberBreaches.some((breach) => {
+      return (
+        breach.dataClasses.includes(dataClass) &&
+        !breach.resolvedDataClasses.includes(dataClass)
+      );
+    });
+  }
+
+  // TODO: instead of resolving entire breaches, only resolve specific data classes
+  //       See ADR 0008-data-class-resolution.
+  if (stepId === "HighRiskSsn") {
+    return isResolved(HighRiskDataTypes.SSN);
+  }
+
+  if (stepId === "HighRiskCreditCard") {
+    return isResolved(HighRiskDataTypes.CreditCard);
+  }
+
+  if (stepId === "HighRiskBankAccount") {
+    return isResolved(HighRiskDataTypes.BankAccount);
+  }
+
+  if (stepId === "HighRiskPin") {
+    return isResolved(HighRiskDataTypes.PIN);
+  }
+
+  if (stepId === "LeakedPasswordsPassword") {
+    return isResolved(BreachDataTypes.Passwords);
+  }
+
+  if (stepId === "LeakedPasswordsSecurityQuestion") {
+    return isResolved(BreachDataTypes.SecurityQuestions);
+  }
+
+  if (stepId === "SecurityTipsPhone") {
+    // TODO: Verify that pressing "Got it" on this screen should actually mark
+    //       phone breaches as resolved.
+    return isResolved(BreachDataTypes.Phone);
+  }
+
+  if (stepId === "SecurityTipsEmail") {
+    return isResolved(BreachDataTypes.Email);
+  }
+
+  if (stepId === "SecurityTipsIp") {
+    return isResolved(BreachDataTypes.IP);
+  }
+
+  if (stepId === "Done") {
+    return false;
+    // All steps should have been covered by the above conditions:
+    /* c8 ignore next 4 */
+  }
+
+  return false as never;
+}

--- a/src/app/functions/server/onerep.ts
+++ b/src/app/functions/server/onerep.ts
@@ -10,7 +10,7 @@ import {
   ISO8601DateString,
 } from "../../../utils/parse.js";
 import { StateAbbr } from "../../../utils/states.js";
-import { getLatestOnerepScan } from "../../../db/tables/onerep_scans";
+import { getLatestOnerepScanResults } from "../../../db/tables/onerep_scans";
 import { isFlagEnabled } from "./featureFlags";
 import { RemovalStatus } from "../universal/scanResult.js";
 const log = mozlog("external.onerep");
@@ -51,6 +51,7 @@ export type ListScansResponse = {
 };
 export type ScanResult = {
   id: number;
+  scan_id: number;
   url: string;
   link: string;
   profile_id: number;
@@ -294,9 +295,9 @@ export async function isEligibleForFreeScan(
 
   const result = await getOnerepProfileId(user.subscriber.id);
   const profileId = result[0]["onerep_profile_id"] as number;
-  const scanResult = await getLatestOnerepScan(profileId);
+  const scanResult = await getLatestOnerepScanResults(profileId);
 
-  if (scanResult?.onerep_scan_results?.data?.length) {
+  if (scanResult.results.length) {
     console.warn("User has already used free scan");
     return false;
   }

--- a/src/app/functions/universal/breach.ts
+++ b/src/app/functions/universal/breach.ts
@@ -21,8 +21,8 @@ export const BreachDataTypes = {
 } as const;
 
 export const HighRiskDataTypes = {
-  SSN: "social-security-numbers",
-  CreditCard: "partial-credit-card-data",
-  BankAccount: "bank-account-numbers",
-  PIN: "pins",
+  SSN: BreachDataTypes.SSN,
+  CreditCard: BreachDataTypes.CreditCard,
+  BankAccount: BreachDataTypes.BankAccount,
+  PIN: BreachDataTypes.PIN,
 } as const;

--- a/src/db/migrations/20230907143204_add_onerep_scanresults_table.js
+++ b/src/db/migrations/20230907143204_add_onerep_scanresults_table.js
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable("onerep_scans", table => {
+    table.unique("onerep_scan_id");
+  });
+
+  await knex.schema
+    .createTable("onerep_scan_results", table => {
+      table.increments("id").primary();
+      table.integer("onerep_scan_result_id").notNullable();
+      table.integer("onerep_scan_id").references("onerep_scans.onerep_scan_id").notNullable();
+      table.string("link").notNullable();
+      table.integer("age").nullable();
+      table.string("data_broker").notNullable();
+      table.integer("data_broker_id").notNullable();
+      table.jsonb("emails").notNullable();
+      table.jsonb("phones").notNullable();
+      table.jsonb("addresses").notNullable();
+      table.jsonb("relatives").notNullable();
+      table.string("first_name").notNullable();
+      table.string("middle_name").nullable();
+      table.string("last_name").notNullable();
+      table.string("status").notNullable();
+      table.timestamp("created_at").defaultTo(knex.fn.now());
+      table.timestamp("updated_at").defaultTo(knex.fn.now());
+      table.index("onerep_scan_id");
+      table.index("onerep_scan_result_id");
+    });
+
+  const scanRows = await knex("onerep_scans")
+    .select("id", "onerep_scan_id", "onerep_scan_results");
+
+  const scanResultRows = scanRows.map(scan => {
+    return scan.onerep_scan_results.data.map(scanResult => {
+      const rowToInsert = {
+        onerep_scan_result_id: scanResult.id,
+        onerep_scan_id: scan.onerep_scan_id,
+        link: scanResult.link,
+        age: typeof scanResult.age === "string" ? Number.parseInt(scanResult.age, 10) : null,
+        data_broker: scanResult.data_broker,
+        data_broker_id: scanResult.data_broker_id,
+        emails: JSON.stringify(scanResult.emails),
+        phones: JSON.stringify(scanResult.phones),
+        addresses: JSON.stringify(scanResult.addresses),
+        relatives: JSON.stringify(scanResult.relatives),
+        first_name: scanResult.first_name,
+        middle_name: scanResult.middle_name,
+        last_name: scanResult.last_name,
+        status: scanResult.status,
+      };
+      return rowToInsert
+    });
+  }).flat();
+
+  if (scanResultRows.length > 0) {
+    await knex("onerep_scan_results")
+      .insert(scanResultRows);
+  }
+
+
+  await knex.schema.alterTable("onerep_scans", table => {
+    table.dropColumn('onerep_scan_results');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable("onerep_scans", table => {
+    // TODO: Restore values from onerep_scan_results, or fetch anew from OneRep API?
+    //       Probably not worth it though, since we never wrote to that column in production.
+    table.jsonb('onerep_scan_results');
+  });
+  await knex.schema.dropTable("onerep_scan_results")
+  await knex.schema.alterTable("onerep_scans", table => {
+    table.dropUnique("onerep_scan_id");
+  });
+}

--- a/src/db/migrations/20230908154315_add_manual_resolution_column.js
+++ b/src/db/migrations/20230908154315_add_manual_resolution_column.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  return knex.schema.alterTable("onerep_scan_results", table => {
+    table.boolean("manually_resolved").notNullable().defaultTo(false);
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema.alterTable("onerep_scan_results", table => {
+    table.dropColumn("manually_resolved");
+  });
+}

--- a/src/db/tables/onerep_profiles.ts
+++ b/src/db/tables/onerep_profiles.ts
@@ -5,6 +5,7 @@
 import initKnex from "knex";
 import knexConfig from "../knexfile.js";
 import { ProfileData } from "../../app/functions/server/onerep.js";
+import { parseIso8601Datetime } from "../../utils/parse.js";
 
 const knex = initKnex(knexConfig);
 
@@ -18,7 +19,11 @@ export async function setProfileDetails(
     last_name: profileData.last_name,
     city_name: profileData.addresses[0]["city"],
     state_code: profileData.addresses[0]["state"],
-    date_of_birth: profileData.birth_date,
+    // TODO: Validate input:
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    date_of_birth: parseIso8601Datetime(profileData.birth_date!)!,
+    // @ts-ignore knex.fn.now() results in it being set to a date,
+    // even if it's not typed as a JS date object:
     created_at: knex.fn.now(),
   });
 }

--- a/src/db/tables/onerep_profiles.ts
+++ b/src/db/tables/onerep_profiles.ts
@@ -4,14 +4,14 @@
 
 import initKnex from "knex";
 import knexConfig from "../knexfile.js";
-import { ProfileData } from "../../app/functions/server/onerep.js";
+import { CreateProfileRequest } from "../../app/functions/server/onerep.js";
 import { parseIso8601Datetime } from "../../utils/parse.js";
 
 const knex = initKnex(knexConfig);
 
 export async function setProfileDetails(
   onerepProfileId: number,
-  profileData: ProfileData
+  profileData: CreateProfileRequest
 ) {
   await knex("onerep_profiles").insert({
     onerep_profile_id: onerepProfileId,

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -72,6 +72,8 @@ async function setOnerepManualScan(
     onerep_profile_id: onerepProfileId,
     onerep_scan_id: onerepScanId,
     onerep_scan_reason: "manual",
+    // @ts-ignore knex.fn.now() results in it being set to a date,
+    // even if it's not typed as a JS date object:
     created_at: knex.fn.now(),
   });
 }
@@ -88,7 +90,9 @@ async function setOnerepScanResults(
       .where("onerep_profile_id", onerepProfileId)
       .andWhere("onerep_scan_id", onerepScanId)
       .update({
-        onerep_scan_results: onerepScanResults,
+        onerep_scan_results: onerepScanResults as ScanResult,
+        // @ts-ignore knex.fn.now() results in it being set to a date,
+        // even if it's not typed as a JS date object:
         updated_at: knex.fn.now(),
       });
   } else {
@@ -96,8 +100,10 @@ async function setOnerepScanResults(
     await knex("onerep_scans").insert({
       onerep_profile_id: onerepProfileId,
       onerep_scan_id: onerepScanId,
-      onerep_scan_results: onerepScanResults,
+      onerep_scan_results: onerepScanResults as ScanResult,
       onerep_scan_reason: onerepScanReason,
+      // @ts-ignore knex.fn.now() results in it being set to a date,
+      // even if it's not typed as a JS date object:
       created_at: knex.fn.now(),
     });
   }

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -111,6 +111,39 @@ async function setOnerepScanResults(
   });
 }
 
+async function isOnerepScanResultForSubscriber(params: {
+  onerepScanResultId: number;
+  subscriberId: number;
+}): Promise<boolean> {
+  const result = await knex("onerep_scan_results")
+    .innerJoin(
+      "onerep_scans",
+      "onerep_scan_results.onerep_scan_id",
+      "onerep_scans.onerep_scan_id"
+    )
+    .innerJoin(
+      "subscribers",
+      "onerep_scans.onerep_profile_id",
+      "subscribers.onerep_profile_id"
+    )
+    .where(
+      "onerep_scan_results.onerep_scan_result_id",
+      params.onerepScanResultId
+    )
+    .andWhere("subscribers.id", params.subscriberId)
+    .first("onerep_scan_result_id");
+
+  return typeof result?.onerep_scan_result_id === "number";
+}
+
+async function markOnerepScanResultAsResolved(
+  onerepScanResultId: number
+): Promise<void> {
+  await knex("onerep_scan_results")
+    .update("manually_resolved", true)
+    .where("onerep_scan_result_id", onerepScanResultId);
+}
+
 async function getScansCount(startDate: string, endDate: string) {
   return await knex("onerep_scans")
     .count("id")
@@ -123,4 +156,6 @@ export {
   setOnerepManualScan,
   setOnerepScanResults,
   getScansCount,
+  isOnerepScanResultForSubscriber,
+  markOnerepScanResultAsResolved,
 };

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -9,17 +9,14 @@ import { Subscriber } from "../../app/(nextjs_migration)/(authenticated)/user/br
 import { OnerepScanResultRow, OnerepScanRow } from "knex/types/tables";
 const knex = initKnex(knexConfig);
 
-export interface GetLatestOnerepScanResult {
-  onerep_scan_id: number;
-  created_at: number;
-  updated_at: number;
-  onerep_scan_results: { data: ScanResult[] } | null;
-  onerep_scan_reason: string;
+export interface LatestOnerepScanData {
+  scan: OnerepScanRow | null;
+  results: OnerepScanResultRow[];
 }
 
 async function getLatestOnerepScanResults(
   onerepProfileId: number
-): Promise<{ scan: OnerepScanRow | null; results: OnerepScanResultRow[] }> {
+): Promise<LatestOnerepScanData> {
   const scan = await knex("onerep_scans")
     .first()
     .where("onerep_profile_id", onerepProfileId)

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -140,7 +140,12 @@ async function markOnerepScanResultAsResolved(
   onerepScanResultId: number
 ): Promise<void> {
   await knex("onerep_scan_results")
-    .update("manually_resolved", true)
+    .update({
+      manually_resolved: true,
+      // @ts-ignore knex.fn.now() results in it being set to a date,
+      // even if it's not typed as a JS date object:
+      updated_at: knex.fn.now(),
+    })
     .where("onerep_scan_result_id", onerepScanResultId);
 }
 

--- a/src/knex-tables.d.ts
+++ b/src/knex-tables.d.ts
@@ -153,6 +153,14 @@ declare module "knex/types/tables" {
     created_at: Date;
     updated_at: Date;
   }
+  type OnerepScanOptionalColumns = Extract<
+    keyof OnerepScanRow,
+    "onerep_profile_id"
+  >;
+  type OnerepScanAutoInsertedColumns = Extract<
+    keyof OnerepScanRow,
+    "id" | "created_at" | "updated_at"
+  >;
 
   interface OnerepProfileRow {
     id: number;
@@ -216,6 +224,19 @@ declare module "knex/types/tables" {
         Partial<Pick<BreachRow, BreachOptionalColumns>>,
       // On updates, don't allow updating the ID; all other fields are optional:
       Partial<Omit<BreachRow, "id">>
+    >;
+
+    onerep_scans: Knex.CompositeTableType<
+      OnerepScanRow,
+      // On updates, auto-generated columns cannot be set, and nullable columns are optional:
+      Omit<
+        OnerepScanRow,
+        OnerepScanAutoInsertedColumns | OnerepScanOptionalColumns
+      > &
+        Partial<Pick<OnerepScanRow, OnerepScanOptionalColumns>>,
+      // On updates, don't allow updating the ID and created date; all other fields are optional, except updated_at:
+      Partial<Omit<OnerepScanRow, "id" | "created_at">> &
+        Pick<OnerepScanRow, "updated_at">
     >;
 
     onerep_profiles: Knex.CompositeTableType<

--- a/src/knex-tables.d.ts
+++ b/src/knex-tables.d.ts
@@ -150,6 +150,7 @@ declare module "knex/types/tables" {
     onerep_profile_id: number;
     onerep_scan_id: number;
     onerep_scan_results: ScanResult;
+    onerep_scan_reason: "manual" | "initial" | "monitoring";
     created_at: Date;
     updated_at: Date;
   }

--- a/src/knex-tables.d.ts
+++ b/src/knex-tables.d.ts
@@ -183,12 +183,13 @@ declare module "knex/types/tables" {
     middle_name?: string;
     last_name: string;
     status: RemovalStatus;
+    manually_resolved: boolean;
     created_at: Date;
     updated_at: Date;
   }
   type OnerepScanResultOptionalColumns = Extract<
     keyof OnerepScanResultRow,
-    "middle_name"
+    "manually_resolved" | "middle_name"
   >;
   type OnerepScanResultSerializedColumns = Extract<
     keyof OnerepScanResultRow,

--- a/src/knex-tables.d.ts
+++ b/src/knex-tables.d.ts
@@ -4,6 +4,7 @@
 
 import { Knex } from "knex";
 import { ScanResult } from "./app/functions/server/onerep";
+import { StateAbbr } from "./utils/states";
 
 // See https://knexjs.org/guide/#typescript
 declare module "knex/types/tables" {
@@ -153,6 +154,26 @@ declare module "knex/types/tables" {
     updated_at: Date;
   }
 
+  interface OnerepProfileRow {
+    id: number;
+    onerep_profile_id: null | SubscriberRow["onerep_profile_id"];
+    first_name: string;
+    last_name: string;
+    city_name: string;
+    state_code: StateAbbr;
+    date_of_birth: Date;
+    created_at: Date;
+    updated_at: Date;
+  }
+  type OnerepProfileOptionalColumns = Extract<
+    keyof OnerepProfileRow,
+    "onerep_profile_id"
+  >;
+  type OnerepProfileAutoInsertedColumns = Extract<
+    keyof OnerepProfileRow,
+    "id" | "created_at" | "updated_at"
+  >;
+
   interface Tables {
     feature_flags: Knex.CompositeTableType<
       FeatureFlagRow,
@@ -195,6 +216,19 @@ declare module "knex/types/tables" {
         Partial<Pick<BreachRow, BreachOptionalColumns>>,
       // On updates, don't allow updating the ID; all other fields are optional:
       Partial<Omit<BreachRow, "id">>
+    >;
+
+    onerep_profiles: Knex.CompositeTableType<
+      OnerepProfileRow,
+      // On updates, auto-generated columns cannot be set, and nullable columns are optional:
+      Omit<
+        OnerepProfileRow,
+        OnerepProfileAutoInsertedColumns | OnerepProfileOptionalColumns
+      > &
+        Partial<Pick<OnerepProfileRow, OnerepProfileOptionalColumns>>,
+      // On updates, don't allow updating the ID and created date; all other fields are optional, except updated_at:
+      Partial<Omit<OnerepProfileRow, "id" | "created_at">> &
+        Pick<OnerepProfileRow, "updated_at">
     >;
   }
 }

--- a/src/knex-tables.d.ts
+++ b/src/knex-tables.d.ts
@@ -5,6 +5,7 @@
 import { Knex } from "knex";
 import { StateAbbr } from "./utils/states";
 import { RemovalStatus } from "./app/functions/universal/scanResult";
+import { BreachDataTypes } from "./app/functions/universal/breach";
 
 // See https://knexjs.org/guide/#typescript
 declare module "knex/types/tables" {
@@ -38,6 +39,11 @@ declare module "knex/types/tables" {
     "name" | "created_at" | "modified_at"
   >;
 
+  interface SubscriberEmail {
+    id: number;
+    email: string;
+  }
+
   interface SubscriberRow {
     id: number;
     primary_sha1: string;
@@ -50,7 +56,7 @@ declare module "knex/types/tables" {
     signup_language: string;
     fxa_refresh_token: null | string;
     fxa_access_token: null | string;
-    fxa_profile_json: null | unknown;
+    fxa_profile_json: null | Profile;
     fxa_uid: null | string;
     // TODO: Find unknown type
     breaches_last_shown: null | unknown;
@@ -59,22 +65,41 @@ declare module "knex/types/tables" {
     breaches_resolved: null | unknown;
     // TODO: Find unknown type
     waitlists_joined: null | unknown;
-    // TODO: Find unknown type
-    breach_stats: null | unknown;
+    breach_stats: null | {
+      passwords: { count: number; numResolved: number };
+      numBreaches: {
+        count: number;
+        numResolved: number;
+        numUnresolved: number;
+      };
+      monitoredEmails: { count: number };
+    };
     // TODO: Find unknown type
     monthly_email_at: null | unknown;
     // TODO: Find unknown type
     monthly_email_optout: null | unknown;
-    // TODO: Find unknown type
-    breach_resolution: null | unknown;
+    breach_resolution:
+      | null
+      | ({
+          useBreachId: boolean;
+        } & Record<
+          SubscriberEmail.email,
+          Record<
+            BreachRow.id,
+            {
+              isResolved: boolean;
+              resolutionsChecked: Array<
+                (typeof BreachDataTypes)[keyof typeof BreachDataTypes]
+              >;
+            }
+          >
+        >);
     // TODO: Find unknown type
     db_migration_1: null | unknown;
     // TODO: Find unknown type
     db_migration_2: null | unknown;
-    // TODO: Find unknown type
-    onerep_profile_id: null | unknown;
-    // TODO: Find unknown type
-    email_addresses: unknown[];
+    onerep_profile_id: null | OnerepProfileRow.onerep_profile_id;
+    email_addresses: SubscriberEmail[];
   }
   type SubscriberOptionalColumns = Extract<
     keyof SubscriberRow,

--- a/src/utils/breachResolution.js
+++ b/src/utils/breachResolution.js
@@ -9,6 +9,8 @@ import { getMessage } from './fluent.js'
  * Equivalent of Typescript "enum"
  * These enum types map to HIBP's breach data types, defined in HIBP's API
  * Always reference enum instead of strings to avoid spelling error / typos (ie. BreachDataTypes.Passwords)
+ *
+ * @deprecated Use the object with the same name from /src/app/functions/universal/breach.ts instead.
  */
 const BreachDataTypes = {
   Passwords: 'passwords',

--- a/src/utils/subscriberBreaches.ts
+++ b/src/utils/subscriberBreaches.ts
@@ -78,16 +78,18 @@ export async function getSubBreaches(
     const breachResolution = subscriber.breach_resolution?.[email.email] ?? {};
 
     for (const breach of foundBreaches) {
-      const filteredBreachDataClasses: string[] = filterBreachDataTypes(
-        breach.DataClasses
-      );
+      type ArrayOfDataClasses = Array<
+        (typeof BreachDataTypes)[keyof typeof BreachDataTypes]
+      >;
+      const filteredBreachDataClasses: ArrayOfDataClasses =
+        filterBreachDataTypes(breach.DataClasses);
       const subscriberBreach: SubscriberBreach = {
         id: breach.Id,
         addedDate: breach.AddedDate,
         breachDate: breach.BreachDate,
         dataClasses: filteredBreachDataClasses,
-        resolvedDataClasses:
-          breachResolution[breach.Id]?.resolutionsChecked ?? [],
+        resolvedDataClasses: (breachResolution[breach.Id]?.resolutionsChecked ??
+          []) as ArrayOfDataClasses,
         description: breach.Description,
         domain: breach.Domain,
         isResolved: breachResolution[breach.Id]?.isResolved || false,

--- a/src/utils/subscriberBreaches.ts
+++ b/src/utils/subscriberBreaches.ts
@@ -5,11 +5,12 @@
 import { getUserEmails } from "../db/tables/emailAddresses.js";
 import { HibpLikeDbBreach, getBreachesForEmail } from "./hibp.js";
 import { getSha1 } from "./fxa.js";
-import { BreachDataTypes, filterBreachDataTypes } from "./breachResolution.js";
+import { filterBreachDataTypes } from "./breachResolution.js";
 import {
   Breach,
   Subscriber,
 } from "../app/(nextjs_migration)/(authenticated)/user/breaches/breaches.js";
+import { BreachDataTypes } from "../app/functions/universal/breach";
 
 export type DataClassEffected = {
   [dataType: string]: number | string[];
@@ -17,7 +18,10 @@ export type DataClassEffected = {
 export interface SubscriberBreach {
   addedDate: string;
   breachDate: string;
-  dataClasses: string[];
+  dataClasses: Array<(typeof BreachDataTypes)[keyof typeof BreachDataTypes]>;
+  resolvedDataClasses: Array<
+    (typeof BreachDataTypes)[keyof typeof BreachDataTypes]
+  >;
   description: string;
   domain: string;
   id: number;
@@ -82,6 +86,8 @@ export async function getSubBreaches(
         addedDate: breach.AddedDate,
         breachDate: breach.BreachDate,
         dataClasses: filteredBreachDataClasses,
+        resolvedDataClasses:
+          breachResolution[breach.Id]?.resolutionsChecked ?? [],
         description: breach.Description,
         domain: breach.Domain,
         isResolved: breachResolution[breach.Id]?.isResolved || false,


### PR DESCRIPTION
I'm honestly not sure if this actually makes it easier to write tests, or if it just adds a whole lot of noise for tests that aren't _that_ valuable - so happy to hear opinions on this. To emphasise, I wouldn't mind closing this PR unmerged.

Documentation for the new helper function: https://github.com/mozilla/blurts-server/blob/1aafabc8e0607db980201fa38073c1751fcbd95b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx#L80-L109

Example use: https://github.com/mozilla/blurts-server/blob/1aafabc8e0607db980201fa38073c1751fcbd95b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx#L277-L287

That runs ~15 tests to ensure the "Start a free scan" is never shown outside the US.

Writing that, I realise that you'd probably want a similar test for use cases where the scan status is _not_ `no-scan` and the user is Premium, which this function doesn't help with. So actually I'm already leaning towards not merging this and just writing the separate tests manually :sweat_smile: 