### PR TITLE
Unset engine-strict option

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,4 +18,4 @@
   # Default build command.
   command = "npm ci; npm run build-storybook"
 
-  environment = { NODE_VERSION = "18.12.1", NPM_VERSION = "8.19.3" }
+  environment = { NODE_VERSION = "18.12.1", NPM_VERSION = "9.6.5" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
       },
       "engines": {
         "node": "18.12.x",
-        "npm": "8.x"
+        "npm": "9.6.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Firefox Monitor",
   "engines": {
     "node": "18.12.x",
-    "npm": "8.x"
+    "npm": "9.6.5"
   },
   "type": "module",
   "scripts": {
@@ -46,7 +46,7 @@
   "license": "MPL-2.0",
   "volta": {
     "node": "18.12.1",
-    "npm": "8.19.3"
+    "npm": "9.6.5"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.360.0",


### PR DESCRIPTION
Dependabot was [logging the following error](https://github.com/mozilla/blurts-server/network/updates/723120103):

    Dependabot uses Node.js v18.17.1 and NPM 9.6.5.
    Due to the engine-strict setting, the update will not succeed.

Since we use Volta locally, and explicitly configure our Node versions elsewhere, I don't think engine-strict is necessary. And it would be good to get JS dependency updates again.

~~We might want to update our npm version to align with Dependabot though.~~ I added e3685adc0 to align our npm version with Dependabot - I expect that that's a relatively safe change, i.e. not as impactful as e.g. [changing our Node version](https://github.com/mozilla/blurts-server/pull/3295).
