### PR TITLE
Replace named connect script imports

### DIFF
--- a/src/db/connect.js
+++ b/src/db/connect.js
@@ -2,18 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import initKnex, { Knex } from "knex";
+import knex from "knex";
 import knexConfig from "./knexfile.js";
 
-/** @returns {Knex} */
-const createDbConnection = () => {
+/** @returns {knex.Knex} */
+export default function createDbConnection() {
     /* c8 ignore start */
     if (process.env.NODE_ENV === "development") {
         /** @type {import("./knexfile").KnexConfig} knexConfig */
         const { client } = knexConfig;
         if (!(client in global)) {
             // @ts-ignore-next-line: globalThis is a read-only property
-            global[client] = initKnex(knexConfig);
+            global[client] = knex(knexConfig);
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -23,7 +23,5 @@ const createDbConnection = () => {
     /* c8 ignore stop */
 
     // @ts-ignore-next-line: knexConfig is expected to have @type KnexConfig
-    return initKnex(knexConfig);
-};
-
-export { createDbConnection };
+    return knex(knexConfig);
+}

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createDbConnection } from "./connect.js";
+import createDbConnection from "./connect.js";
 
 let knex = createDbConnection();
 

--- a/src/db/tables/breaches.js
+++ b/src/db/tables/breaches.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createDbConnection } from "../connect.js";
+import createDbConnection from "../connect.js";
 
 const knex = createDbConnection();
 

--- a/src/db/tables/emailAddresses.js
+++ b/src/db/tables/emailAddresses.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { v4 as uuidv4 } from 'uuid'
-import { createDbConnection } from "../connect.js";
+import createDbConnection from "../connect.js";
 import { subscribeHash } from '../../utils/hibp.js'
 import { getSha1 } from '../../utils/fxa.js'
 import { getSubscriberByEmail, updateFxAData } from './subscribers.js'

--- a/src/db/tables/email_notifications.js
+++ b/src/db/tables/email_notifications.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createDbConnection } from "../connect.js";
+import createDbConnection from "../connect.js";
 
 const knex = createDbConnection();
 

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createDbConnection } from "../connect.js";
+import createDbConnection from "../connect.js";
 import { logger } from "../../app/functions/server/logging";
 import { FeatureFlagRow } from "knex/types/tables";
 

--- a/src/db/tables/onerep_profiles.ts
+++ b/src/db/tables/onerep_profiles.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createDbConnection } from "../connect.js";
+import createDbConnection from "../connect.js";
 import { CreateProfileRequest } from "../../app/functions/server/onerep.js";
 import { parseIso8601Datetime } from "../../utils/parse.js";
 

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createDbConnection } from "../connect.js";
+import createDbConnection from "../connect.js";
 import { logger } from "../../app/functions/server/logging";
 
 import { ScanResult, Scan } from "../../app/functions/server/onerep.js";

--- a/src/db/tables/subscribers.js
+++ b/src/db/tables/subscribers.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createDbConnection } from "../connect.js";
+import createDbConnection from "../connect.js";
 import { destroyOAuthToken } from '../../utils/fxa.js'
 import AppConstants from '../../appConstants.js'
 

--- a/src/scripts/convertBreachResolutions.js
+++ b/src/scripts/convertBreachResolutions.js
@@ -8,7 +8,7 @@
  * with the goal of deprecating the column
  */
 
-import { createDbConnection } from "../db/connect.js";
+import createDbConnection from "../db/connect.js";
 import { getAllBreachesFromDb } from "../utils/hibp.js";
 import { getAllEmailsAndBreaches } from "../utils/breaches.js";
 import { setBreachResolution } from "../db/tables/subscribers.js";

--- a/src/scripts/kube-jobs/convertBreachResolutions.js
+++ b/src/scripts/kube-jobs/convertBreachResolutions.js
@@ -8,7 +8,7 @@
  * with the goal of deprecating the column
  */
 
-import { createDbConnection } from "../../db/connect.js";
+import createDbConnection from "../../db/connect.js";
 import { getAllBreachesFromDb } from "../../utils/hibp.js";
 import { getAllEmailsAndBreaches } from "../../utils/breaches.js";
 import { BreachDataTypes } from "../../utils/breach-resolution.js";

--- a/src/scripts/kube-jobs/recencyToBreachId.js
+++ b/src/scripts/kube-jobs/recencyToBreachId.js
@@ -10,7 +10,7 @@
  * `useBreachId: true/false`
  */
 
-import { createDbConnection } from "../../db/connect.js";
+import createDbConnection from "../../db/connect.js";
 import { getAllBreachesFromDb } from "../../utils/hibp.js";
 import { getAllEmailsAndBreaches } from "../../utils/breaches.js";
 

--- a/src/scripts/migrationCleanup.js
+++ b/src/scripts/migrationCleanup.js
@@ -7,7 +7,7 @@
  * The purpose of the script is to clean up some of the failed records during db migration on 3/28/23
  */
 
-import { createDbConnection } from "../db/connect.js";
+import createDbConnection from "../db/connect.js";
 import { getAllBreachesFromDb } from "../utils/hibp.js";
 import { getAllEmailsAndBreaches } from "../utils/breaches.js";
 import { setBreachResolution } from "../db/tables/subscribers.js";

--- a/src/scripts/prod-experiments/benchmarkNoUpsert.js
+++ b/src/scripts/prod-experiments/benchmarkNoUpsert.js
@@ -8,7 +8,7 @@
  * with the goal of deprecating the column
  */
 
-import { createDbConnection } from "../../db/connect.js";
+import createDbConnection from "../../db/connect.js";
 import { getAllBreachesFromDb } from "../../utils/hibp.js";
 import { getAllEmailsAndBreaches } from "../../utils/breaches.js";
 import { BreachDataTypes } from "../../utils/breach-resolution.js";

--- a/src/scripts/prod-experiments/benchmarkWithUpsert.js
+++ b/src/scripts/prod-experiments/benchmarkWithUpsert.js
@@ -8,7 +8,7 @@
  * with the goal of deprecating the column
  */
 
-import { createDbConnection } from "../../db/connect.js";
+import createDbConnection from "../../db/connect.js";
 import { getAllBreachesFromDb } from "../../utils/hibp.js";
 import { getAllEmailsAndBreaches } from "../../utils/breaches.js";
 import { BreachDataTypes } from "../../utils/breach-resolution.js";

--- a/src/scripts/prod-experiments/pullExperiment100.js
+++ b/src/scripts/prod-experiments/pullExperiment100.js
@@ -7,7 +7,7 @@
  * The purpose of the script is to benchmark pure read with limit set as 100
  */
 
-import { createDbConnection } from "../../db/connect.js";
+import createDbConnection from "../../db/connect.js";
 import { getAllBreachesFromDb } from "../../utils/hibp.js";
 
 const knex = createDbConnection();

--- a/src/scripts/prod-experiments/pullExperiment1000.js
+++ b/src/scripts/prod-experiments/pullExperiment1000.js
@@ -7,7 +7,7 @@
  * The purpose of the script is to benchmark pure read with limit set as 1000
  */
 
-import { createDbConnection } from "../../db/connect.js";
+import createDbConnection from "../../db/connect.js";
 import { getAllBreachesFromDb } from "../../utils/hibp.js";
 
 const knex = createDbConnection();


### PR DESCRIPTION
Replace the named imports introduced in PR #3716O to address the following error we are seeing on `stage`:
```
SyntaxError: Named export 'Knex' not found. The requested module 'knex' is a CommonJS module, which may not support all module.exports as named exports.
```