### PR TITLE
Mock <DataBrokerImage> in tests

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
@@ -29,6 +29,17 @@ jest.mock("next/navigation", () => ({
   usePathname: jest.fn(),
 }));
 
+jest.mock("../../../../../components/client/DataBrokerImage", () => {
+  return {
+    // Mock this with an empty React component. Otherwise, tests will complain:
+    // > Warning: A suspended resource finished loading inside a test, but the
+    // > event was not wrapped in act(...).
+    // > When testing, code that resolves suspended data should be wrapped into
+    // > act(...)
+    DataBrokerImage: () => null,
+  };
+});
+
 it("passes the axe accessibility test suite 1", async () => {
   const ComposedDashboard = composeStory(DashboardNonUsNoBreaches, Meta);
   const { container } = render(<ComposedDashboard />);

--- a/src/app/components/client/DataBrokerImage.test.tsx
+++ b/src/app/components/client/DataBrokerImage.test.tsx
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import { DataBrokerImage } from "./DataBrokerImage";
+
+it("renders a fallback icon until the image has loaded", async () => {
+  render(<DataBrokerImage name="SSSSome name" />);
+
+  const falbackLogo = screen.getByRole("img", { hidden: true });
+  expect(falbackLogo).toBeInTheDocument();
+  expect(falbackLogo.textContent).toBe("S");
+  expect(falbackLogo.tagName).not.toBe("IMG");
+
+  await waitForElementToBeRemoved(falbackLogo);
+  const loadedImage = screen.getByRole("img", { hidden: true });
+  expect(loadedImage).toBeInTheDocument();
+  expect(loadedImage.tagName).toBe("IMG");
+});

--- a/src/app/components/client/DataBrokerImage.tsx
+++ b/src/app/components/client/DataBrokerImage.tsx
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { Suspense, lazy } from "react";
+import styles from "./ExposureCard.module.scss";
+import Image from "next/image";
+import { FallbackLogo } from "../server/BreachLogo";
+
+export const DataBrokerImage = (props: { name: string }) => {
+  const LazyLoadedImage = lazy(() => getDataBrokerImage(props.name));
+
+  return (
+    <Suspense fallback={<FallbackLogo name={props.name} />}>
+      <LazyLoadedImage />
+    </Suspense>
+  );
+};
+
+async function getDataBrokerImage(name: string) {
+  try {
+    const DataBrokerLogo = await import(
+      `../client/assets/data-brokers/${name}.png`
+    );
+    const ImageComponent = () => (
+      <Image
+        className={styles.dataBrokerLogo}
+        src={DataBrokerLogo.default}
+        alt=""
+      />
+    );
+    return {
+      default: ImageComponent,
+    };
+    // I don't know how to simulate failing `import()` calls in tests:
+    /* c8 ignore start */
+  } catch {
+    const FallBackLogo = () => <FallbackLogo name={name} />;
+    return {
+      default: FallBackLogo,
+    };
+  }
+  /* c8 ignore stop */
+}

--- a/src/app/components/client/ExposureCard.tsx
+++ b/src/app/components/client/ExposureCard.tsx
@@ -4,7 +4,7 @@
 
 "use client";
 
-import React, { ReactNode, Suspense, lazy, useState } from "react";
+import React, { ReactNode, useState } from "react";
 import Link from "next/link";
 import { OnerepScanResultRow } from "knex/types/tables";
 import styles from "./ExposureCard.module.scss";
@@ -27,6 +27,7 @@ import {
 } from "../../../utils/subscriberBreaches";
 import { FallbackLogo } from "../server/BreachLogo";
 import { BreachDataClass, DataBrokerDataClass } from "./ExposureCardDataClass";
+import { DataBrokerImage } from "./DataBrokerImage";
 
 export type Exposure = OnerepScanResultRow | SubscriberBreach;
 
@@ -43,29 +44,6 @@ export type ExposureCardProps = {
   resolutionCta: ReactNode;
   isExpanded?: boolean;
 };
-
-async function getDataBrokerImage(name: string) {
-  try {
-    const DataBrokerLogo = await import(
-      `../client/assets/data-brokers/${name}.png`
-    );
-    const ImageComponent = () => (
-      <Image
-        className={styles.dataBrokerLogo}
-        src={DataBrokerLogo.default}
-        alt=""
-      />
-    );
-    return {
-      default: ImageComponent,
-    };
-  } catch {
-    const FallBackLogo = () => <FallbackLogo name={name} />;
-    return {
-      default: FallBackLogo,
-    };
-  }
-}
 
 export const ExposureCard = ({ exposureData, ...props }: ExposureCardProps) => {
   return isScanResult(exposureData) ? (
@@ -88,7 +66,6 @@ const ScanResultCard = (props: ScanResultCardProps) => {
   const [exposureCardExpanded, setExposureCardExpanded] = useState(
     props.isExpanded ?? false
   );
-  const DataBrokerLogo = lazy(() => getDataBrokerImage(scanResult.data_broker));
   const dateFormatter = new Intl.DateTimeFormat(locale, {
     // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#datestyle
     dateStyle: "medium",
@@ -165,16 +142,7 @@ const ScanResultCard = (props: ScanResultCardProps) => {
             <dd
               className={`${styles.hideOnMobile} ${styles.exposureImageWrapper}`}
             >
-              {/* While logo is not yet set, the fallback image is the first character of the exposure name */}
-              {
-                // TODO: Add unit test when changing this code:
-                /* c8 ignore next 7 */
-                <Suspense
-                  fallback={<FallbackLogo name={scanResult.data_broker} />}
-                >
-                  <DataBrokerLogo />
-                </Suspense>
-              }
+              <DataBrokerImage name={scanResult.data_broker} />
             </dd>
             <dt className={styles.visuallyHidden}>
               {l10n.getString("exposure-card-label-company")}


### PR DESCRIPTION
The images are wrapped in a <Suspense> call, but since those just wait for images lazily loaded right after first render, rather than after user input, it's a bit annoying to have to wait for that loading in tests. Thus, I extracted it into a separate module and mocked that module.