### PR TITLE
MNTOR-2281/optimize email breaches

### DIFF
--- a/src/app/api/v1/hibp/notify/route.ts
+++ b/src/app/api/v1/hibp/notify/route.ts
@@ -3,11 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { NextRequest, NextResponse } from "next/server";
+
 import { bearerToken } from "../../../utils/auth";
 import { logger } from "../../../../functions/server/logging";
 
 import { PubSub } from "@google-cloud/pubsub";
 import { getEnabledFeatureFlags } from "../../../../../db/tables/featureFlags";
+import {
+  getAllBreachesFromDb,
+  getBreachByName,
+} from "../../../../../utils/hibp";
 
 const projectId = process.env.GCP_PUBSUB_PROJECT_ID;
 const topicName = process.env.GCP_PUBSUB_TOPIC_NAME;
@@ -49,15 +54,71 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ success: false }, { status: 400 });
     }
 
+    const breaches = await getAllBreachesFromDb();
+
+    const { breachName, _hashPrefix, _hashSuffixes } = json;
+    const breachAlert = getBreachByName(breaches, breachName);
+
+    if (!breachAlert) {
+      logger.error("HIBP breach notification: breach not found:", json);
+      return NextResponse.json({ success: false }, { status: 400 });
+    }
+
+    const { IsVerified, Domain, IsFabricated, IsSpamList } = breachAlert;
+
+    // If any of the following conditions are not satisfied:
+    // Do not send the breach alert email! The `logId`s are being used for
+    // logging in case we decide to not send the alert.
+    const emailDeliveryConditions = [
+      {
+        logId: "isNotVerified",
+        condition: !IsVerified,
+      },
+      {
+        logId: "domainEmpty",
+        condition: Domain === "",
+      },
+      {
+        logId: "isFabricated",
+        condition: IsFabricated,
+      },
+      {
+        logId: "isSpam",
+        condition: IsSpamList,
+      },
+    ];
+
+    const unsatisfiedConditions = emailDeliveryConditions.filter(
+      (condition) => condition.condition,
+    );
+
+    if (unsatisfiedConditions.length > 0) {
+      // Get a list of the failed condition `logId`s
+      const conditionLogIds = unsatisfiedConditions
+        .map((condition) => condition.logId)
+        .join(", ");
+
+      logger.info("Breach alert email was not sent.", {
+        name: breachAlert.Name,
+        reason: `The following conditions were not satisfied: ${conditionLogIds}.`,
+      });
+
+      return NextResponse.json({ success: true }, { status: 200 });
+    }
+  } catch (ex) {
+    logger.error("Error processing breach alert:", ex);
+    return NextResponse.json({ success: false }, { status: 500 });
+  }
+
+  try {
     pubsub = new PubSub({ projectId });
   } catch (ex) {
     logger.error("Error connecting to PubSub:", ex);
     return NextResponse.json({ success: false }, { status: 500 });
   }
 
-  let topic;
   try {
-    topic = pubsub.topic(topicName);
+    const topic = pubsub.topic(topicName);
     await topic.publishMessage({ json });
     logger.info("Successfully queued breach notification", json);
     return NextResponse.json({ success: true }, { status: 200 });

--- a/src/scripts/emailBreachAlerts.js
+++ b/src/scripts/emailBreachAlerts.js
@@ -77,6 +77,8 @@ export async function poll(subClient, receivedMessages) {
     subscriptionName,
   );
 
+  const breaches = await getAllBreachesFromDb();
+
   // Process the messages. Skip any that cannot be processed, and do not mark as acknowledged.
   for (const message of receivedMessages) {
     console.log(`Received message: ${message.message.data}`);
@@ -90,8 +92,6 @@ export async function poll(subClient, receivedMessages) {
     }
 
     const { breachName, hashPrefix, hashSuffixes } = data;
-
-    const breaches = await getAllBreachesFromDb();
     const breachAlert = getBreachByName(breaches, breachName);
 
     const {

--- a/src/scripts/emailBreachAlerts.js
+++ b/src/scripts/emailBreachAlerts.js
@@ -221,15 +221,18 @@ export async function poll(subClient, receivedMessages) {
                   email: data.recipientEmail,
                   notificationType: "incident",
                 });
+
+                const emailTemplate = getTemplate(
+                  data,
+                  breachAlertEmailPartial,
+                );
+                const subject = getMessage("breach-alert-subject");
+
+                await sendEmail(data.recipientEmail, subject, emailTemplate);
               } catch (e) {
                 console.error("Failed to add email notification to table: ", e);
-                throw new Error(e);
+                setTimeout(process.exit, 1000);
               }
-
-              const emailTemplate = getTemplate(data, breachAlertEmailPartial);
-              const subject = getMessage("breach-alert-subject");
-
-              await sendEmail(data.recipientEmail, subject, emailTemplate);
 
               // mark email as notified in database
               // if this call ever fails, stop stop the script with an error


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2281


<!-- When adding a new feature: -->

# Description

This adds a few optimizations around email breach alert processing:

1. check to see a breach is actionable breach before queuing
2. move reading breach data out of loop in worker

One thing I'm a little concerned about with (1) is that we've tried to avoid having dependencies on anything except Pub/Sub being up, and this adds a scan of the breach table. We might want to use Redis here.