### PR TITLE
Include locations that have a population of zero on GeoNames (MNTOR-2913)

### DIFF
--- a/src/app/api/v1/location-autocomplete/route.ts
+++ b/src/app/api/v1/location-autocomplete/route.ts
@@ -34,10 +34,11 @@ function getLocationsByQuery(searchQuery: string) {
   }
 
   const locationNames = locationData.data.map((location: RelevantLocation) => {
-    const { name, stateCode, countryCode, alternateNames } = location;
-    const alternateNamesJoined = alternateNames ? alternateNames.join(" ") : "";
+    const { n, s, a } = location;
+    const alternateNamesJoined = a ? a.join(" ") : "";
+    const countryCode = "USA";
 
-    return `${name} ${stateCode} ${countryCode} ${alternateNamesJoined}`;
+    return `${n} ${s} ${countryCode} ${alternateNamesJoined}`;
   });
 
   // For search options see: https://github.com/leeoniya/uFuzzy#options
@@ -79,7 +80,7 @@ function getLocationsByQuery(searchQuery: string) {
       .slice(0, locationSplitIndex)
       .sort(
         (a: RelevantLocation, b: RelevantLocation) =>
-          Number(b.population) - Number(a.population),
+          Number(b.p ?? 0) - Number(a.p ?? 0),
       ),
     ...resultsOrdered.slice(locationSplitIndex + 1),
   ];

--- a/src/app/api/v1/location-autocomplete/types.ts
+++ b/src/app/api/v1/location-autocomplete/types.ts
@@ -835,14 +835,11 @@ export type LocationData = [
 ];
 
 export interface RelevantLocation {
-  id: string;
-  name: string;
-  stateCode: string;
-  countryCode: string;
-  featureClass: string;
-  featureCode: string;
-  population: string;
-  alternateNames?: Array<string>;
+  id: string; // GeoName location ID
+  n: string; // location name
+  s: string; // state code
+  p?: string; // population
+  a?: Array<string>; // alternate location names
 }
 
 export interface RelevantLocationAlternate {

--- a/src/app/api/v1/location-autocomplete/types.ts
+++ b/src/app/api/v1/location-autocomplete/types.ts
@@ -834,6 +834,8 @@ export type LocationData = [
   LocationModificationDate,
 ];
 
+// NOTE: The location JSON uses short keys and
+// optional properties to reduce filesize.
 export interface RelevantLocation {
   id: string; // GeoName location ID
   n: string; // location name

--- a/src/app/components/client/LocationAutocompleteInput.tsx
+++ b/src/app/components/client/LocationAutocompleteInput.tsx
@@ -21,8 +21,8 @@ export function getDetailsFromLocationString(locationString: string) {
 }
 
 function getLocationString(location: RelevantLocation) {
-  const { name, stateCode, countryCode } = location;
-  return `${name}, ${stateCode}, ${countryCode}`;
+  const { n: name, s: stateCode } = location;
+  return `${name}, ${stateCode}, USA`;
 }
 
 function getLocationStringByKey(

--- a/src/app/hooks/__mocks__/locationSuggestions.ts
+++ b/src/app/hooks/__mocks__/locationSuggestions.ts
@@ -14,15 +14,13 @@ export const useLocationSuggestions: typeof ogUseLocationSuggestions = () => {
     items: [
       {
         id: "4553433",
-        name: "Tulsa",
-        stateCode: "OK",
-        countryCode: "USA",
+        n: "Tulsa",
+        s: "OK",
       },
       {
         id: "5318313",
-        name: "Tucson",
-        stateCode: "AZ",
-        countryCode: "USA",
+        n: "Tucson",
+        s: "AZ",
       },
     ] as RelevantLocation[],
     setFilterText: mockSetFilterText,

--- a/src/scripts/uploadAutoCompleteLocations.js
+++ b/src/scripts/uploadAutoCompleteLocations.js
@@ -239,9 +239,8 @@ try {
       const isPopulatedPlaceOfInterest =
         featureClass === allowedFeatureClass &&
         allowedFeatureCodes.includes(featureCode);
-      const hasPopulation = Number(population) !== 0;
 
-      if (isPopulatedPlaceOfInterest && hasPopulation) {
+      if (isPopulatedPlaceOfInterest) {
         const alternateNames = parsedAlternateNames.filter(
           ({ alternateOf, name: alternateName }) =>
             alternateOf === geonameId && alternateName !== name,

--- a/src/scripts/uploadAutoCompleteLocations.js
+++ b/src/scripts/uploadAutoCompleteLocations.js
@@ -261,15 +261,14 @@ try {
         relevantLocations.push({
           id: geonameId,
           // switch names if an alternate name is the preferred location name
-          name: preferredName ? preferredName.name : name,
-          stateCode: admin1Code,
-          countryCode: "USA",
-          featureClass,
-          featureCode,
-          population,
+          n: preferredName ? preferredName.name : name,
+          s: admin1Code,
+          ...(Number(population) > 0 && {
+              p: population,
+            }),
           ...(alternateNames &&
             alternateNames.length > 0 && {
-              alternateNames: alternateNamesFinal,
+              a: alternateNamesFinal,
             }),
         });
       }

--- a/src/scripts/uploadAutoCompleteLocations.js
+++ b/src/scripts/uploadAutoCompleteLocations.js
@@ -258,6 +258,8 @@ try {
           return alternateName.name;
         });
 
+        // NOTE: Using short keys and only including entries when available
+        // keeps the resulting JSON significantly smaller.
         relevantLocations.push({
           id: geonameId,
           // switch names if an alternate name is the preferred location name

--- a/src/scripts/uploadAutoCompleteLocations.js
+++ b/src/scripts/uploadAutoCompleteLocations.js
@@ -264,8 +264,8 @@ try {
           n: preferredName ? preferredName.name : name,
           s: admin1Code,
           ...(Number(population) > 0 && {
-              p: population,
-            }),
+            p: population,
+          }),
           ...(alternateNames &&
             alternateNames.length > 0 && {
               a: alternateNamesFinal,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2913](https://mozilla-hub.atlassian.net/jira/software/c/projects/MNTOR/issues/MNTOR-2913)

<!-- When adding a new feature: -->

# Description

This PR does two things:

1. **Do not filter locations with a population of zero** 
We’ve been filtering out locations with a population of zero so we do not bloat the dataset too much. This seems to have the potential for false positives and we’ve received a report that a user could not enter their populated location. I checked and [GeoNames](https://www.geonames.org/) does not list a population. Even though I’ve contributed the population number from the latest  [2020 US Census](https://www.census.gov/programs-surveys/decennial-census/decade/2020/2020-census-results.html) to that location and this would already fix the issue for the certain location chances are high that this will be the only instance — so let’s better include those locations.

2. **Reduce filesize of `locationAutocompleteData.json`**
The original filesize of the locations JSON we generate was `4.4 MB`. When including all the locations with no entered population the size grew to `~22 MB`. Just by excluding info we do not necessarily need for the location autosuggestion shrunk it to `~12 MB` and with the additional shorting of the key names we are now at `~8 MB` — at this size the `LocationAutocompleteInput` is still very responsive and seems to work well.

# How to test

1. Navigate to `/user/welcome` to the “Enter info” step.
4. Search for the previously missing location mentioned in [MNTOR-2913](https://mozilla-hub.atlassian.net/jira/software/c/projects/MNTOR/issues/MNTOR-2913).

[MNTOR-2913]: https://mozilla-hub.atlassian.net/browse/MNTOR-2913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ