### PR TITLE
Downgrade Glean to version 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@google-cloud/pubsub": "^4.0.6",
         "@grpc/grpc-js": "1.9.5",
         "@leeoniya/ufuzzy": "^1.0.8",
-        "@mozilla/glean": "^2.0.4",
+        "@mozilla/glean": "2.0.2",
         "@sentry/nextjs": "^7.74.0",
         "@sentry/node": "^7.58.1",
         "@sentry/tracing": "^7.74.0",
@@ -5212,9 +5212,9 @@
       }
     },
     "node_modules/@mozilla/glean": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.4.tgz",
-      "integrity": "sha512-nvXocG6PC946Wk7VAgcjk1dM3r6XGbvBNR1pmE1BWcHh76uKFksThZAZTvZMeMpk/IptZ8Y4D0bqNaTiQKmUYA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.2.tgz",
+      "integrity": "sha512-ggboBpkNUraL+e3q+UtUMZmJ2ETS60/tiudIzqx8W1sZPZHRqiYf6eN64/NWr9pf7GfIvHXFwaisscTE/9UhdA==",
       "dependencies": {
         "fflate": "^0.8.0",
         "jose": "^4.0.4",
@@ -33336,9 +33336,9 @@
       }
     },
     "@mozilla/glean": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.4.tgz",
-      "integrity": "sha512-nvXocG6PC946Wk7VAgcjk1dM3r6XGbvBNR1pmE1BWcHh76uKFksThZAZTvZMeMpk/IptZ8Y4D0bqNaTiQKmUYA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.2.tgz",
+      "integrity": "sha512-ggboBpkNUraL+e3q+UtUMZmJ2ETS60/tiudIzqx8W1sZPZHRqiYf6eN64/NWr9pf7GfIvHXFwaisscTE/9UhdA==",
       "requires": {
         "fflate": "^0.8.0",
         "jose": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@google-cloud/pubsub": "^4.0.6",
     "@grpc/grpc-js": "1.9.5",
     "@leeoniya/ufuzzy": "^1.0.8",
-    "@mozilla/glean": "^2.0.4",
+    "@mozilla/glean": "2.0.2",
     "@sentry/nextjs": "^7.74.0",
     "@sentry/node": "^7.58.1",
     "@sentry/tracing": "^7.74.0",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2366
Figma: N/A


<!-- When adding a new feature: -->

# Description

v2.0.3 set window.Glean, which appears to break our other scripts. See
https://github.com/mozilla/glean.js/blob/main/CHANGELOG.md#v203-2023-09-27

# How to test

Visit the non-redesigned `/user/breaches`. Everything should look normal, whereas it breaks on `main`.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, third-party dependency
