### PR TITLE
Don't count manual resolves as unresolved

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
@@ -117,7 +117,8 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                     bannerData.totalDataPointsNum -
                     bannerData.dataBrokerAutoFixedDataPointsNum -
                     bannerData.dataBreachFixedDataPointsNum -
-                    bannerData.dataBrokerInProgressDataPointsNum,
+                    bannerData.dataBrokerInProgressDataPointsNum -
+                    bannerData.dataBrokerManuallyResolvedDataPointsNum,
                   data_breach_unresolved_num:
                     bannerData.dataBreachUnresolvedNum,
                 },
@@ -277,7 +278,8 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                     bannerData.totalDataPointsNum -
                     bannerData.dataBreachFixedDataPointsNum -
                     bannerData.dataBrokerAutoFixedDataPointsNum -
-                    bannerData.dataBrokerInProgressDataPointsNum,
+                    bannerData.dataBrokerInProgressDataPointsNum -
+                    bannerData.dataBrokerManuallyResolvedDataPointsNum,
                 },
               )}
             </p>
@@ -333,7 +335,8 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                     bannerData.totalDataPointsNum -
                     bannerData.dataBreachFixedDataPointsNum -
                     bannerData.dataBrokerAutoFixedDataPointsNum -
-                    bannerData.dataBrokerInProgressDataPointsNum,
+                    bannerData.dataBrokerInProgressDataPointsNum -
+                    bannerData.dataBrokerManuallyResolvedDataPointsNum,
                 },
               )}
             </p>
@@ -415,7 +418,8 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                     bannerData.totalDataPointsNum -
                     bannerData.dataBrokerAutoFixedDataPointsNum -
                     bannerData.dataBreachFixedDataPointsNum -
-                    bannerData.dataBrokerInProgressDataPointsNum,
+                    bannerData.dataBrokerInProgressDataPointsNum -
+                    bannerData.dataBrokerManuallyResolvedDataPointsNum,
                 },
               )}
               <br />
@@ -447,7 +451,8 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                     bannerData.totalDataPointsNum -
                     bannerData.dataBrokerAutoFixedDataPointsNum -
                     bannerData.dataBreachFixedDataPointsNum -
-                    bannerData.dataBrokerInProgressDataPointsNum,
+                    bannerData.dataBrokerInProgressDataPointsNum -
+                    bannerData.dataBrokerManuallyResolvedDataPointsNum,
                 },
               )}
               <br />
@@ -478,7 +483,8 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                   exposures_resolved_num:
                     bannerData.dataBrokerAutoFixedDataPointsNum +
                     bannerData.dataBreachFixedDataPointsNum +
-                    bannerData.dataBrokerInProgressDataPointsNum,
+                    bannerData.dataBrokerInProgressDataPointsNum -
+                    bannerData.dataBrokerManuallyResolvedDataPointsNum,
                 },
               )}
               <br />

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
@@ -53,11 +53,11 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
       <ProgressCard
         isPremiumUser={isPremiumUser}
         resolvedByYou={
-          bannerData.dataBrokerManuallyResolvedExposuresNum +
-          bannerData.dataBreachFixedExposuresNum
+          bannerData.dataBrokerManuallyResolvedDataPointsNum +
+          bannerData.dataBreachFixedDataPointsNum
         }
-        autoRemoved={bannerData.dataBrokerFixedExposuresNum}
-        inProgress={bannerData.dataBrokerInProgressExposuresNum}
+        autoRemoved={bannerData.dataBrokerAutoFixedDataPointsNum}
+        inProgress={bannerData.dataBrokerInProgressDataPointsNum}
       />
     );
   }
@@ -114,10 +114,10 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                 "dashboard-exposures-breaches-scan-progress-description",
                 {
                   exposures_unresolved_num:
-                    bannerData.totalExposures -
-                    bannerData.dataBrokerFixedExposuresNum -
-                    bannerData.dataBreachFixedExposuresNum -
-                    bannerData.dataBrokerInProgressExposuresNum,
+                    bannerData.totalDataPointsNum -
+                    bannerData.dataBrokerAutoFixedDataPointsNum -
+                    bannerData.dataBreachFixedDataPointsNum -
+                    bannerData.dataBrokerInProgressDataPointsNum,
                   data_breach_unresolved_num:
                     bannerData.dataBreachUnresolvedNum,
                 },
@@ -142,7 +142,7 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
               {l10n.getString(
                 "dashboard-top-banner-non-us-your-data-is-protected-description",
                 {
-                  exposures_resolved_num: bannerData.totalExposures,
+                  exposures_resolved_num: bannerData.totalDataPointsNum,
                 },
               )}
             </p>
@@ -249,7 +249,7 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                     bannerData.dataBreachUnresolvedNum,
                   data_broker_unresolved_num:
                     bannerData.dataBrokerTotalNum -
-                    bannerData.dataBrokerFixedNum -
+                    bannerData.dataBrokerAutoFixedNum -
                     bannerData.dataBrokerInProgressNum,
                 },
               )}
@@ -274,10 +274,10 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                 "dashboard-top-banner-lets-keep-protecting-description",
                 {
                   exposures_unresolved_num:
-                    bannerData.totalExposures -
-                    bannerData.dataBreachFixedExposuresNum -
-                    bannerData.dataBrokerFixedExposuresNum -
-                    bannerData.dataBrokerInProgressExposuresNum,
+                    bannerData.totalDataPointsNum -
+                    bannerData.dataBreachFixedDataPointsNum -
+                    bannerData.dataBrokerAutoFixedDataPointsNum -
+                    bannerData.dataBrokerInProgressDataPointsNum,
                 },
               )}
             </p>
@@ -302,7 +302,7 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
               {l10n.getString(
                 "dashboard-top-banner-your-data-is-protected-all-fixed-description",
                 {
-                  starting_exposure_total_num: bannerData.totalExposures,
+                  starting_exposure_total_num: bannerData.totalDataPointsNum,
                 },
               )}
             </p>
@@ -330,10 +330,10 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                 "dashboard-top-banner-lets-keep-protecting-description",
                 {
                   exposures_unresolved_num:
-                    bannerData.totalExposures -
-                    bannerData.dataBreachFixedExposuresNum -
-                    bannerData.dataBrokerFixedExposuresNum -
-                    bannerData.dataBrokerInProgressExposuresNum,
+                    bannerData.totalDataPointsNum -
+                    bannerData.dataBreachFixedDataPointsNum -
+                    bannerData.dataBrokerAutoFixedDataPointsNum -
+                    bannerData.dataBrokerInProgressDataPointsNum,
                 },
               )}
             </p>
@@ -382,7 +382,7 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
               {l10n.getString(
                 "dashboard-top-banner-your-data-is-protected-description",
                 {
-                  starting_exposure_total_num: bannerData.totalExposures,
+                  starting_exposure_total_num: bannerData.totalDataPointsNum,
                 },
               )}
             </p>
@@ -412,10 +412,10 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                 "dashboard-top-banner-scan-in-progress-unresolved-description",
                 {
                   unresolved_exposures:
-                    bannerData.totalExposures -
-                    bannerData.dataBrokerFixedExposuresNum -
-                    bannerData.dataBreachFixedExposuresNum -
-                    bannerData.dataBrokerInProgressExposuresNum,
+                    bannerData.totalDataPointsNum -
+                    bannerData.dataBrokerAutoFixedDataPointsNum -
+                    bannerData.dataBreachFixedDataPointsNum -
+                    bannerData.dataBrokerInProgressDataPointsNum,
                 },
               )}
               <br />
@@ -444,10 +444,10 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                 "dashboard-top-banner-scan-in-progress-unresolved-description",
                 {
                   unresolved_exposures:
-                    bannerData.totalExposures -
-                    bannerData.dataBrokerFixedExposuresNum -
-                    bannerData.dataBreachFixedExposuresNum -
-                    bannerData.dataBrokerInProgressExposuresNum,
+                    bannerData.totalDataPointsNum -
+                    bannerData.dataBrokerAutoFixedDataPointsNum -
+                    bannerData.dataBreachFixedDataPointsNum -
+                    bannerData.dataBrokerInProgressDataPointsNum,
                 },
               )}
               <br />
@@ -476,9 +476,9 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                 "dashboard-top-banner-your-data-scan-in-progress-all-fixed-description",
                 {
                   exposures_resolved_num:
-                    bannerData.dataBrokerFixedExposuresNum +
-                    bannerData.dataBreachFixedExposuresNum +
-                    bannerData.dataBrokerInProgressExposuresNum,
+                    bannerData.dataBrokerAutoFixedDataPointsNum +
+                    bannerData.dataBreachFixedDataPointsNum +
+                    bannerData.dataBrokerInProgressDataPointsNum,
                 },
               )}
               <br />

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner/index.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/DashboardTopBanner/index.tsx
@@ -31,8 +31,8 @@ export const DashboardTopBanner = (props: DashboardTopBannerProps) => {
   const isShowFixed = props.tabType === "fixed";
 
   const chartDataKey = isShowFixed
-    ? "inProgressFixedSanitizedExposures"
-    : "unresolvedSanitizedExposures";
+    ? "inProgressFixedSanitizedDataPoints"
+    : "unresolvedSanitizedDataPoints";
 
   const chartData: [string, number][] = props.bannerData[chartDataKey].map(
     (obj) => {

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -178,12 +178,12 @@ export const View = (props: Props) => {
     const {
       dataBreachUnresolvedNum,
       dataBrokerTotalNum,
-      dataBrokerFixedNum,
+      dataBrokerAutoFixedNum,
       dataBrokerInProgressNum,
-      dataBreachFixedExposuresNum,
-      dataBrokerFixedExposuresNum,
-      dataBrokerInProgressExposuresNum,
-      totalExposures,
+      dataBreachFixedDataPointsNum,
+      dataBrokerAutoFixedDataPointsNum,
+      dataBrokerInProgressDataPointsNum,
+      totalDataPointsNum,
     } = dataSummary;
 
     let exposuresAreaDescription;
@@ -193,13 +193,15 @@ export const View = (props: Props) => {
         "dashboard-exposures-area-description",
         {
           exposures_unresolved_num:
-            totalExposures -
-            dataBrokerFixedExposuresNum -
-            dataBreachFixedExposuresNum -
-            dataBrokerInProgressExposuresNum,
+            totalDataPointsNum -
+            dataBrokerAutoFixedDataPointsNum -
+            dataBreachFixedDataPointsNum -
+            dataBrokerInProgressDataPointsNum,
           data_breach_unresolved_num: dataBreachUnresolvedNum,
           data_broker_unresolved_num:
-            dataBrokerTotalNum - dataBrokerFixedNum - dataBrokerInProgressNum,
+            dataBrokerTotalNum -
+            dataBrokerAutoFixedNum -
+            dataBrokerInProgressNum,
         },
       );
     }
@@ -209,10 +211,10 @@ export const View = (props: Props) => {
         "dashboard-exposures-breaches-scan-progress-description",
         {
           exposures_unresolved_num:
-            totalExposures -
-            dataBrokerFixedExposuresNum -
-            dataBreachFixedExposuresNum -
-            dataBrokerInProgressExposuresNum,
+            totalDataPointsNum -
+            dataBrokerAutoFixedDataPointsNum -
+            dataBreachFixedDataPointsNum -
+            dataBrokerInProgressDataPointsNum,
           data_breach_unresolved_num: dataBreachUnresolvedNum,
         },
       );

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/ResolutionContainer.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/ResolutionContainer.tsx
@@ -54,11 +54,11 @@ export const ResolutionContainer = (props: ResolutionContainerProps) => {
             <ProgressCard
               isPremiumUser={props.isPremiumUser}
               resolvedByYou={
-                resolutionSummary.dataBrokerManuallyResolvedExposuresNum +
-                resolutionSummary.dataBreachFixedExposuresNum
+                resolutionSummary.dataBrokerManuallyResolvedDataPointsNum +
+                resolutionSummary.dataBreachFixedDataPointsNum
               }
-              autoRemoved={resolutionSummary.dataBrokerFixedExposuresNum}
-              inProgress={resolutionSummary.dataBrokerInProgressExposuresNum}
+              autoRemoved={resolutionSummary.dataBrokerAutoFixedDataPointsNum}
+              inProgress={resolutionSummary.dataBrokerInProgressDataPointsNum}
             />
           </div>
         ) : (

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/ManualRemove.test.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/ManualRemove.test.tsx
@@ -8,6 +8,16 @@ import { composeStory } from "@storybook/react";
 import { axe } from "jest-axe";
 import { userEvent } from "@testing-library/user-event";
 
+const mockedRouterRefresh = jest.fn();
+
+jest.mock("next/navigation", () => {
+  return {
+    useRouter: () => ({
+      refresh: mockedRouterRefresh,
+    }),
+    usePathname: jest.fn(),
+  };
+});
 jest.mock("../../../../../../../../functions/server/l10n");
 
 import Meta, { ManualRemoveViewStory } from "./ManualRemove.stories";
@@ -47,6 +57,24 @@ it("removes the manual resolution button once a profile has been resolved", asyn
   expect(resolveButtonsAfterResolving.length).toBeLessThan(
     resolveButtonsBeforeResolving.length,
   );
+});
+
+it("refreshes the client-side router cache after resolving a profile", async () => {
+  const user = userEvent.setup();
+  global.fetch = jest.fn().mockResolvedValueOnce({ ok: true });
+  const ComposedManualRemoveView = composeStory(ManualRemoveViewStory, Meta);
+  render(<ComposedManualRemoveView />);
+
+  expect(mockedRouterRefresh).not.toHaveBeenCalled();
+
+  const resolveButtonsBeforeResolving = screen.getAllByRole("button", {
+    name: "Mark as fixed",
+  });
+
+  await user.click(resolveButtonsBeforeResolving[0]);
+
+  // See https://nextjs.org/docs/app/building-your-application/caching#4-nextjs-caching-on-the-client-router-cache
+  expect(mockedRouterRefresh).toHaveBeenCalledTimes(1);
 });
 
 it("keeps the manual resolution button if resolving a profile failed", async () => {

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/ManualRemoveView.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/ManualRemoveView.tsx
@@ -17,7 +17,7 @@ import { LatestOnerepScanData } from "../../../../../../../../../db/tables/onere
 import { Button } from "../../../../../../../../components/server/Button";
 import {
   getDashboardSummary,
-  getExposureReduction,
+  getDataPointReduction,
 } from "../../../../../../../../functions/server/dashboard";
 import { SubscriberBreach } from "../../../../../../../../../utils/subscriberBreaches";
 import { RemovalCard } from "./RemovalCard";
@@ -44,7 +44,7 @@ export function ManualRemoveView(props: Props) {
 
   const countOfDataBrokerProfiles = props.scanData.results.length;
   const estimatedTime = countOfDataBrokerProfiles * 10; // 10 minutes per data broker site.
-  const exposureReduction = getExposureReduction(summary);
+  const dataPointReduction = getDataPointReduction(summary);
 
   const data: StepDeterminationData = {
     countryCode: props.countryCode,
@@ -178,7 +178,7 @@ export function ManualRemoveView(props: Props) {
           <div>
             <AvatarIcon width="18" height="18" alt="" />
             {l10n.getString("data-broker-profiles-exposure-reduction", {
-              exposure_reduction: exposureReduction,
+              exposure_reduction: dataPointReduction,
             })}
           </div>
         </div>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/RemovalCard.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/manual-remove/RemovalCard.tsx
@@ -4,6 +4,7 @@
 
 "use client";
 
+import { useRouter } from "next/navigation";
 import { OnerepScanResultRow } from "knex/types/tables";
 import { Button } from "../../../../../../../../components/server/Button";
 import { useL10n } from "../../../../../../../../hooks/l10n";
@@ -20,6 +21,7 @@ export type Props = {
 
 export const RemovalCard = (props: Props) => {
   const l10n = useL10n();
+  const router = useRouter();
   const [isResolved, setIsResolved] = useState(
     props.scanResult.manually_resolved,
   );
@@ -33,6 +35,10 @@ export const RemovalCard = (props: Props) => {
         credentials: "same-origin",
       },
     );
+    // Ensure previously-visited pages that still have this scan result marked
+    // as unfixed are removed from the cache. See
+    // https://nextjs.org/docs/app/building-your-application/caching#invalidation-1
+    router.refresh();
     if (!response.ok) {
       setIsResolved(false);
     }

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/welcome-to-premium/WelcomeToPremiumView.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/welcome-to-premium/WelcomeToPremiumView.tsx
@@ -7,7 +7,7 @@ import { getL10n } from "../../../../../../../../functions/server/l10n";
 import { PercentageChart } from "../../../../../../../../components/client/PercentageChart";
 import {
   getDashboardSummary,
-  getExposureReduction,
+  getDataPointReduction,
 } from "../../../../../../../../functions/server/dashboard";
 import { Button } from "../../../../../../../../components/server/Button";
 import {
@@ -30,7 +30,7 @@ export function WelcomeToPremiumView(props: Props) {
     props.data.latestScanData?.results ?? [],
     props.data.subscriberBreaches,
   );
-  const exposureReduction = getExposureReduction(summary);
+  const dataPointReduction = getDataPointReduction(summary);
 
   return (
     <FixView
@@ -55,7 +55,7 @@ export function WelcomeToPremiumView(props: Props) {
               "welcome-to-premium-data-broker-profiles-description-part-one",
               {
                 profile_total_num: countOfDataBrokerProfiles,
-                exposure_reduction_percentage: exposureReduction,
+                exposure_reduction_percentage: dataPointReduction,
               },
             )}
           </p>
@@ -82,7 +82,7 @@ export function WelcomeToPremiumView(props: Props) {
           </div>
         </div>
         <div className={styles.chart}>
-          <PercentageChart exposureReduction={exposureReduction} />
+          <PercentageChart exposureReduction={dataPointReduction} />
         </div>
       </div>
     </FixView>

--- a/src/app/components/client/Chart.tsx
+++ b/src/app/components/client/Chart.tsx
@@ -246,11 +246,11 @@ export const DoughnutChart = (props: Props) => {
             ? l10n.getFragment("exposure-chart-caption-fixed", {
                 vars: {
                   total_fixed_exposures_num:
-                    props.summary.dataBreachFixedExposuresNum +
-                    props.summary.dataBrokerFixedExposuresNum +
-                    props.summary.dataBrokerInProgressExposuresNum +
-                    props.summary.dataBrokerManuallyResolvedExposuresNum,
-                  total_exposures_num: props.summary.totalExposures,
+                    props.summary.dataBreachFixedDataPointsNum +
+                    props.summary.dataBrokerAutoFixedDataPointsNum +
+                    props.summary.dataBrokerInProgressDataPointsNum +
+                    props.summary.dataBrokerManuallyResolvedDataPointsNum,
+                  total_exposures_num: props.summary.totalDataPointsNum,
                 },
               })
             : l10n.getString("exposure-chart-caption")}

--- a/src/app/functions/server/dashboard.test.ts
+++ b/src/app/functions/server/dashboard.test.ts
@@ -694,7 +694,7 @@ describe("getDashboardSummary", () => {
       summary.dataBrokerTotalDataPointsNum,
     );
     expect(summary.dataBrokerManuallyResolvedDataPointsNum).toBe(12);
-    expect(summary.unresolvedDataPoints.emailAddresses).toBe(3);
+    expect(summary.unresolvedDataPoints.emailAddresses).toBe(0);
   });
 
   it("gets mix scanned results & breaches summary", () => {

--- a/src/app/functions/server/dashboard.test.ts
+++ b/src/app/functions/server/dashboard.test.ts
@@ -6,8 +6,8 @@ import { OnerepScanResultRow } from "knex/types/tables";
 import {
   DashboardSummary,
   getDashboardSummary,
-  getExposureReduction,
-  Exposures,
+  getDataPointReduction,
+  DataPoints,
 } from "./dashboard";
 import { SubscriberBreach } from "../../../utils/subscriberBreaches";
 import { RemovalStatus, RemovalStatusMap } from "../universal/scanResult";
@@ -474,28 +474,28 @@ describe("getExposureReduction", () => {
     };
     const testSummary: DashboardSummary = {
       dataBreachTotalNum: 10,
-      dataBreachTotalExposuresNum: 10,
-      dataBreachFixedExposuresNum: 10,
+      dataBreachTotalDataPointsNum: 10,
+      dataBreachFixedDataPointsNum: 10,
       dataBrokerTotalNum: 10,
-      dataBrokerTotalExposuresNum: 8,
-      dataBrokerFixedExposuresNum: 8,
-      dataBrokerFixedNum: 10,
-      dataBrokerInProgressExposuresNum: 10,
+      dataBrokerTotalDataPointsNum: 8,
+      dataBrokerAutoFixedDataPointsNum: 8,
+      dataBrokerAutoFixedNum: 10,
+      dataBrokerInProgressDataPointsNum: 10,
       dataBrokerInProgressNum: 10,
-      dataBrokerManuallyResolvedExposuresNum: 0,
-      totalExposures: 10,
-      allExposures: testExposure,
-      unresolvedExposures: testExposure,
-      inProgressExposures: testExposure,
-      fixedExposures: testExposure,
-      inProgressFixedExposures: testExposure,
-      unresolvedSanitizedExposures: [],
-      inProgressFixedSanitizedExposures: [],
+      dataBrokerManuallyResolvedDataPointsNum: 0,
+      totalDataPointsNum: 10,
+      allDataPoints: testExposure,
+      unresolvedDataPoints: testExposure,
+      inProgressDataPoints: testExposure,
+      fixedDataPoints: testExposure,
+      inProgressFixedDataPoints: testExposure,
+      unresolvedSanitizedDataPoints: [],
+      inProgressFixedSanitizedDataPoints: [],
       dataBreachUnresolvedNum: 0,
       dataBreachResolvedNum: 0,
     };
 
-    const exposureReduction = getExposureReduction(testSummary);
+    const exposureReduction = getDataPointReduction(testSummary);
     expect(exposureReduction).toBe(80);
   });
   it("gets exposure reduction number when total exposure is 0", () => {
@@ -519,28 +519,28 @@ describe("getExposureReduction", () => {
     };
     const testSummary: DashboardSummary = {
       dataBreachTotalNum: 10,
-      dataBreachTotalExposuresNum: 10,
-      dataBreachFixedExposuresNum: 10,
+      dataBreachTotalDataPointsNum: 10,
+      dataBreachFixedDataPointsNum: 10,
       dataBrokerTotalNum: 10,
-      dataBrokerTotalExposuresNum: 8,
-      dataBrokerFixedExposuresNum: 8,
-      dataBrokerFixedNum: 10,
-      dataBrokerInProgressExposuresNum: 10,
+      dataBrokerTotalDataPointsNum: 8,
+      dataBrokerAutoFixedDataPointsNum: 8,
+      dataBrokerAutoFixedNum: 10,
+      dataBrokerInProgressDataPointsNum: 10,
       dataBrokerInProgressNum: 10,
-      dataBrokerManuallyResolvedExposuresNum: 0,
-      totalExposures: 0,
-      allExposures: testExposure,
-      unresolvedExposures: testExposure,
-      inProgressExposures: testExposure,
-      fixedExposures: testExposure,
-      inProgressFixedExposures: testExposure,
-      unresolvedSanitizedExposures: [],
-      inProgressFixedSanitizedExposures: [],
+      dataBrokerManuallyResolvedDataPointsNum: 0,
+      totalDataPointsNum: 0,
+      allDataPoints: testExposure,
+      unresolvedDataPoints: testExposure,
+      inProgressDataPoints: testExposure,
+      fixedDataPoints: testExposure,
+      inProgressFixedDataPoints: testExposure,
+      unresolvedSanitizedDataPoints: [],
+      inProgressFixedSanitizedDataPoints: [],
       dataBreachUnresolvedNum: 0,
       dataBreachResolvedNum: 0,
     };
 
-    const exposureReduction = getExposureReduction(testSummary);
+    const exposureReduction = getDataPointReduction(testSummary);
     expect(exposureReduction).toBe(100);
   });
 });
@@ -548,23 +548,23 @@ describe("getExposureReduction", () => {
 describe("getDashboardSummary", () => {
   // sanity checks
   const noNegativeCounts = (summary: DashboardSummary) => {
-    for (const k in summary.unresolvedExposures) {
+    for (const k in summary.unresolvedDataPoints) {
       expect(
-        summary.unresolvedExposures[k as keyof Exposures],
+        summary.unresolvedDataPoints[k as keyof DataPoints],
       ).toBeGreaterThanOrEqual(0);
     }
-    for (const k in summary.fixedExposures) {
+    for (const k in summary.fixedDataPoints) {
       expect(
-        summary.fixedExposures[k as keyof Exposures],
+        summary.fixedDataPoints[k as keyof DataPoints],
       ).toBeGreaterThanOrEqual(0);
     }
-    for (const k in summary.inProgressExposures) {
+    for (const k in summary.inProgressDataPoints) {
       expect(
-        summary.inProgressExposures[k as keyof Exposures],
+        summary.inProgressDataPoints[k as keyof DataPoints],
       ).toBeGreaterThanOrEqual(0);
     }
 
-    summary.unresolvedSanitizedExposures.forEach(
+    summary.unresolvedSanitizedDataPoints.forEach(
       (unresolvedSanitizedExposure) => {
         Object.values(unresolvedSanitizedExposure).forEach((count) => {
           expect(count).toBeGreaterThanOrEqual(0);
@@ -572,7 +572,7 @@ describe("getDashboardSummary", () => {
       },
     );
 
-    summary.inProgressFixedSanitizedExposures.forEach(
+    summary.inProgressFixedSanitizedDataPoints.forEach(
       (inProgressFixedSanitizedExposure) => {
         Object.values(inProgressFixedSanitizedExposure).forEach((count) => {
           expect(count).toBeGreaterThanOrEqual(0);
@@ -585,12 +585,14 @@ describe("getDashboardSummary", () => {
     const summary = getDashboardSummary([], unresolvedBreaches);
     noNegativeCounts(summary);
     expect(summary.dataBreachTotalNum).toBe(3);
-    expect(summary.dataBreachFixedExposuresNum).toBe(0);
+    expect(summary.dataBreachFixedDataPointsNum).toBe(0);
     expect(summary.dataBrokerTotalNum).toBe(0);
-    expect(summary.dataBrokerTotalExposuresNum).toBe(0);
-    expect(summary.dataBrokerFixedNum).toBe(0);
-    expect(summary.totalExposures).toBe(summary.dataBreachTotalExposuresNum);
-    expect(summary.dataBrokerInProgressExposuresNum).toBe(0);
+    expect(summary.dataBrokerTotalDataPointsNum).toBe(0);
+    expect(summary.dataBrokerAutoFixedNum).toBe(0);
+    expect(summary.totalDataPointsNum).toBe(
+      summary.dataBreachTotalDataPointsNum,
+    );
+    expect(summary.dataBrokerInProgressDataPointsNum).toBe(0);
   });
 
   it("gets breaches only all fixed summary", () => {
@@ -598,34 +600,40 @@ describe("getDashboardSummary", () => {
     noNegativeCounts(summary);
     expect(summary.dataBreachTotalNum).toBe(3);
     expect(summary.dataBrokerTotalNum).toBe(0);
-    expect(summary.dataBrokerTotalExposuresNum).toBe(0);
-    expect(summary.dataBrokerFixedNum).toBe(0);
-    expect(summary.totalExposures).toBe(summary.dataBreachTotalExposuresNum);
-    expect(summary.totalExposures).toBe(summary.dataBreachFixedExposuresNum);
-    expect(summary.dataBrokerInProgressExposuresNum).toBe(0);
-    expect(summary.unresolvedExposures.emailAddresses).toBe(0);
+    expect(summary.dataBrokerTotalDataPointsNum).toBe(0);
+    expect(summary.dataBrokerAutoFixedNum).toBe(0);
+    expect(summary.totalDataPointsNum).toBe(
+      summary.dataBreachTotalDataPointsNum,
+    );
+    expect(summary.totalDataPointsNum).toBe(
+      summary.dataBreachFixedDataPointsNum,
+    );
+    expect(summary.dataBrokerInProgressDataPointsNum).toBe(0);
+    expect(summary.unresolvedDataPoints.emailAddresses).toBe(0);
   });
 
   it("gets scanned results only summary", () => {
     const summary = getDashboardSummary(unresolvedScannedResults, []);
     noNegativeCounts(summary);
     expect(summary.dataBreachTotalNum).toBe(0);
-    expect(summary.dataBreachTotalExposuresNum).toBe(0);
-    expect(summary.dataBreachFixedExposuresNum).toBe(0);
+    expect(summary.dataBreachTotalDataPointsNum).toBe(0);
+    expect(summary.dataBreachFixedDataPointsNum).toBe(0);
     expect(summary.dataBrokerTotalNum).toBe(1);
-    expect(summary.dataBrokerFixedNum).toBe(0);
-    expect(summary.totalExposures).toBe(summary.dataBrokerTotalExposuresNum);
-    expect(summary.unresolvedExposures.emailAddresses).toBe(
-      summary.allExposures.emailAddresses,
+    expect(summary.dataBrokerAutoFixedNum).toBe(0);
+    expect(summary.totalDataPointsNum).toBe(
+      summary.dataBrokerTotalDataPointsNum,
     );
-    expect(summary.unresolvedExposures.phoneNumbers).toBe(
-      summary.allExposures.phoneNumbers,
+    expect(summary.unresolvedDataPoints.emailAddresses).toBe(
+      summary.allDataPoints.emailAddresses,
     );
-    expect(summary.unresolvedExposures.addresses).toBe(
-      summary.allExposures.addresses,
+    expect(summary.unresolvedDataPoints.phoneNumbers).toBe(
+      summary.allDataPoints.phoneNumbers,
     );
-    expect(summary.unresolvedExposures.familyMembers).toBe(
-      summary.allExposures.familyMembers,
+    expect(summary.unresolvedDataPoints.addresses).toBe(
+      summary.allDataPoints.addresses,
+    );
+    expect(summary.unresolvedDataPoints.familyMembers).toBe(
+      summary.allDataPoints.familyMembers,
     );
   });
 
@@ -633,14 +641,16 @@ describe("getDashboardSummary", () => {
     const summary = getDashboardSummary(allResolvedScannedResults, []);
     noNegativeCounts(summary);
     expect(summary.dataBreachTotalNum).toBe(0);
-    expect(summary.dataBreachTotalExposuresNum).toBe(0);
-    expect(summary.dataBreachFixedExposuresNum).toBe(0);
+    expect(summary.dataBreachTotalDataPointsNum).toBe(0);
+    expect(summary.dataBreachFixedDataPointsNum).toBe(0);
     expect(summary.dataBrokerTotalNum).toBe(3);
-    expect(summary.totalExposures).toBe(summary.dataBrokerTotalExposuresNum);
-    expect(summary.dataBrokerFixedExposuresNum).toBe(
-      summary.dataBrokerTotalExposuresNum,
+    expect(summary.totalDataPointsNum).toBe(
+      summary.dataBrokerTotalDataPointsNum,
     );
-    expect(summary.unresolvedExposures.emailAddresses).toBe(0);
+    expect(summary.dataBrokerAutoFixedDataPointsNum).toBe(
+      summary.dataBrokerTotalDataPointsNum,
+    );
+    expect(summary.unresolvedDataPoints.emailAddresses).toBe(0);
   });
 
   it("gets scanned results in-progress and fixed summary", () => {
@@ -650,38 +660,41 @@ describe("getDashboardSummary", () => {
     );
     noNegativeCounts(summary);
     expect(summary.dataBreachTotalNum).toBe(0);
-    expect(summary.dataBreachTotalExposuresNum).toBe(0);
-    expect(summary.dataBreachFixedExposuresNum).toBe(0);
+    expect(summary.dataBreachTotalDataPointsNum).toBe(0);
+    expect(summary.dataBreachFixedDataPointsNum).toBe(0);
     expect(summary.dataBrokerTotalNum).toBe(4);
-    expect(summary.inProgressFixedExposures.emailAddresses).toBe(
-      summary.inProgressExposures.emailAddresses +
-        summary.fixedExposures.emailAddresses,
+    expect(summary.inProgressFixedDataPoints.emailAddresses).toBe(
+      summary.inProgressDataPoints.emailAddresses +
+        summary.fixedDataPoints.emailAddresses,
     );
-    expect(summary.inProgressFixedExposures.phoneNumbers).toBe(
-      summary.inProgressExposures.phoneNumbers +
-        summary.fixedExposures.phoneNumbers,
+    expect(summary.inProgressFixedDataPoints.phoneNumbers).toBe(
+      summary.inProgressDataPoints.phoneNumbers +
+        summary.fixedDataPoints.phoneNumbers,
     );
-    expect(summary.inProgressFixedExposures.addresses).toBe(
-      summary.inProgressExposures.addresses + summary.fixedExposures.addresses,
+    expect(summary.inProgressFixedDataPoints.addresses).toBe(
+      summary.inProgressDataPoints.addresses +
+        summary.fixedDataPoints.addresses,
     );
-    expect(summary.inProgressFixedExposures.familyMembers).toBe(
-      summary.inProgressExposures.familyMembers +
-        summary.fixedExposures.familyMembers,
+    expect(summary.inProgressFixedDataPoints.familyMembers).toBe(
+      summary.inProgressDataPoints.familyMembers +
+        summary.fixedDataPoints.familyMembers,
     );
-    expect(summary.unresolvedExposures.emailAddresses).toBe(0);
+    expect(summary.unresolvedDataPoints.emailAddresses).toBe(0);
   });
 
   it("gets scanned results manually removed summary", () => {
     const summary = getDashboardSummary(manuallyResolvedScannedResults, []);
     noNegativeCounts(summary);
     expect(summary.dataBreachTotalNum).toBe(0);
-    expect(summary.dataBreachTotalExposuresNum).toBe(0);
-    expect(summary.dataBreachFixedExposuresNum).toBe(0);
+    expect(summary.dataBreachTotalDataPointsNum).toBe(0);
+    expect(summary.dataBreachFixedDataPointsNum).toBe(0);
     expect(summary.dataBrokerTotalNum).toBe(1);
-    expect(summary.dataBrokerFixedNum).toBe(0);
-    expect(summary.totalExposures).toBe(summary.dataBrokerTotalExposuresNum);
-    expect(summary.dataBrokerManuallyResolvedExposuresNum).toBe(12);
-    expect(summary.unresolvedExposures.emailAddresses).toBe(3);
+    expect(summary.dataBrokerAutoFixedNum).toBe(0);
+    expect(summary.totalDataPointsNum).toBe(
+      summary.dataBrokerTotalDataPointsNum,
+    );
+    expect(summary.dataBrokerManuallyResolvedDataPointsNum).toBe(12);
+    expect(summary.unresolvedDataPoints.emailAddresses).toBe(3);
   });
 
   it("gets mix scanned results & breaches summary", () => {
@@ -691,14 +704,15 @@ describe("getDashboardSummary", () => {
     );
     noNegativeCounts(summary);
     expect(summary.dataBreachTotalNum).toBe(3);
-    expect(summary.dataBreachTotalExposuresNum).toBe(8);
-    expect(summary.dataBreachFixedExposuresNum).toBe(0);
+    expect(summary.dataBreachTotalDataPointsNum).toBe(8);
+    expect(summary.dataBreachFixedDataPointsNum).toBe(0);
     expect(summary.dataBrokerTotalNum).toBe(1);
-    expect(summary.dataBrokerTotalExposuresNum).toBe(12);
-    expect(summary.totalExposures).toBe(
-      summary.dataBrokerTotalExposuresNum + summary.dataBreachTotalExposuresNum,
+    expect(summary.dataBrokerTotalDataPointsNum).toBe(12);
+    expect(summary.totalDataPointsNum).toBe(
+      summary.dataBrokerTotalDataPointsNum +
+        summary.dataBreachTotalDataPointsNum,
     );
-    expect(summary.unresolvedExposures.emailAddresses).toBe(6);
+    expect(summary.unresolvedDataPoints.emailAddresses).toBe(6);
   });
 
   it("gets mix scanned results & breaches all resolved summary", () => {
@@ -708,16 +722,17 @@ describe("getDashboardSummary", () => {
     );
     noNegativeCounts(summary);
     expect(summary.dataBreachTotalNum).toBe(3);
-    expect(summary.dataBreachTotalExposuresNum).toBe(8);
-    expect(summary.dataBreachFixedExposuresNum).toBe(8);
+    expect(summary.dataBreachTotalDataPointsNum).toBe(8);
+    expect(summary.dataBreachFixedDataPointsNum).toBe(8);
     expect(summary.dataBrokerTotalNum).toBe(3);
-    expect(summary.dataBrokerTotalExposuresNum).toBe(36);
-    expect(summary.dataBrokerFixedExposuresNum).toBe(36);
-    expect(summary.dataBrokerInProgressExposuresNum).toBe(0);
-    expect(summary.totalExposures).toBe(
-      summary.dataBreachFixedExposuresNum + summary.dataBrokerFixedExposuresNum,
+    expect(summary.dataBrokerTotalDataPointsNum).toBe(36);
+    expect(summary.dataBrokerAutoFixedDataPointsNum).toBe(36);
+    expect(summary.dataBrokerInProgressDataPointsNum).toBe(0);
+    expect(summary.totalDataPointsNum).toBe(
+      summary.dataBreachFixedDataPointsNum +
+        summary.dataBrokerAutoFixedDataPointsNum,
     );
-    expect(summary.unresolvedExposures.emailAddresses).toBe(0);
+    expect(summary.unresolvedDataPoints.emailAddresses).toBe(0);
   });
 
   it("manuallyResolvedDataBrokerExposures is counted once", () => {
@@ -728,10 +743,10 @@ describe("getDashboardSummary", () => {
     const summary = getDashboardSummary(combinedScannedResults, []);
     noNegativeCounts(summary);
     expect(summary.dataBrokerTotalNum).toBe(2);
-    expect(summary.dataBrokerTotalExposuresNum).toBe(24);
-    expect(summary.dataBrokerFixedNum).toBe(0);
-    expect(summary.dataBrokerInProgressExposuresNum).toBe(0);
-    expect(summary.dataBrokerManuallyResolvedExposuresNum).toBe(12);
+    expect(summary.dataBrokerTotalDataPointsNum).toBe(24);
+    expect(summary.dataBrokerAutoFixedNum).toBe(0);
+    expect(summary.dataBrokerInProgressDataPointsNum).toBe(0);
+    expect(summary.dataBrokerManuallyResolvedDataPointsNum).toBe(12);
   });
 
   it("inProgressFixedSanitizedExposures counts manually resolved exposures", () => {
@@ -760,9 +775,9 @@ describe("getDashboardSummary", () => {
     noNegativeCounts(summary);
     console.log(
       "yay ",
-      JSON.stringify(summary.inProgressFixedSanitizedExposures),
+      JSON.stringify(summary.inProgressFixedSanitizedDataPoints),
     );
-    expect(summary.inProgressFixedSanitizedExposures).toEqual(
+    expect(summary.inProgressFixedSanitizedDataPoints).toEqual(
       expectedSanitizedExposures,
     );
   });
@@ -774,14 +789,14 @@ describe("getDashboardSummary", () => {
     ];
     const summary = getDashboardSummary(combinedScannedResults, []);
     noNegativeCounts(summary);
-    expect(summary.manuallyResolvedDataBrokerExposures.passwords).toBe(
-      summary.inProgressFixedExposures.passwords,
+    expect(summary.manuallyResolvedDataBrokerDataPoints.passwords).toBe(
+      summary.inProgressFixedDataPoints.passwords,
     );
-    expect(summary.manuallyResolvedDataBrokerExposures.pins).toBe(
-      summary.inProgressFixedExposures.pins,
+    expect(summary.manuallyResolvedDataBrokerDataPoints.pins).toBe(
+      summary.inProgressFixedDataPoints.pins,
     );
-    expect(summary.manuallyResolvedDataBrokerExposures.phoneNumbers).toBe(
-      summary.inProgressFixedExposures.phoneNumbers,
+    expect(summary.manuallyResolvedDataBrokerDataPoints.phoneNumbers).toBe(
+      summary.inProgressFixedDataPoints.phoneNumbers,
     );
   });
 });

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -208,7 +208,7 @@ export function getDashboardSummary(
   if (scannedResults) {
     scannedResults.forEach((r) => {
       // check removal status
-      const isManuallyResolved = r.manually_resolved;
+      const isManuallyResolved = r.status === "new" && r.manually_resolved;
       const isAutoFixed =
         r.status === RemovalStatusMap.Removed && !isManuallyResolved;
       const isInProgress =
@@ -388,7 +388,8 @@ export function getDashboardSummary(
       a[k as keyof DataPoints] =
         summary.allDataPoints[k as keyof DataPoints] -
         summary.fixedDataPoints[k as keyof DataPoints] -
-        summary.inProgressDataPoints[k as keyof DataPoints];
+        summary.inProgressDataPoints[k as keyof DataPoints] -
+        summary.manuallyResolvedDataBrokerDataPoints[k as keyof DataPoints];
       return a;
     },
     {} as DataPoints,
@@ -411,7 +412,8 @@ export function getDashboardSummary(
     summary.totalDataPointsNum -
       summary.dataBreachFixedDataPointsNum -
       summary.dataBrokerAutoFixedDataPointsNum -
-      summary.dataBrokerInProgressDataPointsNum,
+      summary.dataBrokerInProgressDataPointsNum -
+      summary.dataBrokerManuallyResolvedDataPointsNum,
     isBreachesOnly,
   );
 

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -7,7 +7,7 @@ import { BreachDataTypes } from "../universal/breach";
 import { RemovalStatusMap } from "../universal/scanResult";
 import { SubscriberBreach } from "../../../utils/subscriberBreaches";
 
-export type Exposures = {
+export type DataPoints = {
   // shared
   emailAddresses: number;
   phoneNumbers: number;
@@ -26,7 +26,7 @@ export type Exposures = {
   bankAccountNumbers: number;
 };
 
-type SanitizedExposures = Array<Record<string, number>>;
+type SanitizedDataPoints = Array<Record<string, number>>;
 export interface DashboardSummary {
   /** total number of user data breaches */
   dataBreachTotalNum: number;
@@ -34,47 +34,47 @@ export interface DashboardSummary {
   dataBreachUnresolvedNum: number;
   /** total number of user data breaches that are resolved */
   dataBreachResolvedNum: number;
-  /** total number of exposures from user breaches */
-  dataBreachTotalExposuresNum: number;
-  /**total number of fixed exposures from user breaches */
-  dataBreachFixedExposuresNum: number;
+  /** total number of data points from user breaches */
+  dataBreachTotalDataPointsNum: number;
+  /** total number of fixed data points from user breaches */
+  dataBreachFixedDataPointsNum: number;
   /** total number of user data broker scans */
   dataBrokerTotalNum: number;
-  /** total number of exposures from user data broker scanned results */
-  dataBrokerTotalExposuresNum: number;
+  /** total number of data points from user data broker scanned results */
+  dataBrokerTotalDataPointsNum: number;
   /** total number of fixed scans from user data broker scanned results */
-  dataBrokerFixedNum: number;
-  /** total number of fixed exposures from user data broker scanned results */
-  dataBrokerFixedExposuresNum: number;
+  dataBrokerAutoFixedNum: number;
+  /** total number of fixed data points from user data broker scanned results */
+  dataBrokerAutoFixedDataPointsNum: number;
   /** total number of in-progress scans from user data broker scanned results */
   dataBrokerInProgressNum: number;
-  /** total number of in-progress exposures from user data broker scanned results */
-  dataBrokerInProgressExposuresNum: number;
-  /** total number of exposures resolved manually */
-  dataBrokerManuallyResolvedExposuresNum: number;
+  /** total number of in-progress data points from user data broker scanned results */
+  dataBrokerInProgressDataPointsNum: number;
+  /** total number of data points resolved manually */
+  dataBrokerManuallyResolvedDataPointsNum: number;
 
-  /** total number of exposures: sum of data breaches & data broker exposures */
-  totalExposures: number;
-  /** all exposures separated by data types */
-  allExposures: Exposures;
-  /** unresolved exposures separated by data types */
-  unresolvedExposures: Exposures;
-  /** in-progress exposures separated by data types */
-  inProgressExposures: Exposures;
-  /** resolved/removed exposures separated by data types */
-  fixedExposures: Exposures;
-  /** manually resolved data broker exposures separated by data types */
-  manuallyResolvedDataBrokerExposures: Exposures;
-  /** in-progress & resolved/removed exposures separated by data types */
-  inProgressFixedExposures: Exposures;
+  /** total number of data points: sum of data breaches & data broker data points */
+  totalDataPointsNum: number;
+  /** all data points separated by data classes */
+  allDataPoints: DataPoints;
+  /** unresolved data points separated by data classes */
+  unresolvedDataPoints: DataPoints;
+  /** in-progress data points separated by data classes */
+  inProgressDataPoints: DataPoints;
+  /** resolved/removed data points separated by data classes */
+  fixedDataPoints: DataPoints;
+  /** manually resolved data broker data points separated by data classes */
+  manuallyResolvedDataBrokerDataPoints: DataPoints;
+  /** in-progress & resolved/removed data points separated by data classes */
+  inProgressFixedDataPoints: DataPoints;
 
-  /** sanitized all exposures for frontend display */
-  unresolvedSanitizedExposures: SanitizedExposures;
-  /** sanitized resolved/removed exposures for frontend display */
-  inProgressFixedSanitizedExposures: SanitizedExposures;
+  /** sanitized all data points for frontend display */
+  unresolvedSanitizedDataPoints: SanitizedDataPoints;
+  /** sanitized resolved/removed data points for frontend display */
+  inProgressFixedSanitizedDataPoints: SanitizedDataPoints;
 }
 
-const exposureKeyMap: Record<string, string> = {
+const dataClassKeyMap: Record<string, string> = {
   emailAddresses: "email-addresses",
   phoneNumbers: "phone-numbers",
 
@@ -100,17 +100,17 @@ export function getDashboardSummary(
     dataBreachTotalNum: 0,
     dataBreachResolvedNum: 0,
     dataBreachUnresolvedNum: 0,
-    dataBreachTotalExposuresNum: 0,
-    dataBreachFixedExposuresNum: 0,
+    dataBreachTotalDataPointsNum: 0,
+    dataBreachFixedDataPointsNum: 0,
     dataBrokerTotalNum: scannedResults.length,
-    dataBrokerTotalExposuresNum: 0,
-    dataBrokerFixedNum: 0,
-    dataBrokerFixedExposuresNum: 0,
+    dataBrokerTotalDataPointsNum: 0,
+    dataBrokerAutoFixedNum: 0,
+    dataBrokerAutoFixedDataPointsNum: 0,
     dataBrokerInProgressNum: 0,
-    dataBrokerInProgressExposuresNum: 0,
-    dataBrokerManuallyResolvedExposuresNum: 0,
-    totalExposures: 0,
-    allExposures: {
+    dataBrokerInProgressDataPointsNum: 0,
+    dataBrokerManuallyResolvedDataPointsNum: 0,
+    totalDataPointsNum: 0,
+    allDataPoints: {
       emailAddresses: 0,
       phoneNumbers: 0,
       addresses: 0,
@@ -125,7 +125,7 @@ export function getDashboardSummary(
       securityQuestions: 0,
       bankAccountNumbers: 0,
     },
-    unresolvedExposures: {
+    unresolvedDataPoints: {
       emailAddresses: 0,
       phoneNumbers: 0,
       addresses: 0,
@@ -140,7 +140,7 @@ export function getDashboardSummary(
       securityQuestions: 0,
       bankAccountNumbers: 0,
     },
-    inProgressExposures: {
+    inProgressDataPoints: {
       emailAddresses: 0,
       phoneNumbers: 0,
       addresses: 0,
@@ -155,7 +155,7 @@ export function getDashboardSummary(
       securityQuestions: 0,
       bankAccountNumbers: 0,
     },
-    fixedExposures: {
+    fixedDataPoints: {
       emailAddresses: 0,
       phoneNumbers: 0,
       addresses: 0,
@@ -170,7 +170,7 @@ export function getDashboardSummary(
       securityQuestions: 0,
       bankAccountNumbers: 0,
     },
-    manuallyResolvedDataBrokerExposures: {
+    manuallyResolvedDataBrokerDataPoints: {
       emailAddresses: 0,
       phoneNumbers: 0,
       addresses: 0,
@@ -185,7 +185,7 @@ export function getDashboardSummary(
       securityQuestions: 0,
       bankAccountNumbers: 0,
     },
-    inProgressFixedExposures: {
+    inProgressFixedDataPoints: {
       emailAddresses: 0,
       phoneNumbers: 0,
       addresses: 0,
@@ -200,8 +200,8 @@ export function getDashboardSummary(
       securityQuestions: 0,
       bankAccountNumbers: 0,
     },
-    unresolvedSanitizedExposures: [],
-    inProgressFixedSanitizedExposures: [],
+    unresolvedSanitizedDataPoints: [],
+    inProgressFixedSanitizedDataPoints: [],
   };
 
   // calculate broker summary from scanned results
@@ -209,7 +209,7 @@ export function getDashboardSummary(
     scannedResults.forEach((r) => {
       // check removal status
       const isManuallyResolved = r.manually_resolved;
-      const isFixed =
+      const isAutoFixed =
         r.status === RemovalStatusMap.Removed && !isManuallyResolved;
       const isInProgress =
         (r.status === RemovalStatusMap.OptOutInProgress ||
@@ -217,51 +217,51 @@ export function getDashboardSummary(
         !isManuallyResolved;
       if (isInProgress) {
         summary.dataBrokerInProgressNum++;
-      } else if (isFixed) {
-        summary.dataBrokerFixedNum++;
+      } else if (isAutoFixed) {
+        summary.dataBrokerAutoFixedNum++;
       }
-      // total exposure: add email, phones, addresses, relatives, full name (1)
-      const exposureIncrement =
+      // total data points: add email, phones, addresses, relatives, full name (1)
+      const dataPointsIncrement =
         r.emails.length +
         r.phones.length +
         r.addresses.length +
         r.relatives.length;
-      summary.totalExposures += exposureIncrement;
-      summary.dataBrokerTotalExposuresNum += exposureIncrement;
+      summary.totalDataPointsNum += dataPointsIncrement;
+      summary.dataBrokerTotalDataPointsNum += dataPointsIncrement;
 
-      // for all exposures: email, phones, addresses, relatives, full name (1)
-      summary.allExposures.emailAddresses += r.emails.length;
-      summary.allExposures.phoneNumbers += r.phones.length;
-      summary.allExposures.addresses += r.addresses.length;
-      summary.allExposures.familyMembers += r.relatives.length;
+      // for all data points: email, phones, addresses, relatives, full name (1)
+      summary.allDataPoints.emailAddresses += r.emails.length;
+      summary.allDataPoints.phoneNumbers += r.phones.length;
+      summary.allDataPoints.addresses += r.addresses.length;
+      summary.allDataPoints.familyMembers += r.relatives.length;
 
       if (isInProgress) {
-        summary.inProgressExposures.emailAddresses += r.emails.length;
-        summary.inProgressExposures.phoneNumbers += r.phones.length;
-        summary.inProgressExposures.addresses += r.addresses.length;
-        summary.inProgressExposures.familyMembers += r.relatives.length;
-        summary.dataBrokerInProgressExposuresNum += exposureIncrement;
+        summary.inProgressDataPoints.emailAddresses += r.emails.length;
+        summary.inProgressDataPoints.phoneNumbers += r.phones.length;
+        summary.inProgressDataPoints.addresses += r.addresses.length;
+        summary.inProgressDataPoints.familyMembers += r.relatives.length;
+        summary.dataBrokerInProgressDataPointsNum += dataPointsIncrement;
       }
 
-      // for fixed exposures: email, phones, addresses, relatives, full name (1)
-      if (isFixed) {
-        summary.fixedExposures.emailAddresses += r.emails.length;
-        summary.fixedExposures.phoneNumbers += r.phones.length;
-        summary.fixedExposures.addresses += r.addresses.length;
-        summary.fixedExposures.familyMembers += r.relatives.length;
-        summary.dataBrokerFixedExposuresNum += exposureIncrement;
+      // for fixed data points: email, phones, addresses, relatives, full name (1)
+      if (isAutoFixed) {
+        summary.fixedDataPoints.emailAddresses += r.emails.length;
+        summary.fixedDataPoints.phoneNumbers += r.phones.length;
+        summary.fixedDataPoints.addresses += r.addresses.length;
+        summary.fixedDataPoints.familyMembers += r.relatives.length;
+        summary.dataBrokerAutoFixedDataPointsNum += dataPointsIncrement;
       }
 
       if (isManuallyResolved) {
-        summary.manuallyResolvedDataBrokerExposures.emailAddresses +=
+        summary.manuallyResolvedDataBrokerDataPoints.emailAddresses +=
           r.emails.length;
-        summary.manuallyResolvedDataBrokerExposures.phoneNumbers +=
+        summary.manuallyResolvedDataBrokerDataPoints.phoneNumbers +=
           r.phones.length;
-        summary.manuallyResolvedDataBrokerExposures.addresses +=
+        summary.manuallyResolvedDataBrokerDataPoints.addresses +=
           r.addresses.length;
-        summary.manuallyResolvedDataBrokerExposures.familyMembers +=
+        summary.manuallyResolvedDataBrokerDataPoints.familyMembers +=
           r.relatives.length;
-        summary.dataBrokerManuallyResolvedExposuresNum += exposureIncrement;
+        summary.dataBrokerManuallyResolvedDataPointsNum += dataPointsIncrement;
       }
     });
   }
@@ -283,79 +283,79 @@ export function getDashboardSummary(
 
     // count emails
     if (dataClasses.includes(BreachDataTypes.Email)) {
-      summary.totalExposures += increment;
-      summary.dataBreachTotalExposuresNum += increment;
-      summary.allExposures.emailAddresses += increment;
+      summary.totalDataPointsNum += increment;
+      summary.dataBreachTotalDataPointsNum += increment;
+      summary.allDataPoints.emailAddresses += increment;
       if (b.isResolved) {
-        summary.fixedExposures.emailAddresses += increment;
-        summary.dataBreachFixedExposuresNum += increment;
+        summary.fixedDataPoints.emailAddresses += increment;
+        summary.dataBreachFixedDataPointsNum += increment;
       }
     }
 
     // count phone numbers
     if (dataClasses.includes(BreachDataTypes.Phone)) {
-      summary.totalExposures += increment;
-      summary.dataBreachTotalExposuresNum += increment;
-      summary.allExposures.phoneNumbers += increment;
+      summary.totalDataPointsNum += increment;
+      summary.dataBreachTotalDataPointsNum += increment;
+      summary.allDataPoints.phoneNumbers += increment;
       if (b.isResolved) {
-        summary.fixedExposures.phoneNumbers += increment;
-        summary.dataBreachFixedExposuresNum += increment;
+        summary.fixedDataPoints.phoneNumbers += increment;
+        summary.dataBreachFixedDataPointsNum += increment;
       }
     }
 
     // count password
     if (dataClasses.includes(BreachDataTypes.Passwords)) {
-      summary.totalExposures += increment;
-      summary.dataBreachTotalExposuresNum += increment;
-      summary.allExposures.passwords += increment;
+      summary.totalDataPointsNum += increment;
+      summary.dataBreachTotalDataPointsNum += increment;
+      summary.allDataPoints.passwords += increment;
       if (b.isResolved) {
-        summary.fixedExposures.passwords += increment;
-        summary.dataBreachFixedExposuresNum += increment;
+        summary.fixedDataPoints.passwords += increment;
+        summary.dataBreachFixedDataPointsNum += increment;
       }
     }
 
     // count ssn
     if (dataClasses.includes(BreachDataTypes.SSN)) {
-      summary.totalExposures += increment;
-      summary.dataBreachTotalExposuresNum += increment;
-      summary.allExposures.socialSecurityNumbers += increment;
+      summary.totalDataPointsNum += increment;
+      summary.dataBreachTotalDataPointsNum += increment;
+      summary.allDataPoints.socialSecurityNumbers += increment;
       if (b.isResolved) {
-        summary.fixedExposures.socialSecurityNumbers += increment;
-        summary.dataBreachFixedExposuresNum += increment;
+        summary.fixedDataPoints.socialSecurityNumbers += increment;
+        summary.dataBreachFixedDataPointsNum += increment;
       }
     }
 
     // count IP
     if (dataClasses.includes(BreachDataTypes.IP)) {
-      summary.totalExposures += increment;
-      summary.dataBreachTotalExposuresNum += increment;
-      summary.allExposures.ipAddresses += increment;
+      summary.totalDataPointsNum += increment;
+      summary.dataBreachTotalDataPointsNum += increment;
+      summary.allDataPoints.ipAddresses += increment;
       if (b.isResolved) {
-        summary.fixedExposures.ipAddresses += increment;
-        summary.dataBreachFixedExposuresNum += increment;
+        summary.fixedDataPoints.ipAddresses += increment;
+        summary.dataBreachFixedDataPointsNum += increment;
       }
     }
 
     // count credit card
     if (dataClasses.includes(BreachDataTypes.CreditCard)) {
-      summary.totalExposures += increment;
-      summary.dataBreachTotalExposuresNum += increment;
-      summary.allExposures.creditCardNumbers += increment;
+      summary.totalDataPointsNum += increment;
+      summary.dataBreachTotalDataPointsNum += increment;
+      summary.allDataPoints.creditCardNumbers += increment;
       if (b.isResolved) {
-        summary.fixedExposures.creditCardNumbers += increment;
-        summary.dataBreachFixedExposuresNum += increment;
+        summary.fixedDataPoints.creditCardNumbers += increment;
+        summary.dataBreachFixedDataPointsNum += increment;
       }
     }
 
     /* c8 ignore start */
     // count pin numbers
     if (dataClasses.includes(BreachDataTypes.PIN)) {
-      summary.totalExposures += increment;
-      summary.dataBreachTotalExposuresNum += increment;
-      summary.allExposures.pins += increment;
+      summary.totalDataPointsNum += increment;
+      summary.dataBreachTotalDataPointsNum += increment;
+      summary.allDataPoints.pins += increment;
       if (b.isResolved) {
-        summary.fixedExposures.pins += increment;
-        summary.dataBreachFixedExposuresNum += increment;
+        summary.fixedDataPoints.pins += increment;
+        summary.dataBreachFixedDataPointsNum += increment;
       }
     }
     /* c8 ignore stop */
@@ -363,12 +363,12 @@ export function getDashboardSummary(
     /** c8 ignore start */
     // count security questions
     if (dataClasses.includes(BreachDataTypes.SecurityQuestions)) {
-      summary.totalExposures += increment;
-      summary.dataBreachTotalExposuresNum += increment;
-      summary.allExposures.securityQuestions += increment;
+      summary.totalDataPointsNum += increment;
+      summary.dataBreachTotalDataPointsNum += increment;
+      summary.allDataPoints.securityQuestions += increment;
       if (b.isResolved) {
-        summary.fixedExposures.securityQuestions += increment;
-        summary.dataBreachFixedExposuresNum += increment;
+        summary.fixedDataPoints.securityQuestions += increment;
+        summary.dataBreachFixedDataPointsNum += increment;
       }
     }
     /** c8 ignore stop */
@@ -382,80 +382,79 @@ export function getDashboardSummary(
     summary.dataBreachTotalNum - summary.dataBreachResolvedNum;
   const isBreachesOnly = summary.dataBrokerTotalNum === 0;
 
-  // count unresolved exposures
-  summary.unresolvedExposures = Object.keys(summary.allExposures).reduce(
+  // count unresolved data points
+  summary.unresolvedDataPoints = Object.keys(summary.allDataPoints).reduce(
     (a, k) => {
-      a[k as keyof Exposures] =
-        summary.allExposures[k as keyof Exposures] -
-        summary.fixedExposures[k as keyof Exposures] -
-        summary.inProgressExposures[k as keyof Exposures];
+      a[k as keyof DataPoints] =
+        summary.allDataPoints[k as keyof DataPoints] -
+        summary.fixedDataPoints[k as keyof DataPoints] -
+        summary.inProgressDataPoints[k as keyof DataPoints];
       return a;
     },
-    {} as Exposures,
+    {} as DataPoints,
   );
 
-  // count fixed, in-progress, and manually resolved (data brokers) exposures
-  summary.inProgressFixedExposures = Object.keys(summary.fixedExposures).reduce(
-    (a, k) => {
-      a[k as keyof Exposures] =
-        summary.fixedExposures[k as keyof Exposures] +
-        summary.inProgressExposures[k as keyof Exposures] +
-        summary.manuallyResolvedDataBrokerExposures[k as keyof Exposures];
-      return a;
-    },
-    {} as Exposures,
-  );
+  // count fixed, in-progress, and manually resolved (data brokers) data points
+  summary.inProgressFixedDataPoints = Object.keys(
+    summary.fixedDataPoints,
+  ).reduce((a, k) => {
+    a[k as keyof DataPoints] =
+      summary.fixedDataPoints[k as keyof DataPoints] +
+      summary.inProgressDataPoints[k as keyof DataPoints] +
+      summary.manuallyResolvedDataBrokerDataPoints[k as keyof DataPoints];
+    return a;
+  }, {} as DataPoints);
 
-  // sanitize unresolved exposures
-  summary.unresolvedSanitizedExposures = sanitizeExposures(
-    summary.unresolvedExposures,
-    summary.totalExposures -
-      summary.dataBreachFixedExposuresNum -
-      summary.dataBrokerFixedExposuresNum -
-      summary.dataBrokerInProgressExposuresNum,
+  // sanitize unresolved data points
+  summary.unresolvedSanitizedDataPoints = sanitizeDataPoints(
+    summary.unresolvedDataPoints,
+    summary.totalDataPointsNum -
+      summary.dataBreachFixedDataPointsNum -
+      summary.dataBrokerAutoFixedDataPointsNum -
+      summary.dataBrokerInProgressDataPointsNum,
     isBreachesOnly,
   );
 
-  // sanitize fixed + inprogress exposures
-  summary.inProgressFixedSanitizedExposures = sanitizeExposures(
-    summary.inProgressFixedExposures,
-    summary.dataBreachFixedExposuresNum +
-      summary.dataBrokerFixedExposuresNum +
-      summary.dataBrokerInProgressExposuresNum +
-      summary.dataBrokerManuallyResolvedExposuresNum,
+  // sanitize fixed + inprogress data points
+  summary.inProgressFixedSanitizedDataPoints = sanitizeDataPoints(
+    summary.inProgressFixedDataPoints,
+    summary.dataBreachFixedDataPointsNum +
+      summary.dataBrokerAutoFixedDataPointsNum +
+      summary.dataBrokerInProgressDataPointsNum +
+      summary.dataBrokerManuallyResolvedDataPointsNum,
     isBreachesOnly,
   );
 
   return summary;
 }
 
-function sanitizeExposures(
-  exposures: Exposures,
-  totalExposures: number,
+function sanitizeDataPoints(
+  dataPoints: DataPoints,
+  dataPointCount: number,
   breachesOnly = false,
-): SanitizedExposures {
-  let numOfTopExposures = 4; // when we have both exposure types
+): SanitizedDataPoints {
+  let numOfTopDataPoints = 4; // when we have both exposure types
   if (breachesOnly) {
-    numOfTopExposures = 2; // when we have breaches only
+    numOfTopDataPoints = 2; // when we have breaches only
   }
-  const sanitizedExposures = Object.entries(exposures)
+  const sanitizedExposures = Object.entries(dataPoints)
     .sort((a, b) => b[1] - a[1])
     .map((e) => {
-      const key = exposureKeyMap[e[0]];
+      const key = dataClassKeyMap[e[0]];
       return { [key]: e[1] };
     })
-    .splice(0, numOfTopExposures);
+    .splice(0, numOfTopDataPoints);
   const other = sanitizedExposures.reduce(
     (total, cur) => total - (Object.values(cur).pop() || 0),
-    totalExposures,
+    dataPointCount,
   );
   sanitizedExposures.push({ "other-data-class": other });
   return sanitizedExposures;
 }
 
-export function getExposureReduction(summary: DashboardSummary): number {
-  if (summary.totalExposures <= 0) return 100;
+export function getDataPointReduction(summary: DashboardSummary): number {
+  if (summary.totalDataPointsNum <= 0) return 100;
   return Math.round(
-    (summary.dataBrokerTotalExposuresNum / summary.totalExposures) * 100,
+    (summary.dataBrokerTotalDataPointsNum / summary.totalDataPointsNum) * 100,
   );
 }

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -437,19 +437,24 @@ function sanitizeDataPoints(
   if (breachesOnly) {
     numOfTopDataPoints = 2; // when we have breaches only
   }
-  const sanitizedExposures = Object.entries(dataPoints)
-    .sort((a, b) => b[1] - a[1])
-    .map((e) => {
-      const key = dataClassKeyMap[e[0]];
-      return { [key]: e[1] };
-    })
-    .splice(0, numOfTopDataPoints);
-  const other = sanitizedExposures.reduce(
+  const sanitizedAllDataPoints = Object.entries(dataPoints)
+    .sort(([_dataClassA, countA], [_dataClassB, countB]) => countB - countA)
+    .map(([dataClass, count]) => {
+      const key = dataClassKeyMap[dataClass];
+      return { [key]: count };
+    });
+  const sanitizedTopDataPoints = sanitizedAllDataPoints.slice(
+    0,
+    numOfTopDataPoints,
+  );
+
+  const otherCount = sanitizedTopDataPoints.reduce(
     (total, cur) => total - (Object.values(cur).pop() || 0),
     dataPointCount,
   );
-  sanitizedExposures.push({ "other-data-class": other });
-  return sanitizedExposures;
+  const sanitizedDataPoints = [...sanitizedTopDataPoints];
+  sanitizedDataPoints.push({ "other-data-class": otherCount });
+  return sanitizedDataPoints;
 }
 
 export function getDataPointReduction(summary: DashboardSummary): number {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2268
Figma: N/A


<!-- When adding a new feature: -->

# Description

This PR does _three_ things. The most important thing is that manual resolutions are now subtracted from the count of the "Action needed" dashboard: 1a58a4e8daac0c27bbae6c31e3329f701ac63fa4.

That is the part that fixes the issue. Most of the code changes, however, are renames (b0caf54218fe1545d09b638323b226dd8de00d41) and a small bit of refactoring (d1c0498b1e8f8805edd52d60cb843d8d8485f79c). I had to do those to be able to understand what was going on and how to fix it. The main thing with big impact is that I renamed `exposure` in `dashboard.ts` to `dataPoint`, because we already used "exposure" to mean "broker scan result or data breach" elsewhere in the code, and I kept getting confused. **I would recommend filtering the review by commits** to ease review.

And then finally, there's **clearing the router cache** (c2a5769ac68c1d96bb026ef480cb0a4525963482). This solves the issue where, going back to the dashboard, the numbers would not actually be updated. ([See docs](https://nextjs.org/docs/app/building-your-application/caching#invalidation-1).) We will probably need to use that elsewhere as well?

# How to test

Manually resolve a data broker scan result, then visit the dashboard and verify that it is updated.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug. - Sort of - I fixed an existing incorrect unit test.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
