### PR TITLE
MNTOR-2711 - update database from subscription webhook before onerep

### DIFF
--- a/src/app/api/v1/fxa-rp-events/route.ts
+++ b/src/app/api/v1/fxa-rp-events/route.ts
@@ -286,8 +286,31 @@ export async function POST(request: NextRequest) {
             }
 
             // activate and opt out profiles
-            await activateProfile(oneRepProfileId);
-            await optoutProfile(oneRepProfileId);
+            try {
+              await activateProfile(oneRepProfileId);
+            } catch (ex) {
+              if (
+                (ex as Error).message ===
+                "Failed to activate OneRep profile: [403] [Forbidden]"
+              )
+                logger.error("profile_already_activated", {
+                  subscriber_id: subscriber.id,
+                  exception: ex,
+                });
+            }
+
+            try {
+              await optoutProfile(oneRepProfileId);
+            } catch (ex) {
+              if (
+                (ex as Error).message ===
+                "Failed to opt-out OneRep profile: [403] [Forbidden]"
+              )
+                logger.error("profile_already_opted_out", {
+                  subscriber_id: subscriber.id,
+                  exception: ex,
+                });
+            }
 
             logger.info("activated_onerep_profile", {
               subscriber_id: subscriber.id,

--- a/src/app/api/v1/fxa-rp-events/route.ts
+++ b/src/app/api/v1/fxa-rp-events/route.ts
@@ -245,44 +245,49 @@ export async function POST(request: NextRequest) {
           subscriber_id: subscriber.id,
         });
 
-        // get profile id
-        const result = await getOnerepProfileId(subscriber.id);
-        const oneRepProfileId = result?.[0]?.["onerep_profile_id"] as number;
+        try {
+          // get profile id
+          const result = await getOnerepProfileId(subscriber.id);
+          const oneRepProfileId = result?.[0]?.["onerep_profile_id"] as number;
 
-        logger.info("get_onerep_profile", {
-          subscriber_id: subscriber.id,
-          result: JSON.stringify(result),
-        });
-
-        // MNTOR-2103: if one rep profile id doesn't exist in the db, fail silently
-        if (!oneRepProfileId) {
-          logger.error("onerep_profile_not_found", {
+          logger.info("get_onerep_profile", {
             subscriber_id: subscriber.id,
+            result: JSON.stringify(result),
           });
 
-          captureException(
-            new Error(`No OneRep profile Id found, subscriber: ${
-              subscriber.id as string
-            }\n
-            Event: ${event}\n
-            updateFromEvent: ${JSON.stringify(updatedSubscriptionFromEvent)}`),
-          );
-          break;
-        }
-
-        try {
           if (
             updatedSubscriptionFromEvent.isActive &&
             updatedSubscriptionFromEvent.capabilities.includes(
               MONITOR_PREMIUM_CAPABILITY,
             )
           ) {
+            // Update fxa profile data to match subscription status.
+            // This is done before trying to activate the OneRep subscription, in case there are
+            // any problems with activation.
+            await changeSubscription(subscriber, true);
+
+            // MNTOR-2103: if one rep profile id doesn't exist in the db, fail immediately
+            if (!oneRepProfileId) {
+              logger.error("onerep_profile_not_found", {
+                subscriber_id: subscriber.id,
+              });
+
+              captureException(
+                new Error(`No OneRep profile Id found, subscriber: ${
+                  subscriber.id as string
+                }\n
+            Event: ${event}\n
+            updateFromEvent: ${JSON.stringify(updatedSubscriptionFromEvent)}`),
+              );
+              return NextResponse.json(
+                { success: false, message: "failed_activating_subscription" },
+                { status: 500 },
+              );
+            }
+
             // activate and opt out profiles
             await activateProfile(oneRepProfileId);
             await optoutProfile(oneRepProfileId);
-
-            // update fxa profile data to match subscription status
-            await changeSubscription(subscriber, true);
 
             logger.info("activated_onerep_profile", {
               subscriber_id: subscriber.id,
@@ -293,11 +298,34 @@ export async function POST(request: NextRequest) {
               MONITOR_PREMIUM_CAPABILITY,
             )
           ) {
+            // Update fxa profile data to match subscription status.
+            // This is done before trying to deactivate the OneRep subscription, in case there are
+            // any problems with deactivation.
+            await changeSubscription(subscriber, false);
+
+            // MNTOR-2103: if one rep profile id doesn't exist in the db, fail immediately
+            if (!oneRepProfileId) {
+              logger.error("onerep_profile_not_found", {
+                subscriber_id: subscriber.id,
+              });
+
+              captureException(
+                new Error(`No OneRep profile Id found, subscriber: ${
+                  subscriber.id as string
+                }\n
+                        Event: ${event}\n
+                        updateFromEvent: ${JSON.stringify(
+                          updatedSubscriptionFromEvent,
+                        )}`),
+              );
+              return NextResponse.json(
+                { success: false, message: "failed_activating_subscription" },
+                { status: 500 },
+              );
+            }
+
             // deactivation stops opt out process
             await deactivateProfile(oneRepProfileId);
-
-            // update fxa profile data to match subscription status
-            await changeSubscription(subscriber, false);
 
             logger.info("deactivated_onerep_profile", {
               subscriber_id: subscriber.id,

--- a/src/app/api/v1/fxa-rp-events/route.ts
+++ b/src/app/api/v1/fxa-rp-events/route.ts
@@ -348,7 +348,18 @@ export async function POST(request: NextRequest) {
             }
 
             // deactivation stops opt out process
-            await deactivateProfile(oneRepProfileId);
+            try {
+              await deactivateProfile(oneRepProfileId);
+            } catch (ex) {
+              if (
+                (ex as Error).message ===
+                "Failed to deactivate OneRep profile: [403] [Forbidden]"
+              )
+                logger.error("profile_already_opted_out", {
+                  subscriber_id: subscriber.id,
+                  exception: ex,
+                });
+            }
 
             logger.info("deactivated_onerep_profile", {
               subscriber_id: subscriber.id,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2711

<!-- When adding a new feature: -->

# Description

When testing on staging, I encountered a situation where the subscription webhook came through but OneRep activation failed. In this case our webhook handler returns an HTTP error so FxA retries, but the badge doesn't show up right away. 

We should update our database first.

# How to test

I ran into this on stage, this can be tested by pointing the `ONEREP_API_BASE` var to an endpoint that always returns `500`.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).