### PR TITLE
MNTOR-2421 - taking out unnecessary step to store locally

### DIFF
--- a/src/scripts/syncBreaches.js
+++ b/src/scripts/syncBreaches.js
@@ -10,10 +10,6 @@
  */
 
 import { readdir } from "node:fs/promises";
-import { resolve as pathResolve } from "node:path";
-import { finished } from "node:stream/promises";
-import { createWriteStream } from "node:fs";
-import { Readable } from "node:stream";
 import os from "node:os";
 import Sentry from "@sentry/nextjs";
 import { req, formatDataClassesArray } from "../utils/hibp.js";
@@ -52,7 +48,6 @@ export async function getBreachIcons(breaches) {
         return;
       }
       const logoFilename = breachDomain.toLowerCase() + ".ico";
-      const logoPath = pathResolve(logoFolder, logoFilename);
       if (existingLogos.includes(logoFilename)) {
         console.log("skipping ", logoFilename);
         await updateBreachFaviconUrl(
@@ -71,17 +66,16 @@ export async function getBreachIcons(breaches) {
         await updateBreachFaviconUrl(breachName, null);
         return;
       }
-      await uploadToS3(logoFilename, Buffer.from(await res.arrayBuffer()));
-      const fileStream = createWriteStream(logoPath, { flags: "wx" });
-      const bodyReadable = Readable.fromWeb(res.body);
+
       try {
-        await finished(bodyReadable.pipe(fileStream));
+        await uploadToS3(logoFilename, Buffer.from(await res.arrayBuffer()));
         await updateBreachFaviconUrl(
           breachName,
           `https://s3.amazonaws.com/${process.env.S3_BUCKET}/${logoFilename}`,
         );
       } catch (e) {
         console.error(e);
+        return;
       }
     }),
   );


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2421


<!-- When adding a new feature: -->

# Description
Taking out unnecessary step to cache logos locally on disk in `tmp`
The step adds more time/complexity to the script where the actual s3 step is append-only anyways, making it impossible to delete existing logos


# Screenshot (if applicable)

Not applicable.

# How to test



# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
