### PR TITLE
Adjust redesign Monitor logo link target

### DIFF
--- a/src/app/(proper_react)/redesign/Shell.tsx
+++ b/src/app/(proper_react)/redesign/Shell.tsx
@@ -45,7 +45,7 @@ export const Shell = (props: Props) => {
             className={styles.mainMenu}
             aria-label={l10n.getString("main-nav-label")}
           >
-            <Link href="/" className={styles.homeLink}>
+            <Link href="/redesign/user/dashboard" className={styles.homeLink}>
               <Image
                 src={monitorLogo}
                 alt={l10n.getString("main-nav-link-home-label")}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2436](https://mozilla-hub.atlassian.net/browse/MNTOR-2436): Redesigned Monitor logo button redirects to the landing page instead of the dashboard

[MNTOR-2436]: https://mozilla-hub.atlassian.net/browse/MNTOR-2436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ