### PR TITLE
Add missing dashboard view event

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/View.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/View.tsx
@@ -52,7 +52,7 @@ import {
 export type Props = {
   enabledFeatureFlags: FeatureFlagName[];
   user: Session["user"];
-  userId: string;
+  userId?: string;
   userBreaches: SubscriberBreach[];
   userScanData: LatestOnerepScanData;
   isEligibleForFreeScan: boolean;

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/View.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/View.tsx
@@ -52,6 +52,7 @@ import {
 export type Props = {
   enabledFeatureFlags: FeatureFlagName[];
   user: Session["user"];
+  userId: string;
   userBreaches: SubscriberBreach[];
   userScanData: LatestOnerepScanData;
   isEligibleForFreeScan: boolean;
@@ -65,6 +66,7 @@ export type Props = {
   fxaSettingsUrl: string;
   scanCount: number;
   totalNumberOfPerformedScans?: number;
+  isNewUser?: boolean;
 };
 
 export type TabType = "action-needed" | "fixed";
@@ -270,6 +272,14 @@ export const View = (props: Props) => {
         "dashboard-exposures-no-breaches-scan-progress-description",
       );
     }
+
+    recordTelemetry("dashboard", "view", {
+      user_id: props.userId,
+      dashboard_tab: selectedTab,
+      legacy_user: props.isNewUser,
+      breach_count: breachesDataArray.length,
+      broker_count: dataBrokerTotalNum,
+    });
 
     return (
       <>

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/page.tsx
@@ -36,6 +36,7 @@ import {
   addAttributionForSubscriber,
   getLatestAttributionForSubscriberWithType,
 } from "../../../../../../../db/tables/attributions";
+import { getUserId } from "../../../../../../functions/server/getUserId";
 
 export default async function DashboardPage() {
   const session = await getServerSession(authOptions);
@@ -175,6 +176,7 @@ export default async function DashboardPage() {
   return (
     <View
       user={session.user}
+      userId={getUserId(session)}
       isEligibleForPremium={userIsEligibleForPremium}
       isEligibleForFreeScan={userIsEligibleForFreeScan}
       userScanData={latestScan}
@@ -186,6 +188,7 @@ export default async function DashboardPage() {
       fxaSettingsUrl={fxaSettingsUrl}
       scanCount={scanCount}
       totalNumberOfPerformedScans={profileStats?.total}
+      isNewUser={isNewUser}
     />
   );
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When adding a new feature: -->

# Description

I noticed when reviewing with the data team that we're missing the `dashboard.view` event.
