### PR TITLE
MNTOR-2385 - add more logging for onerep scans

### DIFF
--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -89,7 +89,7 @@ async function addOnerepScanResults(
 
     // Create a new scan if it does not already exist. If it already exists:
     // Update the status of the scan.
-    logger.info("new_scan_created", {
+    logger.info("scan_created_or_updated", {
       onerepScanId,
       onerepScanReason,
       onerepScanStatus,
@@ -110,27 +110,29 @@ async function addOnerepScanResults(
         updated_at: knex.fn.now(),
       });
 
-    await transaction("onerep_scan_results").insert(
-      onerepScanResults.map((scanResult) => ({
-        onerep_scan_result_id: scanResult.id,
-        onerep_scan_id: scanResult.scan_id,
-        link: scanResult.link,
-        age:
-          typeof scanResult.age === "string"
-            ? Number.parseInt(scanResult.age, 10)
-            : undefined,
-        data_broker: scanResult.data_broker,
-        data_broker_id: scanResult.data_broker_id,
-        emails: JSON.stringify(scanResult.emails),
-        phones: JSON.stringify(scanResult.phones),
-        addresses: JSON.stringify(scanResult.addresses),
-        relatives: JSON.stringify(scanResult.relatives),
-        first_name: scanResult.first_name,
-        middle_name: scanResult.middle_name,
-        last_name: scanResult.last_name,
-        status: scanResult.status,
-      })),
-    );
+    const scanResultsMap = onerepScanResults.map((scanResult) => ({
+      onerep_scan_result_id: scanResult.id,
+      onerep_scan_id: scanResult.scan_id,
+      link: scanResult.link,
+      age:
+        typeof scanResult.age === "string"
+          ? Number.parseInt(scanResult.age, 10)
+          : undefined,
+      data_broker: scanResult.data_broker,
+      data_broker_id: scanResult.data_broker_id,
+      emails: JSON.stringify(scanResult.emails),
+      phones: JSON.stringify(scanResult.phones),
+      addresses: JSON.stringify(scanResult.addresses),
+      relatives: JSON.stringify(scanResult.relatives),
+      first_name: scanResult.first_name,
+      middle_name: scanResult.middle_name,
+      last_name: scanResult.last_name,
+      status: scanResult.status,
+    }));
+
+    logger.info("scan_result", scanResultsMap);
+
+    await transaction("onerep_scan_results").insert(scanResultsMap);
   });
 }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2385

<!-- When adding a new feature: -->

# Description

Discovered during spike for https://mozilla-hub.atlassian.net/browse/MNTOR-1431 - we need to be logging this info at the level of each broker so we can see how long removals take.


# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
