### PR TITLE
Ensure an initialised page when signing in

### DIFF
--- a/src/app/(nextjs_migration)/components/client/SignInButton.tsx
+++ b/src/app/(nextjs_migration)/components/client/SignInButton.tsx
@@ -7,6 +7,7 @@
 import { signIn } from "next-auth/react";
 import { usePathname } from "next/navigation";
 import { useL10n } from "../../../hooks/l10n";
+import { useEffect } from "react";
 
 export type Props = {
   autoSignIn?: boolean;
@@ -19,10 +20,15 @@ function initSignIn(callbackUrl: string) {
 export const SignInButton = ({ autoSignIn }: Props) => {
   const l10n = useL10n();
   const pathname = usePathname();
-
   const callbackUrl = pathname === "/" ? "/user/breaches" : pathname;
+
+  useEffect(() => {
+    if (autoSignIn) {
+      initSignIn(callbackUrl);
+    }
+  }, [autoSignIn, callbackUrl]);
+
   if (autoSignIn) {
-    initSignIn(callbackUrl);
     return null;
   }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2260
Figma: N/A


<!-- When adding a new feature: -->

# Description

It's a bit unpredictable right now, but sometimes, when following a link to /user/breaches in a new tab while logged out, instead of being redirected to FxA, you get an error. I'm not 100% sure why this is, but I think it might be related to a CSRF token not being added to the page, or something else that needs to be rendered in the DOM before we initiate the redirect.

Thus, I've now wrapped the login into a useEffect() to align it to React's rendering lifecycle. So far, I haven't been able to reproduce the problem.

# How to test

Enter an email address on the homepage, then on the breach results page,  open the main CTA in a new tab, opening the dev tools as you do. You should not run into an error.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
