### PR TITLE
Align on Node 20.9 everywhere

### DIFF
--- a/.github/workflows/e2e_cron.yml
+++ b/.github/workflows/e2e_cron.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.5.1
+          node-version: 20.9
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.5.1
+          node-version: 20.9
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.5.x'
+          node-version: '20.9.x'
       - run: npm ci
       - run: cp .env-dist .env
       - run: npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.10-alpine
+FROM node:20.9-alpine
 
 RUN addgroup -g 10001 app && \
     adduser -D -G app -h /app -u 10001 app

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,4 +18,4 @@
   # Default build command.
   command = "npm ci; cp .env-dist .env; npm run build-storybook"
 
-  environment = { NODE_VERSION = "18.12.1", NPM_VERSION = "9.6.5" }
+  environment = { NODE_VERSION = "20.9.0", NPM_VERSION = "10.2.4" }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Firefox Monitor",
   "engines": {
-    "node": "20.10.x",
+    "node": "20.9.x",
     "npm": "10.2.x"
   },
   "type": "module",
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/mozilla/blurts-server",
   "license": "MPL-2.0",
   "volta": {
-    "node": "20.10.0",
+    "node": "20.9.0",
     "npm": "10.2.4"
   },
   "dependencies": {


### PR DESCRIPTION
Something changed in how V8 measures coverage, it seems, because running the tests in Node 20.10 results in <100% coverage. Among the uncovered lines are some inside of `getLocale`, although running specifically the `getLocale` tests results in full coverage.

We didn't catch this in CI because CI didn't use the same Node version as we do locally. This aligns CI and local versions, but due to the above problem, on Node 20.9. Once we figure out the actual issue, we can merge https://github.com/mozilla/blurts-server/pull/3869.