### PR TITLE
Set fallback id for GA

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -126,7 +126,7 @@ ADMINS=
 # Enable monthly cron-job, currently for sending unresolved breach reminder emails
 MONTHLY_CRON_ENABLED=
 
-NEXT_PUBLIC_GA4_MEASUREMENT_ID=test
+NEXT_PUBLIC_GA4_MEASUREMENT_ID=G-CXG8K4KW4P
 
 # E2E Tests
 E2E_TEST_ENV=


### PR DESCRIPTION
Add fallback value for the public env var `NEXT_PUBLIC_GA4_MEASUREMENT_ID`.
