### PR TITLE
MNTOR-2022/add content type header for cirrus

### DIFF
--- a/src/app/functions/server/getExperiments.ts
+++ b/src/app/functions/server/getExperiments.ts
@@ -26,7 +26,10 @@ export async function getExperiments(
         "Content-Type": "application/json",
       },
       method: "POST",
-      body: JSON.stringify({ client_id: userId, context: {} }),
+      body: JSON.stringify({
+        client_id: userId,
+        context: { key: "example-key" },
+      }),
     });
   } catch (ex) {
     console.error(`Could not connect to Cirrus on ${serverUrl}`, ex);

--- a/src/app/functions/server/getExperiments.ts
+++ b/src/app/functions/server/getExperiments.ts
@@ -22,6 +22,9 @@ export async function getExperiments(
   let features;
   try {
     features = await fetch(`${serverUrl}/v1/features/`, {
+      headers: {
+        "Content-Type": "application/json",
+      },
       method: "POST",
       body: JSON.stringify({ client_id: userId, context: {} }),
     });


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2022


<!-- When adding a new feature: -->

# Description

The Cirrus container requires `Content-Type: application/json` (or it returns HTTP 422), and additionally `context` may not be empty.

# How to test

I ran the Cirrus container in https://github.com/mozilla/experimenter/ locally, but I think we can just deploy to stage and test it there at this point.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
