### PR TITLE
Make the Firefox Accounts rebrand permanent

### DIFF
--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -864,11 +864,6 @@ ad-unit-6-before-you-complete = Before you complete that next signup, use an ema
 
 ##
 
-# “account” can be localized, “Firefox” must be treated as a brand,
-# and kept in English.
-# Deprecated - to be replaced by -brand-mozilla-account
--brand-fx-account = Firefox account
-
 # “account” can be localized, “Mozilla” must be treated as a brand,
 # and kept in English.
 -brand-mozilla-account = Mozilla account
@@ -897,11 +892,7 @@ brand-mozilla-vpn = { -brand-mozilla-vpn }
 menu-button-title = User menu
 menu-button-alt = Open user menu
 menu-list-accessible-label = Account menu
-# Deprecated
-menu-item-fxa = Manage your { -brand-fx-account }
 menu-item-fxa-2 = Manage your { -brand-mozilla-account }
-# Deprecated
-menu-item-fxa-alt = Open { -brand-fx-account } page
 menu-item-fxa-alt-2 = Open { -brand-mozilla-account } page
 menu-item-settings = Settings
 menu-item-settings-alt = Open settings page

--- a/locales/en/settings.ftl
+++ b/locales/en/settings.ftl
@@ -47,16 +47,11 @@ settings-email-number-of-breaches-info =
 
 settings-cancel-premium-subscription-title = Cancel { -brand-premium } subscription
 settings-cancel-premium-subscription-info = Your subscription will revert to a free account after the current billing cycle ends. Your privacy protection scan results will be permanently deleted, and you’ll only have data breach monitoring for 1 email address.
-settings-cancel-premium-subscription-link-label = Cancel from your { -brand-fx-account }
 
 ## Deactivate account
 
 settings-deactivate-account-title = Deactivate account
-# Deprecated
-settings-deactivate-account-info = You can deactivate { -product-short-name } by deleting your { -brand-fx-account }.
 settings-deactivate-account-info-2 = You can deactivate { -product-short-name } by deleting your { -brand-mozilla-account }.
-# Deprecated
-settings-fxa-link-label = Go to { -brand-firefox } Settings
 settings-fxa-link-label-3 = Go to { -brand-mozilla-account } settings
 
 ## Add email dialog

--- a/src/app/(nextjs_migration)/(authenticated)/user/settings/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/user/settings/page.tsx
@@ -249,11 +249,7 @@ export default async function Settings() {
                 {l10n.getString("settings-deactivate-account-title")}
               </h3>
               <p className="settings-section-info">
-                {l10n.getString(
-                  enabledFlags.includes("FxaRebrand")
-                    ? "settings-deactivate-account-info-2"
-                    : "settings-deactivate-account-info",
-                )}
+                {l10n.getString("settings-deactivate-account-info-2")}
               </p>
               <a
                 className="settings-link-fxa"
@@ -261,11 +257,7 @@ export default async function Settings() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                {l10n.getString(
-                  enabledFlags.includes("FxaRebrand")
-                    ? "settings-fxa-link-label-3"
-                    : "settings-fxa-link-label",
-                )}
+                {l10n.getString("settings-fxa-link-label-3")}
               </a>
             </section>
           </div>

--- a/src/app/(nextjs_migration)/components/client/UserMenu.tsx
+++ b/src/app/(nextjs_migration)/components/client/UserMenu.tsx
@@ -67,11 +67,7 @@ export const UserMenu = ({
           <a href={fxaSettingsUrl} target="_blank" className="user-menu-header">
             <b className="user-menu-email">{session.user?.email}</b>
             <div className="user-menu-subtitle">
-              {l10n.getString(
-                enabledFeatureFlags.includes("FxaRebrand")
-                  ? "menu-item-fxa-2"
-                  : "menu-item-fxa",
-              )}
+              {l10n.getString("menu-item-fxa-2")}
               <Image alt="" src={OpenInIcon} />
             </div>
           </a>

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -29,7 +29,6 @@ async function getAllFeatureFlags() {
 
 /** Add any feature flag you want to refer to in the code here */
 export type FeatureFlagName =
-  | "FxaRebrand"
   | "FreeBrokerScan"
   | "PremiumBrokerRemoval"
   | "FalseDoorTest"


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2304
Figma: N/A


<!-- When adding a new feature: -->

# Description

The `FxaRebrand` feature flag has now been enabled successfully, so we can make that change permanent and always use "Mozilla accounts" everywhere.

# How to test

Nothing should have changed compared to `main` if you've enabled the `FxaRebrand` flag.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been ~~added~~ <ins>removed</ins>.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
