### PR TITLE
MNTOR-2385 - use map not foreach to re-map scan results for logging

### DIFF
--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -133,7 +133,7 @@ async function addOnerepScanResults(
     // Only log metadata. This is used for reporting purposes.
     logger.info(
       "scan_result",
-      scanResultsMap.forEach((result) => {
+      scanResultsMap.map((result) => {
         return {
           onerepScanId: result.onerep_scan_id,
           onerepScanResultId: result.onerep_scan_result_id,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2385

<!-- When adding a new feature: -->

# Description

A previous patch attempted to use `.forEach()` on an array-of-objects to exclude PII for logging purposes, but it should have used `.map()` instead.