### PR TITLE
Subscriber not eligible for free scan redirect (MNTOR-2613)

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/[[...slug]]/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/[[...slug]]/page.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { getServerSession } from "next-auth";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { isEligibleForFreeScan } from "../../../../../../functions/server/onerep";
 import { View } from "../View";
 import { getAllBreachesCount } from "../../../../../../../db/tables/breaches";
@@ -47,9 +47,10 @@ export default async function Onboarding({ params, searchParams }: Props) {
   );
 
   if (!userIsEligible) {
-    throw new Error(
+    console.error(
       `Subscriber not eligible for free scan, ID: ${session?.user?.subscriber?.id}`,
     );
+    return redirect("/user/dashboard");
   }
 
   const allBreachesCount = await getAllBreachesCount();


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2613](https://mozilla-hub.atlassian.net/browse/MNTOR-2613)

<!-- When adding a new feature: -->

# Description

Redirect to the dashboard instead of throwing an application error if a user is not eligible for a free scan.

# How to test

1. Navigate to `/user/welcome` as a user who is not eligible for a free scan.
2. Instead of an application error you should be redirected to `/user/dashboard`.

[MNTOR-2613]: https://mozilla-hub.atlassian.net/browse/MNTOR-2613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ