### PR TITLE
Only show the free scan CTA for users that are eligible for one

### DIFF
--- a/locales-pending/premium.ftl
+++ b/locales-pending/premium.ftl
@@ -343,8 +343,8 @@ dashboard-exposures-scan-progress-label = Scan in progress
 # $data_broker_total_num is the total number of data brokers selling the user’s data.
 dashboard-exposures-all-fixed-free-scan = {
     $data_broker_total_num ->
-      [one] Next <link>start your free scan</link> of { $data_broker_total_num } site that may be selling your personal info.
-     *[other] Next <link>start your free scan</link> of { $data_broker_total_num } sites that may be selling your personal info.
+      [one] Next <start_free_scan_link>start your free scan</start_free_scan_link> of { $data_broker_total_num } site that may be selling your personal info.
+     *[other] Next <start_free_scan_link>start your free scan</start_free_scan_link> of { $data_broker_total_num } sites that may be selling your personal info.
   }
 
 ## False door test

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -147,7 +147,6 @@ export const View = (props: Props) => {
       </li>
     );
   });
-  const isScanResultItemsEmpty = props.userScanData.results.length === 0;
   const noUnresolvedExposures = exposureCardElems.length === 0;
   const dataSummary = getDashboardSummary(
     props.userScanData.results,
@@ -234,7 +233,7 @@ export const View = (props: Props) => {
     </>
   );
 
-  const freeScanCta = isScanResultItemsEmpty && (
+  const freeScanCta = props.isEligibleForFreeScan && (
     <p>
       {l10n.getFragment("dashboard-exposures-all-fixed-free-scan", {
         vars: {
@@ -244,7 +243,7 @@ export const View = (props: Props) => {
           ),
         },
         elems: {
-          free_scan_link: <a href="/redesign/user/welcome" />,
+          start_free_scan_link: <a href="/redesign/user/welcome" />,
         },
       })}
     </p>
@@ -258,7 +257,6 @@ export const View = (props: Props) => {
           <strong>
             {l10n.getString("dashboard-exposures-scan-progress-label")}
           </strong>
-          {freeScanCta}
         </>
       );
     }
@@ -270,6 +268,7 @@ export const View = (props: Props) => {
           <strong>
             {l10n.getString("dashboard-exposures-all-fixed-label")}
           </strong>
+          {freeScanCta}
         </>
       );
     }
@@ -278,6 +277,7 @@ export const View = (props: Props) => {
       <>
         <Image src={NoExposuresIllustration} alt="" />
         <strong>{l10n.getString("dashboard-no-exposures-label")}</strong>
+        {freeScanCta}
       </>
     );
   };


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Figma: [Dashboard permutations](https://www.figma.com/file/pb1X1JlHT3ZMmFf2rKKRu1/Permutations?type=whiteboard&node-id=41-9169&t=IAvbvLZoTkl0RYgl-0)

<!-- When adding a new feature: -->

# Description

Only show the free scan CTA for the dashboard zero state to eligible users. This also fixes the link tags within the string which did not show.