### PR TITLE
Fallback behavior for case-sensitivity issues in email lookup

### DIFF
--- a/src/app/functions/server/getUserBreaches.ts
+++ b/src/app/functions/server/getUserBreaches.ts
@@ -97,8 +97,17 @@ export async function getUserBreaches({
 export async function getSubscriberBreaches(
   user: Session["user"],
 ): Promise<SubscriberBreach[]> {
-  // FIXME this does not always return a subscriber https://mozilla-hub.atlassian.net/browse/MNTOR-2936
-  const subscriber = await getSubscriberByEmail(user.email);
+  // FIXME case-insensitivity issues, fallback to previous behavior https://mozilla-hub.atlassian.net/browse/MNTOR-2936
+  const email = user.subscriber?.fxa_profile_json?.email;
+
+  let subscriber;
+  if (email) {
+    subscriber = await getSubscriberByEmail(email);
+  }
+  if (!subscriber?.id) {
+    logger.warn("fallback_subscriber_email", { user });
+    subscriber = await getSubscriberByEmail(user.email);
+  }
   if (!subscriber?.id) {
     logger.error("no_subscriber_for_email", { user });
     throw new Error("no subscriber ID for email");

--- a/src/db/tables/subscribers.js
+++ b/src/db/tables/subscribers.js
@@ -83,9 +83,10 @@ async function getSubscriberByFxaUid (uid) {
 // Not covered by tests; mostly side-effects. See test-coverage.md#mock-heavy
 /* c8 ignore start */
 async function getSubscriberByEmail (email) {
-  const [subscriber] = await knex('subscribers')
-  .where("primary_verified", true)
-  .whereILike('primary_email', email)
+  const [subscriber] = await knex('subscribers').where({
+    primary_email: email,
+    primary_verified: true
+  })
   const subscriberAndEmails = await joinEmailAddressesToSubscriber(subscriber)
   return subscriberAndEmails
 }

--- a/src/db/tables/subscribers.js
+++ b/src/db/tables/subscribers.js
@@ -85,7 +85,7 @@ async function getSubscriberByFxaUid (uid) {
 async function getSubscriberByEmail (email) {
   const [subscriber] = await knex('subscribers')
   .where("primary_verified", true)
-  .whereILike("primary_email", email)
+  .whereILike('primary_email', email)
   const subscriberAndEmails = await joinEmailAddressesToSubscriber(subscriber)
   return subscriberAndEmails
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2929


<!-- When adding a new feature: -->

# Description

We've identified a case-sensitivity problem causing issues for some users when loading the dashboard pages, including the welcome-to-plus page. We'd like to get a fix out quickly while we work on cleaning up the reason the data is like this. This PR tries to first look up users using the email address in their FxA profile information, and if that fails, it falls back to current behavior.

It also reverts the `ilike` commits that were causing high database utilization due to missing indexes. There is a FIXME comment to follow up.

# How to test

Test and watch PG stats, the query quickly rose to the top before.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
