### PR TITLE
MNTOR-2938 - switch from looking up by email to fxa_uid wherever possible

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/actions.ts
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/actions.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../../../../../db/tables/emailAddresses";
 import {
   deleteResolutionsWithEmail,
-  getSubscriberByEmail,
+  getSubscriberByFxaUid,
 } from "../../../../../../../db/tables/subscribers";
 import { validateEmailAddress } from "../../../../../../../utils/emailAddress";
 import { initEmail } from "../../../../../../../utils/email";
@@ -38,15 +38,15 @@ export async function onAddEmail(
 ): Promise<AddEmailFormState> {
   const l10n = getL10n();
   const session = await getServerSession();
-  if (!session?.user.email) {
+  if (!session?.user.subscriber?.fxa_uid) {
     return {
       success: false,
       error: "add-email-without-active-session",
       errorMessage: l10n.getString("user-add-invalid-email"),
     };
   }
-  const subscriber = (await getSubscriberByEmail(
-    session.user.email,
+  const subscriber = (await getSubscriberByFxaUid(
+    session.user.subscriber?.fxa_uid,
   )) as SubscriberRow | null;
   if (!subscriber) {
     return {
@@ -130,14 +130,14 @@ export async function onAddEmail(
 
 export async function onRemoveEmail(email: EmailRow) {
   const session = await getServerSession();
-  if (!session?.user.email) {
+  if (!session?.user.subscriber?.fxa_uid) {
     logger.error(
       `Tried to delete email [${email.id}] without an active session.`,
     );
     return;
   }
-  const subscriber = (await getSubscriberByEmail(
-    session.user.email,
+  const subscriber = (await getSubscriberByFxaUid(
+    session.user.subscriber.fxa_uid,
   )) as SubscriberRow | null;
   if (email.subscriber_id !== subscriber?.id) {
     logger.error(

--- a/src/app/api/v1/user/breaches/bulk-resolve/route.ts
+++ b/src/app/api/v1/user/breaches/bulk-resolve/route.ts
@@ -13,13 +13,16 @@ import {
 import { getBreaches } from "../../../../../functions/server/getBreaches";
 import { getAllEmailsAndBreaches } from "../../../../../../utils/breaches";
 import {
-  getSubscriberByEmail,
+  getSubscriberByFxaUid,
   setBreachResolution,
 } from "../../../../../../db/tables/subscribers";
 
 export async function PUT(req: NextRequest): Promise<NextResponse> {
   const session = await getServerSession(authOptions);
-  if (!session?.user?.subscriber || typeof session?.user?.email !== "string") {
+  if (
+    !session?.user?.subscriber ||
+    typeof session?.user?.subscriber.fxa_uid !== "string"
+  ) {
     return new NextResponse(
       JSON.stringify({ success: false, message: "Unauthenticated" }),
       { status: 401 },
@@ -27,8 +30,8 @@ export async function PUT(req: NextRequest): Promise<NextResponse> {
   }
 
   try {
-    const subscriber: Subscriber = await getSubscriberByEmail(
-      session.user.email,
+    const subscriber: Subscriber = await getSubscriberByFxaUid(
+      session.user.subscriber.fxa_uid,
     );
     const allBreaches = await getBreaches();
     const { dataType: dataTypeToResolve }: BreachBulkResolutionRequest =

--- a/src/app/api/v1/user/breaches/route.ts
+++ b/src/app/api/v1/user/breaches/route.ts
@@ -13,7 +13,7 @@ import {
 import { getBreaches } from "../../../../functions/server/getBreaches";
 import { getAllEmailsAndBreaches } from "../../../../../utils/breaches";
 import {
-  getSubscriberByEmail,
+  getSubscriberByFxaUid,
   setBreachResolution,
 } from "../../../../../db/tables/subscribers";
 import appConstants from "../../../../../appConstants";
@@ -21,10 +21,12 @@ import appConstants from "../../../../../appConstants";
 // Get breaches data
 export async function GET(req: NextRequest) {
   const token = await getToken({ req });
-  if (typeof token?.email === "string") {
+  if (typeof token?.subscriber?.fxa_uid === "string") {
     // Signed in
     try {
-      const subscriber: Subscriber = await getSubscriberByEmail(token.email);
+      const subscriber: Subscriber = await getSubscriberByFxaUid(
+        token.subscriber?.fxa_uid,
+      );
       const allBreaches = await getBreaches();
       const breaches = await getAllEmailsAndBreaches(subscriber, allBreaches);
       const successResponse = {
@@ -44,9 +46,11 @@ export async function GET(req: NextRequest) {
 
 export async function PUT(req: NextRequest) {
   const token = await getToken({ req });
-  if (typeof token?.email === "string") {
+  if (typeof token?.subscriber?.fxa_uid === "string") {
     try {
-      const subscriber: Subscriber = await getSubscriberByEmail(token.email);
+      const subscriber: Subscriber = await getSubscriberByFxaUid(
+        token.subscriber?.fxa_uid,
+      );
       const allBreaches = await getBreaches();
       const j = await req.json();
       const {

--- a/src/app/api/v1/user/email/route.ts
+++ b/src/app/api/v1/user/email/route.ts
@@ -6,7 +6,7 @@ import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
 import AppConstants from "../../../../../appConstants";
 
-import { getSubscriberByEmail } from "../../../../../db/tables/subscribers";
+import { getSubscriberByFxaUid } from "../../../../../db/tables/subscribers";
 import { addSubscriberUnverifiedEmailHash } from "../../../../../db/tables/emailAddresses.js";
 
 import { sendVerificationEmail } from "../../../utils/email";
@@ -25,11 +25,11 @@ export async function POST(req: NextRequest) {
   const token = await getToken({ req });
   const l10n = getL10n();
 
-  if (typeof token?.email === "string") {
+  if (typeof token?.subscriber?.fxa_uid === "string") {
     try {
       const body: EmailAddRequest = await req.json();
-      const subscriber = (await getSubscriberByEmail(
-        token.email,
+      const subscriber = (await getSubscriberByFxaUid(
+        token.subscriber?.fxa_uid,
       )) as Subscriber & {
         email_addresses: Array<{ id: number; email: string }>;
       };

--- a/src/app/api/v1/user/remove-email/route.ts
+++ b/src/app/api/v1/user/remove-email/route.ts
@@ -8,7 +8,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { logger } from "../../../../functions/server/logging";
 import AppConstants from "../../../../../appConstants";
 import {
-  getSubscriberByEmail,
+  getSubscriberByFxaUid,
   deleteResolutionsWithEmail,
 } from "../../../../../db/tables/subscribers";
 import {
@@ -25,10 +25,10 @@ export async function POST(req: NextRequest) {
   const l10n = getL10n();
   const token = await getToken({ req });
 
-  if (typeof token?.email === "string") {
+  if (typeof token?.subscriber?.fxa_uid === "string") {
     try {
       const { emailId }: EmailDeleteRequest = await req.json();
-      const subscriber = await getSubscriberByEmail(token.email);
+      const subscriber = await getSubscriberByFxaUid(token.subscriber?.fxa_uid);
       const existingEmail = await getEmailById(emailId);
 
       if (existingEmail?.subscriber_id !== subscriber.id) {

--- a/src/app/api/v1/user/resend-email/route.ts
+++ b/src/app/api/v1/user/resend-email/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { logger } from "../../../../functions/server/logging";
 import AppConstants from "../../../../../appConstants";
-import { getSubscriberByEmail } from "../../../../../db/tables/subscribers";
+import { getSubscriberByFxaUid } from "../../../../../db/tables/subscribers";
 import { getUserEmails } from "../../../../../db/tables/emailAddresses";
 import { sendVerificationEmail } from "../../../utils/email";
 import { getL10n } from "../../../../functions/server/l10n";
@@ -21,10 +21,10 @@ export async function POST(req: NextRequest) {
   const token = await getToken({ req });
   const l10n = getL10n();
 
-  if (typeof token?.email === "string") {
+  if (typeof token?.subscriber?.fxa_uid === "string") {
     try {
       const { emailId }: EmailResendRequest = await req.json();
-      const subscriber = await getSubscriberByEmail(token.email);
+      const subscriber = await getSubscriberByFxaUid(token.subscriber?.fxa_uid);
       const existingEmail = await getUserEmails(subscriber.id);
 
       const filteredEmail = existingEmail.filter(

--- a/src/app/api/v1/user/update-comm-option/route.ts
+++ b/src/app/api/v1/user/update-comm-option/route.ts
@@ -9,7 +9,7 @@ import { logger } from "../../../../functions/server/logging";
 import AppConstants from "../../../../../appConstants";
 
 import {
-  getSubscriberByEmail,
+  getSubscriberByFxaUid,
   setAllEmailsToPrimary,
 } from "../../../../../db/tables/subscribers";
 
@@ -21,11 +21,11 @@ export interface EmailUpdateCommOptionRequest {
 export async function POST(req: NextRequest) {
   const token = await getToken({ req });
 
-  if (typeof token?.email === "string") {
+  if (typeof token?.subscriber?.fxa_uid === "string") {
     try {
       const { communicationOption }: EmailUpdateCommOptionRequest =
         await req.json();
-      const subscriber = await getSubscriberByEmail(token.email);
+      const subscriber = await getSubscriberByFxaUid(token.subscriber?.fxa_uid);
       // 0 = Send breach alerts to the corresponding affected emails.
       // 1 = Send all breach alerts to user's primary email address.
       const allEmailsToPrimary = Number(communicationOption) === 1 ?? false;

--- a/src/app/api/v1/user/welcome-scan/create/route.ts
+++ b/src/app/api/v1/user/welcome-scan/create/route.ts
@@ -16,7 +16,7 @@ import {
 import type { CreateProfileRequest } from "../../../../../functions/server/onerep";
 import { meetsAgeRequirement } from "../../../../../functions/universal/user";
 import AppConstants from "../../../../../../appConstants";
-import { getSubscriberByEmail } from "../../../../../../db/tables/subscribers";
+import { getSubscriberByFxaUid } from "../../../../../../db/tables/subscribers";
 import {
   setOnerepProfileId,
   setOnerepScan,
@@ -80,9 +80,11 @@ export async function POST(
     birth_date: dateOfBirth,
   };
 
-  if (typeof session?.user?.email === "string") {
+  if (typeof session?.user?.subscriber.fxa_uid === "string") {
     try {
-      const subscriber = await getSubscriberByEmail(session.user.email);
+      const subscriber = await getSubscriberByFxaUid(
+        session.user.subscriber.fxa_uid,
+      );
 
       if (!subscriber.onerep_profile_id) {
         // Create OneRep profile

--- a/src/app/api/v1/user/welcome-scan/create/route.ts
+++ b/src/app/api/v1/user/welcome-scan/create/route.ts
@@ -44,7 +44,7 @@ export async function POST(
 ): Promise<NextResponse<WelcomeScanBody> | NextResponse<unknown>> {
   const session = await getServerSession(authOptions);
   if (!session?.user?.subscriber) {
-    throw new Error("No session");
+    throw new Error("No fxa_uid found in session");
   }
 
   const eligible = await isEligibleForFreeScan(

--- a/src/app/api/v1/user/welcome-scan/progress/route.ts
+++ b/src/app/api/v1/user/welcome-scan/progress/route.ts
@@ -11,7 +11,7 @@ import { logger } from "../../../../../functions/server/logging";
 import AppConstants from "../../../../../../appConstants";
 import {
   getOnerepProfileId,
-  getSubscriberByEmail,
+  getSubscriberByFxaUid,
 } from "../../../../../../db/tables/subscribers";
 
 import {
@@ -38,9 +38,11 @@ export async function GET(
   _req: NextRequest,
 ): Promise<NextResponse<ScanProgressBody> | NextResponse<unknown>> {
   const session = await getServerSession(authOptions);
-  if (typeof session?.user?.email === "string") {
+  if (typeof session?.user?.subscriber?.fxa_uid === "string") {
     try {
-      const subscriber = await getSubscriberByEmail(session.user.email);
+      const subscriber = await getSubscriberByFxaUid(
+        session.user.subscriber?.fxa_uid,
+      );
       const profileId = await getOnerepProfileId(subscriber.id);
 
       const latestScan = await getLatestOnerepScanResults(profileId);

--- a/src/app/api/v1/user/welcome-scan/result/route.ts
+++ b/src/app/api/v1/user/welcome-scan/result/route.ts
@@ -12,7 +12,7 @@ import { logger } from "../../../../../functions/server/logging";
 import AppConstants from "../../../../../../appConstants";
 import {
   getOnerepProfileId,
-  getSubscriberByEmail,
+  getSubscriberByFxaUid,
 } from "../../../../../../db/tables/subscribers";
 
 import { getLatestOnerepScanResults } from "../../../../../../db/tables/onerep_scans";
@@ -26,9 +26,11 @@ export type WelcomeScanResultResponse =
 
 export async function GET() {
   const session = await getServerSession(authOptions);
-  if (typeof session?.user?.email === "string") {
+  if (typeof session?.user?.subscriber?.fxa_uid === "string") {
     try {
-      const subscriber = await getSubscriberByEmail(session.user.email);
+      const subscriber = await getSubscriberByFxaUid(
+        session.user.subscriber?.fxa_uid,
+      );
       const profileId = await getOnerepProfileId(subscriber.id);
 
       const scanResults = await getLatestOnerepScanResults(profileId);

--- a/src/app/functions/server/getSubscriberEmails.ts
+++ b/src/app/functions/server/getSubscriberEmails.ts
@@ -15,7 +15,7 @@ export async function getSubscriberEmails(
   user: Session["user"],
 ): Promise<string[]> {
   if (!user.subscriber?.fxa_uid) {
-    throw new Error("No session");
+    throw new Error("No fxa_uid found in session");
   }
   const emailArray: string[] = [user.email];
   const subscriber = await getSubscriberByFxaUid(user.subscriber?.fxa_uid);

--- a/src/app/functions/server/getUserBreaches.ts
+++ b/src/app/functions/server/getUserBreaches.ts
@@ -42,7 +42,10 @@ export async function getUserBreaches({
   user: Session["user"];
   options?: Parameters<typeof appendBreachResolutionChecklist>[1];
 }): Promise<UserBreaches> {
-  const subscriber = await getSubscriberByFxaUid(user.subscriber?.fxa_uid);
+  if (!user.subscriber?.fxa_uid) {
+    throw new Error("No fxa_uid found in session");
+  }
+  const subscriber = await getSubscriberByFxaUid(user.subscriber.fxa_uid);
   const allBreaches = await getBreaches();
   const breachesData = await getAllEmailsAndBreaches(subscriber, allBreaches);
   appendBreachResolutionChecklist(breachesData, options);
@@ -97,9 +100,9 @@ export async function getSubscriberBreaches(
   user: Session["user"],
 ): Promise<SubscriberBreach[]> {
   if (!user.subscriber?.fxa_uid) {
-    throw new Error("No session");
+    throw new Error("No fxa_uid found in session");
   }
-  const subscriber = await getSubscriberByFxaUid(user.subscriber?.fxa_uid);
+  const subscriber = await getSubscriberByFxaUid(user.subscriber.fxa_uid);
   const allBreaches = await getBreaches();
   const breachesData = await getSubBreaches(subscriber, allBreaches);
   return breachesData;

--- a/src/app/functions/server/onerep.ts
+++ b/src/app/functions/server/onerep.ts
@@ -361,7 +361,7 @@ export async function isEligibleForFreeScan(
   }
 
   if (!user?.subscriber?.id) {
-    throw new Error("No session");
+    throw new Error("No fxa_uid found in session");
   }
 
   const enabledFlags = await getEnabledFeatureFlags({ email: user.email });

--- a/src/app/functions/server/onerep.ts
+++ b/src/app/functions/server/onerep.ts
@@ -361,7 +361,7 @@ export async function isEligibleForFreeScan(
   }
 
   if (!user?.subscriber?.id) {
-    throw new Error("No fxa_uid found in session");
+    throw new Error("No session with a known subscriber found");
   }
 
   const enabledFlags = await getEnabledFeatureFlags({ email: user.email });


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2938


<!-- When adding a new feature: -->

# Description

We've been trying to fix problems with email mixed-case in a one-off way, but I think at the end of the day email addresses are a poor choice of identifier. The `fxa_uid` is a stable identifier that represents a Mozilla Accounts user, we should switch to this wherever possible. Email addresses are very complex and notoriously difficult to validate, since they are more about what servers accept historically and aren't really intended to be a stable identifier.

I've left `getSubscriberByEmail()` in a few places where it makes sense (e.g. looking up and removing an email address that is bouncing), but when we have a JWT from Mozilla Accounts, we should prefer the UID over the email.

# How to test

This should entirely eliminate the class of bugs that happen when registering with a mixed-case email address. Otherwise, this should be exactly the same. We should ensure that indexes are in place so user lookups are still fast.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
