### PR TITLE
WIP: Use manual resolution in stats calculation

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
@@ -113,6 +113,7 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                   exposures_unresolved_num:
                     bannerData.totalExposures -
                     bannerData.dataBrokerFixedExposuresNum -
+                    bannerData.dataBrokerManuallyResolvedExposuresNum -
                     bannerData.dataBreachFixedExposuresNum -
                     bannerData.dataBrokerInProgressExposuresNum,
                   data_breach_unresolved_num:
@@ -265,6 +266,7 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                     bannerData.totalExposures -
                     bannerData.dataBreachFixedExposuresNum -
                     bannerData.dataBrokerFixedExposuresNum -
+                    bannerData.dataBrokerManuallyResolvedExposuresNum -
                     bannerData.dataBrokerInProgressExposuresNum,
                 },
               )}
@@ -315,6 +317,7 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                     bannerData.totalExposures -
                     bannerData.dataBreachFixedExposuresNum -
                     bannerData.dataBrokerFixedExposuresNum -
+                    bannerData.dataBrokerManuallyResolvedExposuresNum -
                     bannerData.dataBrokerInProgressExposuresNum,
                 },
               )}
@@ -396,6 +399,7 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                   unresolved_exposures:
                     bannerData.totalExposures -
                     bannerData.dataBrokerFixedExposuresNum -
+                    bannerData.dataBrokerManuallyResolvedExposuresNum -
                     bannerData.dataBreachFixedExposuresNum -
                     bannerData.dataBrokerInProgressExposuresNum,
                 },
@@ -428,6 +432,7 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                   unresolved_exposures:
                     bannerData.totalExposures -
                     bannerData.dataBrokerFixedExposuresNum -
+                    bannerData.dataBrokerManuallyResolvedExposuresNum -
                     bannerData.dataBreachFixedExposuresNum -
                     bannerData.dataBrokerInProgressExposuresNum,
                 },
@@ -459,6 +464,7 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                 {
                   exposures_resolved_num:
                     bannerData.dataBrokerFixedExposuresNum +
+                    bannerData.dataBrokerManuallyResolvedExposuresNum -
                     bannerData.dataBreachFixedExposuresNum +
                     bannerData.dataBrokerInProgressExposuresNum,
                 },

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -180,6 +180,7 @@ export const View = (props: Props) => {
       dataBrokerInProgressNum,
       dataBreachFixedExposuresNum,
       dataBrokerFixedExposuresNum,
+      dataBrokerManuallyResolvedExposuresNum,
       dataBrokerInProgressExposuresNum,
       totalExposures,
     } = dataSummary;
@@ -193,6 +194,7 @@ export const View = (props: Props) => {
           exposures_unresolved_num:
             totalExposures -
             dataBrokerFixedExposuresNum -
+            dataBrokerManuallyResolvedExposuresNum -
             dataBreachFixedExposuresNum -
             dataBrokerInProgressExposuresNum,
           data_breach_unresolved_num: dataBreachUnresolvedNum,
@@ -209,6 +211,7 @@ export const View = (props: Props) => {
           exposures_unresolved_num:
             totalExposures -
             dataBrokerFixedExposuresNum -
+            dataBrokerManuallyResolvedExposuresNum -
             dataBreachFixedExposuresNum -
             dataBrokerInProgressExposuresNum,
           data_breach_unresolved_num: dataBreachUnresolvedNum,

--- a/src/app/components/client/Chart.tsx
+++ b/src/app/components/client/Chart.tsx
@@ -34,13 +34,13 @@ export const DoughnutChart = (props: Props) => {
     { type: "dialog" },
     explainerDialogState,
   );
-  const sumOfFixedExposures = props.data.reduce(
+  const sumOfShownExposures = props.data.reduce(
     (total, [_label, num]) => total + num,
     0,
   );
 
   const percentages = props.data.map(([label, num]) => {
-    return [label, num / sumOfFixedExposures] as const;
+    return [label, num / sumOfShownExposures] as const;
   });
 
   const diameter = 100;
@@ -139,7 +139,7 @@ export const DoughnutChart = (props: Props) => {
             role="img"
             aria-label={l10n
               .getString("exposure-chart-heading", {
-                nr: sumOfFixedExposures,
+                nr: sumOfShownExposures,
               })
               .replace("<nr>", "")
               .replace("</nr>", "")
@@ -179,7 +179,7 @@ export const DoughnutChart = (props: Props) => {
                       />
                     ),
                   },
-                  vars: { nr: sumOfFixedExposures },
+                  vars: { nr: sumOfShownExposures },
                 })
               : l10n.getFragment("exposure-chart-heading", {
                   elems: {
@@ -202,7 +202,7 @@ export const DoughnutChart = (props: Props) => {
                       />
                     ),
                   },
-                  vars: { nr: sumOfFixedExposures },
+                  vars: { nr: sumOfShownExposures },
                 })}
           </svg>
           <div className={styles.legend}>

--- a/src/app/functions/server/dashboard.test.ts
+++ b/src/app/functions/server/dashboard.test.ts
@@ -478,7 +478,8 @@ describe("getExposureReduction", () => {
       dataBreachFixedExposuresNum: 10,
       dataBrokerTotalNum: 10,
       dataBrokerTotalExposuresNum: 8,
-      dataBrokerFixedExposuresNum: 8,
+      dataBrokerFixedExposuresNum: 6,
+      dataBrokerManuallyResolvedNum: 2,
       dataBrokerFixedNum: 10,
       dataBrokerInProgressExposuresNum: 10,
       dataBrokerInProgressNum: 10,
@@ -488,6 +489,7 @@ describe("getExposureReduction", () => {
       unresolvedExposures: testExposure,
       inProgressExposures: testExposure,
       fixedExposures: testExposure,
+      manuallyResolvedExposures: testExposure,
       inProgressFixedExposures: testExposure,
       unresolvedSanitizedExposures: [],
       inProgressFixedSanitizedExposures: [],
@@ -523,7 +525,8 @@ describe("getExposureReduction", () => {
       dataBreachFixedExposuresNum: 10,
       dataBrokerTotalNum: 10,
       dataBrokerTotalExposuresNum: 8,
-      dataBrokerFixedExposuresNum: 8,
+      dataBrokerFixedExposuresNum: 6,
+      dataBrokerManuallyResolvedNum: 2,
       dataBrokerFixedNum: 10,
       dataBrokerInProgressExposuresNum: 10,
       dataBrokerInProgressNum: 10,
@@ -533,6 +536,7 @@ describe("getExposureReduction", () => {
       unresolvedExposures: testExposure,
       inProgressExposures: testExposure,
       fixedExposures: testExposure,
+      manuallyResolvedExposures: testExposure,
       inProgressFixedExposures: testExposure,
       unresolvedSanitizedExposures: [],
       inProgressFixedSanitizedExposures: [],
@@ -715,7 +719,9 @@ describe("getDashboardSummary", () => {
     expect(summary.dataBrokerFixedExposuresNum).toBe(36);
     expect(summary.dataBrokerInProgressExposuresNum).toBe(0);
     expect(summary.totalExposures).toBe(
-      summary.dataBreachFixedExposuresNum + summary.dataBrokerFixedExposuresNum,
+      summary.dataBreachFixedExposuresNum +
+        summary.dataBrokerFixedExposuresNum +
+        summary.dataBrokerManuallyResolvedExposuresNum,
     );
     expect(summary.unresolvedExposures.emailAddresses).toBe(0);
   });


### PR DESCRIPTION
I thought this was going to be a quick fix, but I'm finding it very hard to follow what is going on in the touched code — so I'm sharing this as in-progress work rather than a solution.

The problem was that manually resolving a data broker scan result would not result in the stats at the top of the dashboard being updated. Additionally, I saw the number of fixed items on the "Fixed" tab show 0, even though multiple exposures were listed there.

What was suspicious, is that the `sanitizeExposures` functions appeared to iterate over `sanitizedExposures` to create `other`, and then added all items in there *to that same* object.

However, with my changes, I still see a couple of suspicious things:

- The number of items "Resolved by you" on the fixed tab doesn't match the number in the doughnut chart.
- Likewise, the number of exposures mentioned as left to fix in the top banner content on the "Action needed" tab doesn't match the number in the doughnut chart.
- There are *a lot* of entries in the "Other" category now.

All of which is to say: this probably needs more work. Sharing this PR so I can hopefully hand over this ticket.
