### PR TITLE
Change Firefox Accounts to Mozilla Accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ To create the database tables ...
 
 Monitor generates multiple emails that get sent to subscribers. To preview or test-send these emails see documentation [here](docs/monitor-emails.md).
 
-### Firefox Accounts
+### Mozilla accounts ("FxA", formerly known as Firefox accounts)
 
-Subscribe with a Firefox Account is controlled via the `FXA_ENABLED`
+Subscribe with a Mozilla account is controlled via the `FXA_ENABLED`
 environment variable. (See `.env-dist`)
 
 The repo comes with a development FxA oauth app pre-configured in `.env`, which

--- a/locales-pending/premium.ftl
+++ b/locales-pending/premium.ftl
@@ -25,7 +25,7 @@ toolbar-app-picker-by-mozilla = Made by { -brand-mozilla }
 
 user-menu-trigger-label = Open user menu
 user-menu-trigger-tooltip = Profile
-user-menu-manage-fxa-label = Manage your { -brand-fx-account }
+user-menu-manage-fxa-label = Manage your { -brand-mozilla-account }
 user-menu-settings-label = Settings
 user-menu-settings-tooltip = Configure { -brand-fx-monitor }
 user-menu-help-label = Help and support
@@ -69,8 +69,8 @@ exposure-chart-scan-in-progress-prompt = <b>Scan in progress:</b> address, famil
 modal-active-number-of-exposures-title = About your number of active exposures
 # Variables:
 #   $limit (number) - Number of email addresses included in the plan
-modal-active-number-of-exposures-part-one = 
-  { $limit -> 
+modal-active-number-of-exposures-part-one =
+  { $limit ->
     [one] This chart includes the total number of times we found each type of data exposed across all data broker profiles and all data breaches for the { $limit } email address that you are currently monitoring.
     *[other] This chart includes the total number of times we found each type of data exposed across all data broker profiles and all data breaches for up to { $limit } email addresses that you are currently monitoring.
   }
@@ -98,8 +98,8 @@ full-name = Full name
 # Here’s What We Fixed Modal
 
 modal-heres-what-we-fixed-title = About what we fixed
-modal-heres-what-we-fixed-description-part-one = <b>Resolved by you</b> includes anything you have manually fixed. 
-  All data breaches that require access to your accounts need to be fixed manually, 
+modal-heres-what-we-fixed-description-part-one = <b>Resolved by you</b> includes anything you have manually fixed.
+  All data breaches that require access to your accounts need to be fixed manually,
   even if you have upgraded to { -brand-premium }.
 modal-heres-what-we-fixed-description-part-two = <b>Auto-removed</b> includes any exposures from data broker
   profiles that we have removed for you. This is available only for
@@ -162,11 +162,11 @@ modal-exposure-type-title = About exposure types
 # Variables:
 # $data_broker_sites_total_num is the total number of data broker sites available to scan. It will always be more than 1.
 modal-exposure-type-description = We search for you in all known data breaches and { $data_broker_sites_total_num } data broker sites that sell your personal info. Here are the two types of exposures we find:
-modal-exposure-type-data-breach = <b>Data breach</b> means your information has been compromised in a breach and could be in the wrong hands. 
+modal-exposure-type-data-breach = <b>Data breach</b> means your information has been compromised in a breach and could be in the wrong hands.
   Resolving these typically requires accessing your accounts, so you’ll need to take manual steps to resolve each breach even if you’ve upgraded to { -brand-premium }.
-modal-exposure-type-data-broker-part-one = <b>Info for sale</b> means a data broker site is publicly publishing and selling your personal info. 
-  You’ll need to manually request removal from each site. 
-modal-exposure-type-data-broker-part-two = If you’re a { -brand-premium } user, we automatically remove all profiles for you. 
+modal-exposure-type-data-broker-part-one = <b>Info for sale</b> means a data broker site is publicly publishing and selling your personal info.
+  You’ll need to manually request removal from each site.
+modal-exposure-type-data-broker-part-two = If you’re a { -brand-premium } user, we automatically remove all profiles for you.
   In both cases, removals typically take 7-14 days. Some can take longer, while others can happen within the hour.
 
 # About Exposure Statuses Modal
@@ -175,7 +175,7 @@ modal-exposure-status-title = About exposure statuses
 # Variables:
 # $data_broker_sites_total_num is the total number of data broker sites available to scan. It will always be plural.
 modal-exposure-status-description = We search for exposures in all known data breaches and { $data_broker_sites_total_num } data broker sites that sell your personal info.
-  Your exposures will have one of the following statuses: 
+  Your exposures will have one of the following statuses:
 modal-exposure-status-action-needed = <b>Action needed</b> means it is currently active and you need to take steps to fix it.
 modal-exposure-status-in-progress = <b>In progress</b> means we are actively working on fixing the exposure for you. This is a { -brand-premium } feature.
 modal-exposure-status-fixed = <b>Fixed</b> means the exposure has been resolved and theres no action for you to take.
@@ -228,7 +228,7 @@ dashboard-top-banner-protect-your-data-cta = Let’s fix it
 dashboard-top-banner-monitor-protects-your-even-more-title = { -product-short-name } now protects you even more
 # Variables:
 # $data_broker_sites_total_num is the total number of data broker sites available to scan.
-dashboard-top-banner-monitor-protects-your-even-more-description = 
+dashboard-top-banner-monitor-protects-your-even-more-description =
   { $data_broker_sites_total_num ->
       [one] We can now find exposures of your personal info on { $data_broker_sites_total_num } data broker site that publish and sell your personal info for a profit.
       *[other] We can now find exposures of your personal info on { $data_broker_sites_total_num } data broker sites that publish and sell your personal info for a profit.
@@ -247,8 +247,8 @@ dashboard-no-exposures-label = No exposures found
 dashboard-top-banner-lets-keep-protecting-title = Let’s keep protecting your data
 # Variables:
 # $exposures_unresolved_num is the remaining number of exposures the user has to resolve.
-dashboard-top-banner-lets-keep-protecting-description = 
-  { $exposures_unresolved_num -> 
+dashboard-top-banner-lets-keep-protecting-description =
+  { $exposures_unresolved_num ->
     [one] You still have { $exposures_unresolved_num } exposure left to fix. Keep going and protect yourself. We’ll guide you step-by-step.
     *[other] You still have { $exposures_unresolved_num } exposures left to fix. Keep going and protect yourself. We’ll guide you step-by-step.
   }
@@ -257,7 +257,7 @@ dashboard-top-banner-lets-keep-protecting-cta = Let’s keep going
 dashboard-top-banner-your-data-is-protected-title = Your data is protected
 # Variables:
 # $starting_exposure_total_num is the number of exposures the user has resolved.
-dashboard-top-banner-your-data-is-protected-description = 
+dashboard-top-banner-your-data-is-protected-description =
   { $starting_exposure_total_num ->
     [one] Great work, the exposure of your data is fixed or in progress! We’ll keep monitoring and will alert you of any new exposures.
     *[other] Great work, all { $starting_exposure_total_num } exposures of your data are fixed or in progress! We’ll keep monitoring and will alert you of any new exposures.
@@ -266,7 +266,7 @@ dashboard-top-banner-your-data-is-protected-cta = See what’s fixed
 
 # Variables:
 # $starting_exposure_total_num is the number of exposures the user has resolved.
-dashboard-top-banner-your-data-is-protected-all-fixed-description = 
+dashboard-top-banner-your-data-is-protected-all-fixed-description =
   { $starting_exposure_total_num ->
     [one] Great work, { $starting_exposure_total_num } exposure of your data is fixed! Upgrade to { -brand-premium } and we’ll continue to monitor for new exposures. Plus, we’ll automatically remove your info from any sites that are selling it.
     *[other] Great work, all { $starting_exposure_total_num } exposures of your data are fixed! Upgrade to { -brand-premium } and we’ll continue to monitor for new exposures. Plus, we’ll automatically remove your info from any sites that are selling it.
@@ -397,7 +397,7 @@ welcome-to-premium-data-broker-profiles-title-part-two = We’ll remove those pr
 # Variables:
 # $profile_total_num is the number of exposures came back from user data broker scans.
 # $exposure_reduction_percentage is the percent by which exposures are reduced
-welcome-to-premium-data-broker-profiles-description-part-one =  
+welcome-to-premium-data-broker-profiles-description-part-one =
   { $profile_total_num ->
     [one] We’ve already started our auto-removal process of 1 profile — which will reduce your exposures by { $exposure_reduction_percentage }%.
     *[other] We’ve already started our auto-removal process of { $profile_total_num } profiles — which will reduce your exposures by { $exposure_reduction_percentage }%.
@@ -418,7 +418,7 @@ high-risk-breach-summary = { $num_breaches ->
 }
 # Variables
 # $breach_name is the name of the breach where the high risk data was found.
-# $breach_date is the date when the breach occurred. 
+# $breach_date is the date when the breach occurred.
 # An example of this string is Twitter on 13/09/18.
 high-risk-breach-name-and-date = { $breach_name } <breach_date>on { $breach_date }</breach_date>
 high-risk-breach-mark-as-fixed = Mark as fixed
@@ -454,14 +454,14 @@ high-risk-breach-social-security-step-two = <link_to_info>Check your credit repo
 # Social Security Number Modal
 
 ssn-modal-title = About fraud alerts and credit freezes
-ssn-modal-description-fraud-part-one = <b>A fraud alert</b> requires businesses to verify your identity before it issues new credit in your name. It’s free, lasts one year, and won’t negatively affect your credit score. 
+ssn-modal-description-fraud-part-one = <b>A fraud alert</b> requires businesses to verify your identity before it issues new credit in your name. It’s free, lasts one year, and won’t negatively affect your credit score.
 ssn-modal-description-fraud-part-two = To set one up, contact any one of the three credit bureaus. You don’t have to contact all three.
-ssn-modal-description-freeze-credit-part-one = <b>Freezing your credit</b> prevents anyone from opening a new account in your name. It’s free and won’t negatively affect your credit score, but you’ll need to unfreeze it before opening any new accounts. 
+ssn-modal-description-freeze-credit-part-one = <b>Freezing your credit</b> prevents anyone from opening a new account in your name. It’s free and won’t negatively affect your credit score, but you’ll need to unfreeze it before opening any new accounts.
 ssn-modal-description-freeze-credit-part-two = To freeze your credit, contact each of the three credit bureaus — <equifax_link>Equifax</equifax_link>, <experian_link>Experian</experian_link>, and <transunion_link>TransUnion</transunion_link>.
 ssn-modal-learn-more = Learn more about fraud alerts and credit freezes
 ssn-modal-ok = OK
 
-# PIN Breaches 
+# PIN Breaches
 
 high-risk-breach-pin-title = Your PIN was exposed
 high-risk-breach-pin-description = Taking action ASAP could give you more legal protections to help you recover any losses.
@@ -473,7 +473,7 @@ high-risk-breach-pin-step-three = Check your accounts for unauthorized charges.
 
 high-risk-breach-none-title = Great news, we didn’t find any high risk data breaches
 # Variables
-# $email_list is list of emails that the user is monitoring for breaches. E.g. john@yahoo.com, ali@gmail.com, sam@hotmail.com 
+# $email_list is list of emails that the user is monitoring for breaches. E.g. john@yahoo.com, ali@gmail.com, sam@hotmail.com
 high-risk-breach-none-description = We detect data breaches based on your email address, and we didn’t find any high risk data breaches for { $email_list }.
 high-risk-breach-none-sub-description-part-one = High risk data breaches include:
 high-risk-breach-none-sub-description-ssn = Social security number
@@ -532,7 +532,7 @@ security-recommendation-ip-step-one = Use a VPN (such as <link_to_info>{ -brand-
 # $breach_name is the name of the breach where the leaked password was found.
 leaked-passwords-title = Your { $breach_name } password was exposed.
 # Variables
-# $breach_date is the date when the breach occurred. 
+# $breach_date is the date when the breach occurred.
 leaked-passwords-summary = It appeared in a data breach on { $breach_date }.
 leaked-passwords-description = Scammers can access your account and will likely try to use it on other accounts to see if you’ve used the same password. Change it anywhere you’ve used it to protect yourself.
 leaked-passwords-steps-title = Here’s what to do
@@ -554,7 +554,7 @@ leaked-passwords-estimated-time = Est. time to complete: { $estimated_time } min
 leaked-security-questions-title = Your security questions were exposed
 # Variables
 # $breach_name is the name of the breach where the leaked security questions were found.
-# $breach_date is the date when the breach occurred. 
+# $breach_date is the date when the breach occurred.
 # An example of this string is Twitter on 13/09/18.
 leaked-security-questions-summary = They appeared in a data breach on { $breach_name } on { $breach_date }.
 leaked-security-questions-description = Scammers can use these to access your accounts, and any other site where you’ve used the same security questions. Update them now to protect your accounts.

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -866,7 +866,12 @@ ad-unit-6-before-you-complete = Before you complete that next signup, use an ema
 
 # “account” can be localized, “Firefox” must be treated as a brand,
 # and kept in English.
+# Deprecated - to be replaced by -brand-mozilla-account
 -brand-fx-account = Firefox account
+
+# “account” can be localized, “Mozilla” must be treated as a brand,
+# and kept in English.
+-brand-mozilla-account = Mozilla account
 
 ## Search Engine Optimization
 
@@ -882,7 +887,7 @@ sign-in = Sign In
 site-nav-breaches-link = Resolve Data Breaches
 site-nav-settings-link = Settings
 site-nav-help-link = Help and Support
-# This call-out is above 2 image links for Firefox Relay and Mozilla VPN 
+# This call-out is above 2 image links for Firefox Relay and Mozilla VPN
 site-nav-ad-callout = Try our other security tools:
 brand-relay = { -brand-relay }
 brand-mozilla-vpn = { -brand-mozilla-vpn }
@@ -892,8 +897,12 @@ brand-mozilla-vpn = { -brand-mozilla-vpn }
 menu-button-title = User menu
 menu-button-alt = Open user menu
 menu-list-accessible-label = Account menu
+# Deprecated
 menu-item-fxa = Manage your { -brand-fx-account }
+menu-item-fxa-2 = Manage your { -brand-mozilla-account }
+# Deprecated
 menu-item-fxa-alt = Open { -brand-fx-account } page
+menu-item-fxa-alt-2 = Open { -brand-mozilla-account } page
 menu-item-settings = Settings
 menu-item-settings-alt = Open settings page
 menu-item-help = Help and support

--- a/locales/en/settings.ftl
+++ b/locales/en/settings.ftl
@@ -52,8 +52,12 @@ settings-cancel-premium-subscription-link-label = Cancel from your { -brand-fx-a
 ## Deactivate account
 
 settings-deactivate-account-title = Deactivate account
+# Deprecated
 settings-deactivate-account-info = You can deactivate { -product-short-name } by deleting your { -brand-fx-account }.
+settings-deactivate-account-info-2 = You can deactivate { -product-short-name } by deleting your { -brand-mozilla-account }.
+# Deprecated
 settings-fxa-link-label = Go to { -brand-firefox } Settings
+settings-fxa-link-label-2 = Go to { -brand-mozilla } Settings
 
 ## Add email dialog
 

--- a/src/app/(nextjs_migration)/(authenticated)/user/layout.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/user/layout.tsx
@@ -20,6 +20,8 @@ import { authOptions } from "../../../api/utils/auth";
 import { getNonce } from "../../functions/server/getNonce";
 import { PageLoadEvent } from "../../components/client/PageLoadEvent";
 import { getExperiments } from "../../../functions/server/getExperiments";
+import { getEnabledFeatureFlags } from "../../../../db/tables/featureFlags";
+
 export type Props = {
   children: ReactNode;
 };
@@ -57,6 +59,9 @@ const MainLayout = async (props: Props) => {
   }
 
   const l10n = getL10n();
+  const enabledFeatureFlags = await getEnabledFeatureFlags({
+    email: session.user.email,
+  });
 
   return (
     <>
@@ -101,6 +106,7 @@ const MainLayout = async (props: Props) => {
               session={session}
               fxaSettingsUrl={AppConstants.NEXT_PUBLIC_FXA_SETTINGS_URL}
               nonce={getNonce()}
+              enabledFeatureFlags={enabledFeatureFlags}
             />
           </div>
         </div>

--- a/src/app/(nextjs_migration)/(authenticated)/user/settings/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/user/settings/page.tsx
@@ -21,6 +21,7 @@ import { getBreachesForEmail } from "../../../../../utils/hibp";
 import { getSha1 } from "../../../../../utils/fxa";
 import { getSubscriberById } from "../../../../../db/tables/subscribers";
 import { getNonce } from "../../../functions/server/getNonce";
+import { getEnabledFeatureFlags } from "../../../../../db/tables/featureFlags";
 
 const emailNeedsVerificationSub = (email: EmailRow) => {
   const l10n = getL10n();
@@ -152,6 +153,9 @@ export default async function Settings() {
   if (!session || !session.user?.subscriber) {
     return redirect("/");
   }
+  const enabledFlags = await getEnabledFeatureFlags({
+    email: session.user.email,
+  });
   // Re-fetch the subscriber every time, rather than reading it from `session`
   // - if the user changes their preferences on this page, the JSON web token
   // containing the subscriber data won't be updated until the next sign-in.
@@ -245,7 +249,11 @@ export default async function Settings() {
                 {l10n.getString("settings-deactivate-account-title")}
               </h3>
               <p className="settings-section-info">
-                {l10n.getString("settings-deactivate-account-info")}
+                {l10n.getString(
+                  enabledFlags.includes("FxaRebrand")
+                    ? "settings-deactivate-account-info-2"
+                    : "settings-deactivate-account-info"
+                )}
               </p>
               <a
                 className="settings-link-fxa"
@@ -253,7 +261,11 @@ export default async function Settings() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                {l10n.getString("settings-fxa-link-label")}
+                {l10n.getString(
+                  enabledFlags.includes("FxaRebrand")
+                    ? "settings-fxa-link-label-2"
+                    : "settings-fxa-link-label"
+                )}
               </a>
             </section>
           </div>

--- a/src/app/(nextjs_migration)/components/client/UserMenu.tsx
+++ b/src/app/(nextjs_migration)/components/client/UserMenu.tsx
@@ -14,14 +14,21 @@ import OpenInIcon from "../../../../client/images/icon-open-in.svg";
 import SettingsIcon from "../../../../client/images/icon-settings.svg";
 import HelpIcon from "../../../../client/images/icon-help.svg";
 import SignOutIcon from "../../../../client/images/icon-signout.svg";
+import { FeatureFlagName } from "../../../../db/tables/featureFlags";
 
 export type Props = {
   session: Session;
   fxaSettingsUrl: string;
   nonce: string | undefined;
+  enabledFeatureFlags: FeatureFlagName[];
 };
 
-export const UserMenu = ({ session, fxaSettingsUrl, nonce }: Props) => {
+export const UserMenu = ({
+  session,
+  fxaSettingsUrl,
+  nonce,
+  enabledFeatureFlags,
+}: Props) => {
   const l10n = useL10n();
   if (!session) {
     return null;
@@ -60,7 +67,11 @@ export const UserMenu = ({ session, fxaSettingsUrl, nonce }: Props) => {
           <a href={fxaSettingsUrl} target="_blank" className="user-menu-header">
             <b className="user-menu-email">{session.user?.email}</b>
             <div className="user-menu-subtitle">
-              {l10n.getString("menu-item-fxa")}
+              {l10n.getString(
+                enabledFeatureFlags.includes("FxaRebrand")
+                  ? "menu-item-fxa-2"
+                  : "menu-item-fxa"
+              )}
               <Image alt="" src={OpenInIcon} />
             </div>
           </a>

--- a/src/app/api/utils/auth.ts
+++ b/src/app/api/utils/auth.ts
@@ -29,7 +29,7 @@ const fxaProviderConfig: OAuthConfig<FxaProfile> = {
   // a redirect URL of /api/auth/callback/fxa for Firefox Monitor,
   // for every environment we deploy to:
   id: "fxa",
-  name: "Firefox Accounts",
+  name: "Mozilla accounts",
   type: "oauth",
   authorization: {
     url: AppConstants.OAUTH_AUTHORIZATION_URI,

--- a/src/app/components/client/toolbar/UserMenu.test.tsx
+++ b/src/app/components/client/toolbar/UserMenu.test.tsx
@@ -51,7 +51,7 @@ it("checks if the user menu items are interactive", async () => {
   expect(menuItems.length).toBe(4);
 
   // FxA link
-  const fxaItem = screen.getByText("Manage your ⁨Firefox account⁩");
+  const fxaItem = screen.getByText("Manage your ⁨Mozilla account⁩");
   expect(fxaItem).toBeInTheDocument();
   const fxaItemWrapper = fxaItem.parentElement;
   const clickFxAItemSpy = jest.spyOn(fxaItem, "click");

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -30,6 +30,7 @@ async function getAllFeatureFlags() {
 
 /** Add any feature flag you want to refer to in the code here */
 export type FeatureFlagName =
+  | "FxaRebrand"
   | "FreeBrokerScan"
   | "PremiumBrokerRemoval"
   | "FalseDoorTest"

--- a/src/e2e/specs/breachResolution.spec.ts
+++ b/src/e2e/specs/breachResolution.spec.ts
@@ -132,7 +132,7 @@ test.describe("Breaches Dashboard - Headers", () => {
       // head text
       expect(
         await dataBreachPage.dataBreachesNavbarProfileMenuHeaderSubtitle.textContent()
-      ).toEqual("Manage your Firefox account");
+      ).toEqual("Manage your Mozilla account");
 
       // check settings
       await expect(


### PR DESCRIPTION
Builds on https://github.com/mozilla/blurts-server/pull/3525.

Hidden behind the "FxaRebrand" flag so we can roll it out across different products at the same time.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1852
Figma: N/A

# Screenshot (if applicable)

![image](https://github.com/mozilla/blurts-server/assets/4251/1a1dc831-59b0-4555-a041-5fa1d586a7e3)

![image](https://github.com/mozilla/blurts-server/assets/4251/5d05b26f-1fd4-4a14-980b-b0722e939b97)

![image](https://github.com/mozilla/blurts-server/assets/4251/0b344255-4ab5-491f-a5a9-526cfddb14c9)

# How to test

Visit the settings page, and the old and new user menu. If you have enabled the flat `FxaRebrand`, you should only see "Mozilla account" and "Mozilla settings". If the flag is off, it should be "Firefox account" / "Firefox settings".

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
