### PR TITLE
emailBreachAlerts: Move sentry cron check-in to end of finally block

### DIFF
--- a/src/scripts/emailBreachAlerts.js
+++ b/src/scripts/emailBreachAlerts.js
@@ -311,11 +311,6 @@ if (process.env.NODE_ENV !== "test") {
           "env vars not set: GCP_PUBSUB_PROJECT_ID and GCP_PUBSUB_SUBSCRIPTION_NAME",
         );
       }
-      Sentry.captureCheckIn({
-        checkInId,
-        monitorSlug: SENTRY_SLUG,
-        status: "ok",
-      });
     })
     .catch((err) => console.error(err))
     .finally(async () => {
@@ -323,6 +318,11 @@ if (process.env.NODE_ENV !== "test") {
       await knexSubscribers.destroy();
       await knexEmailAddresses.destroy();
       await knexHibp.destroy();
+      Sentry.captureCheckIn({
+        checkInId,
+        monitorSlug: SENTRY_SLUG,
+        status: "ok",
+      });
     });
 }
 /* c8 ignore stop */

--- a/src/scripts/emailBreachAlerts.js
+++ b/src/scripts/emailBreachAlerts.js
@@ -323,6 +323,7 @@ if (process.env.NODE_ENV !== "test") {
         monitorSlug: SENTRY_SLUG,
         status: "ok",
       });
+      setTimeout(process.exit, 1000);
     });
 }
 /* c8 ignore stop */


### PR DESCRIPTION
<!-- When adding a new feature: -->

# Description

We're trying to diagnose whether the script is hanging in stage/prod or not, I noticed that the Sentry check-in comes after tearing down Postgres connections. We should have it be the very last thing the script does instead, this will allow Sentry to alert us to hanging cron jobs.
