### PR TITLE
Add local admin interface to administer users

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/UserAdmin.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/UserAdmin.module.scss
@@ -1,0 +1,68 @@
+@import "../../../../../tokens";
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2xl;
+  background-color: $color-grey-05;
+  height: 100%;
+  padding: $layout-lg $layout-2xl;
+
+  @media screen and (max-width: $screen-lg) {
+    padding: $spacing-lg;
+  }
+}
+
+.header {
+  font: $text-title-xs;
+  font-weight: normal;
+
+  b {
+    font-weight: bold;
+  }
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2xl;
+
+  .userPicker {
+    flex: 1 0 auto;
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-2xl;
+    min-height: $layout-2xl;
+
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: $spacing-sm;
+      min-width: 50%;
+    }
+
+    input {
+      padding: $spacing-sm;
+      font: $text-body-md;
+    }
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $spacing-xl;
+
+    button {
+      flex: 1 1 25%;
+    }
+  }
+}
+
+.status {
+  background-color: $color-yellow-05;
+  border: 2px solid $color-yellow-20;
+  border-radius: $border-radius-sm;
+  padding: $spacing-md $spacing-lg;
+  font: $text-body-md;
+}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/UserAdmin.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/UserAdmin.tsx
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use client";
+
+import { ChangeEventHandler, useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import styles from "./UserAdmin.module.scss";
+import { Button } from "../../../../../components/client/Button";
+import {
+  type UserStateAction,
+  type PutUserStateRequestBody,
+  GetUserStateResponseBody,
+} from "../../../../../api/v1/admin/users/[primarySha1]/route";
+
+export const UserAdmin = () => {
+  const session = useSession();
+  const [emailInput, setEmailInput] = useState("");
+  const [status, setStatus] = useState<null | string>(null);
+  const [subscriberData, setSubscriberData] =
+    useState<GetUserStateResponseBody | null>(null);
+
+  useEffect(() => {
+    if (emailInput.length <= 5) {
+      return;
+    }
+
+    const abortController = new AbortController();
+    void getSha1(emailInput).then(async (emailHash) => {
+      const response = await fetch(`/api/v1/admin/users/${emailHash}`, {
+        signal: abortController.signal,
+      });
+      if (!response.ok) {
+        setSubscriberData(null);
+        return;
+      }
+      const data = await response.json();
+      setSubscriberData(data);
+    });
+
+    return () => {
+      abortController.abort();
+    };
+  }, [emailInput]);
+
+  const onChangeEmail: ChangeEventHandler<HTMLInputElement> = (event) => {
+    event.preventDefault();
+
+    setStatus(null);
+    setSubscriberData(null);
+    setEmailInput(event.target.value);
+  };
+
+  const performAction = async (action: UserStateAction) => {
+    setStatus(null);
+
+    const emailHash = await getSha1(emailInput);
+
+    const requestBody: PutUserStateRequestBody = {
+      actions: [action],
+    };
+    const response = await fetch(`/api/v1/admin/users/${emailHash}`, {
+      method: "PUT",
+      body: JSON.stringify(requestBody),
+    });
+
+    if (!response.ok) {
+      setStatus(
+        `[${action}] failed: [${response.status}] [${response.statusText}].`,
+      );
+      return;
+    }
+
+    setStatus(`[${action}] succeeded for email address [${emailInput}].`);
+  };
+
+  return (
+    <main className={styles.wrapper}>
+      <header className={styles.header}>
+        Logged in as <b>{session.data?.user.email}</b>.
+      </header>
+      <form className={styles.form} onSubmit={(e) => e.preventDefault()}>
+        <div className={styles.userPicker}>
+          <label>
+            Find user by email address:
+            <input
+              value={emailInput}
+              onChange={onChangeEmail}
+              type="email"
+              name="email"
+              id="email"
+            />
+          </label>
+          {subscriberData && (
+            <pre>{JSON.stringify(subscriberData, null, 2)}</pre>
+          )}
+        </div>
+        {subscriberData && (
+          <div className={styles.actions}>
+            <Button
+              variant="secondary"
+              onPress={() => void performAction("subscribe")}
+            >
+              Give Plus
+            </Button>
+            <Button
+              variant="secondary"
+              onPress={() => void performAction("unsubscribe")}
+            >
+              Remove Plus
+            </Button>
+            <Button
+              variant="secondary"
+              destructive={true}
+              onPress={() => void performAction("delete_onerep_profile")}
+            >
+              Delete OneRep profile
+            </Button>
+            <Button
+              variant="secondary"
+              destructive={true}
+              onPress={() => void performAction("delete_onerep_scans")}
+            >
+              Delete OneRep scans
+            </Button>
+            <Button
+              variant="secondary"
+              destructive={true}
+              onPress={() => void performAction("delete_onerep_scan_results")}
+            >
+              Delete OneRep scan results
+            </Button>
+            <Button
+              variant="secondary"
+              destructive={true}
+              onPress={() => void performAction("delete_subscriber")}
+            >
+              Delete subscriber
+            </Button>
+          </div>
+        )}
+      </form>
+      {status && <p className={styles.status}>{status}</p>}
+    </main>
+  );
+};
+
+async function getSha1(source: string): Promise<string> {
+  const msgUint8 = new TextEncoder().encode(source);
+  const hashBuffer = await crypto.subtle.digest("SHA-1", msgUint8);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return hashHex;
+}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/UserAdmin.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/UserAdmin.tsx
@@ -73,6 +73,10 @@ export const UserAdmin = () => {
     }
 
     setStatus(`[${action}] succeeded for email address [${emailInput}].`);
+    const refreshResponse = await fetch(`/api/v1/admin/users/${emailHash}`);
+    if (refreshResponse.ok) {
+      setSubscriberData(await refreshResponse.json());
+    }
   };
 
   return (

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/page.tsx
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getServerSession } from "next-auth";
+import { notFound } from "next/navigation";
+import { authOptions, isAdmin } from "../../../../../api/utils/auth";
+import { UserAdmin } from "./UserAdmin";
+
+export default async function DevPage() {
+  const session = await getServerSession(authOptions);
+
+  if (
+    !session?.user?.email ||
+    !isAdmin(session.user.email) ||
+    process.env.APP_ENV !== "local"
+  ) {
+    return notFound();
+  }
+
+  return <UserAdmin />;
+}

--- a/src/app/api/v1/admin/users/[primarySha1]/route.ts
+++ b/src/app/api/v1/admin/users/[primarySha1]/route.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
+import { Profile, getServerSession } from "next-auth";
 import { SubscriberRow } from "knex/types/tables";
 import { logger } from "../../../../../functions/server/logging";
 import { isAdmin, authOptions } from "../../../../utils/auth";
@@ -33,6 +33,7 @@ export type GetUserStateResponseBody = {
   updatedAt: SubscriberRow["updated_at"];
   signupLanguage: SubscriberRow["signup_language"];
   all_emails_to_primary: SubscriberRow["all_emails_to_primary"];
+  subscriptions: Profile["subscriptions"];
 };
 
 /**
@@ -66,6 +67,7 @@ export async function GET(
         updatedAt: subscriber.updated_at,
         signupLanguage: subscriber.signup_language,
         all_emails_to_primary: subscriber.all_emails_to_primary,
+        subscriptions: subscriber.fxa_profile_json?.subscriptions,
       };
       return NextResponse.json(responseBody);
     } catch (e) {

--- a/src/app/components/client/Button.module.scss
+++ b/src/app/components/client/Button.module.scss
@@ -48,6 +48,16 @@
       background-color: $color-blue-50;
       color: $color-white;
     }
+
+    &.destructive {
+      color: $color-red-70;
+      box-shadow: inset 0 0 0 2px $color-red-70;
+
+      &:hover {
+        background-color: $color-red-70;
+        color: $color-white;
+      }
+    }
   }
 
   &.tertiary {


### PR DESCRIPTION
This provides a simple frontend for the API `/api/v1/admin/users/[sha1]/`, allowing the addition and removal of Plus status and scans, to make problems there easier to debug.

It is only accessible when running locally (i.e. when `APP_ENV="local"`), at `/admin/dev/`.