### PR TITLE
Fix invalid rollback

### DIFF
--- a/src/db/migrations/20240111101826_subscriber_email_cascade_delete.js
+++ b/src/db/migrations/20240111101826_subscriber_email_cascade_delete.js
@@ -19,6 +19,6 @@ export async function up(knex) {
  */
 export async function down(knex) {
   await knex.schema.alterTable("email_addresses", table => {
-    table.foreign("subscriber_id").references("subscribers.id")
+    table.dropForeign("subscriber_id").foreign("subscriber_id").references("subscribers.id")
   });
 }


### PR DESCRIPTION
It didn't drop the modified foreign index before re-creating it without the cascades.