### PR TITLE
Do not assign to read-only property

### DIFF
--- a/src/app/functions/server/logging.ts
+++ b/src/app/functions/server/logging.ts
@@ -14,10 +14,8 @@ const loggingWinston = new LoggingWinston({
 
 export const logger = createLogger({
   level: "info",
-  transports: [new transports.Console()],
+  // In GCP environments, use cloud logging instead of stdout.
+  transports: ["stage", "production"].includes(process.env.APP_ENV ?? "local")
+    ? [loggingWinston]
+    : [new transports.Console()],
 });
-
-// In GCP environments, use cloud logging instead of stdout.
-if (["stage", "production"].includes(process.env.APP_ENV ?? "local")) {
-  logger.transports = [loggingWinston];
-}


### PR DESCRIPTION
I think this should resolve the issue of https://github.com/mozilla/blurts-server/pull/3646 without needing a revert.

Without this change, we see the following error on staging:

    TypeError: Cannot set property transports of #<Logger> which has only a getter
        at 40066 (/app/.next/server/chunks/1701.js:1:352)
        at __webpack_require__ (/app/.next/server/webpack-runtime.js:1:161)
        at 5183 (/app/.next/server/chunks/5183.js:1:139)
        at __webpack_require__ (/app/.next/server/webpack-runtime.js:1:161)
        at 4205 (/app/.next/server/chunks/5127.js:1:1956)
        at Function.__webpack_require__ (/app/.next/server/webpack-runtime.js:1:161)
        at runNextTicks (node:internal/process/task_queues:60:5)
        at listOnTimeout (node:internal/timers:540:9)
        at process.processTimers (node:internal/timers:514:7)
        at async eq (/app/node_modules/next/dist/compiled/next-server/app-page.runtime.prod.js:107:38102)
