### PR TITLE
Add plans to the landing page on wide screens

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,6 +52,25 @@
         "varsIgnorePattern": "^_"
       }
     ],
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            // react-aria's <VisuallyHidden> component adds inline styles to
+            // visually hide its children, but our Content Security Policy
+            // disallows inline styles. By adding the equivalent styles to a CSS
+            // file, which automatically gets added to our Content Security
+            // Policy, our own <VisuallyHidden> component avoids this
+            // restriction.
+            "name": "react-aria",
+            "importNames": ["VisuallyHidden"],
+            "message":
+              "Please use the <VisuallyHidden> component from `/src/app/components/server/VisuallyHidden.tsx` instead of the one from react-aria, since the latter's (inline) styles will be stripped by our Content Security Policy."
+          }
+        ]
+      }
+    ],
     "@typescript-eslint/ban-ts-comment": [
       "error",
       {

--- a/locales-pending/landing-premium.ftl
+++ b/locales-pending/landing-premium.ftl
@@ -12,3 +12,69 @@ landing-premium-hero-image-removal-badge-label = exposures auto‑removed
 
 # This is a label underneath a big number "50" - it's an image that demos Monitor.
 landing-premium-hero-image-chart-label = fixed
+
+landing-premium-plans-heading = Choose your level of protection
+landing-premium-plans-lead = We believe in your right to privacy, so data breach monitoring is always free. For more robust protection, { -brand-monitor } also offers continuous automatic removal of your personal information.
+landing-premium-plans-table-annotation-plus = Recommended
+landing-premium-plans-table-heading-feature = Features
+# Users can click a button with this label to see a popover with a bit more detail.
+landing-premium-plans-table-feature-callout-trigger = More info
+landing-premium-plans-table-heading-free-title = { -brand-monitor }
+landing-premium-plans-table-heading-free-subtitle = Free breach alerts
+landing-premium-plans-table-heading-plus-title = { -brand-monitor } <b>Plus</b>
+landing-premium-plans-table-heading-plus-subtitle = Automatic data removal
+# Variables:
+#   $dataBrokerTotalCount (number) - number of scanned data broker sites, e.g. 190
+landing-premium-plans-table-feature-scan-label =
+    { $dataBrokerTotalCount ->
+        [one] Scan { $dataBrokerTotalCount } data broker site that may be selling your personal info
+       *[other] Scan { $dataBrokerTotalCount } data broker sites that may be selling your personal info
+    }
+landing-premium-plans-table-feature-scan-free = One-time
+landing-premium-plans-table-feature-scan-plus = Monthly
+landing-premium-plans-table-feature-removal-label = Remove personal info from sites that are selling it
+landing-premium-plans-table-feature-removal-free = Manual removal
+landing-premium-plans-table-feature-removal-plus = Automatic removal
+landing-premium-plans-table-feature-removal-free-callout = We’ll let you know which data brokers are selling your info so you can contact them to request removal.
+# Variables:
+#   $dataBrokerTotalCount (number) - number of scanned data broker sites, e.g. 190
+landing-premium-plans-table-feature-removal-plus-callout =
+    { $dataBrokerTotalCount ->
+        [one] We’ll automatically request removal of your private info across { $dataBrokerTotalCount } data broker site.
+       *[other] We’ll automatically request removal of your private info across more than { $dataBrokerTotalCount } data broker sites.
+    }
+landing-premium-plans-table-feature-alerts-label = Get alerts when your data has been breached
+landing-premium-plans-table-feature-alerts-free = Included
+landing-premium-plans-table-feature-alerts-plus = Included
+landing-premium-plans-table-feature-guidance-label = Fix high-risk data breaches
+landing-premium-plans-table-feature-guidance-free = Guided
+landing-premium-plans-table-feature-guidance-plus = Guided
+landing-premium-plans-table-feature-monitoring-label = Continuous monitoring
+landing-premium-plans-table-feature-monitoring-free = Included
+landing-premium-plans-table-feature-monitoring-plus = Included
+landing-premium-plans-table-billing-label = Price
+landing-premium-plans-table-billing-free = Always free
+# Label for the options "Yearly" and "Monthly"
+landing-premium-plans-table-billing-plus-period-label = Billing
+landing-premium-plans-table-billing-plus-period-yearly = Yearly
+landing-premium-plans-table-billing-plus-period-monthly = Monthly
+# There is not much room in the UI for this string, so abbreviating "month",
+# if possible, is probably a good idea:
+# Variables:
+#   $monthlyPrice (string) - annual plan's price per month, including currency, e.g. "$13.37"
+landing-premium-plans-table-price-plus-yearly = { $monthlyPrice }/mo.
+# Variables:
+#   $discountPercentage (number) - how much percent the yearly plan is cheaper than the monthly plan, without the percentage sign, e.g. `42`
+landing-premium-plans-table-price-plus-yearly-discount = Save { $discountPercentage }%
+# Variables:
+#   $yearlyPrice (string) - annual plan's price in total, including currency, e.g. "$13.37"
+landing-premium-plans-table-price-plus-yearly-sum = { $yearlyPrice } total
+# There is not much room in the UI for this string, so abbreviating "month",
+# if possible, is probably a good idea:
+# Variables:
+#   $monthlyPrice (string) - monthly plan's price, including currency, e.g. "$13.37"
+landing-premium-plans-table-price-plus-monthly = { $monthlyPrice }/mo.
+landing-premium-plans-table-cta-free-label = Start free monitoring
+landing-premium-plans-table-cta-plus-label = Get data removal
+landing-premium-plans-table-reassurance-free-label = Upgrade anytime
+landing-premium-plans-table-reassurance-plus-label = Cancel anytime

--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -853,6 +853,7 @@ ad-unit-6-before-you-complete = Before you complete that next signup, use an ema
 ## The following messages are brands and should be kept entirely in English
 
 -brand-firefox = Firefox
+-brand-monitor = Monitor
 -brand-fx-monitor = Firefox Monitor
 -brand-mozilla = Mozilla
 -brand-premium = Premium

--- a/src/app/(proper_react)/redesign/(public)/LandingView.module.scss
+++ b/src/app/(proper_react)/redesign/(public)/LandingView.module.scss
@@ -141,3 +141,18 @@
     }
   }
 }
+
+.plans {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-lg;
+  background-color: $color-grey-05;
+  padding: $layout-lg 0;
+
+  .planName,
+  .lead,
+  table {
+    width: $content-lg;
+  }
+}

--- a/src/app/(proper_react)/redesign/(public)/LandingView.test.tsx
+++ b/src/app/(proper_react)/redesign/(public)/LandingView.test.tsx
@@ -46,4 +46,91 @@ describe("When Premium is available", () => {
     const { container } = render(<ComposedDashboard />);
     expect(await axe(container)).toHaveNoViolations();
   });
+
+  it("can open and close the tooltip with the keyboard", async () => {
+    const user = userEvent.setup();
+
+    const ComposedDashboard = composeStory(LandingUs, Meta);
+    render(<ComposedDashboard />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    const moreInfoButton = screen.getAllByRole("button", {
+      name: "More info",
+    })[0];
+    await user.click(moreInfoButton);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await user.keyboard("[Escape]");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("can switch from the yearly to the monthly plan with the keyboard", async () => {
+    const user = userEvent.setup();
+
+    const ComposedDashboard = composeStory(LandingUs, Meta);
+    render(<ComposedDashboard />);
+
+    // Regular expression:
+    //
+    //   Save   Starts with the characters `Save `,
+    //
+    //   (.+?)  followed by one or more (`+`) arbitrary characters (`.`), until
+    //          the next part of the regular expression matches…
+    //
+    //   %      …which is a single `%` character.
+    //
+    // All that combines to a string like "Save 13.37%".
+    expect(screen.getByText(/Save (.+?)%/)).toBeInTheDocument();
+
+    const yearlyToggle = screen.getByRole("radio", { name: "Yearly" });
+    await user.click(yearlyToggle);
+    await user.keyboard("[ArrowRight][Space]");
+
+    // Regular expression:
+    //
+    //   Save   Starts with the characters `Save `,
+    //
+    //   (.+?)  followed by one or more (`+`) arbitrary characters (`.`), until
+    //          the next part of the regular expression matches…
+    //
+    //   %      …which is a single `%` character.
+    //
+    // All that combines to a string like "Save 13.37%".
+    expect(screen.queryByText(/Save (.+?)%/)).not.toBeInTheDocument();
+  });
+
+  it("can move to the subscribe button with the keyboard", async () => {
+    const user = userEvent.setup();
+
+    const ComposedDashboard = composeStory(LandingUs, Meta);
+    render(<ComposedDashboard />);
+
+    const plusSubscribeButton = screen.getByRole("link", {
+      name: "Get data removal",
+    });
+    expect(plusSubscribeButton).not.toHaveFocus();
+
+    const yearlyToggle = screen.getByRole("radio", { name: "Yearly" });
+    await user.click(yearlyToggle);
+    await user.keyboard("[ArrowRight][ArrowRight]");
+
+    expect(plusSubscribeButton).toHaveFocus();
+  });
+
+  it("can initiate sign in from the pricing table", async () => {
+    const user = userEvent.setup();
+
+    const ComposedDashboard = composeStory(LandingUs, Meta);
+    render(<ComposedDashboard />);
+
+    expect(signIn).not.toHaveBeenCalled();
+
+    const yearlyToggle = screen.getByRole("radio", { name: "Yearly" });
+    await user.click(yearlyToggle);
+    await user.keyboard("[ArrowLeft][Space]");
+
+    expect(signIn).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/app/(proper_react)/redesign/(public)/LandingView.tsx
+++ b/src/app/(proper_react)/redesign/(public)/LandingView.tsx
@@ -6,6 +6,8 @@ import styles from "./LandingView.module.scss";
 import { HeroImageAll, HeroImagePremium } from "./HeroImage";
 import { SignUpForm } from "./SignUpForm";
 import { ExtendedReactLocalization } from "../../../hooks/l10n";
+import { PlansTable } from "./PlansTable";
+import { useId } from "react";
 
 export type Props = {
   eligibleForPremium: boolean;
@@ -37,6 +39,7 @@ export const View = (props: Props) => {
           <HeroImage {...props} />
         </div>
       </header>
+      <Plans {...props} />
     </main>
   );
 };
@@ -68,5 +71,25 @@ const HeroImage = (props: Props) => {
         </span>
       </div>
     </>
+  );
+};
+
+const Plans = (props: Props) => {
+  const headingId = useId();
+
+  if (!props.eligibleForPremium) {
+    return null;
+  }
+
+  return (
+    <section className={styles.plans}>
+      <h2 id={headingId} className={styles.planName}>
+        {props.l10n.getString("landing-premium-plans-heading")}
+      </h2>
+      <p className={styles.lead}>
+        {props.l10n.getString("landing-premium-plans-lead")}
+      </p>
+      <PlansTable aria-labelledby={headingId} />
+    </section>
   );
 };

--- a/src/app/(proper_react)/redesign/(public)/PlansTable.module.scss
+++ b/src/app/(proper_react)/redesign/(public)/PlansTable.module.scss
@@ -1,0 +1,253 @@
+@import "../../../tokens";
+
+.plansTable {
+  border-spacing: $spacing-xl 0;
+  table-layout: fixed;
+  width: 100%;
+
+  // Set column widths:
+  thead th {
+    width: calc(30% - $spacing-xl);
+  }
+
+  // Styles for the column headings
+  thead {
+    th.featureHeadingCell {
+      text-align: start;
+      vertical-align: bottom;
+      padding-block: $spacing-lg;
+    }
+
+    .freeHeadingCell,
+    .plusHeadingCell {
+      padding-block: $spacing-2xl;
+      position: relative;
+    }
+
+    h3 {
+      font: $text-title-xs;
+      font-weight: 600;
+
+      b {
+        color: $color-purple-70;
+      }
+    }
+  }
+
+  // Styles for the non-heading parts of the columns:
+  tbody {
+    // Ideally, the top border would span the entire row, but then it won't show
+    // up because we haven't set `border-collapse: collapse` today. So as a
+    // compromise, we only show it on individual cells, rather than on the `tr`:
+    tr td,
+    tr th {
+      border-top: 1px solid $color-grey-20;
+      font-weight: 400;
+    }
+
+    .featureBodyCell {
+      text-align: start;
+    }
+
+    // This rule is less specific than the `tr td, tr th` above, but since
+    // that line ideally would have been just `tr`, I'm leaving it up there:
+    /* stylelint-disable-next-line no-descending-specificity */
+    th,
+    td {
+      padding-block: $spacing-md;
+
+      .cellWrapper {
+        display: flex;
+        align-items: center;
+      }
+
+      svg.checkIcon {
+        display: inline-block;
+        color: $color-blue-50;
+      }
+    }
+
+    .priceCell {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: $spacing-lg;
+      text-align: center;
+      padding-block-end: $spacing-md;
+      padding-inline: $spacing-md;
+      width: 100%;
+
+      .billingPeriod {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: $layout-md;
+        font-weight: 500;
+        color: $color-blue-50;
+      }
+
+      .price {
+        font: $text-title-sm;
+      }
+
+      .total {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: $layout-xl;
+        font: $text-body-lg;
+
+        .discount {
+          color: $color-purple-70;
+          font-weight: 700;
+          font-style: normal;
+        }
+
+        .sum {
+          color: $color-grey-40;
+          font-weight: 500;
+        }
+      }
+
+      button {
+        font-weight: 700;
+      }
+
+      .reassurance {
+        font: $text-body-sm;
+        font-weight: 400;
+      }
+    }
+  }
+
+  // Draw purple border around the Plus plan column:
+  .freeCell,
+  .plusCell {
+    background-color: $color-white;
+    vertical-align: middle;
+    color: $color-grey-50;
+
+    .cellWrapper {
+      justify-content: center;
+    }
+  }
+
+  .plusCell {
+    font-weight: 700;
+    border-inline: 4px solid $color-purple-70;
+  }
+
+  .badge {
+    position: absolute;
+    top: 0;
+    background-color: $color-purple-70;
+    color: $color-white;
+    transform: translateX(-50%) translateY(-50%);
+    border-radius: $border-radius-md;
+    font: $text-body-sm;
+    font-weight: 600;
+    padding: $spacing-sm $spacing-md;
+
+    // CSS uppercasing is not reliable for some locales, so limit it to
+    // English, where it is. See
+    // https://mozilla-l10n.github.io/documentation/localization/dev_best_practices.html#css-issues
+    [lang="en"] &,
+    [lang="en-US"] &,
+    [lang="en-CA"] &,
+    [lang="en-GB"] & {
+      text-transform: uppercase;
+    }
+  }
+
+  th.plusHeadingCell {
+    border-top: 4px solid $color-purple-70;
+    border-top-right-radius: $border-radius-md;
+    border-top-left-radius: $border-radius-md;
+
+    &::before {
+      content: "+";
+      position: absolute;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: $color-purple-70;
+      color: $color-white;
+      width: $spacing-2xl;
+      height: $spacing-2xl;
+      border-radius: $border-radius-xl;
+      font: $text-title-sm;
+      inset-block-start: 0;
+      inset-inline-start: 0;
+      transform: translateX(-50%) translateY(-50%);
+    }
+  }
+
+  tbody tr:last-child .plusBodyCell {
+    border-bottom: 4px solid $color-purple-70;
+    border-bottom-right-radius: $border-radius-md;
+    border-bottom-left-radius: $border-radius-md;
+  }
+
+  // Draw a light-grey line around the Free plan column:
+  .freeCell {
+    border-inline: 1px solid $color-grey-20;
+  }
+
+  th.freeHeadingCell {
+    border-top: 1px solid $color-grey-20;
+    border-top-right-radius: $border-radius-md;
+    border-top-left-radius: $border-radius-md;
+  }
+
+  tbody tr:last-child td:nth-child(2) {
+    border-bottom: 1px solid $color-grey-20;
+    border-bottom-right-radius: $border-radius-md;
+    border-bottom-left-radius: $border-radius-md;
+  }
+}
+
+.popoverTrigger {
+  background-color: transparent;
+  border-style: none;
+  cursor: pointer;
+  border-radius: $border-radius-md;
+
+  svg {
+    width: $layout-2xs;
+    height: $layout-2xs;
+  }
+}
+
+.popoverUnderlay {
+  position: fixed;
+  inset: 0;
+}
+
+.popover {
+  box-shadow: $box-shadow-sm;
+  background-color: $color-white;
+  border: 1px solid $color-grey-20;
+  border-radius: $border-radius-md;
+  padding: $spacing-md;
+  max-width: $content-sm;
+}
+
+.popoverArrow {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  fill: $color-white;
+  stroke: $color-grey-20;
+  stroke-width: 1px;
+
+  &[data-placement="top"] {
+    top: 100%;
+    transform: translateX(-50%);
+  }
+
+  &[data-placement="bottom"] {
+    bottom: 100%;
+    transform: translateX(-50%) rotate(180deg);
+  }
+}

--- a/src/app/(proper_react)/redesign/(public)/PlansTable.tsx
+++ b/src/app/(proper_react)/redesign/(public)/PlansTable.tsx
@@ -1,0 +1,597 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use client";
+
+import { ReactNode, cloneElement, useRef, useState } from "react";
+import {
+  AriaDialogProps,
+  AriaPopoverProps,
+  AriaTableCellProps,
+  AriaTableColumnHeaderProps,
+  AriaTableProps,
+  DismissButton,
+  GridRowProps,
+  Overlay,
+  mergeProps,
+  useButton,
+  useDialog,
+  useFocusRing,
+  useOverlayTrigger,
+  usePopover,
+  useTable,
+  useTableCell,
+  useTableColumnHeader,
+  useTableHeaderRow,
+  useTableRow,
+  useTableRowGroup,
+} from "react-aria";
+import {
+  Cell,
+  Column,
+  OverlayTriggerProps,
+  OverlayTriggerState,
+  Row,
+  TableBody,
+  TableHeader,
+  TableState,
+  TableStateProps,
+  useOverlayTriggerState,
+  useTableState,
+} from "react-stately";
+import styles from "./PlansTable.module.scss";
+import { useL10n } from "../../../hooks/l10n";
+import {
+  CheckIcon,
+  QuestionMarkCircle,
+} from "../../../components/server/Icons";
+import { VisuallyHidden } from "../../../components/server/VisuallyHidden";
+import {
+  BillingPeriod,
+  BillingPeriodToggle,
+} from "../../../components/client/BillingPeriod";
+import { getLocale } from "../../../functions/universal/getLocale";
+import { Button } from "../../../components/server/Button";
+import { signIn } from "next-auth/react";
+import getPremiumSubscriptionUrl from "../../../functions/server/getPremiumSubscriptionUrl";
+
+export type Props = {
+  "aria-labelledby": string;
+};
+
+const monthlyPriceAnnualBilling = 13.37;
+const monthlyPriceMonthlyBilling = 42.42;
+
+export const PlansTable = (props: Props) => {
+  const l10n = useL10n();
+  const roundedPriceFormatter = new Intl.NumberFormat(getLocale(l10n), {
+    style: "currency",
+    currency: "USD",
+    currencyDisplay: "narrowSymbol",
+    maximumFractionDigits: 0,
+  });
+  const priceFormatter = new Intl.NumberFormat(getLocale(l10n), {
+    style: "currency",
+    currency: "USD",
+    currencyDisplay: "narrowSymbol",
+  });
+  const [billingPeriod, setBillingPeriod] = useState<BillingPeriod>("yearly");
+
+  return (
+    <Table aria-labelledby={props["aria-labelledby"]} selectionMode="none">
+      <TableHeader>
+        <Column>
+          {l10n.getString("landing-premium-plans-table-heading-feature")}
+        </Column>
+        <Column>
+          <h3>
+            {l10n.getString("landing-premium-plans-table-heading-free-title")}
+          </h3>
+          <p>
+            {l10n.getString(
+              "landing-premium-plans-table-heading-free-subtitle",
+            )}
+          </p>
+        </Column>
+        <Column>
+          <b className={styles.badge}>
+            {l10n.getString("landing-premium-plans-table-annotation-plus")}
+          </b>
+          <h3>
+            {l10n.getFragment(
+              "landing-premium-plans-table-heading-plus-title",
+              { elems: { b: <b /> } },
+            )}
+          </h3>
+          <p>
+            {l10n.getString(
+              "landing-premium-plans-table-heading-plus-subtitle",
+            )}
+          </p>
+        </Column>
+      </TableHeader>
+      <TableBody>
+        <Row>
+          <Cell>
+            {l10n.getString("landing-premium-plans-table-feature-scan-label", {
+              dataBrokerTotalCount: process.env
+                .NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
+            })}
+          </Cell>
+          <Cell>
+            {l10n.getString("landing-premium-plans-table-feature-scan-free")}
+          </Cell>
+          <Cell>
+            {l10n.getString("landing-premium-plans-table-feature-scan-plus")}
+          </Cell>
+        </Row>
+        <Row>
+          <Cell>
+            {l10n.getString(
+              "landing-premium-plans-table-feature-removal-label",
+            )}
+          </Cell>
+          <Cell>
+            {l10n.getString("landing-premium-plans-table-feature-removal-free")}
+            <InfoPopover>
+              <PopoverContent>
+                {l10n.getString(
+                  "landing-premium-plans-table-feature-removal-free-callout",
+                )}
+              </PopoverContent>
+            </InfoPopover>
+          </Cell>
+          <Cell>
+            {l10n.getString("landing-premium-plans-table-feature-removal-plus")}
+            <InfoPopover>
+              <PopoverContent>
+                {l10n.getString(
+                  "landing-premium-plans-table-feature-removal-plus-callout",
+                  {
+                    dataBrokerTotalCount: process.env
+                      .NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
+                  },
+                )}
+              </PopoverContent>
+            </InfoPopover>
+          </Cell>
+        </Row>
+        <Row>
+          <Cell>
+            {l10n.getString("landing-premium-plans-table-feature-alerts-label")}
+          </Cell>
+          <Cell>
+            <CheckIcon
+              className={styles.checkIcon}
+              alt={l10n.getString(
+                "landing-premium-plans-table-feature-alerts-free",
+              )}
+            />
+          </Cell>
+          <Cell>
+            <CheckIcon
+              className={styles.checkIcon}
+              alt={l10n.getString(
+                "landing-premium-plans-table-feature-alerts-plus",
+              )}
+            />
+          </Cell>
+        </Row>
+        <Row>
+          <Cell>
+            {l10n.getString(
+              "landing-premium-plans-table-feature-guidance-label",
+            )}
+          </Cell>
+          <Cell>
+            {l10n.getString(
+              "landing-premium-plans-table-feature-guidance-free",
+            )}
+          </Cell>
+          <Cell>
+            {l10n.getString(
+              "landing-premium-plans-table-feature-guidance-plus",
+            )}
+          </Cell>
+        </Row>
+        <Row>
+          <Cell>
+            {l10n.getString(
+              "landing-premium-plans-table-feature-monitoring-label",
+            )}
+          </Cell>
+          <Cell>
+            <CheckIcon
+              className={styles.checkIcon}
+              alt={l10n.getString(
+                "landing-premium-plans-table-feature-monitoring-free",
+              )}
+            />
+          </Cell>
+          <Cell>
+            <CheckIcon
+              className={styles.checkIcon}
+              alt={l10n.getString(
+                "landing-premium-plans-table-feature-monitoring-plus",
+              )}
+            />
+          </Cell>
+        </Row>
+        <Row>
+          <Cell>
+            <VisuallyHidden>
+              {l10n.getString("landing-premium-plans-table-billing-label")}
+            </VisuallyHidden>
+          </Cell>
+          <Cell>
+            <div className={styles.priceCell}>
+              <p className={styles.billingPeriod}>
+                {l10n.getString("landing-premium-plans-table-billing-free")}
+              </p>
+              <p className={styles.cost}>
+                <b className={styles.price}>
+                  {roundedPriceFormatter.format(0)}
+                </b>
+                <span className={styles.total} />
+              </p>
+              <Button variant="secondary" onPress={() => void signIn("fxa")}>
+                {l10n.getString("landing-premium-plans-table-cta-free-label")}
+              </Button>
+              <small className={styles.reassurance}>
+                {l10n.getString(
+                  "landing-premium-plans-table-reassurance-free-label",
+                )}
+              </small>
+            </div>
+          </Cell>
+          <Cell>
+            <div className={styles.priceCell}>
+              <div className={styles.billingPeriod}>
+                <BillingPeriodToggle
+                  onChange={(newValue) => setBillingPeriod(newValue)}
+                />
+              </div>
+              <p aria-live="polite" className={styles.cost}>
+                <b className={styles.price}>
+                  {billingPeriod === "yearly"
+                    ? l10n.getString(
+                        "landing-premium-plans-table-price-plus-yearly",
+                        {
+                          monthlyPrice: priceFormatter.format(
+                            monthlyPriceAnnualBilling,
+                          ),
+                        },
+                      )
+                    : l10n.getString(
+                        "landing-premium-plans-table-price-plus-monthly",
+                        {
+                          monthlyPrice: priceFormatter.format(
+                            monthlyPriceMonthlyBilling,
+                          ),
+                        },
+                      )}
+                </b>
+                <span className={styles.total}>
+                  {billingPeriod === "yearly" && (
+                    <em className={styles.discount}>
+                      {l10n.getString(
+                        "landing-premium-plans-table-price-plus-yearly-discount",
+                        {
+                          discountPercentage:
+                            ((monthlyPriceMonthlyBilling -
+                              monthlyPriceAnnualBilling) *
+                              100) /
+                            monthlyPriceMonthlyBilling,
+                        },
+                      )}
+                    </em>
+                  )}
+                  <br />
+                  <span className={styles.sum}>
+                    {l10n.getString(
+                      "landing-premium-plans-table-price-plus-yearly-sum",
+                      {
+                        yearlyPrice: priceFormatter.format(
+                          12 *
+                            (billingPeriod === "yearly"
+                              ? monthlyPriceAnnualBilling
+                              : monthlyPriceMonthlyBilling),
+                        ),
+                      },
+                    )}
+                  </span>
+                </span>
+              </p>
+              <Button
+                variant="primary"
+                href={getPremiumSubscriptionUrl({ type: billingPeriod })}
+              >
+                {l10n.getString("landing-premium-plans-table-cta-plus-label")}
+              </Button>
+              <small className={styles.reassurance}>
+                {l10n.getString(
+                  "landing-premium-plans-table-reassurance-plus-label",
+                )}
+              </small>
+            </div>
+          </Cell>
+        </Row>
+      </TableBody>
+    </Table>
+  );
+};
+
+const Table = (props: TableStateProps<object> & AriaTableProps<object>) => {
+  const tableRef = useRef<HTMLTableElement>(null);
+  const tableState = useTableState(props);
+  const { collection } = tableState;
+  const { gridProps } = useTable(props, tableState, tableRef);
+
+  return (
+    <table {...gridProps} ref={tableRef} className={styles.plansTable}>
+      <TableRowGroup type="thead">
+        {collection.headerRows.map((headerRow) => (
+          <TableHeaderRow
+            key={headerRow.key}
+            item={headerRow}
+            state={tableState}
+          >
+            {[...headerRow.childNodes].map((column) => (
+              <TableColumnHeader
+                key={column.key}
+                column={column}
+                state={tableState}
+              />
+            ))}
+          </TableHeaderRow>
+        ))}
+      </TableRowGroup>
+      <TableRowGroup type="tbody">
+        {[...collection.body.childNodes].map((row) => (
+          <TableRow key={row.key} item={row} state={tableState}>
+            {[...row.childNodes].map((cell) => (
+              <TableCell key={cell.key} cell={cell} state={tableState} />
+            ))}
+          </TableRow>
+        ))}
+      </TableRowGroup>
+    </table>
+  );
+};
+
+const TableRowGroup = (props: {
+  type: "thead" | "tbody";
+  children: ReactNode;
+}) => {
+  const { rowGroupProps } = useTableRowGroup();
+
+  return props.type === "thead" ? (
+    <thead {...rowGroupProps}>{props.children}</thead>
+  ) : (
+    <tbody {...rowGroupProps}>{props.children}</tbody>
+  );
+};
+
+const TableHeaderRow = (props: {
+  item: GridRowProps<object>["node"];
+  state: TableState<object>;
+  children: ReactNode;
+}) => {
+  const rowRef = useRef<HTMLTableRowElement>(null);
+  const { rowProps } = useTableHeaderRow(
+    { node: props.item },
+    props.state,
+    rowRef,
+  );
+
+  return (
+    <tr {...rowProps} ref={rowRef}>
+      {props.children}
+    </tr>
+  );
+};
+
+const TableColumnHeader = (props: {
+  column: AriaTableColumnHeaderProps<unknown>["node"];
+  state: TableState<object>;
+}) => {
+  const columnRef = useRef<HTMLTableCellElement>(null);
+  const { columnHeaderProps } = useTableColumnHeader(
+    { node: props.column },
+    props.state,
+    columnRef,
+  );
+  const { isFocusVisible, focusProps } = useFocusRing();
+
+  return (
+    <th
+      {...mergeProps(columnHeaderProps, focusProps)}
+      colSpan={props.column.colspan}
+      ref={columnRef}
+      // We don't currently do anything with focused table cells, so we don't
+      // have any tests for it either:
+      /* c8 ignore next */
+      className={`${isFocusVisible ? styles.isFocused : styles.isBlurred} ${
+        props.column.index === 0
+          ? `${styles.featureCell} ${styles.featureHeadingCell}`
+          : props.column.index === 1
+            ? `${styles.freeCell} ${styles.freeHeadingCell}`
+            : `${styles.plusCell} ${styles.plusHeadingCell}`
+      }`}
+    >
+      {props.column.rendered}
+    </th>
+  );
+};
+
+const TableRow = (props: {
+  item: GridRowProps<unknown>["node"];
+  state: TableState<object>;
+  children: ReactNode;
+}) => {
+  const rowRef = useRef<HTMLTableRowElement>(null);
+  const { rowProps, isPressed } = useTableRow(
+    { node: props.item },
+    props.state,
+    rowRef,
+  );
+  const { isFocusVisible, focusProps } = useFocusRing();
+
+  return (
+    <tr
+      {...mergeProps(rowProps, focusProps)}
+      ref={rowRef}
+      // We don't currently do anything with focused table cells, so we don't
+      // have any tests for it either:
+      /* c8 ignore next 3 */
+      className={`${isFocusVisible ? styles.isFocused : styles.isBlurred} ${
+        isPressed ? styles.isPressed : styles.isUnpressed
+      }`}
+    >
+      {props.children}
+    </tr>
+  );
+};
+
+const TableCell = (props: {
+  cell: AriaTableCellProps["node"];
+  state: TableState<object>;
+}) => {
+  const cellRef = useRef<HTMLTableCellElement>(null);
+  const { gridCellProps } = useTableCell(
+    { node: props.cell },
+    props.state,
+    cellRef,
+  );
+  const { isFocusVisible, focusProps } = useFocusRing();
+
+  if (props.cell.column?.index === 0) {
+    return (
+      <th
+        {...mergeProps(gridCellProps, focusProps)}
+        ref={cellRef}
+        className={`${styles.tableCell} ${
+          // We don't currently do anything with focused table cells, so we don't
+          // have any tests for it either:
+          /* c8 ignore next */
+          isFocusVisible ? styles.isFocused : styles.isBlurred
+        } ${styles.featureCell} ${styles.featureBodyCell}`}
+      >
+        <span className={styles.cellWrapper}>{props.cell.rendered}</span>
+      </th>
+    );
+  }
+
+  return (
+    <td
+      {...mergeProps(gridCellProps, focusProps)}
+      ref={cellRef}
+      className={`${styles.tableCell} ${
+        // We don't currently do anything with focused table cells, so we don't
+        // have any tests for it either:
+        /* c8 ignore next */
+        isFocusVisible ? styles.isFocused : styles.isBlurred
+      } ${
+        props.cell.column?.index === 1
+          ? `${styles.freeCell} ${styles.freeBodyCell}`
+          : `${styles.plusCell} ${styles.plusBodyCell}`
+      }`}
+    >
+      <span className={styles.cellWrapper}>{props.cell.rendered}</span>
+    </td>
+  );
+};
+
+const InfoPopover = ({
+  children,
+  ...otherProps
+}: { children: Parameters<typeof cloneElement>[0] } & OverlayTriggerProps) => {
+  const l10n = useL10n();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const triggerState = useOverlayTriggerState(otherProps);
+  const { triggerProps, overlayProps } = useOverlayTrigger(
+    { type: "dialog" },
+    triggerState,
+    triggerRef,
+  );
+  const { buttonProps } = useButton(triggerProps, triggerRef);
+
+  return (
+    <>
+      <button
+        {...buttonProps}
+        ref={triggerRef}
+        className={styles.popoverTrigger}
+      >
+        <QuestionMarkCircle
+          alt={l10n.getString(
+            "landing-premium-plans-table-feature-callout-trigger",
+          )}
+        />
+      </button>
+      {triggerState.isOpen && (
+        <Popover
+          {...otherProps}
+          offset={4}
+          triggerRef={triggerRef}
+          state={triggerState}
+        >
+          {cloneElement(children, overlayProps)}
+        </Popover>
+      )}
+    </>
+  );
+};
+
+type PopoverProps = Omit<AriaPopoverProps, "popoverRef"> & {
+  children: ReactNode;
+  state: OverlayTriggerState;
+};
+const Popover = ({ children, state, ...props }: PopoverProps) => {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const { popoverProps, underlayProps, arrowProps, placement } = usePopover(
+    {
+      ...props,
+      popoverRef,
+    },
+    state,
+  );
+
+  return (
+    <Overlay>
+      <div {...underlayProps} className={styles.popoverUnderlay} />
+      <div {...popoverProps} ref={popoverRef} className={styles.popover}>
+        <svg
+          {...arrowProps}
+          className={styles.popoverArrow}
+          data-placement={placement}
+          viewBox="0 0 12 12"
+        >
+          <path d="M0 0 L6 6 L12 0" />
+        </svg>
+        {/* <DismissButton>s are visually hidden and thus not reachable in tests: */}
+        {/* c8 ignore next */}
+        <DismissButton onDismiss={() => state.close()} />
+        {children}
+        {/* <DismissButton>s are visually hidden and thus not reachable in tests: */}
+        {/* c8 ignore next */}
+        <DismissButton onDismiss={() => state.close()} />
+      </div>
+    </Overlay>
+  );
+};
+
+const PopoverContent = ({
+  children,
+  ...otherProps
+}: AriaDialogProps & { children: ReactNode }) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const { dialogProps } = useDialog(otherProps, dialogRef);
+
+  return (
+    <div {...dialogProps} ref={dialogRef} style={{ outline: "none" }}>
+      {children}
+    </div>
+  );
+};

--- a/src/app/components/client/BillingPeriod.module.scss
+++ b/src/app/components/client/BillingPeriod.module.scss
@@ -1,0 +1,32 @@
+@import "../../tokens";
+
+.toggleContainer {
+  background-color: $color-grey-10;
+  border-radius: $border-radius-xl;
+  border: 1px solid $color-grey-30;
+  padding: $spacing-sm;
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+
+  .option {
+    border-radius: $border-radius-xl;
+    padding: $spacing-xs $spacing-md;
+    font-weight: 500;
+    color: $color-grey-50;
+    cursor: pointer;
+
+    &.isFocused {
+      outline: 4px solid $color-purple-70;
+      background-color: $color-purple-10;
+    }
+    &:hover {
+      background-color: $color-purple-20;
+    }
+
+    &.isSelected {
+      background-color: $color-white;
+      color: $color-blue-50;
+    }
+  }
+}

--- a/src/app/components/client/BillingPeriod.tsx
+++ b/src/app/components/client/BillingPeriod.tsx
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use client";
+
+import { ReactNode, createContext, useContext, useRef } from "react";
+import {
+  RadioGroupProps,
+  RadioGroupState,
+  useRadioGroupState,
+} from "react-stately";
+import {
+  AriaRadioGroupProps,
+  AriaRadioProps,
+  mergeProps,
+  useFocusRing,
+  useRadio,
+  useRadioGroup,
+} from "react-aria";
+import styles from "./BillingPeriod.module.scss";
+import { useL10n } from "../../hooks/l10n";
+import { VisuallyHidden } from "../server/VisuallyHidden";
+
+export type BillingPeriod = "yearly" | "monthly";
+
+export type Props = {
+  defaultValue?: BillingPeriod;
+  onChange: (_selectedBillingPeriod: BillingPeriod) => void;
+};
+
+export const BillingPeriodToggle = (props: Props) => {
+  const l10n = useL10n();
+
+  return (
+    <RadioGroup
+      defaultValue={props.defaultValue ?? "yearly"}
+      onChange={(newValue) => props.onChange(newValue as BillingPeriod)}
+      aria-label={l10n.getString(
+        "landing-premium-plans-table-billing-plus-period-label",
+      )}
+      orientation="horizontal"
+    >
+      <Radio value="yearly">
+        {l10n.getString(
+          "landing-premium-plans-table-billing-plus-period-yearly",
+        )}
+      </Radio>
+      <Radio value="monthly">
+        {l10n.getString(
+          "landing-premium-plans-table-billing-plus-period-monthly",
+        )}
+      </Radio>
+    </RadioGroup>
+  );
+};
+
+const RadioContext = createContext<RadioGroupState | null>(null);
+
+const RadioGroup = (
+  props: RadioGroupProps & AriaRadioGroupProps & { children: ReactNode },
+) => {
+  const state = useRadioGroupState(props);
+  const { radioGroupProps } = useRadioGroup(props, state);
+
+  return (
+    <div {...radioGroupProps} className={styles.toggleContainer}>
+      <RadioContext.Provider value={state}>
+        {props.children}
+      </RadioContext.Provider>
+    </div>
+  );
+};
+
+const Radio = (props: AriaRadioProps) => {
+  const groupState = useContext(RadioContext)!;
+  const radioRef = useRef<HTMLInputElement>(null);
+  const { inputProps } = useRadio(props, groupState, radioRef);
+  const { focusProps, isFocusVisible } = useFocusRing();
+  const isSelected = groupState.selectedValue === props.value;
+
+  return (
+    <label
+      className={`${styles.option} ${
+        isSelected ? styles.isSelected : styles.isNotSelected
+      } ${isFocusVisible ? styles.isFocused : styles.isBlurred}`}
+    >
+      <VisuallyHidden>
+        <input {...mergeProps(inputProps, focusProps)} ref={radioRef} />
+      </VisuallyHidden>
+      {props.children}
+    </label>
+  );
+};

--- a/src/app/components/server/VisuallyHidden.module.scss
+++ b/src/app/components/server/VisuallyHidden.module.scss
@@ -1,0 +1,5 @@
+@import "../../tokens";
+
+.visuallyHidden {
+  @include visually-hidden;
+}

--- a/src/app/components/server/VisuallyHidden.tsx
+++ b/src/app/components/server/VisuallyHidden.tsx
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ReactNode } from "react";
+import styles from "./VisuallyHidden.module.scss";
+
+// This is an alternative to react-aria's <VisuallyHidden> component that does
+// not use inline styles, which would be blocked by our Content Security Policy.
+export const VisuallyHidden = (props: { children: ReactNode }) => {
+  return <div className={styles.visuallyHidden}>{props.children}</div>;
+};

--- a/src/app/components/server/button.module.scss
+++ b/src/app/components/server/button.module.scss
@@ -43,6 +43,11 @@
     color: $color-blue-50;
     box-shadow: inset 0 0 0 2px $color-blue-50;
     background-color: transparent;
+
+    &:hover {
+      background-color: $color-blue-50;
+      color: $color-white;
+    }
   }
 
   &.isLoading {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2471
Figma: https://www.figma.com/file/YqpVpUbSTzZMj9Jbp2po8Q/Mozilla-Monitor-Premium-LP?type=design&node-id=1942-21098&mode=dev


<!-- When adding a new feature: -->

# Description

This adds the plans comparison table.

Version for smaller screens will be added later.

# How to test

Make sure the tooltips open, the pricing toggle changes what's shown and where the buttons go to, and that it's accessible.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met. - Mobile view still to come
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
