### PR TITLE
enabling e2e tests on both chrome and firefox

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -103,10 +103,10 @@ export default defineConfig({
   outputDir: 'src/e2e/test-results/',
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run build; npm start',
-  //   port: 6060,
-  //   // Building the app can take some time:
-  //   timeout: 1_800_000,
-  // }
+  webServer: {
+    command: 'npm run build; npm start',
+    port: 6060,
+    // Building the app can take some time:
+    timeout: 1_800_000,
+  }
 })

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -72,12 +72,11 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] }
-    }
-
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] }
-    // }
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] }
+    },
 
     /* Test against mobile viewports. */
     // {
@@ -104,10 +103,10 @@ export default defineConfig({
   outputDir: 'src/e2e/test-results/',
 
   /* Run your local dev server before starting the tests */
-  webServer: {
-    command: 'npm run build; npm start',
-    port: 6060,
-    // Building the app can take some time:
-    timeout: 1_800_000,
-  }
+  // webServer: {
+  //   command: 'npm run build; npm start',
+  //   port: 6060,
+  //   // Building the app can take some time:
+  //   timeout: 1_800_000,
+  // }
 })


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

Enabling e2e tests for chrome and firefox thus reducing amount of manual effort for QA and getting closer to faster deployments

# References: 
Jira: [MNTOR-2165](https://mozilla-hub.atlassian.net/browse/MNTOR-2165) and [MNTOR-2164](https://mozilla-hub.atlassian.net/browse/MNTOR-2164)


[MNTOR-2165]: https://mozilla-hub.atlassian.net/browse/MNTOR-2165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNTOR-2164]: https://mozilla-hub.atlassian.net/browse/MNTOR-2164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ