### PR TITLE
Format date according to a user's locale

### DIFF
--- a/src/app/(nextjs_migration)/(guest)/breach-details/[breachName]/page.tsx
+++ b/src/app/(nextjs_migration)/(guest)/breach-details/[breachName]/page.tsx
@@ -5,7 +5,8 @@
 import Image, { StaticImageData } from "next/image";
 import BreachDetailScanImage from "../../../../../client/images/breach-detail-scan.svg";
 import "../../../../../client/css/partials/breachDetail.css";
-import { getL10n, getLocale } from "../../../../functions/server/l10n";
+import { getL10n } from "../../../../functions/server/l10n";
+import { getLocale } from "../../../../functions/universal/getLocale";
 import { HibpLikeDbBreach, getBreachByName } from "../../../../../utils/hibp";
 import {
   getAllPriorityDataClasses,
@@ -119,7 +120,7 @@ export default async function BreachDetail(props: {
           <div>
             {l10n.getString("breach-overview-new", {
               breachDate: (breach.BreachDate as unknown as Date).toLocaleString(
-                getLocale(),
+                getLocale(l10n),
                 {
                   year: "numeric",
                   month: "long",
@@ -128,7 +129,7 @@ export default async function BreachDetail(props: {
               ),
               breachTitle: breach.Title,
               addedDate: (breach.AddedDate as unknown as Date).toLocaleString(
-                getLocale(),
+                getLocale(l10n),
                 {
                   year: "numeric",
                   month: "long",

--- a/src/app/(nextjs_migration)/(guest)/breaches/page.tsx
+++ b/src/app/(nextjs_migration)/(guest)/breaches/page.tsx
@@ -5,7 +5,8 @@
 import { getBreaches } from "../../../functions/server/getBreaches";
 import Script from "next/script";
 import "../../../../client/css/partials/allBreaches.css";
-import { getL10n, getLocale } from "../../../functions/server/l10n";
+import { getL10n } from "../../../functions/server/l10n";
+import { getLocale } from "../../../functions/universal/getLocale";
 import { BreachLogo } from "../../../components/server/BreachLogo";
 import { HibpLikeDbBreach } from "../../../../utils/hibp";
 import { Breach } from "../../(authenticated)/user/breaches/breaches";
@@ -117,18 +118,22 @@ function BreachCard(props: { breach: HibpLikeDbBreach | Breach }) {
           <div>
             <dt>{l10n.getString("breach-added-label")}</dt>
             <dd>
-              {new Date(props.breach.AddedDate).toLocaleString(getLocale(), {
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-              })}
+              {new Date(props.breach.AddedDate).toLocaleString(
+                getLocale(l10n),
+                {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                }
+              )}
             </dd>
           </div>
           <div>
             <dt>{l10n.getString("exposed-data")}</dt>
             <dd>
               {formatList(
-                props.breach.DataClasses.map((a: string) => l10n.getString(a))
+                props.breach.DataClasses.map((a: string) => l10n.getString(a)),
+                getLocale(l10n)
               )}
             </dd>
           </div>
@@ -141,12 +146,12 @@ function BreachCard(props: { breach: HibpLikeDbBreach | Breach }) {
   );
 }
 
-function formatList(list: string[]) {
+function formatList(list: string[], locale: string) {
   if (typeof Intl.ListFormat === "undefined") {
     return list.join(", ");
   }
 
-  return new Intl.ListFormat(getLocale(), {
+  return new Intl.ListFormat(locale, {
     type: "unit",
     style: "short",
   }).format(list);

--- a/src/app/(nextjs_migration)/layout.tsx
+++ b/src/app/(nextjs_migration)/layout.tsx
@@ -5,7 +5,7 @@
 import { ReactNode } from "react";
 import Script from "next/script";
 import { L10nProvider } from "../../contextProviders/localization";
-import { getL10nBundles, getLocale } from "../functions/server/l10n";
+import { getL10nBundles } from "../functions/server/l10n";
 import { HandleFalseDoorTest } from "./components/client/FalseDoorBanner";
 import { isFlagEnabled } from "../functions/server/featureFlags";
 import { getCountryCode } from "../functions/server/getCountryCode";

--- a/src/app/(proper_react)/layout.tsx
+++ b/src/app/(proper_react)/layout.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ReactNode } from "react";
-import { getL10nBundles, getLocale } from "../functions/server/l10n";
+import { getL10nBundles } from "../functions/server/l10n";
+import { getLocale } from "../functions/universal/getLocale";
 import { L10nProvider } from "../../contextProviders/localization";
 import { ReactAriaI18nProvider } from "../../contextProviders/react-aria";
 

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.stories.tsx
@@ -149,7 +149,6 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
         userBreaches={breaches}
         userScanData={scanData}
         isEligibleForFreeScan={props.countryCode === "us"}
-        locale={"en"}
         featureFlagsEnabled={{
           FreeBrokerScan: true,
           PremiumBrokerRemoval: true,

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -9,6 +9,8 @@ import Image from "next/image";
 import { Session } from "next-auth";
 import { OnerepScanResultRow } from "knex/types/tables";
 import styles from "./View.module.scss";
+import AllFixedLogo from "./images/dashboard-all-fixed.svg";
+import ScanProgressIllustration from "./images/scan-illustration.svg";
 import { Toolbar } from "../../../../../components/client/toolbar/Toolbar";
 import { BannerContent, DashboardTopBanner } from "./DashboardTopBanner";
 import { useL10n } from "../../../../../hooks/l10n";
@@ -29,15 +31,13 @@ import { filterExposures } from "./filterExposures";
 import { SubscriberBreach } from "../../../../../../utils/subscriberBreaches";
 import { hasPremium } from "../../../../../functions/universal/user";
 import { LatestOnerepScanData } from "../../../../../../db/tables/onerep_scans";
-import AllFixedLogo from "./images/dashboard-all-fixed.svg";
-import ScanProgressIllustration from "./images/scan-illustration.svg";
+import { getLocale } from "../../../../../functions/universal/getLocale";
 
 export type Props = {
   featureFlagsEnabled: Pick<
     FeatureFlagsEnabled,
     "FreeBrokerScan" | "PremiumBrokerRemoval"
   >;
-  locale: string;
   user: Session["user"];
   userBreaches: SubscriberBreach[];
   userScanData: LatestOnerepScanData;
@@ -108,7 +108,7 @@ export const View = (props: Props) => {
       >
         <ExposureCard
           exposureData={exposure}
-          locale={props.locale}
+          locale={getLocale(l10n)}
           isPremiumBrokerRemovalEnabled={
             props.featureFlagsEnabled.PremiumBrokerRemoval
           }

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/HighRiskBreachLayout.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/HighRiskBreachLayout.tsx
@@ -10,16 +10,13 @@ import { ResolutionContent } from "../ResolutionContent";
 import { Button } from "../../../../../../../components/server/Button";
 import { useL10n } from "../../../../../../../hooks/l10n";
 import { HighRiskBreach } from "./highRiskBreachData";
+import { getLocale } from "../../../../../../../functions/universal/getLocale";
 
 export type HighRiskBreachLayoutProps = {
-  locale: string;
   pageData: HighRiskBreach;
 };
 
-export function HighRiskBreachLayout({
-  pageData,
-  locale,
-}: HighRiskBreachLayoutProps) {
+export function HighRiskBreachLayout({ pageData }: HighRiskBreachLayoutProps) {
   const l10n = useL10n();
   const { title, illustration, content, exposedData, type } = pageData;
   const hasBreaches = type !== "none";
@@ -59,7 +56,7 @@ export function HighRiskBreachLayout({
       <ResolutionContent
         content={content}
         exposedData={exposedData}
-        locale={locale}
+        locale={getLocale(l10n)}
       />
     </ResolutionContainer>
   );

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/[type]/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/[type]/page.tsx
@@ -9,7 +9,6 @@ import { HighRiskBreachLayout } from "../HighRiskBreachLayout";
 import { authOptions } from "../../../../../../../../api/utils/auth";
 import { getSubscriberBreaches } from "../../../../../../../../functions/server/getUserBreaches";
 import { getGuidedExperienceBreaches } from "../../../../../../../../functions/universal/guidedExperienceBreaches";
-import { getLocale } from "../../../../../../../../functions/server/l10n";
 import { getHighRiskBreachesByType } from "../highRiskBreachData";
 
 interface SecurityRecommendationsProps {
@@ -22,7 +21,6 @@ export default async function SecurityRecommendations({
   params,
 }: SecurityRecommendationsProps) {
   const session = await getServerSession(authOptions);
-  const locale = getLocale();
   if (!session?.user?.subscriber?.id) {
     return redirect("/");
   }
@@ -37,12 +35,11 @@ export default async function SecurityRecommendations({
   const pageData = getHighRiskBreachesByType({
     dataType: type,
     breaches: guidedExperienceBreaches,
-    locale,
   });
 
   if (!pageData) {
     redirect("/redesign/user/dashboard");
   }
 
-  return <HighRiskBreachLayout pageData={pageData} locale={locale} />;
+  return <HighRiskBreachLayout pageData={pageData} />;
 }

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/highRiskBreachData.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/highRiskBreachData.tsx
@@ -12,6 +12,7 @@ import pinIllustration from "../images/high-risk-data-breach-pin.svg";
 import noBreachesIllustration from "../images/high-risk-breaches-none.svg";
 import { GuidedExperienceBreaches } from "../../../../../../../functions/server/getUserBreaches";
 import { FraudAlertModal } from "./FraudAlertModal";
+import { getLocale } from "../../../../../../../functions/universal/getLocale";
 
 export type HighRiskBreachContent = {
   summary: string;
@@ -41,16 +42,14 @@ export type HighRiskBreach = {
 function getHighRiskBreachesByType({
   dataType,
   breaches,
-  locale,
 }: {
   dataType: string;
   breaches: GuidedExperienceBreaches;
-  locale: string;
 }) {
   const l10n = getL10n();
 
   // TODO: Expose email list & count here https://mozilla-hub.atlassian.net/browse/MNTOR-2112
-  const emailsFormatter = new Intl.ListFormat(locale, {
+  const emailsFormatter = new Intl.ListFormat(getLocale(l10n), {
     style: "long",
     type: "conjunction",
   });

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/page.tsx
@@ -8,13 +8,11 @@ import { HighRiskBreachLayout } from "./HighRiskBreachLayout";
 import { authOptions } from "../../../../../../../api/utils/auth";
 import { getSubscriberEmails } from "../../../../../../../functions/server/getSubscriberEmails";
 import { getGuidedExperienceBreaches } from "../../../../../../../functions/universal/guidedExperienceBreaches";
-import { getLocale } from "../../../../../../../functions/server/l10n";
 import { getSubscriberBreaches } from "../../../../../../../functions/server/getUserBreaches";
 import { getHighRiskBreachesByType } from "./highRiskBreachData";
 
 export default async function HighRiskDataBreaches() {
   const session = await getServerSession(authOptions);
-  const locale = getLocale();
   if (!session?.user?.subscriber?.id) {
     return redirect("/");
   }
@@ -28,7 +26,6 @@ export default async function HighRiskDataBreaches() {
   const pageData = getHighRiskBreachesByType({
     dataType: "none",
     breaches: guidedExperienceBreaches,
-    locale,
   });
 
   if (!pageData) {
@@ -38,7 +35,7 @@ export default async function HighRiskDataBreaches() {
   return (
     <div>
       {/* TODO: MNTOR-1700 Add routing logic here, currently default to no high risk breach data  */}
-      <HighRiskBreachLayout pageData={pageData} locale={locale} />
+      <HighRiskBreachLayout pageData={pageData} />
     </div>
   );
 }

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/leaked-passwords/LeakedPasswordsLayout.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/leaked-passwords/LeakedPasswordsLayout.tsx
@@ -10,16 +10,15 @@ import { Button } from "../../../../../../../components/server/Button";
 import { useL10n } from "../../../../../../../hooks/l10n";
 import { LeakedPassword } from "./leakedPasswordsData";
 import Link from "next/link";
+import { getLocale } from "../../../../../../../functions/universal/getLocale";
 
 export interface LeakedPasswordsLayoutProps {
   label: string;
   pageData: LeakedPassword;
-  locale: string;
 }
 
 export function LeakedPasswordsLayout({
   pageData,
-  locale,
 }: LeakedPasswordsLayoutProps) {
   const l10n = useL10n();
   const { title, illustration, content } = pageData;
@@ -53,7 +52,7 @@ export function LeakedPasswordsLayout({
       }
       estimatedTime={4}
     >
-      <ResolutionContent content={content} locale={locale} />
+      <ResolutionContent content={content} locale={getLocale(l10n)} />
     </ResolutionContainer>
   );
 }

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/leaked-passwords/[type]/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/leaked-passwords/[type]/page.tsx
@@ -7,10 +7,7 @@ import { redirect } from "next/navigation";
 import { authOptions } from "../../../../../../../../api/utils/auth";
 import { getSubscriberBreaches } from "../../../../../../../../functions/server/getUserBreaches";
 import { getGuidedExperienceBreaches } from "../../../../../../../../functions/universal/guidedExperienceBreaches";
-import {
-  getL10n,
-  getLocale,
-} from "../../../../../../../../functions/server/l10n";
+import { getL10n } from "../../../../../../../../functions/server/l10n";
 import { LeakedPasswordsLayout } from "../LeakedPasswordsLayout";
 import { getLeakedPasswords } from "../leakedPasswordsData";
 import { getSubscriberEmails } from "../../../../../../../../functions/server/getSubscriberEmails";
@@ -25,7 +22,6 @@ export default async function LeakedPasswords({
   params,
 }: LeakedPasswordsProps) {
   const session = await getServerSession(authOptions);
-  const locale = getLocale();
   if (!session?.user?.subscriber?.id) {
     return redirect("/");
   }
@@ -51,7 +47,6 @@ export default async function LeakedPasswords({
     <LeakedPasswordsLayout
       label={l10n.getString("security-recommendation-steps-label")}
       pageData={pageData}
-      locale={locale}
     />
   );
 }

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/security-recommendations/SecurityRecommendationsLayout.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/security-recommendations/SecurityRecommendationsLayout.tsx
@@ -9,17 +9,16 @@ import { ResolutionContainer } from "../ResolutionContainer";
 import { ResolutionContent } from "../ResolutionContent";
 import { Button } from "../../../../../../../components/server/Button";
 import { useL10n } from "../../../../../../../hooks/l10n";
+import { getLocale } from "../../../../../../../functions/universal/getLocale";
 
 export interface SecurityRecommendationsLayoutProps {
   label: string;
   pageData: SecurityRecommendation;
-  locale: string;
 }
 
 export function SecurityRecommendationsLayout({
   label,
   pageData,
-  locale,
 }: SecurityRecommendationsLayoutProps) {
   const l10n = useL10n();
   const { title, illustration, content, exposedData } = pageData;
@@ -48,7 +47,7 @@ export function SecurityRecommendationsLayout({
       <ResolutionContent
         content={content}
         exposedData={exposedData}
-        locale={locale}
+        locale={getLocale(l10n)}
       />
     </ResolutionContainer>
   );

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/security-recommendations/[type]/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/security-recommendations/[type]/page.tsx
@@ -10,10 +10,7 @@ import { authOptions } from "../../../../../../../../api/utils/auth";
 import { getSubscriberBreaches } from "../../../../../../../../functions/server/getUserBreaches";
 import { getSubscriberEmails } from "../../../../../../../../functions/server/getSubscriberEmails";
 import { getGuidedExperienceBreaches } from "../../../../../../../../functions/universal/guidedExperienceBreaches";
-import {
-  getL10n,
-  getLocale,
-} from "../../../../../../../../functions/server/l10n";
+import { getL10n } from "../../../../../../../../functions/server/l10n";
 
 interface SecurityRecommendationsProps {
   params: {
@@ -25,7 +22,6 @@ export default async function SecurityRecommendations({
   params,
 }: SecurityRecommendationsProps) {
   const session = await getServerSession(authOptions);
-  const locale = getLocale();
   if (!session?.user?.subscriber?.id) {
     return redirect("/");
   }
@@ -51,7 +47,6 @@ export default async function SecurityRecommendations({
     <SecurityRecommendationsLayout
       label={l10n.getString("security-recommendation-steps-label")}
       pageData={pageData}
-      locale={locale}
     />
   );
 }

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/page.tsx
@@ -9,7 +9,6 @@ import { View } from "./View";
 import { authOptions } from "../../../../../api/utils/auth";
 import { getCountryCode } from "../../../../../functions/server/getCountryCode";
 import { getSubscriberBreaches } from "../../../../../functions/server/getUserBreaches";
-import { getLocale } from "../../../../../functions/server/l10n";
 import { canSubscribeToPremium } from "../../../../../functions/universal/user";
 import { getLatestOnerepScanResults } from "../../../../../../db/tables/onerep_scans";
 import { getOnerepProfileId } from "../../../../../../db/tables/subscribers";
@@ -36,7 +35,6 @@ export default async function DashboardPage() {
 
   const latestScan = await getLatestOnerepScanResults(profileId);
   const subBreaches = await getSubscriberBreaches(session.user);
-  const locale = getLocale();
 
   const userIsEligibleForFreeScan = await isEligibleForFreeScan(
     session.user,
@@ -57,7 +55,6 @@ export default async function DashboardPage() {
       isEligibleForFreeScan={userIsEligibleForFreeScan}
       userScanData={latestScan}
       userBreaches={subBreaches}
-      locale={locale}
       featureFlagsEnabled={featureFlagsEnabled}
     />
   );

--- a/src/app/(proper_react)/redesign/(authenticated)/user/welcome/EnterInfo.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/welcome/EnterInfo.tsx
@@ -24,6 +24,7 @@ import {
   WelcomeScanBody,
 } from "../../../../../api/v1/user/welcome-scan/create/route";
 import { meetsAgeRequirement } from "../../../../../functions/universal/user";
+import { getLocale } from "../../../../../functions/universal/getLocale";
 
 import styles from "./EnterInfo.module.scss";
 
@@ -128,7 +129,7 @@ export const EnterInfo = ({ onScanStarted, onGoBack }: Props) => {
       type: "date",
       placeholder: "",
       value: dateOfBirth,
-      displayValue: new Date(dateOfBirth).toLocaleDateString("en-US", {
+      displayValue: new Date(dateOfBirth).toLocaleDateString(getLocale(l10n), {
         dateStyle: "medium",
         timeZone: "UTC",
       }),

--- a/src/app/functions/server/l10n.ts
+++ b/src/app/functions/server/l10n.ts
@@ -20,10 +20,6 @@ export type LocaleData = {
   bundleSources: string[];
 };
 
-export function getLocale(localeData: LocaleData[] = getL10nBundles()): string {
-  return localeData[0]?.locale ?? "en";
-}
-
 // `require` isn't usually valid JS, so skip type checking for that:
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const translationsContext = (require as any).context(

--- a/src/app/functions/universal/getLocale.test.ts
+++ b/src/app/functions/universal/getLocale.test.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { it, expect } from "@jest/globals";
+import { getLocale } from "./getLocale";
+import { LocaleData } from "../server/l10n";
+import { ReactLocalization } from "@fluent/react";
+import { FluentBundle } from "@fluent/bundle";
+
+it("can detect the applicable locale from plain bundle sources", () => {
+  const localeData: LocaleData[] = [
+    {
+      locale: "nl",
+      bundleSources: [],
+    },
+    {
+      locale: "es",
+      bundleSources: [],
+    },
+  ];
+
+  expect(getLocale(localeData)).toBe("nl");
+});
+
+it("can detect the applicable locale an instantiated ReactLocalization instance", () => {
+  const localeData = new ReactLocalization([
+    new FluentBundle("nl"),
+    new FluentBundle("es"),
+  ]);
+
+  expect(getLocale(localeData)).toBe("nl");
+});
+
+it("falls back to `en` if no locale could be detected", () => {
+  const localeData: LocaleData[] = [];
+
+  expect(getLocale(localeData)).toBe("en");
+});

--- a/src/app/functions/universal/getLocale.ts
+++ b/src/app/functions/universal/getLocale.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ReactLocalization } from "@fluent/react";
+import { LocaleData } from "../server/l10n";
+
+export function getLocale(
+  localeData: LocaleData[] | ReactLocalization
+): string {
+  return (
+    (Array.isArray(localeData)
+      ? localeData[0]?.locale
+      : Array.from(localeData.bundles)[0].locales[0]) ?? "en"
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,8 @@ import { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { getServerSession } from "next-auth";
-import { getLocale, getL10n } from "./functions/server/l10n";
+import { getL10n, getL10nBundles } from "./functions/server/l10n";
+import { getLocale } from "./functions/universal/getLocale";
 import { SessionProvider } from "../contextProviders/session";
 import { authOptions } from "./api/utils/auth";
 import { metropolis } from "./fonts/Metropolis/metropolis";
@@ -45,7 +46,7 @@ export default async function RootLayout({
 }: {
   children: ReactNode;
 }) {
-  const currentLocale = getLocale();
+  const currentLocale = getLocale(getL10nBundles());
   const session = await getServerSession(authOptions);
 
   return (


### PR DESCRIPTION
As called out in https://github.com/mozilla/blurts-server/pull/3427#issuecomment-1729707101, we hardcoded `en-US` here, rather than relying on the user's locale. d500cfac7b72e192480233ea85ca758463faa50d makes that dependent on the user's locale - the main downside is that that locale might not match the language of the website, since this part of the website is forced in English.

This PR also includes 4721768add9bcbfcde33ee3289040f1edab3fd89, which allows calling `getLocale` in client components - but does now require passing in the `l10n` instance.