### PR TITLE
Keep the ManualRemove View universal

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/welcome-to-premium/WelcomeToPremiumView.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/welcome-to-premium/WelcomeToPremiumView.tsx
@@ -15,9 +15,6 @@ import {
   getNextGuidedStep,
 } from "../../../../../../../../functions/server/getRelevantGuidedSteps";
 import { FixView } from "../../FixView";
-import { getServerSession } from "next-auth";
-import { authOptions } from "../../../../../../../../api/utils/auth";
-import { logger } from "../../../../../../../../functions/server/logging";
 
 export type Props = {
   data: StepDeterminationData;
@@ -34,17 +31,6 @@ export function WelcomeToPremiumView(props: Props) {
     props.data.subscriberBreaches,
   );
   const dataPointReduction = getDataPointReduction(summary);
-
-  // MNTOR-2594 - log any users that are on welcome-to-premium page but not subscribed.
-  getServerSession(authOptions)
-    .then((session) => {
-      if (!session?.user.fxa?.subscriptions.includes("monitor")) {
-        logger.error("user_not_subscribed", {
-          page: "welcome-to-premium",
-        });
-      }
-    })
-    .catch((ex) => logger.error(ex));
 
   return (
     <FixView

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/welcome-to-premium/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/fix/data-broker-profiles/welcome-to-premium/page.tsx
@@ -14,6 +14,7 @@ import { getSubscriberEmails } from "../../../../../../../../functions/server/ge
 import { StepDeterminationData } from "../../../../../../../../functions/server/getRelevantGuidedSteps";
 import { getCountryCode } from "../../../../../../../../functions/server/getCountryCode";
 import { activateAndOptoutProfile } from "../../../../../../../../functions/server/onerep";
+import { logger } from "../../../../../../../../functions/server/logging";
 
 export default async function WelcomeToPremiumPage() {
   const session = await getServerSession(authOptions);
@@ -21,6 +22,13 @@ export default async function WelcomeToPremiumPage() {
   // Ensure user is logged in
   if (!session?.user?.subscriber?.id) {
     redirect("/redesign/user/dashboard/");
+  }
+
+  // MNTOR-2594 - log any users that are on welcome-to-premium page but not subscribed.
+  if (!session.user.fxa?.subscriptions.includes("monitor")) {
+    logger.error("user_not_subscribed", {
+      page: "welcome-to-premium",
+    });
   }
 
   const result = await getOnerepProfileId(session.user.subscriber.id);


### PR DESCRIPTION
Although it runs as a server component in production, we also want to render it in Storybook, which runs everything as a client component.

This should make Netlify succeed again.