### PR TITLE
Make setup headed when any browser is

### DIFF
--- a/src/e2e/global-setup.ts
+++ b/src/e2e/global-setup.ts
@@ -5,11 +5,19 @@
 import { setEnvVariables } from "./utils/helpers";
 import { AuthPage } from "./pages/authPage.js";
 import { LandingPage } from "./pages/landingPage.js";
-import { chromium } from "@playwright/test";
+import { FullConfig, chromium } from "@playwright/test";
 
-async function globalSetup() {
+async function globalSetup(config: FullConfig) {
   // playwright setup
-  const browser = await chromium.launch();
+  const browser = await chromium.launch({
+    // If `headless` is set for any `use` parameter in `playwright.config.js`,
+    // also use that value here:
+    headless: config.projects.reduce(
+      (prevValues: undefined | boolean, project) =>
+        prevValues ?? project.use.headless,
+      undefined,
+    ),
+  });
   const page = await browser.newPage();
 
   // generate email and set env variables


### PR DESCRIPTION
It used to be that, even if headless mode was disabled, the setup would still run in headless mode, which can be confusing. This change ensures that the setup is also run in headed mode, if the tests itself are too.