### PR TITLE
Enable Premium features on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,6 +16,6 @@
   publish = "storybook-static/"
 
   # Default build command.
-  command = "npm ci; npm run build-storybook"
+  command = "npm ci; cp .env-dist .env; npm run build-storybook"
 
   environment = { NODE_VERSION = "18.12.1", NPM_VERSION = "9.6.5" }


### PR DESCRIPTION
The main way you'll currently notice the lack of env vars is in the Premium badge not being visible on Netlify, because PREMIUM_ENABLED is not true.

Which does bring up the question... Why do we even have this `PREMIUM_ENABLED` var in the first place?