### PR TITLE
MNTOR-2911 - redirect old oauth endpoint to new

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -151,6 +151,13 @@ const nextConfig = {
         destination: "https://support.mozilla.org/kb/how-stay-safe-web",
         permanent: false,
       },
+      // Some subset of users still find their way to the old login
+      // link, which redirects to a now-404 endpoint. Add a redirect
+      // to the new endpoint while we are investigating.
+      {
+        source: "/oauth/confirmed*",
+        destination: "/api/auth/callback/fxa*"
+      },
     ];
   },
   webpack: (config, options) => {

--- a/next.config.js
+++ b/next.config.js
@@ -155,8 +155,9 @@ const nextConfig = {
       // link, which redirects to a now-404 endpoint. Add a redirect
       // to the new endpoint while we are investigating.
       {
-        source: "/oauth/confirmed*",
-        destination: "/api/auth/callback/fxa*"
+        source: "/oauth/confirmed",
+        destination: "/api/auth/callback/fxa",
+        permanent: false
       },
     ];
   },


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2911 

<!-- When adding a new feature: -->

# Description

We are getting reports of users getting stuck trying to log in because they are somehow triggering the old endpoint. Add a redirect while we investigate.