### PR TITLE
Stop automatically sending the session ID

### DIFF
--- a/src/app/hooks/useTelemetry.ts
+++ b/src/app/hooks/useTelemetry.ts
@@ -5,7 +5,6 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { useSession } from "next-auth/react";
 // Imports for the `useGlean` and `useGa` hooks are restricted.
 /* eslint-disable no-restricted-imports */
 import { useGa } from "./useGa";
@@ -20,7 +19,6 @@ const TelemetryPlatforms = {
 
 export const useTelemetry = () => {
   const path = usePathname();
-  const session = useSession();
   const recordGlean = useGlean();
   const { gtag } = useGa();
 
@@ -39,7 +37,6 @@ export const useTelemetry = () => {
     if (platforms.includes(Glean)) {
       void recordGlean(eventModule, event, {
         path: path,
-        user_id: session.data?.user.subscriber?.fxa_uid ?? undefined,
         ...data,
       });
     }


### PR DESCRIPTION
The `<PageLoadEvent>` component comes up with a deliberate session ID that is also unique for people who aren't logged in, and is gated behind a flag. Thus, we probably want to hold off on setting a session ID until we've come up with the definite strategy and approval there.
