### PR TITLE
Re-enable welcome to premium CTA

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/welcome-to-premium/WelcomeToPremiumView.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/welcome-to-premium/WelcomeToPremiumView.tsx
@@ -73,7 +73,6 @@ export function WelcomeToPremiumView(props: Props) {
             <Button
               variant="primary"
               href="/redesign/user/dashboard/fix/high-risk-data-breaches"
-              disabled
               wide
             >
               {l10n.getString(


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2025: Update Welcome to Premium Card to re-enable the CTA](https://mozilla-hub.atlassian.net/browse/MNTOR-2025)

<!-- When adding a new feature: -->

# Description

Re-enable the welcome to premium CTA that was disabled for the first round of FF.

# How to test

1. Visit `/redesign/user/dashboard/fix/data-broker-profiles/welcome-to-premium`.
2. The “Let’s keep going” button should be enabled again.