### PR TITLE
Fix skip start free scan link

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/start-free-scan/StartFreeScanView.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/start-free-scan/StartFreeScanView.tsx
@@ -86,7 +86,7 @@ export function StartFreeScanView(props: Props) {
           </TelemetryButton>
           <TelemetryButton
             variant="secondary"
-            href="/user/dashboard/fix/high-risk-data-breaches"
+            href={getNextGuidedStep(props.data, "Scan").href}
             event={{
               module: "button",
               name: "click",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2731](https://mozilla-hub.atlassian.net/browse/MNTOR-2731)

<!-- When adding a new feature: -->

# Description

Fixes the skip free scan link. The previous [fix](https://github.com/mozilla/blurts-server/pull/4043) has been reverted due to a merge conflict it seems.