### PR TITLE
MNTOR-2957 - avoid loading client-side analytics on server

### DIFF
--- a/src/app/components/client/GoogleAnalyticsWorkaround.tsx
+++ b/src/app/components/client/GoogleAnalyticsWorkaround.tsx
@@ -91,6 +91,11 @@ export const sendGAEvent = (type: "event", eventName: string, args: object) => {
     return;
   }
 
+  if (typeof window === "undefined") {
+    console.warn("GA4 should only be used on the client");
+    return;
+  }
+
   if (currDataLayerName === undefined) {
     console.warn(`@next/third-parties: GA has not been initialized`);
     return;

--- a/src/app/hooks/useGlean.ts
+++ b/src/app/hooks/useGlean.ts
@@ -15,6 +15,11 @@ export const useGlean = () => {
 
   // Initialize Glean only on the first render of our custom hook.
   useEffect(() => {
+    if (typeof window === "undefined") {
+      console.warn("Glean should only be used on the client");
+      return;
+    }
+
     // Enable upload only if the user has not opted out of tracking.
     const uploadEnabled =
       navigator.doNotTrack !== "1" ||
@@ -22,6 +27,11 @@ export const useGlean = () => {
 
     if (!PUBLIC_APP_ENV) {
       throw new ErrorEvent("No PUBLIC_APP_ENV provided for Glean");
+    }
+
+    if (typeof window === "undefined") {
+      console.warn("Glean should only be used on the client");
+      return;
     }
 
     Glean.initialize("monitor.frontend", uploadEnabled, {
@@ -54,6 +64,10 @@ export const useGlean = () => {
     event: keyof GleanMetricMap[EventModule],
     data: GleanMetricMap[EventModule][EventName],
   ) => {
+    if (typeof window === "undefined") {
+      console.warn("Glean should only be used on the client");
+      return;
+    }
     const mod = (await import(
       `../../telemetry/generated/${eventModule}`
     )) as Record<keyof GleanMetricMap[EventModule], EventMetricType>;

--- a/src/app/hooks/useGlean.ts
+++ b/src/app/hooks/useGlean.ts
@@ -29,11 +29,6 @@ export const useGlean = () => {
       throw new ErrorEvent("No PUBLIC_APP_ENV provided for Glean");
     }
 
-    if (typeof window === "undefined") {
-      console.warn("Glean should only be used on the client");
-      return;
-    }
-
     Glean.initialize("monitor.frontend", uploadEnabled, {
       // This will submit an events ping every time an event is recorded.
       maxEvents: 1,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2957


<!-- When adding a new feature: -->

# Description

Next is attempting to load client-side analytics scripts on the server-side. This is generating spurious logs and HTTP 500s that don't seem to be impacting the product experience, but are most likely causing SSR not to work and impacting performance.

This is a workaround while we investigate.