### PR TITLE
Avoid error about undefined `navigator`

### DIFF
--- a/src/app/(proper_react)/redesign/GaScript.tsx
+++ b/src/app/(proper_react)/redesign/GaScript.tsx
@@ -15,7 +15,7 @@ export const GaScript = ({ nonce }: Props) => {
   const ga4MeasurementId =
     process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID || "G-CXG8K4KW4P";
 
-  return navigator && navigator.doNotTrack !== "1" ? (
+  return typeof navigator !== "undefined" && navigator.doNotTrack !== "1" ? (
     <Script
       src={`https://www.googletagmanager.com/gtag/js?id=${ga4MeasurementId}`}
       nonce={nonce}


### PR DESCRIPTION
When server-rendering, `navigator` is not defined - but by comparing that variable directly with `undefined`, we're still referring to it and thus still triggering an error message. Passing it into `typeof` avoids that.
