### PR TITLE
Remove NEXT_PUBLIC env vars by constants

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -75,7 +75,6 @@ HIBP_BREACH_DOMAIN_BLOCKLIST=a-blocked-domain.com,another-blocked-domain.org
 ONEREP_API_BASE=https://api.onerep.com
 ONEREP_API_KEY=
 ONEREP_WEBHOOK_SECRET="unsafe-default-secret-for-dev"
-NEXT_PUBLIC_ONEREP_MAX_SCANS_THRESHOLD = 280000
 
 # Firefox Remote Settings
 FX_REMOTE_SETTINGS_WRITER_SERVER=https://settings-writer.prod.mozaws.net/v1
@@ -94,7 +93,6 @@ PRODUCT_PROMOS_ENABLED=1
 EXPERIMENT_ACTIVE=0
 
 REDIS_URL=redis-mock
-NEXT_PUBLIC_MAX_NUM_ADDRESSES=5
 
 RECRUITMENT_BANNER_LINK=
 RECRUITMENT_BANNER_TEXT=
@@ -122,8 +120,6 @@ ADMINS=
 # Enable monthly cron-job, currently for sending unresolved breach reminder emails
 MONTHLY_CRON_ENABLED=
 
-NEXT_PUBLIC_GA4_MEASUREMENT_ID=G-CXG8K4KW4P
-
 # E2E Tests
 E2E_TEST_ENV=
 E2E_TEST_BASE_URL=
@@ -131,7 +127,6 @@ E2E_TEST_ACCOUNT_EMAIL=
 E2E_TEST_ACCOUNT_PASSWORD=
 
 # Monitor Premium features
-NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT=190
 # Link to start user on the subscription process. PREMIUM_ENABLED must be set to `true`.
 FXA_SUBSCRIPTIONS_URL=https://accounts.stage.mozaws.net/subscriptions
 PREMIUM_PRODUCT_ID=prod_NErZh679W62lai
@@ -146,14 +141,6 @@ BROKER_SCAN_RELEASE_DATE=2024-02-06
 MONTHLY_SUBSCRIBERS_QUOTA=
 MONTHLY_SCANS_QUOTA=
 STATS_TOKEN=
-
-# Support article link
-NEXT_PUBLIC_MONITOR_SUPPORT_URL=https://support.mozilla.org/kb/firefox-monitor
-
-# Support How it Works page
-NEXT_PUBLIC_HOW_IT_WORKS_SUMO_URL=https://support.mozilla.org/kb/how-does-monitor-plus-work
-
-NEXT_PUBLIC_WAITLIST_URL=https://www.mozilla.org/products/monitor/waitlist-scan/
 
 # GCP PubSub Project ID and subscription name
 GCP_PUBSUB_PROJECT_ID=
@@ -173,11 +160,6 @@ MAX_INITIAL_SCANS=100
 MAX_PROFILES_ACTIVATED=100
 MAX_PROFILES_CREATED=100
 
-# Footer links
-
-NEXT_PUBLIC_MONITOR_FAQ=https://support.mozilla.org/kb/firefox-monitor-faq
-NEXT_PUBLIC_MONITOR_LEGAL=https://www.mozilla.org/about/legal/terms/subscription-services/
-NEXT_PUBLIC_MONITOR_SUBSCRIPTION_SERVICES=https://www.mozilla.org/privacy/subscription-services/
-NEXT_PUBLIC_MONITOR_GITHUB=https://github.com/mozilla/blurts-server
-NEXT_PUBLIC_LEARN_MORE_ABOUT_MONITOR_PLUS_URL=https://support.mozilla.org/kb/how-does-monitor-plus-work
-NEXT_PUBLIC_FAQ_MONITOR=https://support.mozilla.org/kb/firefox-monitor-faq
+# Deprecated, these NEXT_PUBLIC_* env vars can be removed when AppConstants is removed:
+NEXT_PUBLIC_MAX_NUM_ADDRESSES=5
+NEXT_PUBLIC_GA4_MEASUREMENT_ID=G-CXG8K4KW4P

--- a/src/app/(nextjs_migration)/(authenticated)/user/breaches/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/user/breaches/page.tsx
@@ -8,7 +8,6 @@ import { getServerSession } from "next-auth";
 import { headers } from "next/headers";
 import { CircleChartProps } from "./breaches.d";
 
-import AppConstants from "../../../../../appConstants.js";
 import { getL10n } from "../../../../functions/server/l10n";
 import {
   getUserBreaches,
@@ -24,6 +23,7 @@ import { getComponentAsString } from "../../../functions/server/getComponentAsSt
 import { getCountryCode } from "../../../../functions/server/getCountryCode";
 import { getNonce } from "../../../functions/server/getNonce";
 import { SignInButton } from "../../../components/client/SignInButton";
+import { CONST_MAX_NUM_ADDRESSES } from "../../../../../constants";
 
 export function generateMetadata() {
   const l10n = getL10n();
@@ -149,14 +149,14 @@ export default async function UserBreaches() {
             <figure
               className="email-stats"
               data-count={userBreachesData.emailTotalCount}
-              data-total={AppConstants.NEXT_PUBLIC_MAX_NUM_ADDRESSES}
+              data-total={CONST_MAX_NUM_ADDRESSES}
             >
               <Image src={ImageIconEmail} alt="" width={55} height={30} />
               <figcaption>
                 <strong>
                   {l10n.getString("emails-monitored", {
                     count: userBreachesData.emailVerifiedCount,
-                    total: AppConstants.NEXT_PUBLIC_MAX_NUM_ADDRESSES,
+                    total: CONST_MAX_NUM_ADDRESSES,
                   })}
                 </strong>
                 <a href="/user/settings">

--- a/src/app/(nextjs_migration)/(authenticated)/user/settings/page.tsx
+++ b/src/app/(nextjs_migration)/(authenticated)/user/settings/page.tsx
@@ -21,6 +21,7 @@ import { getBreachesForEmail } from "../../../../../utils/hibp";
 import { getSha1 } from "../../../../../utils/fxa";
 import { getSubscriberById } from "../../../../../db/tables/subscribers";
 import { getNonce } from "../../../functions/server/getNonce";
+import { CONST_MAX_NUM_ADDRESSES } from "../../../../../constants";
 
 const emailNeedsVerificationSub = (email: EmailRow) => {
   const l10n = getL10n();
@@ -208,7 +209,7 @@ export default async function Settings() {
               </h3>
               <p className="settings-section-info">
                 {l10n.getString("settings-email-limit-info", {
-                  limit: AppConstants.NEXT_PUBLIC_MAX_NUM_ADDRESSES,
+                  limit: CONST_MAX_NUM_ADDRESSES,
                 })}
               </p>
 
@@ -217,13 +218,7 @@ export default async function Settings() {
                 aria-label={l10n.getString("settings-add-email-button")}
                 className="primary settings-add-email-button"
                 data-dialog="addEmail"
-                disabled={
-                  emails.length >=
-                  Number.parseInt(
-                    AppConstants.NEXT_PUBLIC_MAX_NUM_ADDRESSES,
-                    10,
-                  )
-                }
+                disabled={emails.length >= CONST_MAX_NUM_ADDRESSES}
               >
                 {l10n.getString("settings-add-email-button")}
               </button>

--- a/src/app/(nextjs_migration)/components/server/AddEmailDialog.tsx
+++ b/src/app/(nextjs_migration)/components/server/AddEmailDialog.tsx
@@ -6,10 +6,11 @@ import React from "react";
 import cloudImage from "../../../../client/images/dialog-email-clouds.svg";
 import AppConstants from "../../../../appConstants";
 import { getL10n } from "../../../functions/server/l10n";
+import { CONST_MAX_NUM_ADDRESSES } from "../../../../constants";
 
 export default function AddEmailDialog() {
   const l10n = getL10n();
-  const emailLimit = AppConstants.NEXT_PUBLIC_MAX_NUM_ADDRESSES;
+  const emailLimit = CONST_MAX_NUM_ADDRESSES;
 
   return (
     <>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
@@ -20,6 +20,11 @@ import { useL10n } from "../../../../../../../hooks/l10n";
 import { UpsellButton } from "../../../../../../../components/client/UpsellBadge";
 import { WaitlistDialog } from "../../../../../../../components/client/SubscriberWaitlistDialog";
 import { useTelemetry } from "../../../../../../../hooks/useTelemetry";
+import {
+  CONST_URL_SUMO_HOW_IT_WORKS,
+  CONST_ONEREP_DATA_BROKER_COUNT,
+  CONST_ONEREP_MAX_SCANS_THRESHOLD,
+} from "../../../../../../../../constants";
 
 export interface ContentProps {
   relevantGuidedStep: StepLink;
@@ -212,20 +217,14 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
               {l10n.getString(
                 "dashboard-top-banner-monitor-protects-your-even-more-description",
                 {
-                  data_broker_sites_total_num: parseInt(
-                    process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
-                    10,
-                  ),
+                  data_broker_sites_total_num: CONST_ONEREP_DATA_BROKER_COUNT,
                 },
               )}
             </p>
             <div className={styles.cta}>
               {typeof props.totalNumberOfPerformedScans === "undefined" ||
               props.totalNumberOfPerformedScans <
-                parseInt(
-                  process.env.NEXT_PUBLIC_ONEREP_MAX_SCANS_THRESHOLD as string,
-                  10,
-                ) ? (
+                CONST_ONEREP_MAX_SCANS_THRESHOLD ? (
                 <Button
                   href="/redesign/user/welcome/free-scan?referrer=dashboard"
                   small
@@ -263,7 +262,7 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
               )}
             </div>
             <a
-              href={process.env.NEXT_PUBLIC_HOW_IT_WORKS_SUMO_URL}
+              href={CONST_URL_SUMO_HOW_IT_WORKS}
               target="_blank"
               onClick={() =>
                 recordTelemetry("link", "click", {
@@ -287,10 +286,7 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
               {l10n.getString(
                 "dashboard-top-banner-no-exposures-found-description",
                 {
-                  data_broker_sites_total_num: parseInt(
-                    process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
-                    10,
-                  ),
+                  data_broker_sites_total_num: CONST_ONEREP_DATA_BROKER_COUNT,
                 },
               )}
             </p>
@@ -476,10 +472,7 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
               {l10n.getString(
                 "dashboard-top-banner-no-exposures-found-description",
                 {
-                  data_broker_sites_total_num: parseInt(
-                    process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
-                    10,
-                  ),
+                  data_broker_sites_total_num: CONST_ONEREP_DATA_BROKER_COUNT,
                 },
               )}
             </p>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/View.tsx
@@ -44,6 +44,10 @@ import { WaitlistDialog } from "../../../../../../components/client/SubscriberWa
 import { useOverlayTriggerState } from "react-stately";
 import { useOverlayTrigger } from "react-aria";
 import { useTelemetry } from "../../../../../../hooks/useTelemetry";
+import {
+  CONST_ONEREP_DATA_BROKER_COUNT,
+  CONST_ONEREP_MAX_SCANS_THRESHOLD,
+} from "../../../../../../../constants";
 
 export type Props = {
   enabledFeatureFlags: FeatureFlagName[];
@@ -306,19 +310,13 @@ export const View = (props: Props) => {
       <p>
         {l10n.getFragment("dashboard-exposures-all-fixed-free-scan", {
           vars: {
-            data_broker_total_num: parseInt(
-              process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
-              10,
-            ),
+            data_broker_total_num: CONST_ONEREP_DATA_BROKER_COUNT,
           },
           elems: {
             a:
               typeof props.totalNumberOfPerformedScans === "undefined" ||
               props.totalNumberOfPerformedScans <
-                parseInt(
-                  process.env.NEXT_PUBLIC_ONEREP_MAX_SCANS_THRESHOLD as string,
-                  10,
-                ) ? (
+                CONST_ONEREP_MAX_SCANS_THRESHOLD ? (
                 <a
                   ref={waitlistTriggerRef}
                   href="/redesign/user/welcome/free-scan?referrer=dashboard"

--- a/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/automatic-remove/AutomaticRemoveView.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/automatic-remove/AutomaticRemoveView.tsx
@@ -9,6 +9,7 @@ import styles from "../dataBrokerProfiles.module.scss";
 import { Button } from "../../../../../../../../../components/client/Button";
 import { useL10n } from "../../../../../../../../../hooks/l10n";
 import { FixView } from "../../FixView";
+import { CONST_ONEREP_DATA_BROKER_COUNT } from "../../../../../../../../../../constants";
 
 export type Props = Omit<ComponentProps<typeof FixView>, "children"> & {
   monthlySubscriptionUrl: string;
@@ -20,10 +21,7 @@ export function AutomaticRemoveView(props: Props) {
 
   const [selectedPlanIsYearly, setSelectedPlanIsYearly] = useState(true);
 
-  const dataBrokerCount = parseInt(
-    process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
-    10,
-  );
+  const dataBrokerCount = CONST_ONEREP_DATA_BROKER_COUNT;
 
   const { monthlySubscriptionUrl, yearlySubscriptionUrl, ...fixViewProps } =
     props;

--- a/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/start-free-scan/StartFreeScanView.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/start-free-scan/StartFreeScanView.tsx
@@ -15,6 +15,10 @@ import {
   getNextGuidedStep,
 } from "../../../../../../../../../functions/server/getRelevantGuidedSteps";
 import { useTelemetry } from "../../../../../../../../../hooks/useTelemetry";
+import {
+  CONST_URL_SUMO_HOW_IT_WORKS,
+  CONST_ONEREP_DATA_BROKER_COUNT,
+} from "../../../../../../../../../../constants";
 
 export type Props = {
   data: StepDeterminationData;
@@ -44,10 +48,7 @@ export function StartFreeScanView(props: Props) {
             {l10n.getString(
               "fix-flow-data-broker-profiles-start-free-scan-content-p1",
               {
-                data_broker_count: parseInt(
-                  process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
-                  10,
-                ),
+                data_broker_count: CONST_ONEREP_DATA_BROKER_COUNT,
               },
             )}
           </p>
@@ -56,7 +57,7 @@ export function StartFreeScanView(props: Props) {
               "fix-flow-data-broker-profiles-start-free-scan-content-p2",
             )}{" "}
             <a
-              href={process.env.NEXT_PUBLIC_HOW_IT_WORKS_SUMO_URL}
+              href={CONST_URL_SUMO_HOW_IT_WORKS}
               target="_blank"
               onClick={() => {
                 recordTelemetry("link", "click", {

--- a/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/AboutBrokersIcon.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/AboutBrokersIcon.tsx
@@ -15,6 +15,7 @@ import { useL10n } from "../../../../../../../../../hooks/l10n";
 import { ModalOverlay } from "../../../../../../../../../components/client/dialog/ModalOverlay";
 import { Dialog } from "../../../../../../../../../components/client/dialog/Dialog";
 import { Button } from "../../../../../../../../../components/client/Button";
+import { CONST_ONEREP_DATA_BROKER_COUNT } from "../../../../../../../../../../constants";
 
 export const AboutBrokersIcon = () => {
   const l10n = useL10n();
@@ -28,10 +29,7 @@ export const AboutBrokersIcon = () => {
   const triggerRef = useRef<HTMLButtonElement>(null);
   const { buttonProps } = useButton(triggerProps, triggerRef);
 
-  const dataBrokerCount = parseInt(
-    process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
-    10,
-  );
+  const dataBrokerCount = CONST_ONEREP_DATA_BROKER_COUNT;
 
   return (
     <>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/settings/EmailAddressAdder.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/settings/EmailAddressAdder.tsx
@@ -15,6 +15,7 @@ import { useL10n } from "../../../../../../hooks/l10n";
 import { ModalOverlay } from "../../../../../../components/client/dialog/ModalOverlay";
 import { Dialog } from "../../../../../../components/client/dialog/Dialog";
 import { onAddEmail } from "./actions";
+import { CONST_MAX_NUM_ADDRESSES } from "../../../../../../../constants";
 
 export const EmailAddressAdder = () => {
   const l10n = useL10n();
@@ -66,7 +67,7 @@ const EmailAddressAddForm = () => {
     <>
       <p>
         {l10n.getString("add-email-your-account-includes", {
-          total: process.env.NEXT_PUBLIC_MAX_NUM_ADDRESSES!,
+          total: CONST_MAX_NUM_ADDRESSES,
         })}
       </p>
       <form action={formAction} className={styles.newEmailAddressForm}>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/settings/View.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/settings/View.tsx
@@ -11,6 +11,7 @@ import { OpenInNew } from "../../../../../../components/server/Icons";
 import { EmailListing } from "./EmailListing";
 import { EmailAddressAdder } from "./EmailAddressAdder";
 import { AlertAddressForm } from "./AlertAddressForm";
+import { CONST_MAX_NUM_ADDRESSES } from "../../../../../../../constants";
 
 export type Props = {
   l10n: ExtendedReactLocalization;
@@ -43,7 +44,7 @@ export const SettingsView = (props: Props) => {
             <h3>{l10n.getString("settings-email-list-title")}</h3>
             <p className={styles.description}>
               {l10n.getString("settings-email-limit-info", {
-                limit: process.env.NEXT_PUBLIC_MAX_NUM_ADDRESSES!,
+                limit: CONST_MAX_NUM_ADDRESSES,
               })}
             </p>
           </div>

--- a/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/settings/actions.ts
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/(dashboard)/settings/actions.ts
@@ -21,6 +21,7 @@ import { initEmail } from "../../../../../../../utils/email";
 import { sendVerificationEmail } from "../../../../../../api/utils/email";
 import { getL10n } from "../../../../../../functions/server/l10n";
 import { logger } from "../../../../../../functions/server/logging";
+import { CONST_MAX_NUM_ADDRESSES } from "../../../../../../../constants";
 
 export type AddEmailFormState =
   | { success?: never }
@@ -71,10 +72,7 @@ export async function onAddEmail(
   const existingAddresses = [session.user.email]
     .concat(subscriber.email_addresses.map((emailRow) => emailRow.email))
     .map((address) => address.toLowerCase());
-  if (
-    existingAddresses.length >=
-    Number.parseInt(process.env.NEXT_PUBLIC_MAX_NUM_ADDRESSES!, 10)
-  ) {
+  if (existingAddresses.length >= CONST_MAX_NUM_ADDRESSES) {
     return {
       success: false,
       error: "too-many-emails",

--- a/src/app/(proper_react)/redesign/(authenticated)/user/welcome/[[...slug]]/page.tsx
+++ b/src/app/(proper_react)/redesign/(authenticated)/user/welcome/[[...slug]]/page.tsx
@@ -12,6 +12,7 @@ import { getCountryCode } from "../../../../../../functions/server/getCountryCod
 import { headers } from "next/headers";
 import { authOptions } from "../../../../../../api/utils/auth";
 import { getReferrerUrl } from "../../../../../../functions/server/getReferrerUrl";
+import { CONST_ONEREP_DATA_BROKER_COUNT } from "../../../../../../../constants";
 
 const FreeScanSlug = "free-scan" as const;
 
@@ -61,10 +62,7 @@ export default async function Onboarding({ params, searchParams }: Props) {
   return (
     <View
       user={session.user}
-      dataBrokerCount={parseInt(
-        process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
-        10,
-      )}
+      dataBrokerCount={CONST_ONEREP_DATA_BROKER_COUNT}
       breachesTotalCount={allBreachesCount}
       stepId={firstSlug === FreeScanSlug ? "enterInfo" : "getStarted"}
       previousRoute={previousRoute}

--- a/src/app/(proper_react)/redesign/(public)/Faq.tsx
+++ b/src/app/(proper_react)/redesign/(public)/Faq.tsx
@@ -10,6 +10,11 @@ import styles from "./Faq.module.scss";
 import { CloseBigIcon } from "../../../components/server/Icons";
 import { useTelemetry } from "../../../hooks/useTelemetry";
 import { useButton, useFocusRing } from "react-aria";
+import {
+  CONST_URL_SUMO_MONITOR_FAQ,
+  CONST_ONEREP_DATA_BROKER_COUNT,
+  CONST_URL_SUMO_MONITOR_PLUS,
+} from "../../../../constants";
 
 export type FaqItemProps = {
   question: string;
@@ -80,7 +85,7 @@ export const FaqSection = ({
       </b>
       <a
         className={styles.faqCta}
-        href={process.env.NEXT_PUBLIC_FAQ_MONITOR as string}
+        href={CONST_URL_SUMO_MONITOR_FAQ}
         target="_blank"
         onClick={() => {
           recordTelemetry("link", "click", {
@@ -115,20 +120,11 @@ export const FaqSection = ({
               "landing-premium-continuous-data-removal-ans",
               {
                 vars: {
-                  data_broker_sites_total_num: parseInt(
-                    process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
-                    10,
-                  ),
+                  data_broker_sites_total_num: CONST_ONEREP_DATA_BROKER_COUNT,
                 },
                 elems: {
                   learn_more_link: (
-                    <a
-                      href={
-                        process.env
-                          .NEXT_PUBLIC_LEARN_MORE_ABOUT_MONITOR_PLUS_URL
-                      }
-                      target="_blank"
-                    />
+                    <a href={CONST_URL_SUMO_MONITOR_PLUS} target="_blank" />
                   ),
                 },
               },

--- a/src/app/(proper_react)/redesign/(public)/PlansTable.tsx
+++ b/src/app/(proper_react)/redesign/(public)/PlansTable.tsx
@@ -55,6 +55,7 @@ import {
 import { getLocale } from "../../../functions/universal/getLocale";
 import { Button } from "../../../components/client/Button";
 import { signIn } from "next-auth/react";
+import { CONST_ONEREP_DATA_BROKER_COUNT } from "../../../../constants";
 
 export type Props = {
   "aria-labelledby": string;
@@ -202,8 +203,7 @@ export const PlansTable = (props: Props & ScanLimitProp) => {
                     {
                       elems: { b: <b /> },
                       vars: {
-                        dataBrokerTotalCount: process.env
-                          .NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
+                        dataBrokerTotalCount: CONST_ONEREP_DATA_BROKER_COUNT,
                       },
                     },
                   )}
@@ -222,8 +222,7 @@ export const PlansTable = (props: Props & ScanLimitProp) => {
                     {
                       elems: { b: <b /> },
                       vars: {
-                        dataBrokerTotalCount: process.env
-                          .NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
+                        dataBrokerTotalCount: CONST_ONEREP_DATA_BROKER_COUNT,
                       },
                     },
                   )}
@@ -249,8 +248,7 @@ export const PlansTable = (props: Props & ScanLimitProp) => {
                       {l10n.getString(
                         "landing-premium-plans-table-feature-removal-plus-callout",
                         {
-                          dataBrokerTotalCount: process.env
-                            .NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
+                          dataBrokerTotalCount: CONST_ONEREP_DATA_BROKER_COUNT,
                         },
                       )}
                     </PopoverContent>
@@ -384,8 +382,7 @@ export const PlansTable = (props: Props & ScanLimitProp) => {
                     {
                       elems: { b: <b /> },
                       vars: {
-                        dataBrokerTotalCount: process.env
-                          .NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
+                        dataBrokerTotalCount: CONST_ONEREP_DATA_BROKER_COUNT,
                       },
                     },
                   )}
@@ -404,8 +401,7 @@ export const PlansTable = (props: Props & ScanLimitProp) => {
                     {
                       elems: { b: <b /> },
                       vars: {
-                        dataBrokerTotalCount: process.env
-                          .NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
+                        dataBrokerTotalCount: CONST_ONEREP_DATA_BROKER_COUNT,
                       },
                     },
                   )}
@@ -431,8 +427,7 @@ export const PlansTable = (props: Props & ScanLimitProp) => {
                       {l10n.getString(
                         "landing-premium-plans-table-feature-removal-plus-callout",
                         {
-                          dataBrokerTotalCount: process.env
-                            .NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
+                          dataBrokerTotalCount: CONST_ONEREP_DATA_BROKER_COUNT,
                         },
                       )}
                     </PopoverContent>
@@ -556,8 +551,7 @@ export const PlansTable = (props: Props & ScanLimitProp) => {
               {l10n.getString(
                 "landing-premium-plans-table-feature-scan-label",
                 {
-                  dataBrokerTotalCount: process.env
-                    .NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
+                  dataBrokerTotalCount: CONST_ONEREP_DATA_BROKER_COUNT,
                 },
               )}
             </Cell>
@@ -597,8 +591,7 @@ export const PlansTable = (props: Props & ScanLimitProp) => {
                   {l10n.getString(
                     "landing-premium-plans-table-feature-removal-plus-callout",
                     {
-                      dataBrokerTotalCount: process.env
-                        .NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
+                      dataBrokerTotalCount: CONST_ONEREP_DATA_BROKER_COUNT,
                     },
                   )}
                 </PopoverContent>

--- a/src/app/(proper_react)/redesign/(public)/ScanLimit.tsx
+++ b/src/app/(proper_react)/redesign/(public)/ScanLimit.tsx
@@ -8,6 +8,7 @@ import styles from "./LandingView.module.scss";
 import { useL10n } from "../../../hooks/l10n";
 import { Button } from "../../../components/client/Button";
 import { useTelemetry } from "../../../hooks/useTelemetry";
+import { CONST_URL_WAITLIST } from "../../../../constants";
 
 export const ScanLimit = () => {
   const l10n = useL10n();
@@ -31,7 +32,7 @@ export const WaitlistCta = () => {
     <Button
       className={styles.waitlistCta}
       variant="primary"
-      href={process.env.NEXT_PUBLIC_WAITLIST_URL}
+      href={CONST_URL_WAITLIST}
       onPress={() => {
         record("ctaButton", "click", {
           button_id: "intent_to_join_waitlist_header",

--- a/src/app/(proper_react)/redesign/Footer.tsx
+++ b/src/app/(proper_react)/redesign/Footer.tsx
@@ -6,6 +6,12 @@ import styles from "./Shell.module.scss";
 import Image from "next/image";
 import mozillaLogo from "../images/mozilla-logo.svg";
 import { ExtendedReactLocalization } from "../../hooks/l10n";
+import {
+  CONST_URL_SUMO_MONITOR_FAQ,
+  CONST_URL_MONITOR_GITHUB,
+  CONST_URL_TERMS,
+  CONST_URL_PRIVACY_POLICY,
+} from "../../../constants";
 
 export const Footer = ({ l10n }: { l10n: ExtendedReactLocalization }) => {
   return (
@@ -20,7 +26,7 @@ export const Footer = ({ l10n }: { l10n: ExtendedReactLocalization }) => {
       <ul className={styles.externalLinks}>
         <li>
           <a
-            href={process.env.NEXT_PUBLIC_MONITOR_FAQ}
+            href={CONST_URL_SUMO_MONITOR_FAQ}
             target="_blank"
             title={l10n.getString("footer-external-link-faq-tooltip")}
           >
@@ -28,20 +34,17 @@ export const Footer = ({ l10n }: { l10n: ExtendedReactLocalization }) => {
           </a>
         </li>
         <li>
-          <a href={process.env.NEXT_PUBLIC_MONITOR_LEGAL} target="_blank">
+          <a href={CONST_URL_TERMS} target="_blank">
             {l10n.getString("terms-of-service")}
           </a>
         </li>
         <li>
-          <a
-            href={process.env.NEXT_PUBLIC_MONITOR_SUBSCRIPTION_SERVICES}
-            target="_blank"
-          >
+          <a href={CONST_URL_PRIVACY_POLICY} target="_blank">
             {l10n.getString("privacy-notice")}
           </a>
         </li>
         <li>
-          <a href={process.env.NEXT_PUBLIC_MONITOR_GITHUB} target="_blank">
+          <a href={CONST_URL_MONITOR_GITHUB} target="_blank">
             {l10n.getString("github")}
           </a>
         </li>

--- a/src/app/(proper_react)/redesign/GaScript.tsx
+++ b/src/app/(proper_react)/redesign/GaScript.tsx
@@ -5,6 +5,7 @@
 "use client";
 
 import Script from "next/script";
+import { CONST_GA4_MEASUREMENT_ID } from "../../../constants";
 
 export type Props = {
   nonce: string;
@@ -12,8 +13,7 @@ export type Props = {
 
 export const GaScript = ({ nonce }: Props) => {
   /* c8 ignore next 2 */
-  const ga4MeasurementId =
-    process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID || "G-CXG8K4KW4P";
+  const ga4MeasurementId = CONST_GA4_MEASUREMENT_ID || "G-CXG8K4KW4P";
 
   return typeof navigator !== "undefined" && navigator.doNotTrack !== "1" ? (
     <Script

--- a/src/app/api/v1/user/email/route.ts
+++ b/src/app/api/v1/user/email/route.ts
@@ -15,6 +15,7 @@ import { validateEmailAddress } from "../../../../../utils/emailAddress";
 import { getL10n } from "../../../../functions/server/l10n";
 import { initEmail } from "../../../../../utils/email";
 import { Subscriber } from "../../../../(nextjs_migration)/(authenticated)/user/breaches/breaches";
+import { CONST_MAX_NUM_ADDRESSES } from "../../../../../constants";
 
 interface EmailAddRequest {
   email: string;
@@ -45,10 +46,7 @@ export async function POST(req: NextRequest) {
         );
       }
 
-      if (
-        emailCount >=
-        Number.parseInt(AppConstants.NEXT_PUBLIC_MAX_NUM_ADDRESSES, 10)
-      ) {
+      if (emailCount >= CONST_MAX_NUM_ADDRESSES) {
         return NextResponse.json(
           {
             success: false,

--- a/src/app/components/client/Chart.tsx
+++ b/src/app/components/client/Chart.tsx
@@ -19,6 +19,10 @@ import ModalImage from "../client/assets/modal-default-img.svg";
 import { DashboardSummary } from "../../functions/server/dashboard";
 import { WaitlistDialog } from "./SubscriberWaitlistDialog";
 import { useTelemetry } from "../../hooks/useTelemetry";
+import {
+  CONST_MAX_NUM_ADDRESSES,
+  CONST_ONEREP_MAX_SCANS_THRESHOLD,
+} from "../../../constants";
 
 export type Props = {
   data: Array<[string, number]>;
@@ -106,7 +110,7 @@ export const DoughnutChart = (props: Props) => {
             ? "modal-active-number-of-exposures-part-one-premium"
             : "modal-active-number-of-exposures-part-one-all",
           {
-            limit: process.env.NEXT_PUBLIC_MAX_NUM_ADDRESSES!,
+            limit: CONST_MAX_NUM_ADDRESSES,
           },
         )}
       </p>
@@ -154,10 +158,7 @@ export const DoughnutChart = (props: Props) => {
           </p>
           {typeof props.totalNumberOfPerformedScans === "undefined" ||
           props.totalNumberOfPerformedScans <
-            parseInt(
-              process.env.NEXT_PUBLIC_ONEREP_MAX_SCANS_THRESHOLD as string,
-              10,
-            ) ? (
+            CONST_ONEREP_MAX_SCANS_THRESHOLD ? (
             <Link
               href="/redesign/user/welcome/free-scan?referrer=dashboard"
               onClick={() => {

--- a/src/app/components/client/ExposuresFilterExplainer.tsx
+++ b/src/app/components/client/ExposuresFilterExplainer.tsx
@@ -11,6 +11,7 @@ import { useL10n } from "../../hooks/l10n";
 import { ModalOverlay } from "./dialog/ModalOverlay";
 import { Dialog } from "./dialog/Dialog";
 import { Button } from "../client/Button";
+import { CONST_ONEREP_DATA_BROKER_COUNT } from "../../../constants";
 
 type ExposuresFilterTypeExplainerProps = {
   explainerDialogState: OverlayTriggerState;
@@ -38,10 +39,7 @@ export const ExposuresFilterTypeExplainer = (
         <div className={styles.modalBodyContent}>
           <p>
             {l10n.getString("modal-exposure-type-description", {
-              data_broker_sites_total_num: parseInt(
-                process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
-                10,
-              ),
+              data_broker_sites_total_num: CONST_ONEREP_DATA_BROKER_COUNT,
             })}
           </p>
           <br />
@@ -102,10 +100,7 @@ export const ExposuresFilterStatusExplainer = (
                 ? "modal-exposure-status-description-premium"
                 : "modal-exposure-status-description-all",
               {
-                data_broker_sites_total_num: parseInt(
-                  process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
-                  10,
-                ),
+                data_broker_sites_total_num: CONST_ONEREP_DATA_BROKER_COUNT,
               },
             )}
           </p>

--- a/src/app/components/client/SubscriberWaitlistDialog.tsx
+++ b/src/app/components/client/SubscriberWaitlistDialog.tsx
@@ -13,6 +13,7 @@ import { ModalOverlay } from "./dialog/ModalOverlay";
 import ModalImage from "../client/assets/subscriber-waitlist-dialog-icon.svg";
 import { useL10n } from "../../hooks/l10n";
 import styles from "./SubscriberWaitlistDialog.module.scss";
+import { CONST_URL_WAITLIST } from "../../../constants";
 
 export function WaitlistDialog({
   dialogTriggerState,
@@ -40,10 +41,7 @@ export function WaitlistDialog({
               {l10n.getString("subscriber-waitlist-dialog-instruction-text")}
             </p>
             <div className={styles.buttonWrapper}>
-              <Button
-                variant="primary"
-                href={process.env.NEXT_PUBLIC_WAITLIST_URL}
-              >
+              <Button variant="primary" href={CONST_URL_WAITLIST}>
                 {l10n.getString("subscriber-waitlist-dialog-cta-button-label")}
               </Button>
               <Button

--- a/src/app/components/client/UpsellDialog.tsx
+++ b/src/app/components/client/UpsellDialog.tsx
@@ -15,6 +15,7 @@ import { useL10n } from "../../hooks/l10n";
 import ModalImage from "../client/assets/premium-upsell-dialog-icon.svg";
 import styles from "./UpsellDialog.module.scss";
 import { useTelemetry } from "../../hooks/useTelemetry";
+import { CONST_ONEREP_DATA_BROKER_COUNT } from "../../../constants";
 
 export interface UpsellDialogProps {
   state: OverlayTriggerState;
@@ -120,10 +121,7 @@ function UpsellDialogContent({
           {l10n.getString(
             "fix-flow-data-broker-profiles-automatic-remove-features-monthly-scan",
             {
-              data_broker_count: parseInt(
-                process.env.NEXT_PUBLIC_ONEREP_DATA_BROKER_COUNT as string,
-                10,
-              ),
+              data_broker_count: CONST_ONEREP_DATA_BROKER_COUNT,
             },
           )}
         </dd>

--- a/src/app/components/client/toolbar/UserMenu.tsx
+++ b/src/app/components/client/toolbar/UserMenu.tsx
@@ -31,6 +31,7 @@ import OpenInIcon from "./images/menu-icon-open-in.svg";
 import SettingsIcon from "./images/menu-icon-settings.svg";
 import HelpIcon from "./images/menu-icon-help.svg";
 import SignOutIcon from "./images/menu-icon-signout.svg";
+import { CONST_URL_SUMO_MONITOR_SUPPORT } from "../../../../constants";
 
 export type UserMenuProps = {
   user: Session["user"];
@@ -113,7 +114,7 @@ export const UserMenu = (props: UserMenuProps) => {
       >
         <a
           className={styles.menuItemCta}
-          href={process.env.NEXT_PUBLIC_MONITOR_SUPPORT_URL}
+          href={CONST_URL_SUMO_MONITOR_SUPPORT}
           ref={helpItemRef}
           rel="noopener noreferrer"
           target="_blank"

--- a/src/app/hooks/useGa.ts
+++ b/src/app/hooks/useGa.ts
@@ -5,6 +5,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { CONST_GA4_MEASUREMENT_ID } from "../../constants";
 
 declare global {
   interface Window {
@@ -69,8 +70,7 @@ export const useGa = (): {
 
     if (!window.gtag) {
       /* c8 ignore next 2 */
-      const ga4MeasurementId =
-        process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID || "G-CXG8K4KW4P";
+      const ga4MeasurementId = CONST_GA4_MEASUREMENT_ID || "G-CXG8K4KW4P";
       initGa4({ ga4MeasurementId, debugMode });
     }
   }, [debugMode]);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { PublicEnvProvider } from "../contextProviders/public-env";
 import { SessionProvider } from "../contextProviders/session";
 import { authOptions } from "./api/utils/auth";
 import { metropolis } from "./fonts/Metropolis/metropolis";
+import { CONST_GA4_MEASUREMENT_ID } from "../constants";
 
 // DO NOT ADD SECRETS: Env variables added here become public.
 const PUBLIC_ENVS = {
@@ -61,7 +62,7 @@ export default async function RootLayout({
         className={`${inter.className} ${inter.variable} ${metropolis.variable}`}
         // DO NOT ADD SECRETS HERE: The following data attributes expose
         // variables that are being used in the public analytics scripts
-        data-ga4-measurement-id={process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID}
+        data-ga4-measurement-id={CONST_GA4_MEASUREMENT_ID}
         data-node-env={process.env.NODE_ENV}
       >
         <PublicEnvProvider publicEnvs={PUBLIC_ENVS}>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const CONST_ONEREP_MAX_SCANS_THRESHOLD = 280000 as const;
+export const CONST_MAX_NUM_ADDRESSES = 5 as const;
+export const CONST_GA4_MEASUREMENT_ID = "G-CXG8K4KW4P" as const;
+export const CONST_ONEREP_DATA_BROKER_COUNT = 190 as const;
+export const CONST_URL_SUMO_MONITOR_SUPPORT =
+  "https://support.mozilla.org/kb/firefox-monitor" as const;
+export const CONST_URL_SUMO_HOW_IT_WORKS =
+  "https://support.mozilla.org/kb/how-does-monitor-plus-work" as const;
+export const CONST_URL_SUMO_MONITOR_FAQ =
+  "https://support.mozilla.org/kb/firefox-monitor-faq" as const;
+export const CONST_URL_SUMO_MONITOR_PLUS =
+  "https://support.mozilla.org/kb/how-does-monitor-plus-work" as const;
+export const CONST_URL_WAITLIST =
+  "https://www.mozilla.org/products/monitor/waitlist-scan/" as const;
+export const CONST_URL_TERMS =
+  "https://www.mozilla.org/about/legal/terms/subscription-services/" as const;
+export const CONST_URL_PRIVACY_POLICY =
+  "https://www.mozilla.org/privacy/subscription-services/" as const;
+export const CONST_URL_MONITOR_GITHUB =
+  "https://github.com/mozilla/blurts-server" as const;


### PR DESCRIPTION
We used NEXT_PUBLIC_* env vars for values that:

- were the same across environments, and
- we wanted to easily change.

In other words, they were essentially constants. By turning them into regular, statically-analysable, JS variables, they:

- can easily be renamed,
- are known to be defined and thus don't need non-null or type assertions, and
- can have non-string values, removing the need to e.g. parse integers,
- are more explicitly the same in every environment, avoiding the temptation to attempt (and fail) to set environment-specific env vars to override them.

We'll also no longer have to tell people to copy the values over to their personal `.env` files.