### PR TITLE
MNTOR-2401 - disable structured logging in stage/prod for debugging

### DIFF
--- a/src/app/functions/server/logging.ts
+++ b/src/app/functions/server/logging.ts
@@ -15,7 +15,8 @@ const loggingWinston = new LoggingWinston({
 export const logger = createLogger({
   level: "info",
   // In GCP environments, use cloud logging instead of stdout.
-  transports: ["stage", "production"].includes(process.env.APP_ENV ?? "local")
+  // FIXME https://mozilla-hub.atlassian.net/browse/MNTOR-2401 - enable for stage and production
+  transports: ["gcpdev"].includes(process.env.APP_ENV ?? "local")
     ? [loggingWinston]
     : [new transports.Console()],
 });


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2401

<!-- When adding a new feature: -->

# Description

There appears to be a permission issue in staging with creating structured logs, fall back to console logging for now.

Leave it on for `APP_ENV=gcpdev` so we can debug in a sandbox.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
