### PR TITLE
MNTOR-2627: don't send fxa user id to sentry

### DIFF
--- a/src/app/api/v1/fxa-rp-events/route.ts
+++ b/src/app/api/v1/fxa-rp-events/route.ts
@@ -170,7 +170,6 @@ export async function POST(request: NextRequest) {
       `could not find subscriber with fxa user id: ${fxaUserId}`,
     );
     logger.error("fxaRpEvents", e);
-    captureException(e);
     return NextResponse.json({ success: true, message: "OK" }, { status: 200 });
   }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2627


<!-- When adding a new feature: -->

# Description
Don't send fxa user id to sentry. We'd want to capture in gcp logs though

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
