### PR TITLE
Add property-based test, fix two bugs in stats calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "eslint-plugin-jest": "^27.6.3",
         "eslint-plugin-jsdoc": "^48.0.4",
         "eslint-plugin-storybook": "^0.6.15",
+        "fast-check": "^3.15.1",
         "husky": "^8.0.3",
         "jest": "^29.7.0",
         "jest-axe": "^8.0.0",
@@ -15721,6 +15722,28 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
+    },
+    "node_modules/fast-check": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.15.1.tgz",
+      "integrity": "sha512-GutOXZ+SCxGaFWfHe0Pbeq8PrkpGtPxA9/hdkI3s9YzqeMlrq5RdJ+QfYZ/S93jMX+tAyqgW0z5c9ppD+vkGUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "dependencies": {
+        "pure-rand": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -39744,6 +39767,15 @@
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
+      }
+    },
+    "fast-check": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.15.1.tgz",
+      "integrity": "sha512-GutOXZ+SCxGaFWfHe0Pbeq8PrkpGtPxA9/hdkI3s9YzqeMlrq5RdJ+QfYZ/S93jMX+tAyqgW0z5c9ppD+vkGUw==",
+      "dev": true,
+      "requires": {
+        "pure-rand": "^6.0.0"
       }
     },
     "fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "eslint-plugin-jest": "^27.6.3",
     "eslint-plugin-jsdoc": "^48.0.4",
     "eslint-plugin-storybook": "^0.6.15",
+    "fast-check": "^3.15.1",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
     "jest-axe": "^8.0.0",

--- a/src/app/functions/server/dashboard.test.ts
+++ b/src/app/functions/server/dashboard.test.ts
@@ -1206,6 +1206,15 @@ describe("getDashboardSummary", () => {
       fc.assert(outputCountsMatchInputCounts);
     });
 
+    // The `expect` is called in `outputCountsMatchInputCounts`
+    // eslint-disable-next-line jest/expect-expect
+    it("also counts bank account number breaches", () => {
+      fc.assert(outputCountsMatchInputCounts, {
+        seed: 2102994438,
+        path: "0:0:0:0:0:0:0:0:0:0:0:0:0:1:0:1:1:1:1:1:1:1:1:1:1:1:1:1",
+      });
+    });
+
     function getEmptyDashboardSummary(): Omit<
       DashboardSummary,
       "fixedSanitizedDataPoints" | "unresolvedSanitizedDataPoints"

--- a/src/app/functions/server/dashboard.test.ts
+++ b/src/app/functions/server/dashboard.test.ts
@@ -1215,6 +1215,15 @@ describe("getDashboardSummary", () => {
       });
     });
 
+    // The `expect` is called in `outputCountsMatchInputCounts`
+    // eslint-disable-next-line jest/expect-expect
+    it("also counts credit card breaches", () => {
+      fc.assert(outputCountsMatchInputCounts, {
+        seed: 1708637594,
+        path: "0:0:0:0:0:0:0:0:0:0:0:1:0:0:0:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0",
+      });
+    });
+
     function getEmptyDashboardSummary(): Omit<
       DashboardSummary,
       "fixedSanitizedDataPoints" | "unresolvedSanitizedDataPoints"

--- a/src/app/functions/server/dashboard.test.ts
+++ b/src/app/functions/server/dashboard.test.ts
@@ -869,344 +869,341 @@ describe("getDashboardSummary", () => {
       };
     }
 
-    it("returns the number of exposures that we put in", () => {
-      // We'll generate breaches with 7 different types of exposed data
-      // points, each of which can be in one of two states (unresolved, resolved):
-      const breachDataPointCountsToGenerate = 2 * 7;
-      // We'll generate scan results with 4 different types of exposed data
-      // points, each of which can be in one of four states (unresolved, in
-      // progress, auto-resolved or manually resolved):
-      const scanResultDataPointCountsToGenerate = 4 * 4;
-      fc.assert(
-        fc.property(
-          fc
-            .tuple(
-              fc.array(fc.integer({ min: 0, max: 20 }), {
-                minLength: breachDataPointCountsToGenerate,
-                maxLength: breachDataPointCountsToGenerate,
-              }),
-              fc.array(fc.integer({ min: 0, max: 20 }), {
-                minLength: scanResultDataPointCountsToGenerate,
-                maxLength: scanResultDataPointCountsToGenerate,
-              }),
-            )
-            .map(([breachDataPointCounts, scanResultDataPointCounts]) => {
-              const unresolvedDataPointCounts: DashboardSummary["unresolvedDataPoints"] =
-                {
-                  emailAddresses: scanResultDataPointCounts[0],
-                  phoneNumbers: scanResultDataPointCounts[1],
-                  addresses: scanResultDataPointCounts[2],
-                  familyMembers: scanResultDataPointCounts[3],
+    // We'll generate breaches with 7 different types of exposed data
+    // points, each of which can be in one of two states (unresolved, resolved):
+    const breachDataPointCountsToGenerate = 2 * 7;
+    // We'll generate scan results with 4 different types of exposed data
+    // points, each of which can be in one of four states (unresolved, in
+    // progress, auto-resolved or manually resolved):
+    const scanResultDataPointCountsToGenerate = 4 * 4;
+    const outputCountsMatchInputCounts = fc.property(
+      fc
+        .tuple(
+          fc.array(fc.integer({ min: 0, max: 20 }), {
+            minLength: breachDataPointCountsToGenerate,
+            maxLength: breachDataPointCountsToGenerate,
+          }),
+          fc.array(fc.integer({ min: 0, max: 20 }), {
+            minLength: scanResultDataPointCountsToGenerate,
+            maxLength: scanResultDataPointCountsToGenerate,
+          }),
+        )
+        .map(([breachDataPointCounts, scanResultDataPointCounts]) => {
+          const unresolvedDataPointCounts: DashboardSummary["unresolvedDataPoints"] =
+            {
+              emailAddresses: scanResultDataPointCounts[0],
+              phoneNumbers: scanResultDataPointCounts[1],
+              addresses: scanResultDataPointCounts[2],
+              familyMembers: scanResultDataPointCounts[3],
 
-                  socialSecurityNumbers: breachDataPointCounts[0],
-                  ipAddresses: breachDataPointCounts[1],
-                  passwords: breachDataPointCounts[2],
-                  creditCardNumbers: breachDataPointCounts[3],
-                  pins: breachDataPointCounts[4],
-                  securityQuestions: breachDataPointCounts[5],
-                  bankAccountNumbers: breachDataPointCounts[6],
-                };
-              const resolvedDataPointCounts: DashboardSummary["fixedDataPoints"] =
-                {
-                  emailAddresses: scanResultDataPointCounts[4],
-                  phoneNumbers: scanResultDataPointCounts[5],
-                  addresses: scanResultDataPointCounts[6],
-                  familyMembers: scanResultDataPointCounts[7],
+              socialSecurityNumbers: breachDataPointCounts[0],
+              ipAddresses: breachDataPointCounts[1],
+              passwords: breachDataPointCounts[2],
+              creditCardNumbers: breachDataPointCounts[3],
+              pins: breachDataPointCounts[4],
+              securityQuestions: breachDataPointCounts[5],
+              bankAccountNumbers: breachDataPointCounts[6],
+            };
+          const resolvedDataPointCounts: DashboardSummary["fixedDataPoints"] = {
+            emailAddresses: scanResultDataPointCounts[4],
+            phoneNumbers: scanResultDataPointCounts[5],
+            addresses: scanResultDataPointCounts[6],
+            familyMembers: scanResultDataPointCounts[7],
 
-                  socialSecurityNumbers: breachDataPointCounts[7],
-                  ipAddresses: breachDataPointCounts[8],
-                  passwords: breachDataPointCounts[9],
-                  creditCardNumbers: breachDataPointCounts[10],
-                  pins: breachDataPointCounts[11],
-                  securityQuestions: breachDataPointCounts[12],
-                  bankAccountNumbers: breachDataPointCounts[13],
-                };
-              const inProgressDataPointCounts: DashboardSummary["inProgressDataPoints"] =
-                {
-                  emailAddresses: scanResultDataPointCounts[8],
-                  phoneNumbers: scanResultDataPointCounts[9],
-                  addresses: scanResultDataPointCounts[10],
-                  familyMembers: scanResultDataPointCounts[11],
+            socialSecurityNumbers: breachDataPointCounts[7],
+            ipAddresses: breachDataPointCounts[8],
+            passwords: breachDataPointCounts[9],
+            creditCardNumbers: breachDataPointCounts[10],
+            pins: breachDataPointCounts[11],
+            securityQuestions: breachDataPointCounts[12],
+            bankAccountNumbers: breachDataPointCounts[13],
+          };
+          const inProgressDataPointCounts: DashboardSummary["inProgressDataPoints"] =
+            {
+              emailAddresses: scanResultDataPointCounts[8],
+              phoneNumbers: scanResultDataPointCounts[9],
+              addresses: scanResultDataPointCounts[10],
+              familyMembers: scanResultDataPointCounts[11],
 
-                  socialSecurityNumbers: 0,
-                  ipAddresses: 0,
-                  passwords: 0,
-                  creditCardNumbers: 0,
-                  pins: 0,
-                  securityQuestions: 0,
-                  bankAccountNumbers: 0,
-                };
-              const manuallyResolvedDataPointCounts: DashboardSummary["manuallyResolvedDataBrokerDataPoints"] =
-                {
-                  emailAddresses: scanResultDataPointCounts[12],
-                  phoneNumbers: scanResultDataPointCounts[13],
-                  addresses: scanResultDataPointCounts[14],
-                  familyMembers: scanResultDataPointCounts[15],
+              socialSecurityNumbers: 0,
+              ipAddresses: 0,
+              passwords: 0,
+              creditCardNumbers: 0,
+              pins: 0,
+              securityQuestions: 0,
+              bankAccountNumbers: 0,
+            };
+          const manuallyResolvedDataPointCounts: DashboardSummary["manuallyResolvedDataBrokerDataPoints"] =
+            {
+              emailAddresses: scanResultDataPointCounts[12],
+              phoneNumbers: scanResultDataPointCounts[13],
+              addresses: scanResultDataPointCounts[14],
+              familyMembers: scanResultDataPointCounts[15],
 
-                  socialSecurityNumbers: 0,
-                  ipAddresses: 0,
-                  passwords: 0,
-                  creditCardNumbers: 0,
-                  pins: 0,
-                  securityQuestions: 0,
-                  bankAccountNumbers: 0,
-                };
-              const allDataPointCounts: DashboardSummary["allDataPoints"] =
-                Object.fromEntries(
-                  Object.keys(unresolvedDataPointCounts).map((key) => [
-                    key,
-                    unresolvedDataPointCounts[key as keyof DataPoints] +
-                      resolvedDataPointCounts[key as keyof DataPoints] +
-                      inProgressDataPointCounts[key as keyof DataPoints] +
-                      manuallyResolvedDataPointCounts[key as keyof DataPoints],
-                  ]),
-                ) as DataPoints;
+              socialSecurityNumbers: 0,
+              ipAddresses: 0,
+              passwords: 0,
+              creditCardNumbers: 0,
+              pins: 0,
+              securityQuestions: 0,
+              bankAccountNumbers: 0,
+            };
+          const allDataPointCounts: DashboardSummary["allDataPoints"] =
+            Object.fromEntries(
+              Object.keys(unresolvedDataPointCounts).map((key) => [
+                key,
+                unresolvedDataPointCounts[key as keyof DataPoints] +
+                  resolvedDataPointCounts[key as keyof DataPoints] +
+                  inProgressDataPointCounts[key as keyof DataPoints] +
+                  manuallyResolvedDataPointCounts[key as keyof DataPoints],
+              ]),
+            ) as DataPoints;
 
-              function countTotalDataPoints(
-                counts: DataPoints,
-                type: "breach" | "scan-result",
-              ): number {
-                return type === "scan-result"
-                  ? counts.emailAddresses +
-                      counts.phoneNumbers +
-                      counts.addresses +
-                      counts.familyMembers
-                  : counts.socialSecurityNumbers +
-                      counts.ipAddresses +
-                      counts.passwords +
-                      counts.creditCardNumbers +
-                      counts.pins +
-                      counts.securityQuestions +
-                      counts.bankAccountNumbers;
-              }
+          function countTotalDataPoints(
+            counts: DataPoints,
+            type: "breach" | "scan-result",
+          ): number {
+            return type === "scan-result"
+              ? counts.emailAddresses +
+                  counts.phoneNumbers +
+                  counts.addresses +
+                  counts.familyMembers
+              : counts.socialSecurityNumbers +
+                  counts.ipAddresses +
+                  counts.passwords +
+                  counts.creditCardNumbers +
+                  counts.pins +
+                  counts.securityQuestions +
+                  counts.bankAccountNumbers;
+          }
 
-              function countTotalExposures(
-                counts: DataPoints,
-                type: "breach" | "scan-result",
-              ): number {
-                const pointCounts =
-                  type === "scan-result"
-                    ? [
-                        counts.emailAddresses,
-                        counts.phoneNumbers,
-                        counts.addresses,
-                        counts.familyMembers,
-                      ]
-                    : [
-                        counts.socialSecurityNumbers,
-                        counts.ipAddresses,
-                        counts.passwords,
-                        counts.creditCardNumbers,
-                        counts.pins,
-                        counts.securityQuestions,
-                        counts.bankAccountNumbers,
-                      ];
+          function countTotalExposures(
+            counts: DataPoints,
+            type: "breach" | "scan-result",
+          ): number {
+            const pointCounts =
+              type === "scan-result"
+                ? [
+                    counts.emailAddresses,
+                    counts.phoneNumbers,
+                    counts.addresses,
+                    counts.familyMembers,
+                  ]
+                : [
+                    counts.socialSecurityNumbers,
+                    counts.ipAddresses,
+                    counts.passwords,
+                    counts.creditCardNumbers,
+                    counts.pins,
+                    counts.securityQuestions,
+                    counts.bankAccountNumbers,
+                  ];
 
-                return pointCounts.filter((count) => count > 0).length;
-              }
+            return pointCounts.filter((count) => count > 0).length;
+          }
 
-              const dataBreachResolvedNum = countTotalExposures(
-                resolvedDataPointCounts,
-                "breach",
-              );
-              const dataBreachUnresolvedNum = countTotalExposures(
-                unresolvedDataPointCounts,
-                "breach",
-              );
-              const dataBreachTotalNum =
-                dataBreachResolvedNum + dataBreachUnresolvedNum;
-              const dataBreachFixedDataPointsNum = countTotalDataPoints(
-                resolvedDataPointCounts,
-                "breach",
-              );
-              const dataBreachTotalDataPointsNum = countTotalDataPoints(
-                allDataPointCounts,
-                "breach",
-              );
-              const dataBrokerAutoFixedNum = countTotalExposures(
-                resolvedDataPointCounts,
-                "scan-result",
-              );
-              const dataBrokerAutoFixedDataPointsNum = countTotalDataPoints(
-                resolvedDataPointCounts,
-                "scan-result",
-              );
-              const dataBrokerInProgressNum = countTotalExposures(
-                inProgressDataPointCounts,
-                "scan-result",
-              );
-              const dataBrokerInProgressDataPointsNum = countTotalDataPoints(
-                inProgressDataPointCounts,
-                "scan-result",
-              );
-              const dataBrokerManuallyResolvedNum = countTotalExposures(
-                manuallyResolvedDataPointCounts,
-                "scan-result",
-              );
-              const dataBrokerManuallyResolvedDataPointsNum =
-                countTotalDataPoints(
-                  manuallyResolvedDataPointCounts,
-                  "scan-result",
-                );
-              const dataBrokerUnresolvedNum = countTotalExposures(
-                unresolvedDataPointCounts,
-                "scan-result",
-              );
-              const dataBrokerUnresolvedDataPointsNum = countTotalDataPoints(
-                unresolvedDataPointCounts,
-                "scan-result",
-              );
-              const dataBrokerTotalNum =
-                dataBrokerUnresolvedNum +
-                dataBrokerAutoFixedNum +
-                dataBrokerInProgressNum +
-                dataBrokerManuallyResolvedNum;
-              const dataBrokerTotalDataPointsNum =
-                dataBrokerUnresolvedDataPointsNum +
-                dataBrokerAutoFixedDataPointsNum +
-                dataBrokerInProgressDataPointsNum +
-                dataBrokerManuallyResolvedDataPointsNum;
-              const totalDataPointsNum =
-                dataBreachTotalDataPointsNum + dataBrokerTotalDataPointsNum;
+          const dataBreachResolvedNum = countTotalExposures(
+            resolvedDataPointCounts,
+            "breach",
+          );
+          const dataBreachUnresolvedNum = countTotalExposures(
+            unresolvedDataPointCounts,
+            "breach",
+          );
+          const dataBreachTotalNum =
+            dataBreachResolvedNum + dataBreachUnresolvedNum;
+          const dataBreachFixedDataPointsNum = countTotalDataPoints(
+            resolvedDataPointCounts,
+            "breach",
+          );
+          const dataBreachTotalDataPointsNum = countTotalDataPoints(
+            allDataPointCounts,
+            "breach",
+          );
+          const dataBrokerAutoFixedNum = countTotalExposures(
+            resolvedDataPointCounts,
+            "scan-result",
+          );
+          const dataBrokerAutoFixedDataPointsNum = countTotalDataPoints(
+            resolvedDataPointCounts,
+            "scan-result",
+          );
+          const dataBrokerInProgressNum = countTotalExposures(
+            inProgressDataPointCounts,
+            "scan-result",
+          );
+          const dataBrokerInProgressDataPointsNum = countTotalDataPoints(
+            inProgressDataPointCounts,
+            "scan-result",
+          );
+          const dataBrokerManuallyResolvedNum = countTotalExposures(
+            manuallyResolvedDataPointCounts,
+            "scan-result",
+          );
+          const dataBrokerManuallyResolvedDataPointsNum = countTotalDataPoints(
+            manuallyResolvedDataPointCounts,
+            "scan-result",
+          );
+          const dataBrokerUnresolvedNum = countTotalExposures(
+            unresolvedDataPointCounts,
+            "scan-result",
+          );
+          const dataBrokerUnresolvedDataPointsNum = countTotalDataPoints(
+            unresolvedDataPointCounts,
+            "scan-result",
+          );
+          const dataBrokerTotalNum =
+            dataBrokerUnresolvedNum +
+            dataBrokerAutoFixedNum +
+            dataBrokerInProgressNum +
+            dataBrokerManuallyResolvedNum;
+          const dataBrokerTotalDataPointsNum =
+            dataBrokerUnresolvedDataPointsNum +
+            dataBrokerAutoFixedDataPointsNum +
+            dataBrokerInProgressDataPointsNum +
+            dataBrokerManuallyResolvedDataPointsNum;
+          const totalDataPointsNum =
+            dataBreachTotalDataPointsNum + dataBrokerTotalDataPointsNum;
 
-              const expectedSummary: Omit<
-                DashboardSummary,
-                "fixedSanitizedDataPoints" | "unresolvedSanitizedDataPoints"
-              > = {
-                allDataPoints: allDataPointCounts,
-                unresolvedDataPoints: unresolvedDataPointCounts,
-                inProgressDataPoints: inProgressDataPointCounts,
-                manuallyResolvedDataBrokerDataPoints:
-                  manuallyResolvedDataPointCounts,
-                fixedDataPoints: resolvedDataPointCounts,
-                dataBreachTotalNum: dataBreachTotalNum,
-                dataBreachResolvedNum: dataBreachResolvedNum,
-                dataBreachUnresolvedNum: dataBreachUnresolvedNum,
-                dataBreachTotalDataPointsNum: dataBreachTotalDataPointsNum,
-                dataBreachFixedDataPointsNum: dataBreachFixedDataPointsNum,
-                dataBrokerTotalNum: dataBrokerTotalNum,
-                dataBrokerTotalDataPointsNum: dataBrokerTotalDataPointsNum,
-                dataBrokerAutoFixedNum: dataBrokerAutoFixedNum,
-                dataBrokerAutoFixedDataPointsNum:
-                  dataBrokerAutoFixedDataPointsNum,
-                dataBrokerInProgressNum: dataBrokerInProgressNum,
-                dataBrokerInProgressDataPointsNum:
-                  dataBrokerInProgressDataPointsNum,
-                dataBrokerManuallyResolvedNum: dataBrokerManuallyResolvedNum,
-                dataBrokerManuallyResolvedDataPointsNum:
-                  dataBrokerManuallyResolvedDataPointsNum,
-                totalDataPointsNum: totalDataPointsNum,
-                // TODO: Figure out what these should be and, when we do,
-                //       replace `toMatchObject` by `toStrictEqual`:
-                // unresolvedSanitizedDataPoints: [],
-                // fixedSanitizedDataPoints: [],
-              };
+          const expectedSummary: Omit<
+            DashboardSummary,
+            "fixedSanitizedDataPoints" | "unresolvedSanitizedDataPoints"
+          > = {
+            allDataPoints: allDataPointCounts,
+            unresolvedDataPoints: unresolvedDataPointCounts,
+            inProgressDataPoints: inProgressDataPointCounts,
+            manuallyResolvedDataBrokerDataPoints:
+              manuallyResolvedDataPointCounts,
+            fixedDataPoints: resolvedDataPointCounts,
+            dataBreachTotalNum: dataBreachTotalNum,
+            dataBreachResolvedNum: dataBreachResolvedNum,
+            dataBreachUnresolvedNum: dataBreachUnresolvedNum,
+            dataBreachTotalDataPointsNum: dataBreachTotalDataPointsNum,
+            dataBreachFixedDataPointsNum: dataBreachFixedDataPointsNum,
+            dataBrokerTotalNum: dataBrokerTotalNum,
+            dataBrokerTotalDataPointsNum: dataBrokerTotalDataPointsNum,
+            dataBrokerAutoFixedNum: dataBrokerAutoFixedNum,
+            dataBrokerAutoFixedDataPointsNum: dataBrokerAutoFixedDataPointsNum,
+            dataBrokerInProgressNum: dataBrokerInProgressNum,
+            dataBrokerInProgressDataPointsNum:
+              dataBrokerInProgressDataPointsNum,
+            dataBrokerManuallyResolvedNum: dataBrokerManuallyResolvedNum,
+            dataBrokerManuallyResolvedDataPointsNum:
+              dataBrokerManuallyResolvedDataPointsNum,
+            totalDataPointsNum: totalDataPointsNum,
+            // TODO: Figure out what these should be and, when we do, replace
+            //       `toMatchObject` by `toStrictEqual`:
+            // unresolvedSanitizedDataPoints: [],
+            // fixedSanitizedDataPoints: [],
+          };
 
-              return expectedSummary;
-            }),
-          (expectedSummary) => {
-            function isNotNull<X>(value: X | null): value is X {
-              return value !== null;
-            }
+          return expectedSummary;
+        }),
+      (expectedSummary) => {
+        function isNotNull<X>(value: X | null): value is X {
+          return value !== null;
+        }
 
-            function getBreachesForCounts(
-              dataPointCounts: DataPoints,
-              resolution: Parameters<typeof getBreach>[0],
-            ): SubscriberBreach[] {
-              return (
-                Object.keys(dataClassKeyMap)
-                  // While the following data types can also be found in breaches,
-                  // for these tests we're only generating them for scan results.
-                  // (Because we start out with the final counts, this way we can
-                  // avoid double-counting them.)
-                  .filter(
-                    (dataType) =>
-                      dataType !== "emailAddresses" &&
-                      dataType !== "phoneNumbers" &&
-                      dataType !== "addresses" &&
-                      dataType !== "familyMembers",
-                  )
-                  .map((dataType) => {
-                    const count =
-                      dataPointCounts[dataType as keyof DataPoints] ?? 0;
-
-                    if (count === 0) {
-                      return null;
-                    }
-
-                    return getBreach(
-                      resolution,
-                      dataClassKeyMap[
-                        dataType
-                      ] as SubscriberBreach["dataClasses"][number],
-                      count,
-                    );
-                  })
-                  .filter(isNotNull)
-              );
-            }
-
-            function getScanResultsForCounts(
-              dataPointCounts: DataPoints,
-              resolution: Parameters<typeof getScanResult>[0],
-            ): OnerepScanResultRow[] {
-              return (
-                [
-                  "emailAddresses",
-                  "phoneNumbers",
-                  "addresses",
-                  "familyMembers",
-                ] as const
+        function getBreachesForCounts(
+          dataPointCounts: DataPoints,
+          resolution: Parameters<typeof getBreach>[0],
+        ): SubscriberBreach[] {
+          return (
+            Object.keys(dataClassKeyMap)
+              // While the following data types can also be found in breaches,
+              // for these tests we're only generating them for scan results.
+              // (Because we start out with the final counts, this way we can
+              // avoid double-counting them.)
+              .filter(
+                (dataType) =>
+                  dataType !== "emailAddresses" &&
+                  dataType !== "phoneNumbers" &&
+                  dataType !== "addresses" &&
+                  dataType !== "familyMembers",
               )
-                .map((dataType) => {
-                  const count =
-                    dataPointCounts[dataType as keyof DataPoints] ?? 0;
+              .map((dataType) => {
+                const count =
+                  dataPointCounts[dataType as keyof DataPoints] ?? 0;
 
-                  if (count === 0) {
-                    return null;
-                  }
+                if (count === 0) {
+                  return null;
+                }
 
-                  return getScanResult(resolution, dataType, count);
-                })
-                .filter(isNotNull);
-            }
+                return getBreach(
+                  resolution,
+                  dataClassKeyMap[
+                    dataType
+                  ] as SubscriberBreach["dataClasses"][number],
+                  count,
+                );
+              })
+              .filter(isNotNull)
+          );
+        }
 
-            const scanResults = [
-              ...getScanResultsForCounts(
-                expectedSummary.unresolvedDataPoints,
-                "unresolved",
-              ),
-              ...getScanResultsForCounts(
-                expectedSummary.fixedDataPoints,
-                "auto-resolved",
-              ),
-              ...getScanResultsForCounts(
-                expectedSummary.inProgressDataPoints,
-                "in-progress",
-              ),
-              ...getScanResultsForCounts(
-                expectedSummary.manuallyResolvedDataBrokerDataPoints,
-                "manually-resolved",
-              ),
-            ];
+        function getScanResultsForCounts(
+          dataPointCounts: DataPoints,
+          resolution: Parameters<typeof getScanResult>[0],
+        ): OnerepScanResultRow[] {
+          return (
+            [
+              "emailAddresses",
+              "phoneNumbers",
+              "addresses",
+              "familyMembers",
+            ] as const
+          )
+            .map((dataType) => {
+              const count = dataPointCounts[dataType as keyof DataPoints] ?? 0;
 
-            const breaches = [
-              ...getBreachesForCounts(
-                expectedSummary.unresolvedDataPoints,
-                "unresolved",
-              ),
-              ...getBreachesForCounts(
-                expectedSummary.fixedDataPoints,
-                "resolved",
-              ),
-            ];
+              if (count === 0) {
+                return null;
+              }
 
-            const resultingSummary = getDashboardSummary(scanResults, breaches);
+              return getScanResult(resolution, dataType, count);
+            })
+            .filter(isNotNull);
+        }
 
-            expect(resultingSummary).toMatchObject(expectedSummary);
-          },
-        ),
-      );
+        const scanResults = [
+          ...getScanResultsForCounts(
+            expectedSummary.unresolvedDataPoints,
+            "unresolved",
+          ),
+          ...getScanResultsForCounts(
+            expectedSummary.fixedDataPoints,
+            "auto-resolved",
+          ),
+          ...getScanResultsForCounts(
+            expectedSummary.inProgressDataPoints,
+            "in-progress",
+          ),
+          ...getScanResultsForCounts(
+            expectedSummary.manuallyResolvedDataBrokerDataPoints,
+            "manually-resolved",
+          ),
+        ];
+
+        const breaches = [
+          ...getBreachesForCounts(
+            expectedSummary.unresolvedDataPoints,
+            "unresolved",
+          ),
+          ...getBreachesForCounts(expectedSummary.fixedDataPoints, "resolved"),
+        ];
+
+        const resultingSummary = getDashboardSummary(scanResults, breaches);
+
+        // This function is included in tests below:
+        // eslint-disable-next-line jest/no-standalone-expect
+        expect(resultingSummary).toMatchObject(expectedSummary);
+      },
+    );
+
+    // The `expect` is called in `outputCountsMatchInputCounts`
+    // eslint-disable-next-line jest/expect-expect
+    it("returns the number of exposures that we put in", () => {
+      fc.assert(outputCountsMatchInputCounts);
     });
 
     function getEmptyDashboardSummary(): Omit<

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -74,7 +74,7 @@ export interface DashboardSummary {
   fixedSanitizedDataPoints: SanitizedDataPoints;
 }
 
-export const dataClassKeyMap: Record<string, string> = {
+export const dataClassKeyMap: Record<keyof DataPoints, string> = {
   emailAddresses: "email-addresses",
   phoneNumbers: "phone-numbers",
 
@@ -86,7 +86,7 @@ export const dataClassKeyMap: Record<string, string> = {
   socialSecurityNumbers: "social-security-numbers",
   ipAddresses: "ip-addresses",
   passwords: "passwords",
-  creditCardNumbers: "credit-cards",
+  creditCardNumbers: "partial-credit-card-data",
   pins: "pins",
   securityQuestions: "security-questions-and-answers",
   bankAccountNumbers: "bank-account-numbers",
@@ -435,7 +435,11 @@ function sanitizeDataPoints(
   if (breachesOnly) {
     numOfTopDataPoints = 2; // when we have breaches only
   }
-  const sanitizedAllDataPoints = Object.entries(dataPoints)
+  const sanitizedAllDataPoints = (
+    Object.entries(dataPoints) as Array<
+      [keyof DataPoints, DataPoints[keyof DataPoints]]
+    >
+  )
     .sort(([_dataClassA, countA], [_dataClassB, countB]) => countB - countA)
     .map(([dataClass, count]) => {
       const key = dataClassKeyMap[dataClass];

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -335,7 +335,6 @@ export function getDashboardSummary(
       }
     }
 
-    /* c8 ignore start */
     // count pin numbers
     if (dataClasses.includes(BreachDataTypes.PIN)) {
       summary.totalDataPointsNum += increment;
@@ -346,9 +345,7 @@ export function getDashboardSummary(
         summary.dataBreachFixedDataPointsNum += increment;
       }
     }
-    /* c8 ignore stop */
 
-    /** c8 ignore start */
     // count security questions
     if (dataClasses.includes(BreachDataTypes.SecurityQuestions)) {
       summary.totalDataPointsNum += increment;
@@ -359,7 +356,6 @@ export function getDashboardSummary(
         summary.dataBreachFixedDataPointsNum += increment;
       }
     }
-    /** c8 ignore stop */
 
     if (dataClasses.includes(BreachDataTypes.BankAccount)) {
       summary.totalDataPointsNum += increment;

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -361,6 +361,16 @@ export function getDashboardSummary(
     }
     /** c8 ignore stop */
 
+    if (dataClasses.includes(BreachDataTypes.BankAccount)) {
+      summary.totalDataPointsNum += increment;
+      summary.dataBreachTotalDataPointsNum += increment;
+      summary.allDataPoints.bankAccountNumbers += increment;
+      if (b.resolvedDataClasses.includes(BreachDataTypes.BankAccount)) {
+        summary.fixedDataPoints.bankAccountNumbers += increment;
+        summary.dataBreachFixedDataPointsNum += increment;
+      }
+    }
+
     if (b.isResolved) summary.dataBreachResolvedNum++;
   });
 


### PR DESCRIPTION
<!-- When adding a new feature: -->

# Description

So this is a big PR, but it mainly adds [property-based tests](https://fast-check.dev/docs/introduction/why-property-based/) for the `getDashboardSummary` function. I figured I'd add those after the report about the changing stats data, to rule out errors in the calculation itself.

Basically, what the test does is a bunch of runs of the following:

1. Generate some arbitrary statistics.
2. Create the breaches and scan results to match those statistics.
3. Pass those breaches and scan results to `getDashboardSummary`, then verify that the result matches the numbers generated in step 1. (This is the "property" that is verified to hold, hence the name.)

Step 1 is done randomly, and then when the test fails, it returns the seed that resulted in the invalid test result's input data. I found two bugs this way, and I've explicitly added the applicable seeds in their individual tests: 7f94e736e24d1f9202a90caf5ce9ad1abc53007f and 646a960f3199b54397c7755e9c8793d35b0ee2bc.

With those two bugs fixed, the property-based tests are now succeeding for all generated data, giving more confidence that it's actually working correctly regardless of the user's specific situation.

# How to test

Run `npm test`. Also try introducing a bug into `getDashboardSummary`, to see what the failures look like.

(And maybe try finding an account with only credit card and bank account breaches, and see how they don't get counted.)

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege. N/A
- [ ] All acceptance criteria are met. N/A
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process. N/A
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage. N/A
