### PR TITLE
chore: change nimbus sidecar URL default port to 8001

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -155,4 +155,4 @@ GCP_PUBSUB_SUBSCRIPTION_NAME=
 
 # Randomly-generated UUIDv5 namespace, until/unless we are approved to use FxA UID for Nimbus User ID.
 NIMBUS_UUID_NAMESPACE=00000000-0000-0000-0000-000000000000
-NIMBUS_SIDECAR_URL=http://localhost:6060
+NIMBUS_SIDECAR_URL=http://localhost:8001


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2022


<!-- When adding a new feature: -->

# Description

Change Nimbus sidecar URL default to match the default in infra, so it's more likely to work out-of-the-box.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
