### PR TITLE
MNTOR-2385/only log scan metadata

### DIFF
--- a/src/app/functions/server/logging.ts
+++ b/src/app/functions/server/logging.ts
@@ -15,7 +15,8 @@ const loggingWinston = new LoggingWinston({
 export const logger = createLogger({
   level: "info",
   // In GCP environments, use cloud logging instead of stdout.
-  transports: ["stage", "production"].includes(process.env.APP_ENV ?? "local")
+  // FIXME https://mozilla-hub.atlassian.net/browse/MNTOR-2401 - enable for stage and production
+  transports: ["gcpdev"].includes(process.env.APP_ENV ?? "local")
     ? [loggingWinston]
     : [new transports.Console()],
 });

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -130,7 +130,18 @@ async function addOnerepScanResults(
       status: scanResult.status,
     }));
 
-    logger.info("scan_result", scanResultsMap);
+    // Only log metadata. This is used for reporting purposes.
+    logger.info(
+      "scan_result",
+      scanResultsMap.forEach((result) => {
+        return {
+          onerepScanId: result.onerep_scan_id,
+          onerepScanResultId: result.onerep_scan_result_id,
+          onerepScanStatus: result.status,
+          dataBrokerId: result.data_broker_id,
+        };
+      }),
+    );
 
     await transaction("onerep_scan_results").insert(scanResultsMap);
   });


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2385


<!-- When adding a new feature: -->

# Description

While testing as part of the spike for MNTOR-2385, I noticed that we're collecting more scan data than we should. We only need the IDs and the status.
