### PR TITLE
MNTOR-2143 send page_location with cta_id

### DIFF
--- a/public/nextjs_migration/client/js/analytics.js
+++ b/public/nextjs_migration/client/js/analytics.js
@@ -2,40 +2,47 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const bodyDataset = document.body.dataset
+const bodyDataset = document.body.dataset;
 
 async function init({ debugMode, ga4MeasurementId }) {
-  if (navigator.doNotTrack === '1') {
+  if (navigator.doNotTrack === "1") {
     window.gtag = function () {
-      console.debug('Analytics disabled by DNT')
-    }
-    window.gtag()
+      console.debug("Analytics disabled by DNT");
+    };
+    window.gtag();
   } else {
-    await import(`https://www.googletagmanager.com/gtag/js?id=${ga4MeasurementId}`)
+    await import(
+      `https://www.googletagmanager.com/gtag/js?id=${ga4MeasurementId}`
+    );
 
-    window.dataLayer = window.dataLayer || []
+    window.dataLayer = window.dataLayer || [];
 
     window.gtag = function () {
-      window.dataLayer.push(arguments)
-    }
-    window.gtag('js', new Date())
-    window.gtag('config', ga4MeasurementId, {
+      window.dataLayer.push(arguments);
+    };
+    window.gtag("js", new Date());
+    window.gtag("config", ga4MeasurementId, {
       cookie_domain: window.location.hostname,
-      cookie_flags: 'SameSite=None;Secure',
-      debug_mode: debugMode
-    })
+      cookie_flags: "SameSite=None;Secure",
+      debug_mode: debugMode,
+    });
 
     // Instrument CTA clicks for analytics.
-    document.querySelectorAll('[data-cta-id]').forEach(cta =>
-      cta.addEventListener('click', () => window.gtag('event', 'clicked_cta', { cta_id: cta.dataset.ctaId })))
+    document
+      .querySelectorAll("[data-cta-id]")
+      .forEach((cta) =>
+        cta.addEventListener("click", () =>
+          window.gtag("event", "clicked_cta", { cta_id: cta.dataset.ctaId }),
+        ),
+      );
   }
 }
 
 if (bodyDataset) {
   const analyticsConfig = Object.freeze({
-    debugMode: bodyDataset.nodeEnv !== 'production',
-    ga4MeasurementId: bodyDataset.ga4MeasurementId || 'G-CXG8K4KW4P'
-  })
-  
-  init(analyticsConfig)
+    debugMode: bodyDataset.nodeEnv !== "production",
+    ga4MeasurementId: bodyDataset.ga4MeasurementId || "G-CXG8K4KW4P",
+  });
+
+  init(analyticsConfig);
 }

--- a/public/nextjs_migration/client/js/analytics.js
+++ b/public/nextjs_migration/client/js/analytics.js
@@ -28,13 +28,14 @@ async function init({ debugMode, ga4MeasurementId }) {
     });
 
     // Instrument CTA clicks for analytics.
-    document
-      .querySelectorAll("[data-cta-id]")
-      .forEach((cta) =>
-        cta.addEventListener("click", () =>
-          window.gtag("event", "clicked_cta", { cta_id: cta.dataset.ctaId }),
-        ),
-      );
+    document.querySelectorAll("[data-cta-id]").forEach((cta) =>
+      cta.addEventListener("click", () =>
+        window.gtag("event", "clicked_cta", {
+          cta_id: cta.dataset.ctaId,
+          page_location: window.location.href,
+        }),
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2143


<!-- When adding a new feature: -->

# Description

We're not seeing outbound clicks to `mozilla.org` in GA4, I'm suspecting that we're overriding these with our `click` handler for elements that have `cta_id` data properties.

I think we probably need to be including the page location with `clicked_cta` events anyway, so this would be a "good enough" fix for the problem of being able to count CTA clicks to `mozilla.org`.