### PR TITLE
chore: ignore e2e snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,13 +12,16 @@ loadtests/venv
 .tmp
 public/dist
 dist
+src/client/images/logo_cache/
+public/logo_cache/
+
+#e2e
 **/test-results/
 **/playwright-report/
 **/playwright/.cache/
 **/storageState.json
 state.json
-src/client/images/logo_cache/
-public/logo_cache/
+src/e2e/specs/*-snapshots/**
 
 # Storybook
 */storybook.log


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-null


<!-- When adding a new feature: -->

# Description
Git ignore the snapshots produced by e2e tests


# How to test
`npm run e2e`
