### PR TITLE
MNTOR-2938 exposed that we are not consistently passing `authOptions`…

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/actions.ts
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/actions.ts
@@ -22,6 +22,7 @@ import { sendVerificationEmail } from "../../../../../../api/utils/email";
 import { getL10n } from "../../../../../../functions/server/l10n";
 import { logger } from "../../../../../../functions/server/logging";
 import { CONST_MAX_NUM_ADDRESSES } from "../../../../../../../constants";
+import { authOptions } from "../../../../../../api/utils/auth";
 
 export type AddEmailFormState =
   | { success?: never }
@@ -37,7 +38,7 @@ export async function onAddEmail(
   formData: FormData,
 ): Promise<AddEmailFormState> {
   const l10n = getL10n();
-  const session = await getServerSession();
+  const session = await getServerSession(authOptions);
   if (!session?.user.subscriber?.fxa_uid) {
     return {
       success: false,

--- a/src/app/(proper_react)/(redesign)/(public)/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/page.tsx
@@ -18,7 +18,7 @@ import { authOptions } from "../../../api/utils/auth";
 
 export default async function Page() {
   const session = await getServerSession(authOptions);
-  if (typeof session?.user.email === "string") {
+  if (typeof session?.user.subscriber?.fxa_uid === "string") {
     return redirect("/user/dashboard/");
   }
   const enabledFlags = await getEnabledFeatureFlags({ ignoreAllowlist: true });

--- a/src/app/(proper_react)/(redesign)/(public)/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/page.tsx
@@ -14,9 +14,10 @@ import {
 import { getEnabledFeatureFlags } from "../../../../db/tables/featureFlags";
 import { getL10n } from "../../../functions/server/l10n";
 import { View } from "./LandingView";
+import { authOptions } from "../../../api/utils/auth";
 
 export default async function Page() {
-  const session = await getServerSession();
+  const session = await getServerSession(authOptions);
   if (typeof session?.user.email === "string") {
     return redirect("/user/dashboard/");
   }


### PR DESCRIPTION
… to `getServerSession`

This returns an incomplete `session` object.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2938 

See also https://mozilla-hub.atlassian.net/browse/MNTOR-2954 (filed for tracking the underlying issue)
