### PR TITLE
MNTOR-2423 - captureMessage has a length limit, move logging to server

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
@@ -1698,15 +1698,19 @@ it("shows the correct dashboard banner CTA for US user, with Premium, scan in pr
 });
 
 // Check dashboard banner content for story DashboardInvalidNonPremiumUserScanUnresolvedInProgressResolvedBreaches
-it("logs a warning in the story for an invalid user state", () => {
+it("logs a warning and error in the story for an invalid user state", () => {
   const ComposedDashboard = composeStory(
     DashboardInvalidPremiumUserNoScanResolvedBreaches,
     Meta,
   );
 
+  const errorLogSpy = jest.spyOn(global.console, "error").mockImplementation();
   const warnLogSpy = jest.spyOn(global.console, "warn").mockImplementation();
   render(<ComposedDashboard />);
 
+  expect(errorLogSpy).toHaveBeenCalledWith(
+    `InvalidUserState: {"relevantGuidedStep":{"href":"/redesign/user/dashboard/fix/data-broker-profiles/start-free-scan","id":"Scan","eligible":true,"completed":false},"hasExposures":true,"hasUnresolvedBreaches":false,"hasUnresolvedBrokers":false,"isEligibleForFreeScan":true,"isEligibleForPremium":false,"isPremiumUser":true,"scanInProgress":false}`,
+  );
   expect(warnLogSpy).toHaveBeenCalledWith(
     "No matching condition for dashboard state found.",
   );

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/getUserDashboardState.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/getUserDashboardState.tsx
@@ -4,7 +4,7 @@
 
 import { ContentProps } from "./DashboardTopBanner/DashboardTopBannerContent";
 import { isGuidedResolutionInProgress } from "../../../../../functions/server/getRelevantGuidedSteps";
-import { captureMessage } from "@sentry/nextjs";
+import { captureException } from "@sentry/nextjs";
 
 export type UserDashboardState =
   | "NonEligiblePremiumUserNoBreaches"
@@ -507,7 +507,15 @@ export const getUserDashboardState = (
     return "UsUserScanInProgressResolvedBreaches";
   }
 
-  captureMessage(`InvalidUserState: ${JSON.stringify(contentProps)}`);
+  if (typeof window === "undefined") {
+    import("../../../../../functions/server/logging")
+      .then((module) =>
+        module.logger.error(
+          `InvalidUserState: ${JSON.stringify(contentProps)}`,
+        ),
+      )
+      .catch((err) => captureException(err));
+  }
 
   return "InvalidUserState";
 };

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/getUserDashboardState.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/getUserDashboardState.tsx
@@ -4,7 +4,6 @@
 
 import { ContentProps } from "./DashboardTopBanner/DashboardTopBannerContent";
 import { isGuidedResolutionInProgress } from "../../../../../functions/server/getRelevantGuidedSteps";
-import { captureException } from "@sentry/nextjs";
 
 export type UserDashboardState =
   | "NonEligiblePremiumUserNoBreaches"
@@ -507,16 +506,8 @@ export const getUserDashboardState = (
     return "UsUserScanInProgressResolvedBreaches";
   }
 
-  /* c8 ignore next 9 */
-  if (typeof window === "undefined") {
-    import("../../../../../functions/server/logging")
-      .then((module) =>
-        module.logger.error(
-          `InvalidUserState: ${JSON.stringify(contentProps)}`,
-        ),
-      )
-      .catch((err) => captureException(err));
-  }
+  /* c8 ignore next 1 */
+  console.error(`InvalidUserState: ${JSON.stringify(contentProps)}`);
 
   return "InvalidUserState";
 };

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/getUserDashboardState.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/getUserDashboardState.tsx
@@ -507,6 +507,7 @@ export const getUserDashboardState = (
     return "UsUserScanInProgressResolvedBreaches";
   }
 
+  /* c8 ignore next 9 */
   if (typeof window === "undefined") {
     import("../../../../../functions/server/logging")
       .then((module) =>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2423

<!-- When adding a new feature: -->

# Description

~~Sentry's captureMessage has a length limit, move logging to server - I didn't do this initially because this function appears to be both used by client and server code, so I am guarding against server code by putting the import and function call to the server logger behind a check for the `window` global.~~ EDIT: storybook-build is having trouble with this, instead of worrying about it we can just use `console.error` for now, which will work in both GCP (as a stdout textPayload) or client contexts.