### PR TITLE
Somewhat more resilient selectors for auth page

### DIFF
--- a/src/e2e/pages/authPage.ts
+++ b/src/e2e/pages/authPage.ts
@@ -17,10 +17,10 @@ export class AuthPage {
   constructor(page: Page) {
     this.page = page;
     this.emailInputField = page.locator('input[name="email"]');
-    this.passwordInputField = page.locator("#password");
-    this.passwordConfirmInputField = page.locator("#vpassword");
-    this.ageInputField = page.locator("#age");
-    this.continueButton = page.locator("#submit-btn");
+    this.passwordInputField = page.locator('[type="password"]').nth(0);
+    this.passwordConfirmInputField = page.locator('[type="password"]').nth(1);
+    this.ageInputField = page.getByLabel("How old are you?");
+    this.continueButton = page.locator('[type="submit"]').first();
     this.verifyCodeInputField = page.locator("div.card input");
   }
 


### PR DESCRIPTION
It appears that the IDs on the FxA sign-up page have been removed? Ideally I'd use `getByLabel` and `getByRole` to select on markup that matches what users are looking for, but it looks like these selectors are used on different pages (sign in vs. sign up), and thus the labels differ even though the elements are similar. So for now, I've updated the selectors to ones that appear to work for the different pages (even now that some IDs appear to have disappeared), but ideally, we'd have selectors specific to each page, based on user-visible selection characteristics.