### PR TITLE
Determine subscribe links on the server-side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "react-cookie": "^6.1.1",
         "react-dom": "^18.2.0",
         "react-stately": "^3.28.0",
+        "server-only": "^0.0.1",
         "uuid": "^9.0.1",
         "winston": "^3.11.0"
       },
@@ -24779,6 +24780,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
+    },
     "node_modules/servie": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/servie/-/servie-4.3.3.tgz",
@@ -46176,6 +46182,11 @@
         "parseurl": "~1.3.3",
         "send": "0.18.0"
       }
+    },
+    "server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
     },
     "servie": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "react-cookie": "^6.1.1",
     "react-dom": "^18.2.0",
     "react-stately": "^3.28.0",
+    "server-only": "^0.0.1",
     "uuid": "^9.0.1",
     "winston": "^3.11.0"
   },

--- a/src/app/(proper_react)/redesign/(public)/LandingView.tsx
+++ b/src/app/(proper_react)/redesign/(public)/LandingView.tsx
@@ -8,6 +8,7 @@ import { SignUpForm } from "./SignUpForm";
 import { ExtendedReactLocalization } from "../../../hooks/l10n";
 import { PlansTable } from "./PlansTable";
 import { useId } from "react";
+import getPremiumSubscriptionUrl from "../../../functions/server/getPremiumSubscriptionUrl";
 
 export type Props = {
   eligibleForPremium: boolean;
@@ -89,7 +90,13 @@ const Plans = (props: Props) => {
       <p className={styles.lead}>
         {props.l10n.getString("landing-premium-plans-lead")}
       </p>
-      <PlansTable aria-labelledby={headingId} />
+      <PlansTable
+        aria-labelledby={headingId}
+        premiumSubscriptionUrl={{
+          monthly: getPremiumSubscriptionUrl({ type: "monthly" }),
+          yearly: getPremiumSubscriptionUrl({ type: "yearly" }),
+        }}
+      />
     </section>
   );
 };

--- a/src/app/(proper_react)/redesign/(public)/PlansTable.tsx
+++ b/src/app/(proper_react)/redesign/(public)/PlansTable.tsx
@@ -55,10 +55,13 @@ import {
 import { getLocale } from "../../../functions/universal/getLocale";
 import { Button } from "../../../components/server/Button";
 import { signIn } from "next-auth/react";
-import getPremiumSubscriptionUrl from "../../../functions/server/getPremiumSubscriptionUrl";
 
 export type Props = {
   "aria-labelledby": string;
+  premiumSubscriptionUrl: {
+    monthly: string;
+    yearly: string;
+  };
 };
 
 const monthlyPriceAnnualBilling = 13.37;
@@ -156,7 +159,7 @@ export const PlansTable = (props: Props) => {
             </p>
             <Button
               variant="primary"
-              href={getPremiumSubscriptionUrl({ type: billingPeriod })}
+              href={props.premiumSubscriptionUrl[billingPeriod]}
               className={styles.cta}
             >
               {l10n.getString("landing-premium-plans-table-cta-plus-label")}
@@ -719,7 +722,7 @@ export const PlansTable = (props: Props) => {
                 </p>
                 <Button
                   variant="primary"
-                  href={getPremiumSubscriptionUrl({ type: billingPeriod })}
+                  href={props.premiumSubscriptionUrl[billingPeriod]}
                 >
                   {l10n.getString("landing-premium-plans-table-cta-plus-label")}
                 </Button>

--- a/src/app/functions/server/getPremiumSubscriptionUrl.ts
+++ b/src/app/functions/server/getPremiumSubscriptionUrl.ts
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// We need access to environment variables that are only available on the
+// server-side, because they're set by the server environment:
+import "server-only";
+
 interface GetPremiumSubscriptionUrlParams {
   type: "monthly" | "yearly";
 }


### PR DESCRIPTION
On client-side renders, the environment variables won't be available, and the links will include `undefined`.
