### PR TITLE
Remove session update from PremiumButton

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/welcome-to-premium/WelcomeToPremiumView.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/welcome-to-premium/WelcomeToPremiumView.tsx
@@ -5,7 +5,6 @@
 import styles from "./welcomeToPremium.module.scss";
 import { getL10n } from "../../../../../../../../functions/server/l10n";
 import { PercentageChart } from "../../../../../../../../components/client/PercentageChart";
-import { SubscriptionCheck } from "../../../../../../../../components/client/SubscriptionCheck";
 import {
   getDashboardSummary,
   getExposureReduction,
@@ -34,62 +33,59 @@ export function WelcomeToPremiumView(props: Props) {
   const exposureReduction = getExposureReduction(summary);
 
   return (
-    <>
-      <SubscriptionCheck />
-      <FixView
-        data={props.data}
-        subscriberEmails={props.subscriberEmails}
-        nextStepHref={getNextGuidedStep(props.data, "Scan").href}
-        currentSection="data-broker-profiles"
-      >
-        <div className={styles.contentWrapper}>
-          <div className={styles.content}>
-            <h3>
+    <FixView
+      data={props.data}
+      subscriberEmails={props.subscriberEmails}
+      nextStepHref={getNextGuidedStep(props.data, "Scan").href}
+      currentSection="data-broker-profiles"
+    >
+      <div className={styles.contentWrapper}>
+        <div className={styles.content}>
+          <h3>
+            {l10n.getString(
+              "welcome-to-premium-data-broker-profiles-title-part-one",
+            )}
+            <br />
+            {l10n.getString(
+              "welcome-to-premium-data-broker-profiles-title-part-two",
+            )}
+          </h3>
+          <p>
+            {l10n.getString(
+              "welcome-to-premium-data-broker-profiles-description-part-one",
+              {
+                profile_total_num: countOfDataBrokerProfiles,
+                exposure_reduction_percentage: exposureReduction,
+              },
+            )}
+          </p>
+          <p>
+            {l10n.getString(
+              "welcome-to-premium-data-broker-profiles-description-part-two",
+            )}
+          </p>
+          <p>
+            {l10n.getString(
+              "welcome-to-premium-data-broker-profiles-description-part-three",
+            )}
+          </p>
+          <div className={styles.buttonsWrapper}>
+            <Button
+              variant="primary"
+              href="/redesign/user/dashboard/fix/high-risk-data-breaches"
+              disabled
+              wide
+            >
               {l10n.getString(
-                "welcome-to-premium-data-broker-profiles-title-part-one",
+                "welcome-to-premium-data-broker-profiles-cta-label",
               )}
-              <br />
-              {l10n.getString(
-                "welcome-to-premium-data-broker-profiles-title-part-two",
-              )}
-            </h3>
-            <p>
-              {l10n.getString(
-                "welcome-to-premium-data-broker-profiles-description-part-one",
-                {
-                  profile_total_num: countOfDataBrokerProfiles,
-                  exposure_reduction_percentage: exposureReduction,
-                },
-              )}
-            </p>
-            <p>
-              {l10n.getString(
-                "welcome-to-premium-data-broker-profiles-description-part-two",
-              )}
-            </p>
-            <p>
-              {l10n.getString(
-                "welcome-to-premium-data-broker-profiles-description-part-three",
-              )}
-            </p>
-            <div className={styles.buttonsWrapper}>
-              <Button
-                variant="primary"
-                href="/redesign/user/dashboard/fix/high-risk-data-breaches"
-                disabled
-                wide
-              >
-                {l10n.getString(
-                  "welcome-to-premium-data-broker-profiles-cta-label",
-                )}
-              </Button>
-            </div>
-          </div>
-          <div className={styles.chart}>
-            <PercentageChart exposureReduction={exposureReduction} />
+            </Button>
           </div>
         </div>
-      </FixView>
-    </>
+        <div className={styles.chart}>
+          <PercentageChart exposureReduction={exposureReduction} />
+        </div>
+      </div>
+    </FixView>
   );
 }

--- a/src/app/(proper_react)/redesign/Shell.tsx
+++ b/src/app/(proper_react)/redesign/Shell.tsx
@@ -14,6 +14,7 @@ import { PageLink } from "./PageLink";
 import { ExtendedReactLocalization } from "../../hooks/l10n";
 import { GaScript } from "./GaScript";
 import getPremiumSubscriptionUrl from "../../functions/server/getPremiumSubscriptionUrl";
+import { SubscriptionCheck } from "../../components/client/SubscriptionCheck";
 
 export type Props = {
   l10n: ExtendedReactLocalization;
@@ -33,6 +34,7 @@ export const Shell = (props: Props) => {
   return (
     <>
       <GaScript nonce={props.nonce} />
+      <SubscriptionCheck />
       <MobileShell
         session={props.session}
         monthlySubscriptionUrl={monthlySubscriptionUrl}

--- a/src/app/components/client/PremiumBadge.tsx
+++ b/src/app/components/client/PremiumBadge.tsx
@@ -4,7 +4,7 @@
 
 "use client";
 
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { Session } from "next-auth";
@@ -21,7 +21,6 @@ import ShieldIcon from "./assets/shield-icon.svg";
 import styles from "./PremiumBadge.module.scss";
 import { useGa } from "../../hooks/useGa";
 import { CountryCodeContext } from "../../../contextProviders/country-code";
-import { useSession } from "next-auth/react";
 
 export type Props = {
   label: string;
@@ -74,18 +73,7 @@ export function PremiumBadge(props: Props) {
   const l10n = useL10n();
   const countryCode = useContext(CountryCodeContext);
 
-  const { update } = useSession();
   const { user } = props;
-
-  useEffect(() => {
-    async function updateSession() {
-      await update();
-    }
-    void updateSession();
-
-    // This should only run once per page load - `update` will always appear to be changed.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   if (hasPremium(user)) {
     return (

--- a/src/app/components/client/PremiumBadge.tsx
+++ b/src/app/components/client/PremiumBadge.tsx
@@ -29,7 +29,7 @@ export type Props = {
   yearlySubscriptionUrl: string;
 };
 
-const PremiumLayout = (props: Props) => {
+export function PremiumButton(props: Props) {
   const { gtag } = useGa();
   const pathname = usePathname();
 
@@ -63,10 +63,6 @@ const PremiumLayout = (props: Props) => {
       />
     </>
   );
-};
-
-export function PremiumButton(props: Props) {
-  return <PremiumLayout {...props} />;
 }
 
 export function PremiumBadge(props: Props) {
@@ -85,7 +81,7 @@ export function PremiumBadge(props: Props) {
   }
 
   if (canSubscribeToPremium({ user, countryCode })) {
-    return <PremiumLayout {...props} />;
+    return <PremiumButton {...props} />;
   }
 
   return <></>;


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2396](https://mozilla-hub.atlassian.net/browse/MNTOR-2396)

<!-- When adding a new feature: -->

# Description

Removes the redundant session update from `PremiumBadge` and moves the session update to `Shell` to get the latest subscription status. This ensures that we check the status more consistently and remove the duplicate check from `PremiumBadge`: It is being rendered twice — once in [Toolbar](https://github.com/mozilla/blurts-server/blob/premium-button-remove-session-update/src/app/components/client/toolbar/Toolbar.tsx#L27) and also in [MobileShell](https://github.com/mozilla/blurts-server/blob/premium-button-remove-session-update/src/app/(proper_react)/redesign/MobileShell.tsx#L106).

[MNTOR-2396]: https://mozilla-hub.atlassian.net/browse/MNTOR-2396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ