### PR TITLE
Don't try to store scan results if there are none

### DIFF
--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -136,10 +136,12 @@ async function addOnerepScanResults(
     }),
   });
 
-  await knex("onerep_scan_results")
-    .insert(scanResultsMap)
-    .onConflict("onerep_scan_result_id")
-    .merge();
+  if (scanResultsMap.length > 0) {
+    await knex("onerep_scan_results")
+      .insert(scanResultsMap)
+      .onConflict("onerep_scan_result_id")
+      .merge();
+  }
 }
 
 async function isOnerepScanResultForSubscriber(params: {


### PR DESCRIPTION
This avoids an empty query error if a data broker scan returns 0 results. (Which unfortunately is rare.)