### PR TITLE
Split build step into separate CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,6 @@ jobs:
             - run: npm run build-glean
             - run: npm run lint
             - run: cp .env-dist .env
-            # Runs type checking:
-            - run: npm run build
     deploy:
         docker:
             - image: docker:stable-git

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,20 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.9.x'
+      - run: npm ci
+      - run: npm run build-glean
+      - run: cp .env-dist .env
+      # Verify that the build (incl. type-checking) succeeds
+      - run: npm run build


### PR DESCRIPTION
This should speed up our CI pipelines, work more towards consolidating on GitHub Actions, and minimise the RAM usage of a single CI job.

The trigger for this PR was https://github.com/mozilla/blurts-server/pull/4060#issuecomment-1904453505. This isn't a true solution - it seems like it's a bit much to use 4GB RAM in the build :unamused: But regardless, this is probably a good idea, and might unblock us for the moment.