### PR TITLE
Delete duplicate rows from onerep scan results

### DIFF
--- a/src/db/migrations/20231102024624_add_unique_index_to_scan_results_id.js
+++ b/src/db/migrations/20231102024624_add_unique_index_to_scan_results_id.js
@@ -11,7 +11,7 @@ export async function up (knex) {
   await knex.raw(`
     DELETE FROM onerep_scan_results R1
     USING onerep_scan_results R2
-    WHERE R1.ctid < R2.ctid
+    WHERE R1.ctid > R2.ctid
     AND R1.onerep_scan_result_id = R2.onerep_scan_result_id`
   );
   return knex.schema.table('onerep_scan_results', table => {

--- a/src/db/migrations/20231102024624_add_unique_index_to_scan_results_id.js
+++ b/src/db/migrations/20231102024624_add_unique_index_to_scan_results_id.js
@@ -6,9 +6,9 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-export function up (knex) {
+export async function up (knex) {
   // Delete any duplicate rows, choosing the row that was inserted last.
-  knex.raw(`
+  await knex.raw(`
     DELETE FROM onerep_scan_results R1
     USING onerep_scan_results R2
     WHERE R1.ctid < R2.ctid

--- a/src/db/migrations/20231102024624_add_unique_index_to_scan_results_id.js
+++ b/src/db/migrations/20231102024624_add_unique_index_to_scan_results_id.js
@@ -7,6 +7,13 @@
  * @returns { Promise<void> }
  */
 export function up (knex) {
+  // Delete any duplicate rows, choosing the row that was inserted last.
+  knex.raw(`
+    DELETE FROM onerep_scan_results R1
+    USING onerep_scan_results R2
+    WHERE R1.ctid < R2.ctid
+    AND R1.onerep_scan_result_id = R2.onerep_scan_result_id`
+  );
   return knex.schema.table('onerep_scan_results', table => {
     table.unique('onerep_scan_result_id')
   })

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -139,7 +139,7 @@ async function addOnerepScanResults(
   await knex("onerep_scan_results")
     .insert(scanResultsMap)
     .onConflict("onerep_scan_result_id")
-    .ignore();
+    .merge();
 }
 
 async function isOnerepScanResultForSubscriber(params: {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When adding a new feature: -->

# Description

This migration failed on staging because there are duplicate rows already in the `onrep_scan_results` table - this is probably a result of our early tests. This adds a raw `DELETE` query that generically keeps the latest row if there are any duplicates (using `ctid` which is Postgres-specific). It doesn't require any parameters.
