### PR TITLE
Do not insert empty scan results

### DIFF
--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -143,7 +143,9 @@ async function addOnerepScanResults(
       }),
     );
 
-    await transaction("onerep_scan_results").insert(scanResultsMap);
+    if (scanResultsMap.length > 0) {
+      await transaction("onerep_scan_results").insert(scanResultsMap);
+    }
   });
 }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: Possibly causing [MNTOR-2426](https://mozilla-hub.atlassian.net/browse/MNTOR-2426).


<!-- When adding a new feature: -->

# Description

Inserting an empty results array into the table `onerep_scan_results` results in the following error:
```
Error: The query is empty
```

This might prevent the scans `onerep_scan_status` from `in_progress` to `finished`.

[MNTOR-2426]: https://mozilla-hub.atlassian.net/browse/MNTOR-2426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ