### PR TITLE
Don't run a manual scan for a Plus user

### DIFF
--- a/src/TestComponentWrapper.tsx
+++ b/src/TestComponentWrapper.tsx
@@ -21,7 +21,7 @@ export const TestComponentWrapper = (props: { children: ReactNode }) => {
             process.env.STORYBOOK === "true" ? "storybook" : "test",
         }}
       >
-        <SessionProvider session={null}>
+        <SessionProvider session={{ user: { email: "example@example.com" } }}>
           <ReactAriaI18nProvider locale="en">
             {props.children}
           </ReactAriaI18nProvider>

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/Onboarding.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/Onboarding.stories.tsx
@@ -17,7 +17,6 @@ export const Onboarding: Story = {
   render: (props) => (
     <OnboardingEl
       {...props}
-      user={{ email: "example@example.com" }}
       dataBrokerCount={190}
       breachesTotalCount={678}
       previousRoute={props.previousRoute}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/Onboarding.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/Onboarding.test.tsx
@@ -10,6 +10,20 @@ import { axe } from "jest-axe";
 import Meta, { Onboarding } from "./Onboarding.stories";
 import { useTelemetry } from "../../../../../hooks/useTelemetry";
 
+jest.mock("next-auth/react", () => {
+  return {
+    useSession: () => {
+      return {
+        update: jest.fn(),
+        data: {
+          user: {
+            email: "example@example.com",
+          },
+        },
+      };
+    },
+  };
+});
 jest.mock("next/navigation", () => ({
   useRouter: () => ({
     back: jest.fn(),

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/View.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/View.tsx
@@ -65,7 +65,8 @@ export const View = ({
     // `.update()`, so adding it to the dependencies array would cause an
     // infinite loop. If `session` changes afterwards, we won't need to call
     // `.update` again; after all, it has just been updated.
-  }, [session]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const user = session.data?.user;
   if (!user) {

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/[[...slug]]/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/[[...slug]]/page.tsx
@@ -61,7 +61,6 @@ export default async function Onboarding({ params, searchParams }: Props) {
 
   return (
     <View
-      user={session.user}
       dataBrokerCount={CONST_ONEREP_DATA_BROKER_COUNT}
       breachesTotalCount={allBreachesCount}
       stepId={firstSlug === FreeScanSlug ? "enterInfo" : "getStarted"}

--- a/src/app/api/v1/user/welcome-scan/progress/route.ts
+++ b/src/app/api/v1/user/welcome-scan/progress/route.ts
@@ -22,7 +22,9 @@ import {
   Scan,
   getScanDetails,
   getAllScanResults,
+  optoutProfile,
 } from "../../../../../functions/server/onerep";
+import { hasPremium } from "../../../../../functions/universal/user";
 
 export interface ScanProgressBody {
   success: boolean;
@@ -50,6 +52,14 @@ export async function GET(
       const latestScan = await getLatestOnerepScanResults(profileId);
       const latestScanId = latestScan.scan?.onerep_scan_id;
 
+      if (typeof latestScanId === "undefined" && hasPremium(session.user)) {
+        // If the user already has Plus, we did not start a manual scan right
+        // away, and the automatic initial scan might not have kicked off yet:
+        return NextResponse.json(
+          { success: true, status: "in_progress" as Scan["status"] },
+          { status: 200 },
+        );
+      }
       if (
         typeof latestScanId !== "undefined" &&
         typeof profileId === "number"
@@ -58,6 +68,11 @@ export async function GET(
 
         // Store scan results.
         if (scan.status === "finished") {
+          if (hasPremium(session.user)) {
+            // Start sending data removal requests if the user has Plus:
+            await optoutProfile(profileId);
+          }
+
           const allScanResults = await getAllScanResults(profileId);
           await addOnerepScanResults(profileId, allScanResults);
         }


### PR DESCRIPTION
**Submitting for input on the general approach, and on how to test. Will fix the test later, but figured I'd submit this so people know this code exists.**

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2865
Figma: N/A


<!-- When adding a new feature: -->

# Description

If the user enters the onboarding while having purchased Plus beforehand, with this change we no longer start a manual scan. Instead, we activate the profile, wait for the `initial` scan to come in, and then start the opt-out process when they come in.

I thought this might have been one of the reasons users would see "Action needed" scans even if they had Plus: those would simply be the results of a manual scan that we didn't request an opt-out for.

The main reason is probably the delay between OneRep calling our webhook and us starting the opt-out process, but I figured dealing with this flow is probably a good idea anyway.

# How to test

Unfortunately I'm not sure how best to test; specifically, we'd need to simulate OneRep calling our webhook while the scan is in progress. Any ideas? Maybe that's something to add to the dev dashboard as well?

# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
