### PR TITLE
MNTOR-2423 - add Sentry captureMessage to debug cause of InvalidUserState on dashboard

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/getUserDashboardState.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/getUserDashboardState.tsx
@@ -4,6 +4,7 @@
 
 import { ContentProps } from "./DashboardTopBanner/DashboardTopBannerContent";
 import { isGuidedResolutionInProgress } from "../../../../../functions/server/getRelevantGuidedSteps";
+import { captureMessage } from "@sentry/nextjs";
 
 export type UserDashboardState =
   | "NonEligiblePremiumUserNoBreaches"
@@ -505,6 +506,8 @@ export const getUserDashboardState = (
   ) {
     return "UsUserScanInProgressResolvedBreaches";
   }
+
+  captureMessage(`InvalidUserState: ${JSON.stringify(contentProps)}`);
 
   return "InvalidUserState";
 };


### PR DESCRIPTION


<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2423

<!-- When adding a new feature: -->

# Description

Add debugging (Sentry) for client-side `InvalidUserState` failure on dashboard (which shouldn't happen, but is for some existing accounts on production).
