### PR TITLE
Mark new scan results as in progress for Plus users

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
@@ -445,7 +445,7 @@ it("switches between tab panels", async () => {
 
 it("shows consistent counts in the chart on the active tab", () => {
   const ComposedDashboard = composeStory(
-    DashboardUsPremiumUnresolvedScanUnresolvedBreaches,
+    DashboardUsNoPremiumUnresolvedScanUnresolvedBreaches,
     Meta,
   );
   render(<ComposedDashboard />);
@@ -467,7 +467,7 @@ it("shows consistent counts in the chart on the active tab", () => {
 it("shows consistent counts in the chart on the fixed tab", async () => {
   const user = userEvent.setup();
   const ComposedDashboard = composeStory(
-    DashboardUsPremiumUnresolvedScanUnresolvedBreaches,
+    DashboardUsNoPremiumUnresolvedScanUnresolvedBreaches,
     Meta,
   );
   render(<ComposedDashboard />);
@@ -1949,12 +1949,29 @@ it("shows the correct dashboard banner title for US user, with Premium, unresolv
   });
   const dashboardTopBannerTitle = getByText(
     dashboardTopBanner,
-    "Let’s keep protecting your data",
+    "Your data is protected",
   );
   expect(dashboardTopBannerTitle).toBeInTheDocument();
 });
 
-it("shows the correct dashboard banner CTA and sends telemetry for US user, with Premium, unresolved scan, no breaches", async () => {
+it("tells the user that they don't need to do anything now if they have Premium and have no breaches, even if there are still new scan results (for which opt-out requests will be sent later)", () => {
+  const ComposedDashboard = composeStory(
+    DashboardUsPremiumUnresolvedScanNoBreaches,
+    Meta,
+  );
+
+  render(<ComposedDashboard />);
+
+  const dashboardTopBanner = screen.getByRole("region", {
+    name: "Dashboard summary",
+  });
+  const dashboardTopBannerCta = getByRole(dashboardTopBanner, "button", {
+    name: "See what’s fixed",
+  });
+  expect(dashboardTopBannerCta).toBeInTheDocument();
+});
+
+it("sends telemetry when a US user, with Premium, an unresolved scan, and no breaches clicks the top banner CTA", async () => {
   const ComposedDashboard = composeStory(
     DashboardUsPremiumUnresolvedScanNoBreaches,
     Meta,
@@ -1970,16 +1987,15 @@ it("shows the correct dashboard banner CTA and sends telemetry for US user, with
   const dashboardTopBanner = screen.getByRole("region", {
     name: "Dashboard summary",
   });
-  const dashboardTopBannerCta = getByRole(dashboardTopBanner, "link", {
-    name: "Let’s keep going",
+  const dashboardTopBannerCta = getByRole(dashboardTopBanner, "button", {
+    name: "See what’s fixed",
   });
-  expect(dashboardTopBannerCta).toBeInTheDocument();
   await user.click(dashboardTopBannerCta);
   expect(mockedRecord).toHaveBeenCalledWith(
     "ctaButton",
     "click",
     expect.objectContaining({
-      button_id: "us_premium_unresolved_brokers",
+      button_id: "us_premium_yes_scan_all_resolved",
     }),
   );
 });
@@ -1997,7 +2013,7 @@ it("shows the correct dashboard banner title for US user, with Premium, Unresolv
   });
   const dashboardTopBannerTitle = getByText(
     dashboardTopBanner,
-    "Let’s protect your data",
+    "Let’s keep protecting your data",
   );
   expect(dashboardTopBannerTitle).toBeInTheDocument();
 });
@@ -2019,7 +2035,7 @@ it("shows the correct dashboard banner CTA for US user, with Premium, Unresolved
     name: "Dashboard summary",
   });
   const dashboardTopBannerCta = getByRole(dashboardTopBanner, "link", {
-    name: "Let’s fix it",
+    name: "Let’s keep going",
   });
   expect(dashboardTopBannerCta).toBeInTheDocument();
   await user.click(dashboardTopBannerCta);
@@ -2027,8 +2043,7 @@ it("shows the correct dashboard banner CTA for US user, with Premium, Unresolved
     "ctaButton",
     "click",
     expect.objectContaining({
-      button_id:
-        "us_non_premium_yes_scan_unresolved_breaches_unresolved_brokers",
+      button_id: "us_premium_unresolved_breaches",
     }),
   );
 });
@@ -2046,12 +2061,29 @@ it("shows the correct dashboard banner title for US user, with Premium, unresolv
   });
   const dashboardTopBannerTitle = getByText(
     dashboardTopBanner,
-    "Let’s keep protecting your data",
+    "Your data is protected",
   );
   expect(dashboardTopBannerTitle).toBeInTheDocument();
 });
 
-it("shows the correct dashboard banner CTA and sends telemetry for US user, with Premium, unresolved scan, resolved breaches", async () => {
+it("tells the user that they don't need to do anything now if they have Premium and have resolved all breaches, even if there are still new scan results (for which opt-out requests will be sent later)", () => {
+  const ComposedDashboard = composeStory(
+    DashboardUsPremiumUnresolvedScanResolvedBreaches,
+    Meta,
+  );
+
+  render(<ComposedDashboard />);
+
+  const dashboardTopBanner = screen.getByRole("region", {
+    name: "Dashboard summary",
+  });
+  const dashboardTopBannerCta = getByRole(dashboardTopBanner, "button", {
+    name: "See what’s fixed",
+  });
+  expect(dashboardTopBannerCta).toBeInTheDocument();
+});
+
+it("sends telemetry when a US user, with Premium, an unresolved scan, and resolved breaches clicks the top banner CTA", async () => {
   const ComposedDashboard = composeStory(
     DashboardUsPremiumUnresolvedScanResolvedBreaches,
     Meta,
@@ -2067,16 +2099,15 @@ it("shows the correct dashboard banner CTA and sends telemetry for US user, with
   const dashboardTopBanner = screen.getByRole("region", {
     name: "Dashboard summary",
   });
-  const dashboardTopBannerCta = getByRole(dashboardTopBanner, "link", {
-    name: "Let’s keep going",
+  const dashboardTopBannerCta = getByRole(dashboardTopBanner, "button", {
+    name: "See what’s fixed",
   });
-  expect(dashboardTopBannerCta).toBeInTheDocument();
   await user.click(dashboardTopBannerCta);
   expect(mockedRecord).toHaveBeenCalledWith(
     "ctaButton",
     "click",
     expect.objectContaining({
-      button_id: "us_premium_unresolved_brokers",
+      button_id: "us_premium_yes_scan_all_resolved",
     }),
   );
 });
@@ -2691,7 +2722,7 @@ it("logs a warning and error in the story for an invalid user state", () => {
 it("expands one card at a time", async () => {
   const user = userEvent.setup();
   const ComposedDashboard = composeStory(
-    DashboardUsPremiumUnresolvedScanUnresolvedBreaches,
+    DashboardUsNoPremiumUnresolvedScanUnresolvedBreaches,
     Meta,
   );
   render(<ComposedDashboard />);

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
@@ -335,6 +335,15 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                 onPress={() => {
                   let buttonId = "us_non_premium_yes_scan";
                   if (contentProps.hasUnresolvedBreaches)
+                    // Plus users will no longer have unresolved scan results,
+                    // as we'll send opt-out requests for them - i.e. there's
+                    // nothing for the user to do. That means that there is no
+                    // more code path that will hit this line: instead this
+                    // combination will result in `UsUserNonPremiumNoExposures`.
+                    // Ideally, we'd narrow down the different permutations to
+                    // remove code that's no longer relevant, but to minimise
+                    // disruptions and potential bugs, we're leaving it for now:
+                    /* c8 ignore next */
                     buttonId = buttonId.concat("_unresolved_breaches");
                   if (contentProps.hasUnresolvedBrokers)
                     buttonId = buttonId.concat("_unresolved_brokers");
@@ -447,6 +456,16 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                 onPress={() => {
                   recordTelemetry("ctaButton", "click", {
                     button_id: `us_${isPremiumUser ? "" : "non_"}premium${
+                      // Plus users will no longer have unresolved scan results,
+                      // as we'll send opt-out requests for them - i.e. there's
+                      // nothing for the user to do. That means that there is no
+                      // more code path that will hit this line: instead this
+                      // combination will result in
+                      // `UsUserNonPremiumWithScanRemovalInProgress`.
+                      // Ideally, we'd narrow down the different permutations to
+                      // remove code that's no longer relevant, but to minimise
+                      // disruptions and potential bugs, we're leaving it for now:
+                      /* c8 ignore next 3 */
                       contentProps.hasUnresolvedBreaches
                         ? "_unresolved_breaches"
                         : ""


### PR DESCRIPTION
**Submitting for input on the general approach, and on how to test. Will fix the test later, but figured I'd submit this so people know this code exists.**

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2865
Figma: N/A


<!-- When adding a new feature: -->

# Description

Even if the user has Plus, OneRep won't automatically start removing found exposures; it first sends a request to our webhook, and then the webhook sends an opt-out request to OneRep. Meanwhile, however, we're just waiting for the systems to do their thing, and there's no action for the user to take; hence, this change also marks the exposures as being in progress.

# How to test

With a new Plus user, you should not see "Action needed" "info for sale" cards on the dashboard after completing the free scan flow.

# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
