### PR TITLE
Make scan resolution skip link work

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/FixView.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/FixView.tsx
@@ -20,6 +20,7 @@ import stepSecurityRecommendationsIcon from "./images/step-counter-security-reco
 import { usePathname } from "next/navigation";
 import { GuidedExperienceBreaches } from "../../../../../../functions/server/getUserBreaches";
 import { useL10n } from "../../../../../../hooks/l10n";
+import { stepLinks } from "../../../../../../functions/server/getRelevantGuidedSteps";
 
 export type FixViewProps = {
   children: ReactNode;
@@ -96,6 +97,15 @@ export const FixView = (props: FixViewProps) => {
     );
   };
 
+  const currentStepIndex = stepLinks.findIndex((stepLink) =>
+    stepLink.href.startsWith(pathname)
+  );
+  const prevStepHref =
+    currentStepIndex <= 0
+      ? "/redesign/user/dashboard"
+      : stepLinks[currentStepIndex - 1].href;
+  const nextStepHref = stepLinks[currentStepIndex + 1].href;
+
   return (
     <div className={styles.fixContainer}>
       <div
@@ -111,7 +121,7 @@ export const FixView = (props: FixViewProps) => {
         <section className={styles.fixSection}>
           <Link
             className={`${styles.navArrow} ${styles.navArrowBack}`}
-            href="/redesign/user/dashboard"
+            href={prevStepHref}
             aria-label={l10n.getString("guided-resolution-flow-back-arrow")}
           >
             <Image alt="" src={ImageArrowLeft} />
@@ -119,7 +129,7 @@ export const FixView = (props: FixViewProps) => {
           <div className={styles.viewWrapper}>{props.children}</div>
           <Link
             className={`${styles.navArrow} ${styles.navArrowNext}`}
-            href="/redesign/user/dashboard"
+            href={nextStepHref}
             aria-label={l10n.getString("guided-resolution-flow-next-arrow")}
           >
             <Image alt="" src={ImageArrowRight} />

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/ManualRemove.stories.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/ManualRemove.stories.tsx
@@ -85,6 +85,8 @@ export const ManualRemoveViewStory: Story = {
           <ManualRemoveView
             scanData={mockedScanData}
             breaches={mockedBreaches}
+            countryCode="us"
+            user={mockedSession.user}
           />
         </FixView>
       </Shell>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/ManualRemoveView.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/ManualRemoveView.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { Session } from "next-auth";
 import styles from "./ManualRemoveView.module.scss";
 import { getL10n } from "../../../../../../../../functions/server/l10n";
 import {
@@ -16,10 +17,13 @@ import {
 } from "../../../../../../../../functions/server/dashboard";
 import { SubscriberBreach } from "../../../../../../../../../utils/subscriberBreaches";
 import { RemovalCard } from "./RemovalCard";
+import { getRelevantGuidedSteps } from "../../../../../../../../functions/server/getRelevantGuidedSteps";
 
 export type Props = {
   scanData: LatestOnerepScanData;
   breaches: SubscriberBreach[];
+  user: Session["user"];
+  countryCode: string;
 };
 
 export function ManualRemoveView(props: Props) {
@@ -32,6 +36,16 @@ export function ManualRemoveView(props: Props) {
   const exposureReduction = getExposureReduction(
     summary,
     props.scanData.results
+  );
+
+  const stepAfterSkip = getRelevantGuidedSteps(
+    {
+      countryCode: props.countryCode,
+      latestScanData: props.scanData,
+      subscriberBreaches: props.breaches,
+      user: props.user,
+    },
+    "Scan"
   );
 
   return (
@@ -120,10 +134,7 @@ export function ManualRemoveView(props: Props) {
             "fix-flow-data-broker-profiles-manual-remove-button-remove-for-me"
           )}
         </Button>
-        <Button
-          variant="secondary"
-          href="/" // TODO: MNTOR-1700 Add routing logic here
-        >
+        <Button variant="secondary" href={stepAfterSkip.current?.href}>
           {l10n.getString(
             "fix-flow-data-broker-profiles-manual-remove-button-skip"
           )}

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/page.tsx
@@ -4,11 +4,13 @@
 
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
+import { headers } from "next/headers";
 import { getLatestOnerepScanResults } from "../../../../../../../../../db/tables/onerep_scans";
 import { getOnerepProfileId } from "../../../../../../../../../db/tables/subscribers";
 import { getSubscriberBreaches } from "../../../../../../../../functions/server/getUserBreaches";
 import { ManualRemoveView } from "./ManualRemoveView";
 import { authOptions } from "../../../../../../../../api/utils/auth";
+import { getCountryCode } from "../../../../../../../../functions/server/getCountryCode";
 
 export default async function ManualRemove() {
   const session = await getServerSession(authOptions);
@@ -21,5 +23,12 @@ export default async function ManualRemove() {
   const profileId = result[0]["onerep_profile_id"] as number;
   const scanData = await getLatestOnerepScanResults(profileId);
   const subBreaches = await getSubscriberBreaches(session.user);
-  return <ManualRemoveView breaches={subBreaches} scanData={scanData} />;
+  return (
+    <ManualRemoveView
+      breaches={subBreaches}
+      scanData={scanData}
+      user={session.user}
+      countryCode={getCountryCode(headers())}
+    />
+  );
 }

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/start-free-scan/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/start-free-scan/page.tsx
@@ -2,16 +2,44 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-"use client";
-
+import { headers } from "next/headers";
 import Image from "next/image";
 import ImageCityScape from "./images/city-scape.svg";
 import styles from "../dataBrokerProfiles.module.scss";
-import { useL10n } from "../../../../../../../../hooks/l10n";
 import { Button } from "../../../../../../../../components/server/Button";
+import { getLatestOnerepScanResults } from "../../../../../../../../../db/tables/onerep_scans";
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../../../../../../../../api/utils/auth";
+import { getOnerepProfileId } from "../../../../../../../../../db/tables/subscribers";
+import { getCountryCode } from "../../../../../../../../functions/server/getCountryCode";
+import { getL10n } from "../../../../../../../../functions/server/l10n";
 
-export default function StartFreeScan() {
-  const l10n = useL10n();
+export default async function StartFreeScan() {
+  const l10n = getL10n();
+
+  const countryCode = getCountryCode(headers());
+  if (countryCode !== "us") {
+    redirect("/redesign/user/dashboard");
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.subscriber?.id) {
+    return redirect("/");
+  }
+
+  const result = await getOnerepProfileId(session.user.subscriber.id);
+  const onerepProfileId = result[0]["onerep_profile_id"];
+
+  if (typeof onerepProfileId === "number") {
+    const scanData = await getLatestOnerepScanResults(onerepProfileId);
+    if (scanData.scan !== null) {
+      // If the user already has done a scan, let them view their results:
+      return redirect(
+        "/redesign/user/dashboard/fix/data-broker-profiles/view-data-brokers"
+      );
+    }
+  }
 
   return (
     <div className={styles.contentWrapper}>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/[type]/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/[type]/page.tsx
@@ -9,11 +9,14 @@ import { HighRiskBreachLayout } from "../HighRiskBreachLayout";
 import { authOptions } from "../../../../../../../../api/utils/auth";
 import { getSubscriberBreaches } from "../../../../../../../../functions/server/getUserBreaches";
 import { getGuidedExperienceBreaches } from "../../../../../../../../functions/universal/guidedExperienceBreaches";
-import { getHighRiskBreachesByType } from "../highRiskBreachData";
+import {
+  HighRiskBreachTypes,
+  getHighRiskBreachesByType,
+} from "../highRiskBreachData";
 
 interface SecurityRecommendationsProps {
   params: {
-    type: string;
+    type: HighRiskBreachTypes;
   };
 }
 

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/highRiskBreachData.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/highRiskBreachData.tsx
@@ -43,7 +43,7 @@ function getHighRiskBreachesByType({
   dataType,
   breaches,
 }: {
-  dataType: string;
+  dataType: HighRiskBreachTypes;
   breaches: GuidedExperienceBreaches;
 }) {
   const l10n = getL10n();
@@ -62,7 +62,7 @@ function getHighRiskBreachesByType({
       exposedData: breaches.highRisk.creditCardBreaches,
       content: {
         summary: l10n.getString("high-risk-breach-summary", {
-          num_breaches: 0,
+          num_breaches: breaches.highRisk.creditCardBreaches.length,
         }),
         description: (
           <p>{l10n.getString("high-risk-breach-credit-card-description")}</p>
@@ -89,7 +89,7 @@ function getHighRiskBreachesByType({
       exposedData: breaches.highRisk.ssnBreaches,
       content: {
         summary: l10n.getString("high-risk-breach-summary", {
-          num_breaches: 0,
+          num_breaches: breaches.highRisk.ssnBreaches.length,
         }),
         description: (
           <p>
@@ -140,7 +140,7 @@ function getHighRiskBreachesByType({
       exposedData: breaches.highRisk.bankBreaches,
       content: {
         summary: l10n.getString("high-risk-breach-summary", {
-          num_breaches: 0,
+          num_breaches: breaches.highRisk.bankBreaches.length,
         }),
         description: (
           <p>{l10n.getString("high-risk-breach-bank-account-description")}</p>
@@ -171,7 +171,7 @@ function getHighRiskBreachesByType({
       exposedData: breaches.highRisk.pinBreaches,
       content: {
         summary: l10n.getString("high-risk-breach-summary", {
-          num_breaches: 0,
+          num_breaches: breaches.highRisk.pinBreaches.length,
         }),
         description: (
           <p>{l10n.getString("high-risk-breach-pin-description")}</p>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/getUserDashboardState.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/getUserDashboardState.tsx
@@ -126,7 +126,7 @@ export const getUserDashboardState = (
      * - No scan
      */
     isMatchingContent(contentProps, {
-      isRelevantGuidedStep: relevantGuidedStep.id === "StartScan",
+      isRelevantGuidedStep: relevantGuidedStep.id === "Scan",
       hasExposures: false,
       hasUnresolvedBreaches: false,
       hasUnresolvedBrokers: false,
@@ -142,7 +142,7 @@ export const getUserDashboardState = (
      * - No scan
      */
     isMatchingContent(contentProps, {
-      isRelevantGuidedStep: relevantGuidedStep.id === "StartScan",
+      isRelevantGuidedStep: relevantGuidedStep.id === "Scan",
       hasExposures: true,
       hasUnresolvedBreaches: true,
       hasUnresolvedBrokers: false,
@@ -158,7 +158,7 @@ export const getUserDashboardState = (
      * - No scan
      */
     isMatchingContent(contentProps, {
-      isRelevantGuidedStep: relevantGuidedStep.id === "StartScan",
+      isRelevantGuidedStep: relevantGuidedStep.id === "Scan",
       hasExposures: true,
       hasUnresolvedBreaches: false,
       hasUnresolvedBrokers: false,
@@ -200,7 +200,7 @@ export const getUserDashboardState = (
      * - Scan: Unresolved and removal not started
      */
     isMatchingContent(contentProps, {
-      isRelevantGuidedStep: relevantGuidedStep.id === "ScanResult",
+      isRelevantGuidedStep: relevantGuidedStep.id === "Scan",
       hasExposures: true,
       hasUnresolvedBreaches: false,
       hasUnresolvedBrokers: true,
@@ -216,7 +216,7 @@ export const getUserDashboardState = (
      * - Scan: Unresolved
      */
     isMatchingContent(contentProps, {
-      isRelevantGuidedStep: relevantGuidedStep.id === "ScanResult",
+      isRelevantGuidedStep: relevantGuidedStep.id === "Scan",
       hasExposures: true,
       hasUnresolvedBreaches: true,
       hasUnresolvedBrokers: false,
@@ -226,7 +226,7 @@ export const getUserDashboardState = (
       scanInProgress: false,
     }) ||
     isMatchingContent(contentProps, {
-      isRelevantGuidedStep: relevantGuidedStep.id === "ScanResult",
+      isRelevantGuidedStep: relevantGuidedStep.id === "Scan",
       hasExposures: true,
       hasUnresolvedBreaches: true,
       hasUnresolvedBrokers: true,
@@ -305,7 +305,7 @@ export const getUserDashboardState = (
      * - Scan: Unresolved
      */
     isMatchingContent(contentProps, {
-      isRelevantGuidedStep: relevantGuidedStep.id === "ScanResult",
+      isRelevantGuidedStep: relevantGuidedStep.id === "Scan",
       hasExposures: true,
       hasUnresolvedBreaches: true,
       hasUnresolvedBrokers: true,
@@ -337,7 +337,7 @@ export const getUserDashboardState = (
      * - Scan: Unresolved
      */
     isMatchingContent(contentProps, {
-      isRelevantGuidedStep: relevantGuidedStep.id === "ScanResult",
+      isRelevantGuidedStep: relevantGuidedStep.id === "Scan",
       hasExposures: true,
       hasUnresolvedBreaches: false,
       hasUnresolvedBrokers: true,
@@ -380,7 +380,7 @@ export const getUserDashboardState = (
      */
     isMatchingContent(contentProps, {
       isRelevantGuidedStep:
-        relevantGuidedStep.id === "ScanResult" ||
+        isGuidedResolutionInProgress(relevantGuidedStep.id) ||
         relevantGuidedStep.id === "Done",
       hasExposures: true,
       hasUnresolvedBreaches: false,
@@ -402,7 +402,7 @@ export const getUserDashboardState = (
      * - Scan: Running and no results
      */
     isMatchingContent(contentProps, {
-      isRelevantGuidedStep: relevantGuidedStep.id === "ScanResult",
+      isRelevantGuidedStep: relevantGuidedStep.id === "Done",
       hasExposures: false,
       hasUnresolvedBreaches: false,
       hasUnresolvedBrokers: false,
@@ -423,7 +423,7 @@ export const getUserDashboardState = (
      * - Scan: Running and results found
      */
     isMatchingContent(contentProps, {
-      isRelevantGuidedStep: relevantGuidedStep.id === "ScanResult",
+      isRelevantGuidedStep: relevantGuidedStep.id === "Scan",
       hasExposures: true,
       hasUnresolvedBreaches: false,
       hasUnresolvedBrokers: true,
@@ -439,7 +439,7 @@ export const getUserDashboardState = (
      * - Scan: Running and no results
      */
     isMatchingContent(contentProps, {
-      isRelevantGuidedStep: relevantGuidedStep.id === "ScanResult",
+      isRelevantGuidedStep: isGuidedResolutionInProgress(relevantGuidedStep.id),
       hasExposures: true,
       hasUnresolvedBreaches: true,
       hasUnresolvedBrokers: false,
@@ -455,7 +455,7 @@ export const getUserDashboardState = (
      * - Scan: Running and found results
      */
     isMatchingContent(contentProps, {
-      isRelevantGuidedStep: relevantGuidedStep.id === "ScanResult",
+      isRelevantGuidedStep: relevantGuidedStep.id === "Scan",
       hasExposures: true,
       hasUnresolvedBreaches: true,
       hasUnresolvedBrokers: true,

--- a/src/app/functions/server/getRelevantGuidedSteps.ts
+++ b/src/app/functions/server/getRelevantGuidedSteps.ts
@@ -19,18 +19,14 @@ export type InputData = {
 export const stepLinks = [
   {
     href: "/redesign/user/dashboard/fix/data-broker-profiles/start-free-scan",
-    id: "StartScan",
-  },
-  {
-    href: "/redesign/user/dashboard/fix/data-broker-profiles/view-data-brokers",
-    id: "ScanResult",
+    id: "Scan",
   },
   {
     href: "/redesign/user/dashboard/fix/high-risk-data-breaches/social-security-number",
     id: "HighRiskSsn",
   },
   {
-    href: "/redesign/user/dashboard/fix/high-risk-data-breaches/credit-card-number",
+    href: "/redesign/user/dashboard/fix/high-risk-data-breaches/credit-card",
     id: "HighRiskCreditCard",
   },
   {
@@ -80,12 +76,7 @@ export type OutputData = {
 
 export function isGuidedResolutionInProgress(stepId: StepLink["id"]) {
   const inProgressStepIds = stepLinks
-    .filter(
-      (step) =>
-        step.id !== "StartScan" &&
-        step.id !== "ScanResult" &&
-        step.id !== "Done"
-    )
+    .filter((step) => step.id !== "Scan" && step.id !== "Done")
     .map(({ id }) => id);
   return inProgressStepIds.includes(stepId);
 }
@@ -149,11 +140,7 @@ function getStepWithStatus(
 }
 
 function isEligibleFor(data: InputData, stepId: StepLink["id"]): boolean {
-  if (stepId === "StartScan") {
-    return data.countryCode === "us";
-  }
-
-  if (stepId === "ScanResult") {
+  if (stepId === "Scan") {
     return data.countryCode === "us";
   }
 
@@ -199,22 +186,21 @@ function isEligibleFor(data: InputData, stepId: StepLink["id"]): boolean {
 }
 
 function hasCompleted(data: InputData, stepId: StepLink["id"]): boolean {
-  if (stepId === "StartScan") {
-    return data.latestScanData?.scan !== null;
+  if (stepId === "Scan") {
+    const hasRunScan =
+      typeof data.latestScanData?.scan === "object" &&
+      data.latestScanData?.scan !== null;
+    const hasResolvedAllScanResults =
+      (data.latestScanData?.scan?.onerep_scan_status === "finished" ||
+        data.latestScanData?.scan?.onerep_scan_status === "in_progress") &&
+      data.latestScanData.results.every(
+        (scanResult) =>
+          scanResult.manually_resolved || scanResult.status !== "new"
+      );
+    return hasRunScan && hasResolvedAllScanResults;
   }
 
-  if (stepId === "ScanResult") {
-    return (
-      data.latestScanData !== null &&
-      Array.isArray(data.latestScanData?.results) &&
-      !data.latestScanData.results.some((scanResult) => {
-        return scanResult.status === "new" && !scanResult.manually_resolved;
-      }) &&
-      data.latestScanData?.scan?.onerep_scan_status === "finished"
-    );
-  }
-
-  function isResolved(
+  function isBreachResolved(
     dataClass: (typeof BreachDataTypes)[keyof typeof BreachDataTypes]
   ): boolean {
     return !data.subscriberBreaches.some((breach) => {
@@ -229,39 +215,39 @@ function hasCompleted(data: InputData, stepId: StepLink["id"]): boolean {
   }
 
   if (stepId === "HighRiskSsn") {
-    return isResolved(HighRiskDataTypes.SSN);
+    return isBreachResolved(HighRiskDataTypes.SSN);
   }
 
   if (stepId === "HighRiskCreditCard") {
-    return isResolved(HighRiskDataTypes.CreditCard);
+    return isBreachResolved(HighRiskDataTypes.CreditCard);
   }
 
   if (stepId === "HighRiskBankAccount") {
-    return isResolved(HighRiskDataTypes.BankAccount);
+    return isBreachResolved(HighRiskDataTypes.BankAccount);
   }
 
   if (stepId === "HighRiskPin") {
-    return isResolved(HighRiskDataTypes.PIN);
+    return isBreachResolved(HighRiskDataTypes.PIN);
   }
 
   if (stepId === "LeakedPasswordsPassword") {
-    return isResolved(BreachDataTypes.Passwords);
+    return isBreachResolved(BreachDataTypes.Passwords);
   }
 
   if (stepId === "LeakedPasswordsSecurityQuestion") {
-    return isResolved(BreachDataTypes.SecurityQuestions);
+    return isBreachResolved(BreachDataTypes.SecurityQuestions);
   }
 
   if (stepId === "SecurityTipsPhone") {
-    return isResolved(BreachDataTypes.Phone);
+    return isBreachResolved(BreachDataTypes.Phone);
   }
 
   if (stepId === "SecurityTipsEmail") {
-    return isResolved(BreachDataTypes.Email);
+    return isBreachResolved(BreachDataTypes.Email);
   }
 
   if (stepId === "SecurityTipsIp") {
-    return isResolved(BreachDataTypes.IP);
+    return isBreachResolved(BreachDataTypes.IP);
   }
 
   if (stepId === "Done") {


### PR DESCRIPTION
This also involved merging the scan steps into a single one, since we don't want the "Skip" button on the scan step to skip to the scan results step.

I also fixed some numbers that were hardcoded to 0, and the link to the credit card breach resolution.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2116
Figma: N/A


<!-- When adding a new feature: -->

# Description

This makes the "Skip for now" link on the manual broker resolution page work.

# How to test

Visit http://localhost:6060/redesign/user/dashboard/fix/data-broker-profiles/manual-remove, then click "Skip for now".

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met. N/A
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
