### PR TITLE
Continue button on high-risk resolution step

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/HighRiskBreachLayout.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/HighRiskBreachLayout.tsx
@@ -69,7 +69,7 @@ export function HighRiskBreachLayout(props: HighRiskBreachLayoutProps) {
 
   // TODO: Write unit tests MNTOR-2560
   /* c8 ignore start */
-  const handlePrimaryButtonPress = async () => {
+  const handleResolveBreach = async () => {
     const highRiskBreachClasses: Record<
       HighRiskBreachTypes,
       (typeof HighRiskDataTypes)[keyof typeof HighRiskDataTypes] | null
@@ -138,24 +138,27 @@ export function HighRiskBreachLayout(props: HighRiskBreachLayoutProps) {
         cta={
           !isStepDone && (
             <>
-              <Button
-                variant="primary"
-                small
-                autoFocus={true}
-                /* c8 ignore next */
-                onPress={() => void handlePrimaryButtonPress()}
-                disabled={isResolving}
-              >
-                {
-                  // Theoretically, this page should never be shown if the user
-                  // has no breaches, unless the user directly visits its URL, so
-                  // no tests represents it either:
-                  /* c8 ignore next 3 */
-                  isHighRiskBreachesStep
-                    ? l10n.getString("high-risk-breach-mark-as-fixed")
-                    : l10n.getString("high-risk-breach-none-continue")
-                }
-              </Button>
+              {isHighRiskBreachesStep ? (
+                <Button
+                  variant="primary"
+                  small
+                  autoFocus={true}
+                  /* c8 ignore next */
+                  onPress={() => void handleResolveBreach()}
+                  disabled={isResolving}
+                >
+                  {l10n.getString("high-risk-breach-mark-as-fixed")}
+                </Button>
+              ) : (
+                <Button
+                  variant="primary"
+                  small
+                  autoFocus={true}
+                  href={nextStep.href}
+                >
+                  {l10n.getString("high-risk-breach-none-continue")}
+                </Button>
+              )}
               {isHighRiskBreachesStep && (
                 <Link href={nextStep.href}>
                   {l10n.getString("high-risk-breach-skip")}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2620](https://mozilla-hub.atlassian.net/browse/MNTOR-2620): “Continue” button from the no high-risk data breaches found screen does not work

<!-- When adding a new feature: -->

# Description

Fixes the “Continue” button on the high-risk data breaches step in the guided resolution.

[MNTOR-2620]: https://mozilla-hub.atlassian.net/browse/MNTOR-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ