### PR TITLE
Fix failing e2e tests

### DIFF
--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -82,6 +82,9 @@ jobs:
           # old user accounts, so let's pretend they all are:
           BROKER_SCAN_RELEASE_DATE: "3000-12-31"
           DEBUG: pw:api
+          # Our tests are currently set up to expect accounts to act like
+          # old user accounts, so let's pretend they all are:
+          BROKER_SCAN_RELEASE_DATE: "3000-12-31"
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -81,6 +81,7 @@ jobs:
           # Our tests are currently set up to expect accounts to act like
           # old user accounts, so let's pretend they all are:
           BROKER_SCAN_RELEASE_DATE: "3000-12-31"
+          DEBUG: pw:api
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -75,7 +75,7 @@ export default defineConfig({
     video: 'retry-with-video',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry'
+    trace: 'on',
   },
 
   /* Configure projects for major browsers */

--- a/src/e2e/pages/authPage.ts
+++ b/src/e2e/pages/authPage.ts
@@ -2,66 +2,45 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Locator, Page } from "@playwright/test";
+import { Page } from "@playwright/test";
 import { getVerificationCode } from "../utils/helpers.js";
 
 export class AuthPage {
   readonly page: Page;
-  readonly emailInputField: Locator;
-  readonly passwordInputField: Locator;
-  readonly passwordConfirmInputField: Locator;
-  readonly continueButton: Locator;
-  readonly ageInputField: Locator;
-  readonly verifyCodeInputField: Locator;
 
   constructor(page: Page) {
     this.page = page;
-    this.emailInputField = page.locator('input[name="email"]');
-    this.passwordInputField = page.locator('[type="password"]').nth(0);
-    this.passwordConfirmInputField = page.locator('[type="password"]').nth(1);
-    this.ageInputField = page.getByLabel("How old are you?");
-    this.continueButton = page.locator('[type="submit"]').first();
-    this.verifyCodeInputField = page.locator("div.card input");
-  }
-
-  async continue({ waitForURL = "**/*" }) {
-    await this.continueButton.click();
-    await this.page.waitForURL(waitForURL);
-  }
-
-  async enterVerificationCode(code: string) {
-    await this.verifyCodeInputField.fill(code);
-    await this.continue({ waitForURL: "**/user/**" });
   }
 
   async enterEmail(email: string) {
-    await this.emailInputField.fill(email);
-    await this.continue({ waitForURL: "**/oauth/**" });
-  }
-
-  async enterPassword() {
-    await this.passwordInputField.fill(
-      process.env.E2E_TEST_ACCOUNT_PASSWORD as string,
-    );
-    await this.continue({ waitForURL: "**/user/**" });
+    await this.page
+      .getByRole("textbox", { name: "Enter your email" })
+      .fill(email);
+    await this.page.getByRole("button", { name: "Sign up or sign in" }).click();
   }
 
   async signIn(email: string) {
     await this.enterEmail(email);
-    await this.enterPassword();
+    await this.page
+      .getByRole("textbox", { name: "Password" })
+      .fill(process.env.E2E_TEST_ACCOUNT_PASSWORD as string);
+    await this.page.getByRole("button", { name: "Sign in" }).click();
+    await this.page.waitForURL(`${process.env.E2E_TEST_BASE_URL}/**`);
   }
 
   async signUp(email: string, page: Page) {
     await this.enterEmail(email);
-    await this.passwordInputField.fill(
-      process.env.E2E_TEST_ACCOUNT_PASSWORD as string,
-    );
-    await this.passwordConfirmInputField.fill(
-      process.env.E2E_TEST_ACCOUNT_PASSWORD as string,
-    );
-    await this.ageInputField.type("31");
-    await this.continue({ waitForURL: "**/oauth/**" });
+    await this.page
+      .getByLabel("Password", { exact: true })
+      .fill(process.env.E2E_TEST_ACCOUNT_PASSWORD as string);
+    await this.page
+      .getByLabel("Repeat password")
+      .fill(process.env.E2E_TEST_ACCOUNT_PASSWORD as string);
+    await this.page.getByLabel("How old are you?").fill("31");
+    await this.page.getByRole("button", { name: "Create account" }).click();
     const vc = await getVerificationCode(email, page);
-    await this.enterVerificationCode(vc);
+    await this.page.getByLabel("Enter 6-digit code").fill(vc);
+    await this.page.getByRole("button", { name: "Confirm" }).click();
+    await this.page.waitForURL(`${process.env.E2E_TEST_BASE_URL}/**`);
   }
 }


### PR DESCRIPTION
The E2E tests are still failing even though auth should be stable again. The following error in the logs is attached to the `waitForNavigation` calls removed in this PR:

> Error: page.waitForNavigation: net::ERR_TOO_MANY_REDIRECTS

Additionally, that API is deprecated as a source of raciness, and it didn't seem to be necessary anyway.

I've also split up the password selectors for signing in and signing up, since they're different forms with different labels, and thus trying to come up with a selector that matched both is a losing battle.

So let's see if this is enough to make them succeed again.