### PR TITLE
Direct returning users to the shortened version of the welcome onboarding

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -252,7 +252,7 @@ export const View = (props: Props) => {
           ),
         },
         elems: {
-          a: <a href="/redesign/user/welcome" />,
+          a: <a href="/redesign/user/welcome/free-scan?referrer=dashboard" />,
         },
       })}
     </p>

--- a/src/app/components/client/Chart.tsx
+++ b/src/app/components/client/Chart.tsx
@@ -110,7 +110,7 @@ export const DoughnutChart = (props: Props) => {
           <p>
             {l10n.getString("exposure-chart-returning-user-upgrade-prompt")}
           </p>
-          <Link href="/redesign/user/welcome">
+          <Link href="/redesign/user/welcome/free-scan?referrer=dashboard">
             {l10n.getString("exposure-chart-returning-user-upgrade-prompt-cta")}
           </Link>
         </>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2402](https://mozilla-hub.atlassian.net/browse/MNTOR-2402)

<!-- When adding a new feature: -->

# Description

Direct returning users to the shortened version of the welcome onboarding


# How to test

Example Storybook user state: [US user, without Premium, without scan, with 0 breaches](https://deploy-preview-3661--fx-monitor-storybook.netlify.app/?path=/story/pages-dashboard--dashboard-us-no-premium-no-scan-no-breaches)

[MNTOR-2402]: https://mozilla-hub.atlassian.net/browse/MNTOR-2402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ