### PR TITLE
Open view profile link in a blank target

### DIFF
--- a/src/app/components/client/DataBrokerProfiles.module.scss
+++ b/src/app/components/client/DataBrokerProfiles.module.scss
@@ -87,6 +87,15 @@
     height: auto;
     display: block;
   }
+
+  .openInNewTab {
+    color: $color-blue-50;
+    display: inline-block;
+
+    svg {
+      margin: 0 $spacing-xs;
+    }
+  }
 }
 
 .viewProfilesToggle {

--- a/src/app/components/client/DataBrokerProfiles.tsx
+++ b/src/app/components/client/DataBrokerProfiles.tsx
@@ -10,6 +10,7 @@ import { useL10n } from "../../hooks/l10n";
 import IconChevronDown from "./assets/icon-chevron-down.svg";
 import { useState } from "react";
 import { OnerepScanResultRow } from "knex/types/tables";
+import { OpenInNew } from "../server/Icons";
 
 export type Props = {
   data: OnerepScanResultRow[];
@@ -68,10 +69,17 @@ export const DataBrokerProfileCard = (props: DataBrokerProfileCardProps) => {
       />
       {/* TODO: Add logic to show unique image per data broker */}
       {/* <Image src={} alt={props.data.data_broker} /> */}
-      <a href={props.data.link}>
+      <a href={props.data.link} target="_blank">
         {l10n.getString(
           "fix-flow-data-broker-profiles-view-data-broker-profiles-view-profile",
         )}
+        <span className={styles.openInNewTab}>
+          <OpenInNew
+            alt={l10n.getString("open-in-new-tab-alt")}
+            width="13"
+            height="13"
+          />
+        </span>
       </a>
     </div>
   );


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2440](https://mozilla-hub.atlassian.net/browse/MNTOR-2440): "View your profile" links in guided flow and on the dashboard don't open in a new tab

<!-- When adding a new feature: -->

# Description

Adds an icon for outgoing links and add target `_blank` to the “View your profile” links.

# How to test

1. Visit `/redesign/user/dashboard/fix/data-broker-profiles/view-data-brokers`.
2. The “View your profile” links should have icon beside them and open in a new tab or window.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.


[MNTOR-2440]: https://mozilla-hub.atlassian.net/browse/MNTOR-2440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ