### PR TITLE
Also subtract manually resolved brokers

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/Dashboard.test.tsx
@@ -370,6 +370,27 @@ it("switches between tab panels", async () => {
   expect(tabActionNeededTrigger.getAttribute("aria-selected")).toBe("false");
 });
 
+it("shows consistent counts in the chart on the active tab", () => {
+  const ComposedDashboard = composeStory(
+    DashboardUsPremiumUnresolvedScanUnresolvedBreaches,
+    Meta,
+  );
+  render(<ComposedDashboard />);
+
+  const exposureCounter = 25;
+  const chartElement = screen.getByRole("img", {
+    name: `⁨${exposureCounter}⁩ exposures`,
+  });
+  expect(chartElement).toBeInTheDocument();
+
+  const listSubheading = screen.getByText(
+    new RegExp(
+      `We found your information exposed ⁨${exposureCounter}⁩ times over (.*?) data breaches and ⁨2⁩ data broker sites that are selling your personal info.`,
+    ),
+  );
+  expect(listSubheading).toBeInTheDocument();
+});
+
 it("shows consistent counts in the chart on the fixed tab", async () => {
   const user = userEvent.setup();
   const ComposedDashboard = composeStory(

--- a/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/dashboard/View.tsx
@@ -180,10 +180,12 @@ export const View = (props: Props) => {
       dataBreachUnresolvedNum,
       dataBrokerTotalNum,
       dataBrokerAutoFixedNum,
+      dataBrokerManuallyResolvedNum,
       dataBrokerInProgressNum,
       dataBreachFixedDataPointsNum,
       dataBrokerAutoFixedDataPointsNum,
       dataBrokerInProgressDataPointsNum,
+      dataBrokerManuallyResolvedDataPointsNum,
       totalDataPointsNum,
     } = dataSummary;
 
@@ -197,11 +199,13 @@ export const View = (props: Props) => {
             totalDataPointsNum -
             dataBrokerAutoFixedDataPointsNum -
             dataBreachFixedDataPointsNum -
-            dataBrokerInProgressDataPointsNum,
+            dataBrokerInProgressDataPointsNum -
+            dataBrokerManuallyResolvedDataPointsNum,
           data_breach_unresolved_num: dataBreachUnresolvedNum,
           data_broker_unresolved_num:
             dataBrokerTotalNum -
             dataBrokerAutoFixedNum -
+            dataBrokerManuallyResolvedNum -
             dataBrokerInProgressNum,
         },
       );
@@ -215,7 +219,8 @@ export const View = (props: Props) => {
             totalDataPointsNum -
             dataBrokerAutoFixedDataPointsNum -
             dataBreachFixedDataPointsNum -
-            dataBrokerInProgressDataPointsNum,
+            dataBrokerInProgressDataPointsNum -
+            dataBrokerManuallyResolvedDataPointsNum,
           data_breach_unresolved_num: dataBreachUnresolvedNum,
         },
       );

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -42,8 +42,10 @@ export interface DashboardSummary {
   dataBrokerTotalNum: number;
   /** total number of data points from user data broker scanned results */
   dataBrokerTotalDataPointsNum: number;
-  /** total number of fixed scans from user data broker scanned results */
+  /** total number of auto-fixed scans from user data broker scanned results */
   dataBrokerAutoFixedNum: number;
+  /** total number of manually fixed scans from user data broker scanned results */
+  dataBrokerManuallyResolvedNum: number;
   /** total number of fixed data points from user data broker scanned results */
   dataBrokerAutoFixedDataPointsNum: number;
   /** total number of in-progress scans from user data broker scanned results */
@@ -106,6 +108,7 @@ export function getDashboardSummary(
     dataBrokerAutoFixedDataPointsNum: 0,
     dataBrokerInProgressNum: 0,
     dataBrokerInProgressDataPointsNum: 0,
+    dataBrokerManuallyResolvedNum: 0,
     dataBrokerManuallyResolvedDataPointsNum: 0,
     totalDataPointsNum: 0,
     allDataPoints: {
@@ -202,6 +205,8 @@ export function getDashboardSummary(
         summary.dataBrokerInProgressNum++;
       } else if (isAutoFixed) {
         summary.dataBrokerAutoFixedNum++;
+      } else if (isManuallyResolved) {
+        summary.dataBrokerManuallyResolvedNum++;
       }
       // total data points: add email, phones, addresses, relatives, full name (1)
       const dataPointsIncrement =


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2632
Figma: N/A


<!-- When adding a new feature: -->

# Description

The dashboard overview (the paragraph before the cards) did not incorporate manually-resolved scan results.

# How to test

Manually resolve a scan result, and verify that it is subtracted from the text:

> We found your information exposed `x` times over ⁨198⁩ data breaches and ⁨`y` data broker sites that are selling your personal info.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
