### PR TITLE
MNTOR-2929 - avoid server error and add logging, with followup

### DIFF
--- a/src/app/functions/server/getUserBreaches.ts
+++ b/src/app/functions/server/getUserBreaches.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../utils/subscriberBreaches";
 import { EmailRow } from "../../../db/tables/emailAddresses";
 import { HibpLikeDbBreach } from "../../../utils/hibp";
+import { logger } from "./logging";
 
 //TODO: deprecate with MNTOR-2021
 export type UserBreaches = {
@@ -96,7 +97,12 @@ export async function getUserBreaches({
 export async function getSubscriberBreaches(
   user: Session["user"],
 ): Promise<SubscriberBreach[]> {
+  // FIXME this does not always return a subscriber https://mozilla-hub.atlassian.net/browse/MNTOR-2936
   const subscriber = await getSubscriberByEmail(user.email);
+  if (!subscriber?.id) {
+    logger.warn("no_subscriber_for_email", { user });
+    return [];
+  }
   const allBreaches = await getBreaches();
   const breachesData = await getSubBreaches(subscriber, allBreaches);
   return breachesData;


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2929 


<!-- When adding a new feature: -->

# Description

We can see from Sentry that `getSubscriberByEmail` sometimes returns `undefined`, which is causing server-side errors for some customers. Add temporary logging to diagnose, with a followup ticket filed to actually fix the problem (linked in FIXME comment).

# How to test

We're not sure how to reproduce this yet, this will temporarily add extra logging in production (server only).

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
