### PR TITLE
MNTOR-2444 - handle scan results updates correctly

### DIFF
--- a/src/app/api/v1/user/welcome-scan/create/route.ts
+++ b/src/app/api/v1/user/welcome-scan/create/route.ts
@@ -19,7 +19,7 @@ import AppConstants from "../../../../../../appConstants";
 import { getSubscriberByEmail } from "../../../../../../db/tables/subscribers";
 import {
   setOnerepProfileId,
-  setOnerepManualScan,
+  setOnerepScan,
 } from "../../../../../../db/tables/onerep_scans";
 import { setProfileDetails } from "../../../../../../db/tables/onerep_profiles";
 import { StateAbbr } from "../../../../../../utils/states";
@@ -93,7 +93,7 @@ export async function POST(
         // Start exposure scan
         const scan = await createScan(profileId);
         const scanId = scan.id;
-        await setOnerepManualScan(profileId, scanId, scan.status);
+        await setOnerepScan(profileId, scanId, scan.status, "manual");
 
         return NextResponse.json({ success: true }, { status: 200 });
       }

--- a/src/app/api/v1/user/welcome-scan/progress/route.ts
+++ b/src/app/api/v1/user/welcome-scan/progress/route.ts
@@ -54,13 +54,7 @@ export async function GET(
         // Store scan results.
         if (scan.status === "finished") {
           const allScanResults = await getAllScanResults(profileId);
-          await addOnerepScanResults(
-            profileId,
-            scan.id,
-            allScanResults,
-            "manual",
-            scan.status,
-          );
+          await addOnerepScanResults(profileId, allScanResults);
         }
 
         return NextResponse.json(

--- a/src/app/functions/server/refreshStoredScanResults.ts
+++ b/src/app/functions/server/refreshStoredScanResults.ts
@@ -23,14 +23,14 @@ export async function refreshStoredScanResults(profileId: number) {
     const remoteScans = (await listScans(profileId)).data;
     const localScans = await getAllScansForProfile(profileId);
 
-    const newScan = remoteScans.filter(
+    const newScans = remoteScans.filter(
       (remoteScan) =>
         !localScans.some(
           (localScan) => localScan.onerep_scan_id === remoteScan.id,
         ),
     );
 
-    newScan.forEach((scan) =>
+    newScans.forEach((scan) =>
       logger.info("scan_created_or_updated", {
         onerepScanId: scan.id,
         onerepScanStatus: scan.status,

--- a/src/app/functions/server/refreshStoredScanResults.ts
+++ b/src/app/functions/server/refreshStoredScanResults.ts
@@ -23,16 +23,24 @@ export async function refreshStoredScanResults(profileId: number) {
     const remoteScans = (await listScans(profileId)).data;
     const localScans = await getAllScansForProfile(profileId);
 
-    const newScans = remoteScans.filter(
+    const newScan = remoteScans.filter(
       (remoteScan) =>
         !localScans.some(
           (localScan) => localScan.onerep_scan_id === remoteScan.id,
         ),
     );
 
+    newScan.forEach((scan) =>
+      logger.info("scan_created_or_updated", {
+        onerepScanId: scan.id,
+        onerepScanStatus: scan.status,
+        onerepScanReason: scan.reason,
+      }),
+    );
+
     // Record any new scans.
     await Promise.all(
-      newScans.map(async (scan) => {
+      remoteScans.map(async (scan) => {
         await setOnerepScan(profileId, scan.id, scan.status, scan.reason);
       }),
     );

--- a/src/app/functions/server/refreshStoredScanResults.ts
+++ b/src/app/functions/server/refreshStoredScanResults.ts
@@ -38,7 +38,7 @@ export async function refreshStoredScanResults(profileId: number) {
       }),
     );
 
-    // Record any new scans.
+    // Record any new scans, or change in existing scan status.
     await Promise.all(
       remoteScans.map(async (scan) => {
         await setOnerepScan(profileId, scan.id, scan.status, scan.reason);

--- a/src/app/functions/server/refreshStoredScanResults.ts
+++ b/src/app/functions/server/refreshStoredScanResults.ts
@@ -25,7 +25,6 @@ export async function refreshStoredScanResults(profileId: number) {
 
     const newScans = remoteScans.filter(
       (remoteScan) =>
-        // @ts-ignore FIXME
         !localScans.some(
           (localScan) => localScan.onerep_scan_id === remoteScan.id,
         ),
@@ -37,17 +36,9 @@ export async function refreshStoredScanResults(profileId: number) {
     }
 
     // Refresh results for all scans, new and existing.
+    // The database will ignore any attempt to insert duplicate scan result IDs.
     const allScanResults = await getAllScanResults(profileId);
     await addOnerepScanResults(profileId, allScanResults);
-
-    /*
-
-
-    const newScanResults = remoteScanResults.filter((remoteScanResult) => {
-    });
-
-    await addOnerepScanResults(profileId, newScanResults);
-    */
   } catch (ex) {
     logger.warn("Could not fetch current OneRep results:", ex);
   }

--- a/src/app/functions/server/refreshStoredScanResults.ts
+++ b/src/app/functions/server/refreshStoredScanResults.ts
@@ -31,9 +31,11 @@ export async function refreshStoredScanResults(profileId: number) {
     );
 
     // Record any new scans.
-    for (const scan of newScans) {
-      await setOnerepScan(profileId, scan.id, scan.status, scan.reason);
-    }
+    await Promise.all(
+      newScans.map(async (scan) => {
+        await setOnerepScan(profileId, scan.id, scan.status, scan.reason);
+      }),
+    );
 
     // Refresh results for all scans, new and existing.
     // The database will ignore any attempt to insert duplicate scan result IDs.

--- a/src/db/migrations/20231102024624_add_unique_index_to_scan_results_id.js
+++ b/src/db/migrations/20231102024624_add_unique_index_to_scan_results_id.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export function up (knex) {
+  return knex.schema.table('onerep_scan_results', table => {
+    table.unique('onerep_scan_result_id')
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export function down (knex) {
+  return knex.schema.table('onerep_scan_results', table => {
+    table.dropUnique('onerep_scan_result_id')
+  })
+}

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -51,6 +51,7 @@ async function getLatestOnerepScanResults(
       ? []
       : await knex("onerep_scan_results")
           .select()
+          .where("onerep_profile_id", onerepProfileId)
           .innerJoin(
             "onerep_scans",
             "onerep_scan_results.onerep_scan_id",

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -82,17 +82,21 @@ async function setOnerepScan(
   onerepScanStatus: Scan["status"],
   oneRepScanReason: "manual" | "initial" | "monitoring",
 ) {
-  logger.info("manual_scan_created", { onerepScanId, onerepScanStatus });
-
-  await knex("onerep_scans").insert({
-    onerep_profile_id: onerepProfileId,
-    onerep_scan_id: onerepScanId,
-    onerep_scan_reason: oneRepScanReason,
-    onerep_scan_status: onerepScanStatus,
-    // @ts-ignore knex.fn.now() results in it being set to a date,
-    // even if it's not typed as a JS date object:
-    created_at: knex.fn.now(),
-  });
+  await knex("onerep_scans")
+    .insert({
+      onerep_profile_id: onerepProfileId,
+      onerep_scan_id: onerepScanId,
+      onerep_scan_reason: oneRepScanReason,
+      onerep_scan_status: onerepScanStatus,
+      // @ts-ignore knex.fn.now() results in it being set to a date,
+      // even if it's not typed as a JS date object:
+      created_at: knex.fn.now(),
+    })
+    .onConflict("onerep_scan_id")
+    .merge({
+      onerep_scan_status: onerepScanStatus,
+      updated_at: knex.fn.now(),
+    });
 }
 
 async function addOnerepScanResults(

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -41,25 +41,21 @@ async function getScanResults(
 async function getLatestOnerepScanResults(
   onerepProfileId: number,
 ): Promise<LatestOnerepScanData> {
-  const scanIds = await knex("onerep_scan_results")
-    .select("onerep_scan_id")
-    .from("onerep_scans")
-    .where("onerep_profile_id", onerepProfileId);
-
-  const results =
-    typeof scanIds === "undefined"
-      ? []
-      : await knex("onerep_scan_results")
-          .select()
-          .whereIn(
-            "onerep_scan_id",
-            scanIds.map((scan_id) => scan_id["onerep_scan_id"]),
-          );
-
   const scan = await knex("onerep_scans")
     .first()
     .where("onerep_profile_id", onerepProfileId)
     .orderBy("created_at", "desc");
+
+  const results =
+    typeof scan === "undefined"
+      ? []
+      : await knex("onerep_scan_results")
+          .select()
+          .innerJoin(
+            "onerep_scans",
+            "onerep_scan_results.onerep_scan_id",
+            "onerep_scans.onerep_scan_id",
+          );
 
   return {
     scan: scan ?? null,

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -44,19 +44,22 @@ async function getLatestOnerepScanResults(
   const scanIds = await knex("onerep_scan_results")
     .select("onerep_scan_id")
     .from("onerep_scans")
-    .where("onerep_profile_id", onerepProfileId)
-    .orderBy("created_at", "desc");
-
-  const scanIdMap = scanIds.map((scan_id) => scan_id["onerep_scan_id"]);
+    .where("onerep_profile_id", onerepProfileId);
 
   const results =
     typeof scanIds === "undefined"
       ? []
       : await knex("onerep_scan_results")
           .select()
-          .whereIn("onerep_scan_id", scanIdMap);
+          .whereIn(
+            "onerep_scan_id",
+            scanIds.map((scan_id) => scan_id["onerep_scan_id"]),
+          );
 
-  const scan = await knex("onerep_scans").first();
+  const scan = await knex("onerep_scans")
+    .first()
+    .where("onerep_profile_id", onerepProfileId)
+    .orderBy("created_at", "desc");
 
   return {
     scan: scan ?? null,

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -99,45 +99,43 @@ async function addOnerepScanResults(
   onerepProfileId: number,
   onerepScanResults: Array<ScanResult>,
 ) {
-  await knex.transaction(async (transaction) => {
-    const scanResultsMap = onerepScanResults.map((scanResult) => ({
-      onerep_scan_result_id: scanResult.id,
-      onerep_scan_id: scanResult.scan_id,
-      link: scanResult.link,
-      age:
-        typeof scanResult.age === "string"
-          ? Number.parseInt(scanResult.age, 10)
-          : undefined,
-      data_broker: scanResult.data_broker,
-      data_broker_id: scanResult.data_broker_id,
-      emails: JSON.stringify(scanResult.emails),
-      phones: JSON.stringify(scanResult.phones),
-      addresses: JSON.stringify(scanResult.addresses),
-      relatives: JSON.stringify(scanResult.relatives),
-      first_name: scanResult.first_name,
-      middle_name: scanResult.middle_name,
-      last_name: scanResult.last_name,
-      status: scanResult.status,
-    }));
+  const scanResultsMap = onerepScanResults.map((scanResult) => ({
+    onerep_scan_result_id: scanResult.id,
+    onerep_scan_id: scanResult.scan_id,
+    link: scanResult.link,
+    age:
+      typeof scanResult.age === "string"
+        ? Number.parseInt(scanResult.age, 10)
+        : undefined,
+    data_broker: scanResult.data_broker,
+    data_broker_id: scanResult.data_broker_id,
+    emails: JSON.stringify(scanResult.emails),
+    phones: JSON.stringify(scanResult.phones),
+    addresses: JSON.stringify(scanResult.addresses),
+    relatives: JSON.stringify(scanResult.relatives),
+    first_name: scanResult.first_name,
+    middle_name: scanResult.middle_name,
+    last_name: scanResult.last_name,
+    status: scanResult.status,
+  }));
 
-    // Only log metadata. This is used for reporting purposes.
-    logger.info("scan_result", {
-      onerepProfileId,
-      scan: scanResultsMap.map((result) => {
-        return {
-          onerepScanId: result.onerep_scan_id,
-          onerepScanResultId: result.onerep_scan_result_id,
-          onerepScanStatus: result.status,
-          dataBrokerId: result.data_broker_id,
-        };
-      }),
-    });
-
-    await transaction("onerep_scan_results")
-      .insert(scanResultsMap)
-      .onConflict("onerep_scan_result_id")
-      .ignore();
+  // Only log metadata. This is used for reporting purposes.
+  logger.info("scan_result", {
+    onerepProfileId,
+    scan: scanResultsMap.map((result) => {
+      return {
+        onerepScanId: result.onerep_scan_id,
+        onerepScanResultId: result.onerep_scan_result_id,
+        onerepScanStatus: result.status,
+        dataBrokerId: result.data_broker_id,
+      };
+    }),
   });
+
+  await knex("onerep_scan_results")
+    .insert(scanResultsMap)
+    .onConflict("onerep_scan_result_id")
+    .ignore();
 }
 
 async function isOnerepScanResultForSubscriber(params: {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2444


<!-- When adding a new feature: -->

# Description

More detail in https://mozilla-hub.atlassian.net/browse/MNTOR-2444?focusedCommentId=789660 - the short version is that we were not handling new scan IDs correctly, *and* scan results are not attached to scan IDs in the way we thought they would be.

I tried to simplify and reuse the logic in `refreshStoredScanResults` while I was at it.

# How to test

This is unfortunately very difficult to test, as it relies on the behavior of the production scan service, and requires subscribing (which can't be undone). However, I believe it should fix the existing accounts that are stuck with fewer results than they should be showing (one of these is mine).

We don't really have automated testing around this behavior (outside of mocks), but I'll see if I can add it.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
