### PR TITLE
MNTOR-1932: update destroy oauth token fxa API

### DIFF
--- a/src/db/tables/subscribers.js
+++ b/src/db/tables/subscribers.js
@@ -170,7 +170,7 @@ async function updateFxAData (subscriber, fxaAccessToken, fxaRefreshToken, fxaPr
     .returning('*')
   const updatedSubscriber = Array.isArray(updated) ? updated[0] : null
   if (updatedSubscriber && subscriber.fxa_refresh_token) {
-    destroyOAuthToken({ refresh_token: subscriber.fxa_refresh_token })
+    destroyOAuthToken({ token: subscriber.fxa_refresh_token, token_type_hint: "refresh_token" })
   }
   return updatedSubscriber
 }
@@ -220,10 +220,10 @@ async function removeFxAData (subscriber) {
     .returning('*')
   const updatedSubscriber = Array.isArray(updated) ? updated[0] : null
   if (updatedSubscriber && subscriber.fxa_refresh_token) {
-    await destroyOAuthToken({ refresh_token: subscriber.fxa_refresh_token })
+    await destroyOAuthToken({ token: subscriber.fxa_refresh_token,  token_type_hint: "refresh_token" })
   }
   if (updatedSubscriber && subscriber.fxa_access_token) {
-    await destroyOAuthToken({ token: subscriber.fxa_access_token })
+    await destroyOAuthToken({ token: subscriber.fxa_access_token,  token_type_hint: "access_token" })
   }
   return updatedSubscriber
 }

--- a/src/utils/fxa.js
+++ b/src/utils/fxa.js
@@ -80,7 +80,7 @@ async function verifyOAuthToken (token) {
 /**
  * fxa doc: https://mozilla.github.io/ecosystem-platform/api#tag/Oauth/operation/postOauthDestroy
  *
- * @param {{ token?: any; token_type_hint?: any; }} token
+ * @param {{ token?: string; token_type_hint?: string; }} token
  */
 // TODO: Add unit test when changing this code:
 /* c8 ignore start */

--- a/src/utils/fxa.js
+++ b/src/utils/fxa.js
@@ -78,13 +78,20 @@ async function verifyOAuthToken (token) {
 /* c8 ignore stop */
 
 /**
- * @param {{ token?: any; refresh_token?: any; }} token
+ * fxa doc: https://mozilla.github.io/ecosystem-platform/api#tag/Oauth/operation/postOauthDestroy
+ *
+ * @param {{ token?: any; token_type_hint?: any; }} token
  */
 // TODO: Add unit test when changing this code:
 /* c8 ignore start */
 async function destroyOAuthToken (token) {
+  const tokenBody = {
+    ...token,
+    client_id: AppConstants.OAUTH_CLIENT_ID,
+    client_secret: AppConstants.OAUTH_CLIENT_SECRET
+  }
   try {
-    const response = await postTokenRequest('/v1/destroy', token)
+    const response = await postTokenRequest('/v1/oauth/destroy', tokenBody)
     return response
   } catch (e) {
     if (e instanceof Error) {
@@ -100,8 +107,8 @@ async function destroyOAuthToken (token) {
 // TODO: Add unit test when changing this code:
 /* c8 ignore next 4 */
 async function revokeOAuthTokens (subscriber) {
-  await destroyOAuthToken({ token: subscriber.fxa_access_token })
-  await destroyOAuthToken({ refresh_token: subscriber.fxa_refresh_token })
+  await destroyOAuthToken({ token: subscriber.fxa_access_token, token_type_hint: "access_token" })
+  await destroyOAuthToken({ token: subscriber.fxa_refresh_token, token_type_hint: "refresh_token" })
 }
 
 /**

--- a/src/utils/fxa.js
+++ b/src/utils/fxa.js
@@ -102,7 +102,7 @@ async function destroyOAuthToken (token) {
 /* c8 ignore stop */
 
 /**
- * @param {{ fxa_access_token: any; fxa_refresh_token: any; }} subscriber
+ * @param {{ fxa_access_token: string; fxa_refresh_token: string; }} subscriber
  */
 // TODO: Add unit test when changing this code:
 /* c8 ignore next 4 */


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-1932


<!-- When adding a new feature: -->

# Description
Updating session token revoke URI to use the new FxA endpoint


# Screenshot (if applicable)

Not applicable.

# How to test
In Heroku, go to settings and update your password. Check logs in heroku to make sure there's no 400 or 500 errors


# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
