### PR TITLE
Refresh breaches after resolving some

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/HighRiskBreachLayout.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/HighRiskBreachLayout.tsx
@@ -110,6 +110,13 @@ export function HighRiskBreachLayout(props: HighRiskBreachLayoutProps) {
         );
       }
 
+      // Make sure the dashboard re-fetches the breaches on the next visit,
+      // in order to make resolved breaches move to the "Fixed" tab.
+      // If we had used server actions, we could've called
+      // `revalidatePath("/user/dashboard")` there, but the API doesn't appear
+      // to necessarily share a cache with the client.
+      router.refresh();
+
       const isCurrentStepSection = Object.values(stepMap).includes(nextStep.id);
       const nextRoute = isCurrentStepSection
         ? nextStep.href

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/LeakedPasswordsLayout.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/LeakedPasswordsLayout.tsx
@@ -117,6 +117,13 @@ export function LeakedPasswordsLayout(props: LeakedPasswordsLayoutProps) {
         formattedDataClasses,
       );
 
+      // Make sure the dashboard re-fetches the breaches on the next visit,
+      // in order to make resolved breaches move to the "Fixed" tab.
+      // If we had used server actions, we could've called
+      // `revalidatePath("/user/dashboard")` there, but the API doesn't appear
+      // to necessarily share a cache with the client.
+      router.refresh();
+
       // Manually move to the next step when breach has been marked as fixed.
       const updatedSubscriberBreaches = subscriberBreaches.map(
         (subscriberBreach) => {

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/SecurityRecommendationsLayout.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/SecurityRecommendationsLayout.tsx
@@ -109,6 +109,13 @@ export function SecurityRecommendationsLayout(
         );
       }
 
+      // Make sure the dashboard re-fetches the breaches on the next visit,
+      // in order to make resolved breaches move to the "Fixed" tab.
+      // If we had used server actions, we could've called
+      // `revalidatePath("/user/dashboard")` there, but the API doesn't appear
+      // to necessarily share a cache with the client.
+      router.refresh();
+
       const isCurrentStepSection = Object.values(stepMap).includes(nextStep.id);
       const nextRoute = isCurrentStepSection
         ? nextStep.href


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2464
Figma: 


<!-- When adding a new feature: -->

# Description

This essentially applies the same thing [we already did for data brokers](https://github.com/mozilla/blurts-server/blob/6ce3bcdb02e4e8cf4bf235898699deb58f78eae3/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/manual-remove/RemovalCard.tsx#L39-L42) for data breaches: after we resolve them, we make sure that the next render of the dashboard fetches fresh data. Otherwise, fixed breaches will still be listed under the "active" tab.

# How to test

Open the resolution flow and move to the first breach. Go back to the dashboard and check what data is breached, and then resolve those in the guided flow. With this branch, when you end up at the dashboard at the end, the breach should be moved to the "Fixed" tab, whereas on `main`, it would still be on the "Active" tab until the page is refreshed.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - Would only test that `router.refresh` is called, which wouldn't really catch bugs.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met. - I don't think all bugs of MNTOR-2464 are resolved yet.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
