### PR TITLE
Count fixed breach data classes not only for resolved breaches

### DIFF
--- a/src/app/functions/server/dashboard.test.ts
+++ b/src/app/functions/server/dashboard.test.ts
@@ -368,7 +368,7 @@ const allResolvedBreaches: SubscriberBreach[] = [
     addedDate: new Date("2015-10-26T23:35:45.000Z"),
     breachDate: new Date("2015-03-01T08:00:00.000Z"),
     dataClasses: ["email-addresses", "ip-addresses", "passwords"],
-    resolvedDataClasses: [],
+    resolvedDataClasses: ["email-addresses", "ip-addresses", "passwords"],
     description:
       'In approximately March 2015, the free web hosting provider <a href="http://www.troyhunt.com/2015/10/breaches-traders-plain-text-passwords.html" target="_blank" rel="noopener">000webhost suffered a major data breach</a> that exposed almost 15 million customer records. The data was sold and traded before 000webhost was alerted in October. The breach included names, email addresses and plain text passwords.',
     domain: "000webhost.com",
@@ -400,7 +400,12 @@ const allResolvedBreaches: SubscriberBreach[] = [
       "ip-addresses",
       "passwords",
     ],
-    resolvedDataClasses: [],
+    resolvedDataClasses: [
+      "dates-of-birth",
+      "email-addresses",
+      "ip-addresses",
+      "passwords",
+    ],
     description:
       'In November 2014, the acne website <a href="http://www.acne.org/" target="_blank" rel="noopener">acne.org</a> suffered a data breach that exposed over 430k forum members\' accounts. The data was being actively traded on underground forums and included email addresses, birth dates and passwords.',
     domain: "acne.org",
@@ -431,7 +436,7 @@ const allResolvedBreaches: SubscriberBreach[] = [
     addedDate: new Date("2013-12-04T00:00:00.000Z"),
     breachDate: new Date("2013-10-04T07:00:00.000Z"),
     dataClasses: ["email-addresses", "passwords"],
-    resolvedDataClasses: [],
+    resolvedDataClasses: ["email-addresses", "passwords"],
     description:
       'In October 2013, 153 million Adobe accounts were breached with each containing an internal ID, username, email, <em>encrypted</em> password and a password hint in plain text. The password cryptography was poorly done and many were quickly resolved back to plain text. The unencrypted hints also <a href="http://www.troyhunt.com/2013/11/adobe-credentials-and-serious.html" target="_blank" rel="noopener">disclosed much about the passwords</a> adding further to the risk that hundreds of millions of Adobe customers already faced.',
     domain: "adobe.com",

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -286,7 +286,7 @@ export function getDashboardSummary(
       summary.totalDataPointsNum += increment;
       summary.dataBreachTotalDataPointsNum += increment;
       summary.allDataPoints.emailAddresses += increment;
-      if (b.isResolved) {
+      if (b.resolvedDataClasses.includes(BreachDataTypes.Email)) {
         summary.fixedDataPoints.emailAddresses += increment;
         summary.dataBreachFixedDataPointsNum += increment;
       }
@@ -297,7 +297,7 @@ export function getDashboardSummary(
       summary.totalDataPointsNum += increment;
       summary.dataBreachTotalDataPointsNum += increment;
       summary.allDataPoints.phoneNumbers += increment;
-      if (b.isResolved) {
+      if (b.resolvedDataClasses.includes(BreachDataTypes.Phone)) {
         summary.fixedDataPoints.phoneNumbers += increment;
         summary.dataBreachFixedDataPointsNum += increment;
       }
@@ -308,7 +308,7 @@ export function getDashboardSummary(
       summary.totalDataPointsNum += increment;
       summary.dataBreachTotalDataPointsNum += increment;
       summary.allDataPoints.passwords += increment;
-      if (b.isResolved) {
+      if (b.resolvedDataClasses.includes(BreachDataTypes.Passwords)) {
         summary.fixedDataPoints.passwords += increment;
         summary.dataBreachFixedDataPointsNum += increment;
       }
@@ -319,7 +319,7 @@ export function getDashboardSummary(
       summary.totalDataPointsNum += increment;
       summary.dataBreachTotalDataPointsNum += increment;
       summary.allDataPoints.socialSecurityNumbers += increment;
-      if (b.isResolved) {
+      if (b.resolvedDataClasses.includes(BreachDataTypes.SSN)) {
         summary.fixedDataPoints.socialSecurityNumbers += increment;
         summary.dataBreachFixedDataPointsNum += increment;
       }
@@ -330,7 +330,7 @@ export function getDashboardSummary(
       summary.totalDataPointsNum += increment;
       summary.dataBreachTotalDataPointsNum += increment;
       summary.allDataPoints.ipAddresses += increment;
-      if (b.isResolved) {
+      if (b.resolvedDataClasses.includes(BreachDataTypes.IP)) {
         summary.fixedDataPoints.ipAddresses += increment;
         summary.dataBreachFixedDataPointsNum += increment;
       }
@@ -341,7 +341,7 @@ export function getDashboardSummary(
       summary.totalDataPointsNum += increment;
       summary.dataBreachTotalDataPointsNum += increment;
       summary.allDataPoints.creditCardNumbers += increment;
-      if (b.isResolved) {
+      if (b.resolvedDataClasses.includes(BreachDataTypes.CreditCard)) {
         summary.fixedDataPoints.creditCardNumbers += increment;
         summary.dataBreachFixedDataPointsNum += increment;
       }
@@ -353,7 +353,7 @@ export function getDashboardSummary(
       summary.totalDataPointsNum += increment;
       summary.dataBreachTotalDataPointsNum += increment;
       summary.allDataPoints.pins += increment;
-      if (b.isResolved) {
+      if (b.resolvedDataClasses.includes(BreachDataTypes.PIN)) {
         summary.fixedDataPoints.pins += increment;
         summary.dataBreachFixedDataPointsNum += increment;
       }
@@ -366,7 +366,7 @@ export function getDashboardSummary(
       summary.totalDataPointsNum += increment;
       summary.dataBreachTotalDataPointsNum += increment;
       summary.allDataPoints.securityQuestions += increment;
-      if (b.isResolved) {
+      if (b.resolvedDataClasses.includes(BreachDataTypes.SecurityQuestions)) {
         summary.fixedDataPoints.securityQuestions += increment;
         summary.dataBreachFixedDataPointsNum += increment;
       }


### PR DESCRIPTION

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2622](https://mozilla-hub.atlassian.net/browse/MNTOR-2622)

<!-- When adding a new feature: -->

# Description

Individual fixed breach data classes were only counted if a breach had been resolved entirely. Instead, we should increase the summary for breach classes as soon as the affected class is resolved.

[MNTOR-2622]: https://mozilla-hub.atlassian.net/browse/MNTOR-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ