### PR TITLE
Remove OneRep ID on deletion via API

### DIFF
--- a/src/app/api/v1/admin/users/[primarySha1]/route.ts
+++ b/src/app/api/v1/admin/users/[primarySha1]/route.ts
@@ -7,6 +7,7 @@ import { getServerSession } from "next-auth";
 import { logger } from "../../../../../functions/server/logging";
 import { isAdmin, authOptions } from "../../../../utils/auth";
 import {
+  deleteOnerepProfileId,
   deleteSubscriber,
   getOnerepProfileId,
   getSubscribersByHashes,
@@ -15,7 +16,6 @@ import {
   activateAndOptoutProfile,
   deactivateProfile,
 } from "../../../../../functions/server/onerep";
-import { captureException } from "@sentry/node";
 import { deleteProfileDetails } from "../../../../../../db/tables/onerep_profiles";
 import {
   deleteScanResultsForProfile,
@@ -135,6 +135,7 @@ export async function PUT(
           }
           case "delete_onerep_profile": {
             await deleteProfileDetails(onerepProfileId);
+            await deleteOnerepProfileId(subscriber.id);
             logger.info("delete_onerep_profile", {
               onerepProfileId,
               primarySha1,
@@ -171,8 +172,8 @@ export async function PUT(
           }
         }
       }
-    } catch (ex) {
-      captureException(ex);
+    } catch (e) {
+      logger.error(e);
       return NextResponse.json({ success: false }, { status: 500 });
     }
 

--- a/src/db/tables/subscribers.js
+++ b/src/db/tables/subscribers.js
@@ -549,6 +549,24 @@ async function joinEmailAddressesToSubscriber (subscriber) {
 }
 /* c8 ignore stop */
 
+/* c8 ignore start */
+/**
+ * @param {number} subscriberId
+ */
+// Not covered by tests; mostly side-effects. See test-coverage.md#mock-heavy
+/* c8 ignore start */
+async function deleteOnerepProfileId (subscriberId) {
+  return await knex('subscribers')
+    .where('id', subscriberId)
+    .update({
+      onerep_profile_id: null,
+      // @ts-ignore knex.fn.now() results in it being set to a date,
+      // even if it's not typed as a JS date object:
+      updated_at: knex.fn.now(),
+    })
+}
+/* c8 ignore stop */
+
 export {
   getOnerepProfileId,
   getSubscriberByToken,
@@ -577,5 +595,6 @@ export {
   deleteUnverifiedSubscribers,
   deleteSubscriber,
   deleteResolutionsWithEmail,
+  deleteOnerepProfileId,
   knex as knexSubscribers
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When adding a new feature: -->

# Description

This API currently deletes the remote profile, but does not remove the ID stored on the Monitor side.

I've also improved the logging to make it easier to determine why things are failing and for better auditing.

# Screenshot (if applicable)

Not applicable.

# How to test

Try a payload such as:
```
{
  "actions": [
    "unsubscribe",
    "delete_onerep_profile",
    "delete_onerep_scan_results",
    "delete_onerep_scans"
  ]
}
```

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
