### PR TITLE
Add banner announcing "Mozilla Monitor" rebrand

### DIFF
--- a/src/app/(proper_react)/(redesign)/(public)/LandingView.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingView.stories.tsx
@@ -11,6 +11,7 @@ const meta: Meta<typeof View> = {
   component: View,
   args: {
     l10n: getOneL10nSync(),
+    enabledFlags: ["RebrandAnnouncement"],
   },
 };
 

--- a/src/app/(proper_react)/(redesign)/(public)/LandingView.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingView.test.tsx
@@ -12,6 +12,7 @@ import {
   queryByText,
   render,
   screen,
+  within,
 } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { axe } from "jest-axe";
@@ -162,6 +163,39 @@ describe("When Premium is not available", () => {
     await user.click(signInButton);
 
     expect(signIn).toHaveBeenCalledTimes(1);
+  });
+
+  it("displays a banner announcing the rebrand to 'Mozilla Monitor' by default", () => {
+    const ComposedDashboard = composeStory(LandingNonUs, Meta);
+    render(<ComposedDashboard />);
+
+    const rebrandAnnouncement = screen.getByText(
+      "New name, look and even more ways to",
+      { exact: false },
+    );
+
+    expect(rebrandAnnouncement).toBeInTheDocument();
+  });
+
+  it("hides the banner announcing the rebrand to 'Mozilla Monitor' after clicking the dismiss button", async () => {
+    const ComposedDashboard = composeStory(LandingNonUs, Meta);
+    render(<ComposedDashboard />);
+
+    const rebrandAnnouncement = screen
+      .getAllByRole("complementary")
+      .find((el) =>
+        el.textContent?.includes(
+          "⁨Mozilla Monitor⁩: New name, look and even more ways to reclaim your privacy.",
+        ),
+      )!;
+    const dismissButton = within(rebrandAnnouncement).getByRole("button", {
+      name: "OK",
+    });
+
+    const user = userEvent.setup();
+    await user.click(dismissButton);
+
+    expect(rebrandAnnouncement).not.toBeInTheDocument();
   });
 
   it("shows the german scanning for exposures illustration", () => {

--- a/src/app/(proper_react)/(redesign)/(public)/LandingView.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingView.test.tsx
@@ -42,6 +42,14 @@ beforeEach(() => {
   // long debugging that already, so I'm settling for this :(
   const mockedUseSession = useSession as jest.Mock;
   mockedUseSession.mockReturnValue({});
+
+  // Delete all cookies, to make the rebrand announcement banner show up by
+  // default (I hate the document.cookie API ¬_¬):
+  const cookieParts = document.cookie.split(";");
+  const cookieNames = cookieParts.map((part) => part.split("=")[0]);
+  cookieNames.forEach((cookieName) => {
+    document.cookie = `${cookieName}=; Thu, 01 Jan 1970 00:00:00 GMT`;
+  });
 });
 
 describe("When Premium is not available", () => {
@@ -196,6 +204,30 @@ describe("When Premium is not available", () => {
     await user.click(dismissButton);
 
     expect(rebrandAnnouncement).not.toBeInTheDocument();
+  });
+
+  it("counts how often people close the banner announcing the rebrand to `'Mozilla Monitor'", async () => {
+    const mockedRecord = useTelemetry();
+    const ComposedDashboard = composeStory(LandingNonUs, Meta);
+    render(<ComposedDashboard />);
+
+    const rebrandAnnouncement = screen.getByText(
+      "New name, look and even more ways to",
+      { exact: false },
+    );
+    const dismissButton = within(rebrandAnnouncement.parentElement!).getByRole(
+      "button",
+      { name: "OK" },
+    );
+
+    const user = userEvent.setup();
+    await user.click(dismissButton);
+
+    expect(mockedRecord).toHaveBeenCalledWith(
+      "button",
+      "click",
+      expect.objectContaining({ button_id: "rebrand_announcement_dismiss" }),
+    );
   });
 
   it("shows the german scanning for exposures illustration", () => {

--- a/src/app/(proper_react)/(redesign)/(public)/LandingView.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingView.tsx
@@ -26,6 +26,7 @@ import { ScanLimit } from "./ScanLimit";
 import { Footer } from "../Footer";
 import { FaqSection } from "./Faq";
 import { SignInButton } from "../../../components/client/SignInButton";
+import { RebrandAnnouncement } from "./RebrandAnnouncement";
 
 export type Props = {
   eligibleForPremium: boolean;
@@ -246,6 +247,7 @@ export const View = (props: Props) => {
         />
       </div>
       <Footer l10n={props.l10n} />
+      <RebrandAnnouncement />
     </main>
   );
 };

--- a/src/app/(proper_react)/(redesign)/(public)/LandingView.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingView.tsx
@@ -27,12 +27,14 @@ import { Footer } from "../Footer";
 import { FaqSection } from "./Faq";
 import { SignInButton } from "../../../components/client/SignInButton";
 import { RebrandAnnouncement } from "./RebrandAnnouncement";
+import { FeatureFlagName } from "../../../../db/tables/featureFlags";
 
 export type Props = {
   eligibleForPremium: boolean;
   l10n: ExtendedReactLocalization;
   countryCode: string;
   scanLimitReached: boolean;
+  enabledFlags: FeatureFlagName[];
 };
 
 export const View = (props: Props) => {
@@ -247,7 +249,9 @@ export const View = (props: Props) => {
         />
       </div>
       <Footer l10n={props.l10n} />
-      <RebrandAnnouncement />
+      {props.enabledFlags.includes("RebrandAnnouncement") && (
+        <RebrandAnnouncement />
+      )}
     </main>
   );
 };

--- a/src/app/(proper_react)/(redesign)/(public)/RebrandAnnouncement.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/RebrandAnnouncement.module.scss
@@ -1,0 +1,38 @@
+@import "../../../tokens";
+
+.rebrandAnnouncement {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-xs;
+  padding: $spacing-lg;
+  background-color: $color-blue-20;
+  font: $text-body-lg;
+
+  @media screen and (max-width: $screen-md) {
+    // (button width) + (.rebrandAnnouncement gap) + (2 * inline button padding)
+    padding-inline-end: calc(24px + calc($spacing-xs + calc(2 * $spacing-sm)));
+
+    button {
+      position: absolute;
+      inset-block-start: $spacing-sm;
+      inset-inline-end: $spacing-sm;
+    }
+  }
+
+  button {
+    flex: 0 0 auto;
+    width: 24px;
+    height: 24px;
+    background-color: transparent;
+    border-style: none;
+    cursor: pointer;
+
+    &:hover svg {
+      color: $color-white;
+    }
+  }
+}

--- a/src/app/(proper_react)/(redesign)/(public)/RebrandAnnouncement.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/RebrandAnnouncement.tsx
@@ -9,9 +9,11 @@ import { CloseBtn } from "../../../components/server/Icons";
 import { useL10n } from "../../../hooks/l10n";
 import { useLocalDismissal } from "../../../hooks/useLocalDismissal";
 import { useHasRenderedClientSide } from "../../../hooks/useHasRenderedClientSide";
+import { useTelemetry } from "../../../hooks/useTelemetry";
 
 export const RebrandAnnouncement = () => {
   const l10n = useL10n();
+  const recordTelemetry = useTelemetry();
   const dismissal = useLocalDismissal("mozilla-monitor-rebrand", {
     duration: Number.MAX_SAFE_INTEGER,
   });
@@ -30,7 +32,12 @@ export const RebrandAnnouncement = () => {
         })}
       </span>
       <button
-        onClick={() => dismissal.dismiss()}
+        onClick={() => {
+          recordTelemetry("button", "click", {
+            button_id: "rebrand_announcement_dismiss",
+          });
+          dismissal.dismiss();
+        }}
         title={l10n.getString("banner-monitor-rebrand-dismiss-button-tooltip")}
       >
         <CloseBtn

--- a/src/app/(proper_react)/(redesign)/(public)/RebrandAnnouncement.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/RebrandAnnouncement.tsx
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use client";
+
+import styles from "./RebrandAnnouncement.module.scss";
+import { CloseBtn } from "../../../components/server/Icons";
+import { useL10n } from "../../../hooks/l10n";
+import { useLocalDismissal } from "../../../hooks/useLocalDismissal";
+import { useHasRenderedClientSide } from "../../../hooks/useHasRenderedClientSide";
+
+export const RebrandAnnouncement = () => {
+  const l10n = useL10n();
+  const dismissal = useLocalDismissal("mozilla-monitor-rebrand", {
+    duration: Number.MAX_SAFE_INTEGER,
+  });
+  // Prevent a flash of a pre-rendered banner if the user has already dismissed it:
+  const hasRenderedClientSide = useHasRenderedClientSide();
+
+  if (!hasRenderedClientSide || dismissal.isDismissed) {
+    return null;
+  }
+
+  return (
+    <aside className={styles.rebrandAnnouncement}>
+      <span>
+        {l10n.getFragment("banner-monitor-rebrand-text", {
+          elems: { b: <b /> },
+        })}
+      </span>
+      <button
+        onClick={() => dismissal.dismiss()}
+        title={l10n.getString("banner-monitor-rebrand-dismiss-button-tooltip")}
+      >
+        <CloseBtn
+          alt={l10n.getString("banner-monitor-rebrand-dismiss-button-label")}
+        />
+      </button>
+    </aside>
+  );
+};

--- a/src/app/(proper_react)/(redesign)/(public)/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/page.tsx
@@ -38,6 +38,7 @@ export default async function Page() {
       l10n={getL10n()}
       countryCode={countryCode}
       scanLimitReached={scanLimitReached}
+      enabledFlags={enabledFlags}
     />
   );
 }

--- a/src/app/hooks/useHasRenderedClientSide.tsx
+++ b/src/app/hooks/useHasRenderedClientSide.tsx
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useEffect, useState } from "react";
+
+/**
+ * Hook to help selectively opting out of static site generation
+ *
+ * Sometimes you want to adapt the appearance of a component based on specific
+ * characteristics of the user's in-browser environment. However, this can
+ * cause problems: we pre-render our components to static HTML before sending
+ * them to the user, and then React re-renders the components on the client-
+ * side, and matches the resulting HTML with the HTML that we already sent to
+ * the browser. If those two don't align, that can cause hydration errors; see
+ * https://nextjs.org/docs/messages/react-hydration-error?trk=public_post_comment-text
+ *
+ * To avoid this, you can use this hook to defer client-side adjustments until
+ * after* hydration. That way, React knows how the adjustments are different
+ * from the initial render, and can apply just those changes.
+ *
+ * @returns Whether the component has already rendered client-side; if `true`,
+ *          subsequent renders are guaranteed to be on the client-side.
+ */
+export function useHasRenderedClientSide() {
+  const [hasRenderedClientSide, setHasRenderedClientSide] = useState(false);
+
+  useEffect(() => {
+    setHasRenderedClientSide(true);
+  }, []);
+
+  return hasRenderedClientSide;
+}

--- a/src/app/hooks/useLocalDismissal.test.tsx
+++ b/src/app/hooks/useLocalDismissal.test.tsx
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { act, renderHook } from "@testing-library/react";
+import { useLocalDismissal } from "./useLocalDismissal";
+import { useCookies } from "react-cookie";
+
+jest.mock("react-cookie", () => {
+  return {
+    useCookies: jest.fn(),
+  };
+});
+
+const mockedUseCookies = useCookies as jest.Mock;
+
+describe("useLocalDismissal", () => {
+  it("marks a dismissal as dismissed if the dismissal cookie is present", () => {
+    mockedUseCookies.mockReturnValueOnce([
+      { some_key_dismissed: Date.now().toString() },
+    ]);
+    const { result } = renderHook(() => useLocalDismissal("some_key"));
+
+    const dismissal = result.current;
+    expect(dismissal.isDismissed).toBe(true);
+  });
+
+  it("marks a dismissal as dismissed if the dismissal cookie is present and returned as a number (see https://github.com/bendotcodes/cookies/issues/448)", () => {
+    mockedUseCookies.mockReturnValueOnce([{ some_key_dismissed: Date.now() }]);
+    const { result } = renderHook(() => useLocalDismissal("some_key"));
+
+    const dismissal = result.current;
+    expect(dismissal.isDismissed).toBe(true);
+  });
+
+  it("does not mark a dismissal as dismissed if the dismissal cookie is present, but too far in the past", () => {
+    // The dismissal cookie should have been set more than a second (the
+    // `duration`) ago:
+    mockedUseCookies.mockReturnValueOnce([
+      { some_key_dismissed: (Date.now() - 1001).toString() },
+    ]);
+    const { result } = renderHook(() =>
+      useLocalDismissal("some_key", { duration: 1 }),
+    );
+
+    const dismissal = result.current;
+    expect(dismissal.isDismissed).toBe(false);
+  });
+
+  it("immediately marks a dismissal as dismissed by default", () => {
+    mockedUseCookies.mockReturnValue([{}, jest.fn()]);
+    const { result } = renderHook(() => useLocalDismissal("arbitrary_key"));
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    const dismissal = result.current;
+    expect(dismissal.isDismissed).toBe(true);
+  });
+
+  it("sets a cookie with a default expiration time of 100 years", () => {
+    const mockedSetCookie = jest.fn();
+    mockedUseCookies.mockReturnValue([{}, mockedSetCookie]);
+    const { result } = renderHook(() => useLocalDismissal("some_key"));
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    expect(mockedSetCookie).toHaveBeenCalledWith(
+      "some_key_dismissed",
+      expect.any(String),
+      { maxAge: 100 * 365 * 24 * 60 * 60 },
+    );
+  });
+
+  it("sets the cookie's expiration time to the given value", () => {
+    const mockedSetCookie = jest.fn();
+    mockedUseCookies.mockReturnValue([{}, mockedSetCookie]);
+    const { result } = renderHook(() =>
+      useLocalDismissal("some_key", { duration: 1337 }),
+    );
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    expect(mockedSetCookie).toHaveBeenCalledWith(
+      "some_key_dismissed",
+      expect.any(String),
+      { maxAge: 1337 },
+    );
+  });
+
+  it("does not immediately mark a dismissal as dismissed if the `soft` option is passed", () => {
+    mockedUseCookies.mockReturnValue([{}, jest.fn()]);
+    const { result } = renderHook(() => useLocalDismissal("arbitrary_key"));
+
+    act(() => {
+      result.current.dismiss({ soft: true });
+    });
+
+    const dismissal = result.current;
+    expect(dismissal.isDismissed).toBe(false);
+  });
+
+  it("sets a cookie with a default expiration time of 100 years, also for `soft` dismissals", () => {
+    const mockedSetCookie = jest.fn();
+    mockedUseCookies.mockReturnValue([{}, mockedSetCookie]);
+    const { result } = renderHook(() => useLocalDismissal("some_key"));
+
+    act(() => {
+      result.current.dismiss({ soft: true });
+    });
+
+    expect(mockedSetCookie).toHaveBeenCalledWith(
+      "some_key_dismissed",
+      expect.any(String),
+      { maxAge: 100 * 365 * 24 * 60 * 60 },
+    );
+  });
+
+  it("sets the cookie's expiration time to the given value, also for `soft` dismissals", () => {
+    const mockedSetCookie = jest.fn();
+    mockedUseCookies.mockReturnValue([{}, mockedSetCookie]);
+    const { result } = renderHook(() =>
+      useLocalDismissal("some_key", { duration: 1337 }),
+    );
+
+    act(() => {
+      result.current.dismiss({ soft: true });
+    });
+
+    expect(mockedSetCookie).toHaveBeenCalledWith(
+      "some_key_dismissed",
+      expect.any(String),
+      { maxAge: 1337 },
+    );
+  });
+});

--- a/src/app/hooks/useLocalDismissal.ts
+++ b/src/app/hooks/useLocalDismissal.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useState } from "react";
+import { useCookies } from "react-cookie";
+
+export type DismissOptions = {
+  /** If true, the dismissal won't take effect right away, but the cookie to store the dismissal _will_ be set. */
+  soft?: boolean;
+};
+
+export type DismissalData = {
+  isDismissed: boolean;
+  dismiss: (options?: DismissOptions) => void;
+};
+
+export type DismissalOptions = {
+  /** How long the dismissal should last, in seconds. Note that by default, the cookie will be deleted in 30 days. */
+  duration?: number;
+};
+
+/**
+ * This can be used to store a cookie to remember that something was dismissed.
+ *
+ * @param key Key to identity the item-to-be-dismissed with (i.e. to use in the cookie name). Tip: incorporate the user's ID to make a dismissal user-specific.
+ * @param options See {@link DismissalOptions}.
+ * @returns Whether the item has been dismissed yet, and a function to call to dismiss the item.
+ */
+export function useLocalDismissal(
+  key: string,
+  options: DismissalOptions = {},
+): DismissalData {
+  const cookieId = key + "_dismissed";
+  const [cookies, setCookie] = useCookies([cookieId]);
+  const cookieValue = cookies[cookieId] as string | undefined;
+
+  const [isDismissed, setIsDismissed] = useState(
+    hasDismissedCookie(cookieValue, options.duration),
+  );
+
+  const dismiss = (dismissOptions?: DismissOptions) => {
+    const maxAgeInSeconds =
+      typeof options.duration === "number"
+        ? options.duration
+        : 100 * 365 * 24 * 60 * 60;
+    setCookie(cookieId, Date.now().toString(), {
+      maxAge: maxAgeInSeconds,
+    });
+    if (dismissOptions?.soft !== true) {
+      setIsDismissed(true);
+    }
+  };
+
+  return {
+    isDismissed: isDismissed,
+    dismiss: dismiss,
+  };
+}
+
+function hasDismissedCookie(cookieValue?: string, duration?: number): boolean {
+  const dismissalTimeStamp =
+    typeof cookieValue === "string"
+      ? Number.parseInt(cookieValue, 10)
+      : // Unfortunately react-cookie seems to implicitly parse the cookie value
+        // into a number based on unknown heuristics. Ideally, we'd just
+        // explicitly do that ourselves (i.e. on the line above) and remove this
+        // condition, but it's not currently possible to pass the `doNotParse`
+        // option to the hook. See
+        // https://github.com/bendotcodes/cookies/issues/448
+        typeof cookieValue === "number"
+        ? cookieValue
+        : undefined;
+
+  const wasDismissedBefore =
+    // To be dismissed, the cookie has to be set, and either...
+    typeof dismissalTimeStamp === "number" &&
+    //   ...the dismissal should not be limited in duration, or...
+    (typeof duration !== "number" ||
+      //   ...the dismissal was long enough ago:
+      Date.now() - dismissalTimeStamp <= duration * 1000);
+
+  return wasDismissedBefore;
+}

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -33,7 +33,8 @@ export type FeatureFlagName =
   | "PremiumBrokerRemoval"
   | "FalseDoorTest"
   | "HibpBreachNotifications"
-  | "FxaUidTelemetry";
+  | "FxaUidTelemetry"
+  | "RebrandAnnouncement";
 
 export async function getEnabledFeatureFlags(
   options:


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2522
Figma: https://www.figma.com/file/51jgudmkBoMMU9twT7UOKB/Monitor-Plus-Launch?type=design&node-id=310-6816&mode=design&t=PAVHr1PiURqF4TxK-0

<!-- When adding a new feature: -->

# Description

(Based on https://github.com/mozilla/blurts-server/pull/4033 to avoid adding this to the wrong directory.)

# Screenshot (if applicable)

![image](https://github.com/mozilla/blurts-server/assets/4251/f382bee9-0ae4-4679-bbec-65c4bf8e58a3)

![image](https://github.com/mozilla/blurts-server/assets/4251/bdeece9b-d168-49cd-ad71-3e6b2a7d17b7)

# How to test

First, enabled the `RebrandAnnouncement` feature flag.

Open the landing page. You should see the announcement. After you click the X, it should go away, and stay away after a refresh.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
