### PR TITLE
Respect the SUPPORTED_LOCALES env var

### DIFF
--- a/src/app/functions/server/l10n.ts
+++ b/src/app/functions/server/l10n.ts
@@ -80,13 +80,14 @@ export function getL10nBundles(): LocaleData[] {
 
   const languages = acceptLangHeader ? acceptedLanguages(acceptLangHeader) : [];
   const supportedLocales = process.env.SUPPORTED_LOCALES?.split(",");
-  const currentLocales = negotiateLanguages(
-    languages,
-    Object.keys(bundleSources).filter(
-      (locale) => supportedLocales?.includes(locale),
-    ),
-    { defaultLocale: "en" },
-  );
+  const availableLocales = Object.keys(bundleSources);
+  const filteredLocales =
+    process.env.APP_ENV === "heroku"
+      ? availableLocales
+      : availableLocales.filter((locale) => supportedLocales?.includes(locale));
+  const currentLocales = negotiateLanguages(languages, filteredLocales, {
+    defaultLocale: "en",
+  });
 
   const relevantBundleSources = currentLocales.map((relevantLocale) => ({
     locale: relevantLocale,

--- a/src/app/functions/server/l10n.ts
+++ b/src/app/functions/server/l10n.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import "server-only";
 import { acceptedLanguages, negotiateLanguages } from "@fluent/langneg";
 import { headers } from "next/headers";
 import { ExtendedReactLocalization, GetFragment } from "../../hooks/l10n";
@@ -78,9 +79,12 @@ export function getL10nBundles(): LocaleData[] {
   }
 
   const languages = acceptLangHeader ? acceptedLanguages(acceptLangHeader) : [];
+  const supportedLocales = process.env.SUPPORTED_LOCALES?.split(",");
   const currentLocales = negotiateLanguages(
     languages,
-    Object.keys(bundleSources),
+    Object.keys(bundleSources).filter(
+      (locale) => supportedLocales?.includes(locale),
+    ),
     { defaultLocale: "en" },
   );
 


### PR DESCRIPTION
This means we won't localise the UI to locales that aren't listed in SUPPORTED_LOCALES. This avoids showing languages with only a few localised strings.

I'm not sure if we decided not to use this for now, but it was so easy to implement that I figured I'd just submit a PR and we'd see.