### PR TITLE
Add missing breach data classes

### DIFF
--- a/locales/en/data-classes.ftl
+++ b/locales/en/data-classes.ftl
@@ -81,6 +81,7 @@ living-costs = Living costs
 # This string refers to financial loans.
 loan-information = Loan information
 login-histories = Login histories
+loyalty-program-details = Loyalty program details
 mac-addresses = MAC addresses
 marital-statuses = Marital statuses
 # Mnemonic phrases are a group of words used to access the content of cryptocurrency wallets.
@@ -141,6 +142,7 @@ spouses-names = Spouses names
 support-tickets = Support tickets
 survey-results = Survey results
 taxation-records = Taxation records
+telecommunications-carrier = Telecommunications carrier
 time-zones = Time zones
 travel-habits = Travel habits
 user-statuses = User statuses


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-
Figma: 


<!-- When adding a new feature: -->

# Description

```sh
npx pdehaan/blurts-server-data-classes

Missing "telecommunications-carrier" data class from ApexSMS breach
Missing "loyalty-program-details" data class from MalindoAir breach
```

Not visible on the details page, but noticed them when browsing on https://monitor.firefox.com/breaches (search for "Apex" or "Mali").

# Screenshot (if applicable)

Not applicable.

# How to test



# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
