### PR TITLE
Fix Next-Auth types

### DIFF
--- a/src/app/api/utils/auth.ts
+++ b/src/app/api/utils/auth.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { NextRequest } from "next/server";
-import { AuthOptions, Profile } from "next-auth";
+import { AuthOptions, Profile as FxaProfile, User } from "next-auth";
 import mozlog from "../../../utils/log.js";
 
 import AppConstants from "../../../appConstants.js";
@@ -19,22 +19,42 @@ import { getEmailCtaHref, initEmail, sendEmail } from "../../../utils/email.js";
 import { getTemplate } from "../../../views/emails/email2022.js";
 import { signupReportEmailPartial } from "../../../views/emails/emailSignupReport.js";
 import { getL10n } from "../../functions/server/l10n";
+import { OAuthConfig } from "next-auth/providers/oauth.js";
 
 const log = mozlog("controllers.auth");
 
-interface FxaProfile {
-  email: string;
-  /** The value of the Accept-Language header when the user signed up for their Firefox Account */
-  locale: string;
-  amrValues: ["pwd", "email"];
-  twoFactorAuthentication: boolean;
-  metricsEnabled: boolean;
-  uid: string;
-  /** URL to an avatar image for the current user */
-  avatar: string;
-  avatarDefault: boolean;
-  subscriptions?: Array<string>;
-}
+const fxaProviderConfig: OAuthConfig<FxaProfile> = {
+  // As per https://mozilla.slack.com/archives/C4D36CAJW/p1683642497940629?thread_ts=1683642325.465929&cid=C4D36CAJW,
+  // we should file a ticket against SVCSE with the `fxa` component to add
+  // a redirect URL of /api/auth/callback/fxa for Firefox Monitor,
+  // for every environment we deploy to:
+  id: "fxa",
+  name: "Firefox Accounts",
+  type: "oauth",
+  authorization: {
+    url: AppConstants.OAUTH_AUTHORIZATION_URI,
+    params: {
+      scope: "profile https://identity.mozilla.com/account/subscriptions",
+      access_type: "offline",
+      action: "email",
+      prompt: "login",
+      max_age: 0,
+    },
+  },
+  token: AppConstants.OAUTH_TOKEN_URI,
+  // userinfo: AppConstants.OAUTH_PROFILE_URI,
+  userinfo: {
+    request: async (context) =>
+      fetchUserInfo(context.tokens.access_token ?? ""),
+  },
+  clientId: AppConstants.OAUTH_CLIENT_ID,
+  clientSecret: AppConstants.OAUTH_CLIENT_SECRET,
+  // Parse data returned by FxA's /userinfo/
+  profile: (profile) => {
+    log.debug("fxa-confirmed-profile-data", profile);
+    return convertFxaProfile(profile);
+  },
+};
 
 export const authOptions: AuthOptions = {
   debug: true,
@@ -42,49 +62,13 @@ export const authOptions: AuthOptions = {
   session: {
     strategy: "jwt",
   },
-  providers: [
-    {
-      // As per https://mozilla.slack.com/archives/C4D36CAJW/p1683642497940629?thread_ts=1683642325.465929&cid=C4D36CAJW,
-      // we should file a ticket against SVCSE with the `fxa` component to add
-      // a redirect URL of /api/auth/callback/fxa for Firefox Monitor,
-      // for every environment we deploy to:
-      id: "fxa",
-      name: "Firefox Accounts",
-      type: "oauth",
-      authorization: {
-        url: AppConstants.OAUTH_AUTHORIZATION_URI,
-        params: {
-          scope: "profile https://identity.mozilla.com/account/subscriptions",
-          access_type: "offline",
-          action: "email",
-          prompt: "login",
-          max_age: 0,
-        },
-      },
-      token: AppConstants.OAUTH_TOKEN_URI,
-      // This function calls `profile` below, which converts the `FxaProfile` -> `Profile`.
-      userinfo: {
-        request: async (context) =>
-          fetchUserInfo(
-            context.tokens.access_token ?? ""
-          ) as unknown as Promise<Profile>,
-      },
-      clientId: AppConstants.OAUTH_CLIENT_ID,
-      clientSecret: AppConstants.OAUTH_CLIENT_SECRET,
-      // Parse data returned by FxA's /userinfo/
-      profile: (profile: FxaProfile) => {
-        log.debug("fxa-confirmed-profile-data", profile);
-        return convertFxaProfile(profile);
-      },
-    },
-  ],
+  providers: [fxaProviderConfig],
   callbacks: {
     // Unused arguments also listed to show what's available:
     async jwt({ token, account, profile, trigger }) {
       if (trigger === "update") {
-        profile = convertFxaProfile(
-          await fetchUserInfo(token.subscriber?.fxa_access_token ?? "")
-        );
+        // Refresh the user data from FxA, in case e.g. new subscriptions got added:
+        profile = await fetchUserInfo(token.subscriber?.fxa_access_token ?? "");
       }
       if (profile) {
         token.fxa = {
@@ -93,7 +77,7 @@ export const authOptions: AuthOptions = {
           metricsEnabled: profile.metricsEnabled,
           avatar: profile.avatar,
           avatarDefault: profile.avatarDefault,
-          subscriptions: profile.subscriptions,
+          subscriptions: profile.subscriptions ?? [],
         };
       }
       if (account && typeof profile?.email === "string") {
@@ -198,26 +182,26 @@ async function fetchUserInfo(accessToken: string) {
       Authorization: `Bearer ${accessToken ?? ""}`,
     },
   });
-  const userInfo = await response.json();
-  return userInfo as FxaProfile;
+  const userInfo = (await response.json()) as FxaProfile;
+  return userInfo;
 }
 
 /**
- * Converts an FxAProfile to a standard OAuth Profile.
+ * Converts an FxAProfile to a Next-Auth user object
  *
  * @param profile
  */
-function convertFxaProfile(profile: FxaProfile) {
+function convertFxaProfile(profile: FxaProfile): User {
   return {
     id: profile.uid,
-    email: profile.email,
+    email: profile.email!,
     avatar: profile.avatar,
     avatarDefault: profile.avatarDefault,
     twoFactorAuthentication: profile.twoFactorAuthentication,
     metricsEnabled: profile.metricsEnabled,
     locale: profile.locale,
-    subscriptions: profile.subscriptions,
-  } as Profile;
+    subscriptions: profile.subscriptions ?? [],
+  };
 }
 
 export function bearerToken(req: NextRequest) {

--- a/src/next-auth.d.ts
+++ b/src/next-auth.d.ts
@@ -8,6 +8,21 @@ import { SubscriberRow } from "knex/types/tables";
 declare module "next-auth" {
   /** The OAuth profile extracted from Firefox Accounts */
   interface Profile {
+    email: string;
+    /** The value of the Accept-Language header when the user signed up for their Firefox Account */
+    locale: string;
+    amrValues: ["pwd", "email"];
+    twoFactorAuthentication: boolean;
+    metricsEnabled: boolean;
+    uid: string;
+    /** URL to an avatar image for the current user */
+    avatar: string;
+    avatarDefault: boolean;
+    subscriptions?: Array<string>;
+  }
+
+  /** Shape of the data the FxaProvider's `profile` callback returns: */
+  interface User {
     id: string;
     email: string;
     /** The value of the Accept-Language header when the user signed up for their Firefox Account */


### PR DESCRIPTION
This is re: https://github.com/mozilla/blurts-server/pull/3486#discussion_r1345652068

I think they represent what they should know. This also separates out the FxA OAuth config from the Next-Auth user session management config, which should hopefully also help with the mental model.

So we now have `Profile`, which represents the shape of the data as returned by FxA's `/userinfo/` endpoint. Then we have the `User`, representing the user object we give to Next-Auth.
