### PR TITLE
address the different redirect after sign up for local and other envs.

### DIFF
--- a/src/e2e/specs/auth.spec.ts
+++ b/src/e2e/specs/auth.spec.ts
@@ -27,7 +27,11 @@ test.describe(`${process.env.E2E_TEST_ENV} - Authentication flow verification @s
     await authPage.signUp(randomEmail, page);
 
     // assert successful login
-    expect(page.url()).toBe(`${process.env.E2E_TEST_BASE_URL}/user/dashboard`);
+    const successUrl =
+      process.env.E2E_TEST_ENV === "local"
+        ? "/user/dashboard"
+        : "/user/welcome";
+    expect(page.url()).toBe(`${process.env.E2E_TEST_BASE_URL}${successUrl}`);
 
     await testInfo.attach(
       `${process.env.E2E_TEST_ENV}-signup-monitor-dashboard.png`,


### PR DESCRIPTION
Chore: the sign up redirect is different for local than it is for other environments, this change should handle addressing it for local vs others