### PR TITLE
Fix: Mark Toolbar as client component

### DIFF
--- a/src/app/components/client/toolbar/Toolbar.tsx
+++ b/src/app/components/client/toolbar/Toolbar.tsx
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+"use client";
+
 import { ReactNode } from "react";
 import styles from "./Toolbar.module.scss";
 import { UserMenu } from "./UserMenu";


### PR DESCRIPTION
We are using Toolbar as a client component and have to explicitly make a client component since we are using useL10n.