### PR TITLE
Move aria-live into <Button>

### DIFF
--- a/src/app/components/client/Button.test.tsx
+++ b/src/app/components/client/Button.test.tsx
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { it, expect } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import { composeStory } from "@storybook/react";
+import Meta, { Primary, PrimaryLink } from "./stories/Button.stories";
+
+describe("<Button> as a button", () => {
+  it("tells screen readers to read out content changes if they happen", () => {
+    const ComposedButton = composeStory(Primary, Meta);
+    render(
+      <ComposedButton isLoading>
+        This content will be replaced by a loading message while isLoading is
+        true.
+      </ComposedButton>,
+    );
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("aria-live", "polite");
+    expect(button).toHaveAccessibleName("Loading");
+  });
+
+  it("tells screen readers to read out content changes if they might happen (i.e. isLoading is not undefined)", () => {
+    const ComposedButton = composeStory(Primary, Meta);
+    render(<ComposedButton isLoading={false}>Some content</ComposedButton>);
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("aria-live", "polite");
+    expect(button).toHaveAccessibleName("Some content");
+  });
+
+  it("does not tell screen readers to read out content changes if they won't happen (i.e. isLoading is not defined)", () => {
+    const ComposedButton = composeStory(Primary, Meta);
+    render(<ComposedButton>Some content</ComposedButton>);
+
+    const button = screen.getByRole("button");
+    expect(button).not.toHaveAttribute("aria-live");
+    expect(button).toHaveAccessibleName("Some content");
+  });
+});
+
+describe("<Button> as a link", () => {
+  it("tells screen readers to read out content changes if they happen", () => {
+    const ComposedButton = composeStory(PrimaryLink, Meta);
+    render(
+      <ComposedButton isLoading>
+        This content will be replaced by a loading message while isLoading is
+        true.
+      </ComposedButton>,
+    );
+
+    const button = screen.getByRole("link");
+    expect(button).toHaveAttribute("aria-live", "polite");
+    expect(button).toHaveAccessibleName("Loading");
+  });
+
+  it("tells screen readers to read out content changes if they might happen (i.e. isLoading is not undefined)", () => {
+    const ComposedButton = composeStory(PrimaryLink, Meta);
+    render(<ComposedButton isLoading={false}>Some content</ComposedButton>);
+
+    const button = screen.getByRole("link");
+    expect(button).toHaveAttribute("aria-live", "polite");
+    expect(button).toHaveAccessibleName("Some content");
+  });
+
+  it("does not tell screen readers to read out content changes if they won't happen (i.e. isLoading is not defined)", () => {
+    const ComposedButton = composeStory(PrimaryLink, Meta);
+    render(<ComposedButton>Some content</ComposedButton>);
+
+    const button = screen.getByRole("link");
+    expect(button).not.toHaveAttribute("aria-live");
+    expect(button).toHaveAccessibleName("Some content");
+  });
+});

--- a/src/app/components/client/Button.tsx
+++ b/src/app/components/client/Button.tsx
@@ -73,12 +73,18 @@ export const Button = (props: ButtonProps) => {
 
   return typeof href === "string" ? (
     <Link
+      aria-live={ariaLiveValue}
       {...buttonProps}
       ref={buttonRef as RefObject<HTMLAnchorElement>}
       href={href}
       className={classes}
     >
-      {children}
+      {
+        /* c8 ignore next 3 */
+        // Since the Node 20.10 upgrade, it's been intermittently marking this (and
+        // this comment) as uncovered, even though I think it's covered by tests.
+        isLoading ? <Loader /> : children
+      }
     </Link>
   ) : (
     <button


### PR DESCRIPTION
This is a followup after testing https://github.com/mozilla/blurts-server/pull/4134#discussion_r1486547071.

Since the Button is now responsible for changing its contents, it also knows enough to decide whether aria-live is needed.

(Additionally, passing `aria-live` to `useButton` doesn't actually apply it to the element itself either, apparently - or at least, my screen reader did not read out the content change.)

# How to test

With your screen reader on, add an email address. When the button changes to the loading state in the dialog, that should be read out by your screen reader - it is not on `main`.
