### PR TITLE
Fix Guided Resolution step 1b. in Storybook

### DIFF
--- a/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/View.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import styles from "../dataBrokerProfiles.module.scss";
-import { getL10n } from "../../../../../../../../../functions/server/l10n";
 import { DataBrokerProfiles } from "../../../../../../../../../components/client/DataBrokerProfiles";
 import { AboutBrokersIcon } from "./AboutBrokersIcon";
 import { Button } from "../../../../../../../../../components/client/Button";
@@ -12,14 +11,16 @@ import {
   StepDeterminationData,
   getNextGuidedStep,
 } from "../../../../../../../../../functions/server/getRelevantGuidedSteps";
+import { ExtendedReactLocalization } from "../../../../../../../../../hooks/l10n";
 
 export type Props = {
   data: StepDeterminationData;
   subscriberEmails: string[];
+  l10n: ExtendedReactLocalization;
 };
 
 export const ViewDataBrokersView = (props: Props) => {
-  const l10n = getL10n();
+  const l10n = props.l10n;
 
   const countOfDataBrokerProfiles =
     props.data.latestScanData?.results.length ?? 0;

--- a/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/ViewDataBrokers.stories.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/ViewDataBrokers.stories.tsx
@@ -91,9 +91,10 @@ const ViewWrapper = (props: ViewWrapperProps) => {
     expires: new Date().toISOString(),
     user: user,
   };
+  const l10n = getOneL10nSync();
 
   return (
-    <Shell l10n={getOneL10nSync()} session={mockedSession} nonce="">
+    <Shell l10n={l10n} session={mockedSession} nonce="">
       <ViewDataBrokersView
         data={{
           latestScanData: scanData,
@@ -101,6 +102,7 @@ const ViewWrapper = (props: ViewWrapperProps) => {
           subscriberBreaches: [],
           user: mockedSession.user,
         }}
+        l10n={l10n}
         subscriberEmails={[]}
       />
     </Shell>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/page.tsx
@@ -13,6 +13,7 @@ import { StepDeterminationData } from "../../../../../../../../../functions/serv
 import { getCountryCode } from "../../../../../../../../../functions/server/getCountryCode";
 import { getSubscriberBreaches } from "../../../../../../../../../functions/server/getUserBreaches";
 import { getSubscriberEmails } from "../../../../../../../../../functions/server/getSubscriberEmails";
+import { getL10n } from "../../../../../../../../../functions/server/l10n";
 
 export default async function ViewDataBrokers() {
   const session = await getServerSession(authOptions);
@@ -33,6 +34,10 @@ export default async function ViewDataBrokers() {
   const subscriberEmails = await getSubscriberEmails(session.user);
 
   return (
-    <ViewDataBrokersView data={data} subscriberEmails={subscriberEmails} />
+    <ViewDataBrokersView
+      data={data}
+      subscriberEmails={subscriberEmails}
+      l10n={getL10n()}
+    />
   );
 }


### PR DESCRIPTION
Storybook renders universal components as client components, so even if they're rendered as server components on the actual website, they shouldn't call server-side APIs like `getL10n` if we can avoid it.

See this broken story on `main`: https://fx-monitor-storybook.netlify.app/?path=/story/pages-guided-resolution-1b-scan-results--none-free

That same story for this PR: https://deploy-preview-3992--fx-monitor-storybook.netlify.app/?path=/story/pages-guided-resolution-1b-scan-results--none-free