### PR TITLE
Don’t include in-progress exposures in dashboard chart subtext

### DIFF
--- a/locales/en/data-classes.ftl
+++ b/locales/en/data-classes.ftl
@@ -81,6 +81,7 @@ living-costs = Living costs
 # This string refers to financial loans.
 loan-information = Loan information
 login-histories = Login histories
+loyalty-program-details = Loyalty program details
 mac-addresses = MAC addresses
 marital-statuses = Marital statuses
 # Mnemonic phrases are a group of words used to access the content of cryptocurrency wallets.
@@ -141,6 +142,7 @@ spouses-names = Spouses names
 support-tickets = Support tickets
 survey-results = Survey results
 taxation-records = Taxation records
+telecommunications-carrier = Telecommunications carriers
 time-zones = Time zones
 travel-habits = Travel habits
 user-statuses = User statuses

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
@@ -368,6 +368,30 @@ it("switches between tab panels", async () => {
   expect(tabActionNeededTrigger.getAttribute("aria-selected")).toBe("false");
 });
 
+it("shows consistent counts in the chart on the fixed tab", async () => {
+  const user = userEvent.setup();
+  const ComposedDashboard = composeStory(
+    DashboardUsPremiumUnresolvedScanUnresolvedBreaches,
+    Meta,
+  );
+  render(<ComposedDashboard />);
+
+  const tabFixedTrigger = screen.getByRole("tab", {
+    name: "Fixed",
+  });
+  await user.click(tabFixedTrigger);
+
+  const fixedCounter = 40;
+  const chartElement = screen.getByRole("img", {
+    name: `⁨${fixedCounter}⁩ exposures`,
+  });
+  expect(chartElement).toBeInTheDocument();
+  const chartCaption = screen.getByText(
+    `This chart shows the total exposures that are fixed (⁨${fixedCounter}⁩ out of ⁨81⁩)`,
+  );
+  expect(chartCaption).toBeInTheDocument();
+});
+
 it("shows US users with Premium the Premium badge", () => {
   const ComposedDashboard = composeStory(
     DashboardUsPremiumEmptyScanNoBreaches,

--- a/src/app/components/client/Chart.tsx
+++ b/src/app/components/client/Chart.tsx
@@ -248,7 +248,6 @@ export const DoughnutChart = (props: Props) => {
                   total_fixed_exposures_num:
                     props.summary.dataBreachFixedDataPointsNum +
                     props.summary.dataBrokerAutoFixedDataPointsNum +
-                    props.summary.dataBrokerInProgressDataPointsNum +
                     props.summary.dataBrokerManuallyResolvedDataPointsNum,
                   total_exposures_num: props.summary.totalDataPointsNum,
                 },


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2502](https://mozilla-hub.atlassian.net/browse/MNTOR-2502)

<!-- When adding a new feature: -->

# Description

In #3870 we removed the in-progress exposures from the count of fixed items, but they were still included in the chart subtext on the Dashboard.

[MNTOR-2502]: https://mozilla-hub.atlassian.net/browse/MNTOR-2502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ