### PR TITLE
Match telemetry event category keys for GA and Glean

### DIFF
--- a/src/app/functions/universal/convertCamelToSnakeCase.test.ts
+++ b/src/app/functions/universal/convertCamelToSnakeCase.test.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { it, expect } from "@jest/globals";
+import { convertCamelToSnakeCase } from "./convertCamelToSnakeCase";
+
+it("returns a camelCase string as snake_case", () => {
+  expect(convertCamelToSnakeCase("camelCase")).toBe("camel_case");
+});
+
+it("returns a snake_case string as snake_case", () => {
+  expect(convertCamelToSnakeCase("camel_case")).toBe("camel_case");
+});
+
+it("returns a lowercase string without permutation", () => {
+  expect(convertCamelToSnakeCase("lowercase")).toBe("lowercase");
+});

--- a/src/app/functions/universal/convertCamelToSnakeCase.ts
+++ b/src/app/functions/universal/convertCamelToSnakeCase.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export function convertCamelToSnakeCase(string: string) {
+  return string.replace(/[A-Z]/g, (segment) => `_${segment.toLowerCase()}`);
+}

--- a/src/app/hooks/useTelemetry.ts
+++ b/src/app/hooks/useTelemetry.ts
@@ -11,6 +11,7 @@ import { useGa } from "./useGa";
 import { useGlean } from "./useGlean";
 /* eslint-enable no-restricted-imports */
 import { GleanMetricMap } from "../../telemetry/generated/_map";
+import { convertCamelToSnakeCase } from "../functions/universal/convertCamelToSnakeCase";
 
 const TelemetryPlatforms = {
   Glean: "glean",
@@ -43,7 +44,9 @@ export const useTelemetry = () => {
     if (platforms.includes(Ga)) {
       gtag.record({
         type: "event",
-        name: eventModule,
+        // Convert event category keys from camelCase to snake_case for GA
+        // so they match the telemetry that is reported by Glean.
+        name: convertCamelToSnakeCase(eventModule),
         params: {
           ...data,
           action: event,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2831](https://mozilla-hub.atlassian.net/browse/MNTOR-2831)

<!-- When adding a new feature: -->

# Description

As [discussed](https://mozilla-hub.atlassian.net/wiki/spaces/PXI/pages/133431380?focusedCommentId=539362916) during the Engineering Office Hours we should convert the GA event categories from `camelCase` to `snake_case` to match the Glean event keys that are being reported.

[MNTOR-2831]: https://mozilla-hub.atlassian.net/browse/MNTOR-2831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ