### PR TITLE
Match high-risk breaches route for /social-security-number

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/HighRiskBreachLayout.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/HighRiskBreachLayout.tsx
@@ -39,7 +39,7 @@ export function HighRiskBreachLayout(props: HighRiskBreachLayoutProps) {
   const [isResolving, setIsResolving] = useState(false);
 
   const stepMap: Record<HighRiskBreachTypes, StepLink["id"]> = {
-    ssn: "HighRiskSsn",
+    "social-security-number": "HighRiskSsn",
     "credit-card": "HighRiskCreditCard",
     "bank-account": "HighRiskBankAccount",
     pin: "HighRiskPin",

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/[type]/HighRiskDataBreach.stories.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/[type]/HighRiskDataBreach.stories.tsx
@@ -151,7 +151,7 @@ type Story = StoryObj<typeof HighRiskBreachWrapper>;
 export const SsnStory: Story = {
   name: "2a. Social Security Number",
   args: {
-    type: "ssn",
+    type: "social-security-number",
   },
 };
 

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/highRiskBreachData.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/high-risk-data-breaches/highRiskBreachData.tsx
@@ -18,7 +18,7 @@ import { StepLink } from "../../../../../../../functions/server/getRelevantGuide
 
 export const highRiskBreachTypes = [
   "credit-card",
-  "ssn",
+  "social-security-number",
   "bank-account",
   "pin",
   "done",
@@ -192,7 +192,7 @@ function getHighRiskBreachesByType({
       },
     },
     {
-      type: "ssn",
+      type: "social-security-number",
       title: l10n.getString("high-risk-breach-social-security-title"),
       illustration: socialSecurityNumberIllustration,
       exposedData: breaches.highRisk.ssnBreaches,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2618](https://mozilla-hub.atlassian.net/browse/MNTOR-2618): Guided experience has the wrong link for Social Security breaches

<!-- When adding a new feature: -->

# Description

Match the route for `/redesign/user/dashboard/fix/high-risk-data-breaches/social-security-number`.