### PR TITLE
Enforce authOptions with getServerSession wrapper

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -77,6 +77,18 @@
             "importNames": ["VisuallyHidden"],
             "message":
               "Please use the <VisuallyHidden> component from `/src/app/components/server/VisuallyHidden.tsx` instead of the one from react-aria, since the latter's (inline) styles will be stripped by our Content Security Policy."
+          },
+          {
+            "name": "next-auth",
+            "importNames": ["getServerSession"],
+            "message":
+              "Please use the `getServerSession` wrapper function from `/src/app/functions/server/getServerSession.ts` instead of the one from next-auth, since the latter's doesn't enforce passing the auth configuration object, resulting in broken sessions."
+          },
+          {
+            "name": "next-auth/next",
+            "importNames": ["getServerSession"],
+            "message":
+              "Please use the `getServerSession` wrapper function from `/src/app/functions/server/getServerSession.ts` instead of the one from next-auth, since the latter's doesn't enforce passing the auth configuration object, resulting in broken sessions."
           }
         ]
       }

--- a/src/app/(migration_remnants)/(guest)/layout.tsx
+++ b/src/app/(migration_remnants)/(guest)/layout.tsx
@@ -10,8 +10,7 @@ import Image from "next/image";
 import MonitorLogo from "../../../client/images/monitor-logo-transparent@2x.webp";
 import MozillaLogo from "../../../client/images/moz-logo-1color-white-rgb-01.svg";
 import { getL10n } from "../../functions/server/l10n";
-import { getServerSession } from "next-auth";
-import { authOptions } from "../../api/utils/auth";
+import { getServerSession } from "../../functions/server/getServerSession";
 import { PageLoadEvent } from "../../components/client/PageLoadEvent";
 import { getExperiments } from "../../functions/server/getExperiments";
 import { getEnabledFeatureFlags } from "../../../db/tables/featureFlags";
@@ -26,7 +25,7 @@ const GuestLayout = async (props: Props) => {
   const l10n = getL10n();
 
   // If the user is logged in, use UUID derived from FxA UID as Nimbus user ID.
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   const userId = getUserId(session);
 
   if (!userId) {

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/page.tsx
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getServerSession } from "next-auth";
+import { getServerSession } from "../../../../../functions/server/getServerSession";
 import { notFound } from "next/navigation";
-import { authOptions, isAdmin } from "../../../../../api/utils/auth";
+import { isAdmin } from "../../../../../api/utils/auth";
 import { UserAdmin } from "./UserAdmin";
 
 export default async function DevPage() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
 
   if (
     !session?.user?.email ||

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/page.tsx
@@ -3,12 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { notFound, redirect } from "next/navigation";
-import { getServerSession } from "next-auth";
+import { getServerSession } from "../../../../../functions/server/getServerSession";
 import { getAllFeatureFlags } from "../../../../../../db/tables/featureFlags";
 import { AddFeatureFlag } from "./components/AddFeatureFlag";
 import { ToggleFlagEnabled } from "./components/ToggleFlagEnabled";
 import { FeatureFlagRow } from "knex/types/tables";
-import { authOptions, isAdmin } from "../../../../../api/utils/auth";
+import { isAdmin } from "../../../../../api/utils/auth";
 import { Toolbar } from "../../../../../components/client/toolbar/Toolbar";
 import styles from "./page.module.scss";
 import { ModifyInputField } from "./components/ModifyInputField";
@@ -18,7 +18,7 @@ import {
 } from "../../../../../functions/server/getPremiumSubscriptionInfo";
 
 export default async function FeatureFlagPage() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
 
   const monthlySubscriptionUrl = getPremiumSubscriptionUrl({ type: "monthly" });
   const yearlySubscriptionUrl = getPremiumSubscriptionUrl({ type: "yearly" });

--- a/src/app/(proper_react)/(redesign)/(authenticated)/layout.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/layout.tsx
@@ -3,12 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ReactNode } from "react";
-import { getServerSession } from "next-auth";
-import { authOptions } from "../../../api/utils/auth";
+import { getServerSession } from "../../../functions/server/getServerSession";
 import { AutoSignIn } from "../../../components/client/AutoSignIn";
 
 export default async function Layout(props: { children: ReactNode }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
 
   if (!session) {
     return <AutoSignIn />;

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/automatic-remove/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/automatic-remove/page.tsx
@@ -4,9 +4,8 @@
 
 import React from "react";
 import { AutomaticRemoveView } from "./AutomaticRemoveView";
-import { getServerSession } from "next-auth";
+import { getServerSession } from "../../../../../../../../../functions/server/getServerSession";
 import { headers } from "next/headers";
-import { authOptions } from "../../../../../../../../../api/utils/auth";
 import { redirect } from "next/navigation";
 import { getOnerepProfileId } from "../../../../../../../../../../db/tables/subscribers";
 import { getLatestOnerepScanResults } from "../../../../../../../../../../db/tables/onerep_scans";
@@ -27,7 +26,7 @@ const monthlySubscriptionUrl = getPremiumSubscriptionUrl({ type: "monthly" });
 const yearlySubscriptionUrl = getPremiumSubscriptionUrl({ type: "yearly" });
 
 export default async function AutomaticRemovePage() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
 
   if (!session?.user?.subscriber?.id) {
     redirect("/user/dashboard/");

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/manual-remove/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/manual-remove/page.tsx
@@ -3,13 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { redirect } from "next/navigation";
-import { getServerSession } from "next-auth";
 import { headers } from "next/headers";
+import { getServerSession } from "../../../../../../../../../functions/server/getServerSession";
 import { getLatestOnerepScanResults } from "../../../../../../../../../../db/tables/onerep_scans";
 import { getOnerepProfileId } from "../../../../../../../../../../db/tables/subscribers";
 import { getSubscriberBreaches } from "../../../../../../../../../functions/server/getUserBreaches";
 import { ManualRemoveView } from "./ManualRemoveView";
-import { authOptions } from "../../../../../../../../../api/utils/auth";
 import { hasPremium } from "../../../../../../../../../functions/universal/user";
 import { getCountryCode } from "../../../../../../../../../functions/server/getCountryCode";
 import { getSubscriberEmails } from "../../../../../../../../../functions/server/getSubscriberEmails";
@@ -17,7 +16,7 @@ import { isEligibleForPremium } from "../../../../../../../../../functions/serve
 import { getEnabledFeatureFlags } from "../../../../../../../../../../db/tables/featureFlags";
 
 export default async function ManualRemovePage() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
 
   if (!session?.user?.subscriber?.id) {
     redirect("/user/dashboard/");

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/start-free-scan/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/start-free-scan/page.tsx
@@ -5,8 +5,7 @@
 import { headers } from "next/headers";
 import { getLatestOnerepScanResults } from "../../../../../../../../../../db/tables/onerep_scans";
 import { redirect } from "next/navigation";
-import { getServerSession } from "next-auth";
-import { authOptions } from "../../../../../../../../../api/utils/auth";
+import { getServerSession } from "../../../../../../../../../functions/server/getServerSession";
 import { getOnerepProfileId } from "../../../../../../../../../../db/tables/subscribers";
 import { getCountryCode } from "../../../../../../../../../functions/server/getCountryCode";
 import { StepDeterminationData } from "../../../../../../../../../functions/server/getRelevantGuidedSteps";
@@ -20,7 +19,7 @@ export default async function StartFreeScanPage() {
     redirect("/user/dashboard");
   }
 
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user?.subscriber?.id) {
     return redirect("/");
   }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/page.tsx
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
+import { getServerSession } from "../../../../../../../../../functions/server/getServerSession";
 import { getLatestOnerepScanResults } from "../../../../../../../../../../db/tables/onerep_scans";
-import { authOptions } from "../../../../../../../../../api/utils/auth";
 import { getOnerepProfileId } from "../../../../../../../../../../db/tables/subscribers";
 import { ViewDataBrokersView } from "./View";
 import { StepDeterminationData } from "../../../../../../../../../functions/server/getRelevantGuidedSteps";
@@ -16,7 +15,7 @@ import { getSubscriberEmails } from "../../../../../../../../../functions/server
 import { getL10n } from "../../../../../../../../../functions/server/l10n";
 
 export default async function ViewDataBrokers() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
 
   if (!session?.user?.subscriber?.id) {
     redirect("/user/dashboard/");

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/page.tsx
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { getLatestOnerepScanResults } from "../../../../../../../../../../db/tables/onerep_scans";
-import { getServerSession } from "next-auth";
 import { headers } from "next/headers";
-import { authOptions } from "../../../../../../../../../api/utils/auth";
+import { getServerSession } from "../../../../../../../../../functions/server/getServerSession";
 import { getOnerepProfileId } from "../../../../../../../../../../db/tables/subscribers";
 import { redirect } from "next/navigation";
 import { getSubscriberBreaches } from "../../../../../../../../../functions/server/getUserBreaches";
@@ -20,7 +19,7 @@ import { refreshStoredScanResults } from "../../../../../../../../../functions/s
 import { checkSession } from "../../../../../../../../../functions/server/checkSession";
 
 export default async function WelcomeToPlusPage() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
 
   // Ensure user is logged in
   if (!checkSession(session) || !session?.user?.subscriber?.id) {

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/[type]/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/[type]/page.tsx
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
+import { getServerSession } from "../../../../../../../../../functions/server/getServerSession";
 import { getSubscriberEmails } from "../../../../../../../../../functions/server/getSubscriberEmails";
 import { HighRiskBreachLayout } from "../HighRiskBreachLayout";
-import { authOptions } from "../../../../../../../../../api/utils/auth";
 import { getSubscriberBreaches } from "../../../../../../../../../functions/server/getUserBreaches";
 import {
   HighRiskBreachTypes,
@@ -28,7 +27,7 @@ interface SecurityRecommendationsProps {
 export default async function SecurityRecommendations({
   params,
 }: SecurityRecommendationsProps) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user?.subscriber?.id) {
     return redirect("/");
   }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/page.tsx
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
+import { getServerSession } from "../../../../../../../../functions/server/getServerSession";
 import { HighRiskBreachLayout } from "./HighRiskBreachLayout";
-import { authOptions } from "../../../../../../../../api/utils/auth";
 import { getSubscriberEmails } from "../../../../../../../../functions/server/getSubscriberEmails";
 import { getSubscriberBreaches } from "../../../../../../../../functions/server/getUserBreaches";
 import { getOnerepProfileId } from "../../../../../../../../../db/tables/subscribers";
@@ -16,7 +15,7 @@ import { getEnabledFeatureFlags } from "../../../../../../../../../db/tables/fea
 import { isEligibleForPremium } from "../../../../../../../../functions/server/onerep";
 
 export default async function HighRiskDataBreaches() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user?.subscriber?.id) {
     return redirect("/");
   }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/[type]/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/[type]/page.tsx
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
-import { authOptions } from "../../../../../../../../../api/utils/auth";
+import { getServerSession } from "../../../../../../../../../functions/server/getServerSession";
 import { getSubscriberBreaches } from "../../../../../../../../../functions/server/getUserBreaches";
 import { LeakedPasswordsLayout } from "../LeakedPasswordsLayout";
 import {
@@ -28,7 +27,7 @@ interface LeakedPasswordsProps {
 export default async function LeakedPasswords({
   params,
 }: LeakedPasswordsProps) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user?.subscriber?.id) {
     return redirect("/");
   }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/[type]/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/[type]/page.tsx
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
+import { getServerSession } from "../../../../../../../../../functions/server/getServerSession";
 import { SecurityRecommendationsLayout } from "../SecurityRecommendationsLayout";
 import {
   SecurityRecommendationTypes,
   securityRecommendationTypes,
 } from "../securityRecommendationsData";
-import { authOptions } from "../../../../../../../../../api/utils/auth";
 import { getSubscriberBreaches } from "../../../../../../../../../functions/server/getUserBreaches";
 import { getSubscriberEmails } from "../../../../../../../../../functions/server/getSubscriberEmails";
 import { getCountryCode } from "../../../../../../../../../functions/server/getCountryCode";
@@ -28,7 +27,7 @@ interface SecurityRecommendationsProps {
 export default async function SecurityRecommendations({
   params,
 }: SecurityRecommendationsProps) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user?.subscriber?.id) {
     return redirect("/");
   }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/page.tsx
@@ -4,9 +4,8 @@
 
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { getServerSession } from "next-auth";
+import { getServerSession } from "../../../../../../functions/server/getServerSession";
 import { View } from "./View";
-import { authOptions } from "../../../../../../api/utils/auth";
 import { getCountryCode } from "../../../../../../functions/server/getCountryCode";
 import { getSubscriberBreaches } from "../../../../../../functions/server/getUserBreaches";
 import {
@@ -37,7 +36,7 @@ import { isPrePlusUser } from "../../../../../../functions/server/isPrePlusUser"
 import { getUserId } from "../../../../../../functions/server/getUserId";
 
 export default async function DashboardPage() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!checkSession(session) || !session?.user?.subscriber?.id) {
     return redirect("/");
   }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/layout.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/layout.tsx
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ReactNode } from "react";
-import { getServerSession } from "next-auth";
+import { getServerSession } from "../../../../../functions/server/getServerSession";
 import { getL10n, getL10nBundles } from "../../../../../functions/server/l10n";
-import { authOptions } from "../../../../../api/utils/auth";
 import { Shell } from "../../../Shell";
 import { headers } from "next/headers";
 import { AutoSignIn } from "../../../../../components/client/AutoSignIn";
@@ -13,7 +12,7 @@ import { AutoSignIn } from "../../../../../components/client/AutoSignIn";
 export default async function Layout({ children }: { children: ReactNode }) {
   const l10nBundles = getL10nBundles();
   const l10n = getL10n(l10nBundles);
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
 
   if (!session) {
     return <AutoSignIn />;

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/actions.ts
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/actions.ts
@@ -5,8 +5,8 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { getServerSession } from "next-auth";
 import { SubscriberRow } from "knex/types/tables";
+import { getServerSession } from "../../../../../../functions/server/getServerSession";
 import {
   EmailRow,
   addSubscriberUnverifiedEmailHash,
@@ -22,7 +22,6 @@ import { sendVerificationEmail } from "../../../../../../api/utils/email";
 import { getL10n } from "../../../../../../functions/server/l10n";
 import { logger } from "../../../../../../functions/server/logging";
 import { CONST_MAX_NUM_ADDRESSES } from "../../../../../../../constants";
-import { authOptions } from "../../../../../../api/utils/auth";
 
 export type AddEmailFormState =
   | { success?: never }
@@ -38,7 +37,7 @@ export async function onAddEmail(
   formData: FormData,
 ): Promise<AddEmailFormState> {
   const l10n = getL10n();
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user.subscriber?.fxa_uid) {
     return {
       success: false,
@@ -131,7 +130,7 @@ export async function onAddEmail(
 
 export async function onRemoveEmail(email: EmailRow) {
   const l10n = getL10n();
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user.subscriber?.fxa_uid) {
     logger.error(
       `Tried to delete email [${email.id}] without an active session.`,

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/page.tsx
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
-import { authOptions } from "../../../../../../api/utils/auth";
+import { getServerSession } from "../../../../../../functions/server/getServerSession";
 import { SettingsView } from "./View";
 import {
   getSubscriptionBillingAmount,
@@ -18,7 +17,7 @@ import { getSha1 } from "../../../../../../../utils/fxa";
 import { getAttributionsFromCookiesOrDb } from "../../../../../../functions/server/attributions";
 
 export default async function SettingsPage() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user?.subscriber?.id) {
     return redirect("/");
   }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/[[...slug]]/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/[[...slug]]/page.tsx
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getServerSession } from "next-auth";
 import { notFound, redirect } from "next/navigation";
+import { getServerSession } from "../../../../../../functions/server/getServerSession";
 import { isEligibleForFreeScan } from "../../../../../../functions/server/onerep";
 import { View } from "../View";
 import { getAllBreachesCount } from "../../../../../../../db/tables/breaches";
 import { getCountryCode } from "../../../../../../functions/server/getCountryCode";
 import { headers } from "next/headers";
-import { authOptions } from "../../../../../../api/utils/auth";
 import { getReferrerUrl } from "../../../../../../functions/server/getReferrerUrl";
 import { CONST_ONEREP_DATA_BROKER_COUNT } from "../../../../../../../constants";
 import { AutoSignIn } from "../../../../../../components/client/AutoSignIn";
@@ -26,7 +25,7 @@ type Props = {
 };
 
 export default async function Onboarding({ params, searchParams }: Props) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session) {
     return <AutoSignIn />;
   }

--- a/src/app/(proper_react)/(redesign)/(public)/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/page.tsx
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { headers } from "next/headers";
-import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
+import { getServerSession } from "../../../functions/server/getServerSession";
 import { getCountryCode } from "../../../functions/server/getCountryCode";
 import {
   isEligibleForPremium,
@@ -14,10 +14,9 @@ import {
 import { getEnabledFeatureFlags } from "../../../../db/tables/featureFlags";
 import { getL10n } from "../../../functions/server/l10n";
 import { View } from "./LandingView";
-import { authOptions } from "../../../api/utils/auth";
 
 export default async function Page() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (typeof session?.user.subscriber?.fxa_uid === "string") {
     return redirect("/user/dashboard/");
   }

--- a/src/app/(proper_react)/layout.tsx
+++ b/src/app/(proper_react)/layout.tsx
@@ -4,7 +4,7 @@
 
 import { ReactNode } from "react";
 import { headers } from "next/headers";
-import { getServerSession } from "next-auth";
+import { getServerSession } from "../functions/server/getServerSession";
 import { getL10nBundles } from "../functions/server/l10n";
 import { getLocale } from "../functions/universal/getLocale";
 import { L10nProvider } from "../../contextProviders/localization";
@@ -12,7 +12,6 @@ import { ReactAriaI18nProvider } from "../../contextProviders/react-aria";
 import { CountryCodeProvider } from "../../contextProviders/country-code";
 import { getCountryCode } from "../functions/server/getCountryCode";
 import { PageLoadEvent } from "../components/client/PageLoadEvent";
-import { authOptions } from "../api/utils/auth";
 import { getUserId } from "../functions/server/getUserId";
 import { getEnabledFeatureFlags } from "../../db/tables/featureFlags";
 
@@ -20,7 +19,7 @@ export default async function Layout({ children }: { children: ReactNode }) {
   const l10nBundles = getL10nBundles();
   const headersList = headers();
   const countryCode = getCountryCode(headersList);
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   const enabledFlags = await getEnabledFeatureFlags({
     email: session?.user.email ?? "",
   });

--- a/src/app/api/v1/admin/feature-flags/[flagId]/route.ts
+++ b/src/app/api/v1/admin/feature-flags/[flagId]/route.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
+import { getServerSession } from "../../../../../functions/server/getServerSession";
 import { logger } from "../../../../../functions/server/logging";
 import {
   enableFeatureFlagByName,
@@ -13,14 +13,14 @@ import {
   updateOwner,
   updateWaitList,
 } from "../../../../../../db/tables/featureFlags";
-import { isAdmin, authOptions } from "../../../../utils/auth";
+import { isAdmin } from "../../../../utils/auth";
 import appConstants from "../../../../../../appConstants";
 
 export async function GET(
   req: NextRequest,
   { params }: { params: { flagId: string } },
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (isAdmin(session?.user?.email || "")) {
     // Signed in
     const flagName = params.flagId;
@@ -38,7 +38,7 @@ export async function GET(
 }
 
 export async function PUT(req: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (isAdmin(session?.user?.email || "")) {
     // Signed in
     try {

--- a/src/app/api/v1/admin/feature-flags/route.ts
+++ b/src/app/api/v1/admin/feature-flags/route.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
+import { getServerSession } from "../../../../functions/server/getServerSession";
 import { logger } from "../../../../functions/server/logging";
 import {
   getAllFeatureFlags,
@@ -15,11 +15,11 @@ import {
   FeatureFlag,
 } from "../../../../../db/tables/featureFlags";
 
-import { isAdmin, authOptions } from "../../../utils/auth";
+import { isAdmin } from "../../../utils/auth";
 import appConstants from "../../../../../appConstants";
 
 export async function GET() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (isAdmin(session?.user?.email || "")) {
     // Signed in
     try {
@@ -35,7 +35,7 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (isAdmin(session?.user?.email || "")) {
     // Signed in
     try {
@@ -63,7 +63,7 @@ export type FeatureFlagPutRequest = {
 };
 
 export async function PUT(req: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (isAdmin(session?.user?.email || "")) {
     // Signed in
     try {

--- a/src/app/api/v1/admin/users/[primarySha1]/route.ts
+++ b/src/app/api/v1/admin/users/[primarySha1]/route.ts
@@ -3,10 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { NextRequest, NextResponse } from "next/server";
-import { Profile, getServerSession } from "next-auth";
+import { Profile } from "next-auth";
 import { SubscriberRow } from "knex/types/tables";
+import { getServerSession } from "../../../../../functions/server/getServerSession";
 import { logger } from "../../../../../functions/server/logging";
-import { isAdmin, authOptions } from "../../../../utils/auth";
+import { isAdmin } from "../../../../utils/auth";
 import {
   deleteOnerepProfileId,
   deleteSubscriber,
@@ -50,7 +51,7 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { primarySha1: string } },
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (isAdmin(session?.user?.email || "")) {
     // Signed in as admin
     try {
@@ -120,7 +121,7 @@ export async function PUT(
   req: NextRequest,
   { params }: { params: { primarySha1: string } },
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (isAdmin(session?.user?.email || "")) {
     // Signed in as admin
     try {

--- a/src/app/api/v1/user/breaches/bulk-resolve/route.ts
+++ b/src/app/api/v1/user/breaches/bulk-resolve/route.ts
@@ -3,8 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { NextRequest, NextResponse } from "next/server";
-import { authOptions } from "../../../../utils/auth";
-import { getServerSession } from "next-auth";
+import { getServerSession } from "../../../../../functions/server/getServerSession";
 import { logger } from "../../../../../functions/server/logging";
 import { BreachBulkResolutionRequest } from "../../../../../deprecated/(authenticated)/user/breaches/breaches.js";
 import { getBreaches } from "../../../../../functions/server/getBreaches";
@@ -15,7 +14,7 @@ import {
 } from "../../../../../../db/tables/subscribers";
 
 export async function PUT(req: NextRequest): Promise<NextResponse> {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (
     !session?.user?.subscriber ||
     typeof session?.user?.subscriber.fxa_uid !== "string"

--- a/src/app/api/v1/user/scan-result/[onerepScanResultId]/resolution/route.ts
+++ b/src/app/api/v1/user/scan-result/[onerepScanResultId]/resolution/route.ts
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "../../../../../../functions/server/getServerSession";
 
 import { logger } from "../../../../../../functions/server/logging";
-import { authOptions } from "../../../../../utils/auth";
 import {
   isOnerepScanResultForSubscriber,
   markOnerepScanResultAsResolved,
@@ -22,7 +21,7 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { onerepScanResultId: string } },
 ): Promise<NextResponse<ResolveScanResultResponse>> {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user?.subscriber) {
     return new NextResponse<ResolveScanResultResponse>(
       JSON.stringify({ success: false, message: "Unauthenticated" }),

--- a/src/app/api/v1/user/welcome-scan/create/route.ts
+++ b/src/app/api/v1/user/welcome-scan/create/route.ts
@@ -2,12 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getServerSession } from "next-auth";
-import { authOptions } from "../../../../utils/auth";
 import { NextRequest, NextResponse } from "next/server";
 
 import { logger } from "../../../../../functions/server/logging";
-
+import { getServerSession } from "../../../../../functions/server/getServerSession";
 import {
   createProfile,
   createScan,
@@ -42,7 +40,7 @@ export interface UserInfo {
 export async function POST(
   req: NextRequest,
 ): Promise<NextResponse<WelcomeScanBody> | NextResponse<unknown>> {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user?.subscriber) {
     throw new Error("No fxa_uid found in session");
   }

--- a/src/app/api/v1/user/welcome-scan/progress/route.ts
+++ b/src/app/api/v1/user/welcome-scan/progress/route.ts
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getServerSession } from "next-auth";
-import { authOptions } from "../../../../utils/auth";
 import { NextRequest, NextResponse } from "next/server";
 
 import { logger } from "../../../../../functions/server/logging";
 
+import { getServerSession } from "../../../../../functions/server/getServerSession";
 import AppConstants from "../../../../../../appConstants";
 import {
   getOnerepProfileId,
@@ -37,7 +36,7 @@ export interface ScanProgressBody {
 export async function GET(
   _req: NextRequest,
 ): Promise<NextResponse<ScanProgressBody> | NextResponse<unknown>> {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (typeof session?.user?.subscriber?.fxa_uid === "string") {
     try {
       const subscriber = await getSubscriberByFxaUid(

--- a/src/app/api/v1/user/welcome-scan/result/route.ts
+++ b/src/app/api/v1/user/welcome-scan/result/route.ts
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getServerSession } from "next-auth";
 import { OnerepScanResultRow, OnerepScanRow } from "knex/types/tables";
-import { authOptions } from "../../../../utils/auth";
 import { NextResponse } from "next/server";
 
 import { logger } from "../../../../../functions/server/logging";
 
+import { getServerSession } from "../../../../../functions/server/getServerSession";
 import AppConstants from "../../../../../../appConstants";
 import {
   getOnerepProfileId,
@@ -25,7 +24,7 @@ export type WelcomeScanResultResponse =
   | { success: false };
 
 export async function GET() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (typeof session?.user?.subscriber?.fxa_uid === "string") {
     try {
       const subscriber = await getSubscriberByFxaUid(

--- a/src/app/deprecated/(authenticated)/admin/emails/[template]/page.tsx
+++ b/src/app/deprecated/(authenticated)/admin/emails/[template]/page.tsx
@@ -4,7 +4,6 @@
 
 import { redirect } from "next/navigation";
 import Script from "next/script";
-import { getServerSession } from "next-auth";
 import appConstants from "../../../../../../appConstants";
 import {
   EmailTemplateType,
@@ -18,10 +17,10 @@ import { verifyPartial } from "../../../../../../views/emails/emailVerify";
 import { breachAlertEmailPartial } from "../../../../../../views/emails/emailBreachAlert";
 import { monthlyUnresolvedEmailPartial } from "../../../../../../views/emails/emailMonthlyUnresolved";
 import { signupReportEmailPartial } from "../../../../../../views/emails/emailSignupReport";
-import { authOptions } from "../../../../../api/utils/auth";
 import { getL10n } from "../../../../../functions/server/l10n";
 import { ReactLocalization } from "@fluent/react";
 import { getNonce } from "../../../../functions/server/getNonce";
+import { getServerSession } from "../../../../../functions/server/getServerSession";
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -38,7 +37,7 @@ declare global {
 export default async function EmailTemplatePage(props: {
   params: { template: string };
 }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
 
   if (!session?.user.email) {
     return redirect("/");

--- a/src/app/deprecated/(authenticated)/admin/emails/page.tsx
+++ b/src/app/deprecated/(authenticated)/admin/emails/page.tsx
@@ -3,12 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { notFound, redirect } from "next/navigation";
-import { getServerSession } from "next-auth";
+import { getServerSession } from "../../../../functions/server/getServerSession";
 import { EmailTemplateType } from "../../../../../utils/email";
-import { authOptions } from "../../../../api/utils/auth";
 
 export default async function EmailRootPage() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
 
   if (!session?.user.email) {
     return notFound();

--- a/src/app/deprecated/(authenticated)/admin/layout.tsx
+++ b/src/app/deprecated/(authenticated)/admin/layout.tsx
@@ -3,17 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ReactNode } from "react";
-import { getServerSession } from "next-auth";
 import { notFound } from "next/navigation";
+import { getServerSession } from "../../../functions/server/getServerSession";
 
 import "../../../../client/css/index.css";
-import { authOptions } from "../../../api/utils/auth";
 export type Props = {
   children: ReactNode;
 };
 
 const AdminLayout = async (props: Props) => {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   const admins = process.env.ADMINS?.split(",") ?? [];
   if (
     !session ||

--- a/src/app/deprecated/(authenticated)/user/breaches/page.tsx
+++ b/src/app/deprecated/(authenticated)/user/breaches/page.tsx
@@ -4,8 +4,8 @@
 
 import Image from "next/image";
 import Script from "next/script";
-import { getServerSession } from "next-auth";
 import { headers } from "next/headers";
+import { getServerSession } from "../../../../functions/server/getServerSession";
 import { CircleChartProps } from "./breaches.d";
 
 import { getL10n } from "../../../../functions/server/l10n";
@@ -13,7 +13,6 @@ import {
   getUserBreaches,
   UserBreaches,
 } from "../../../../functions/server/getUserBreaches";
-import { authOptions } from "../../../../api/utils/auth";
 
 import "../../../../../client/css/partials/breaches.css";
 import ImageIconEmail from "../../../../../client/images/icon-email.svg";
@@ -68,7 +67,7 @@ declare global {
 }
 
 export default async function UserBreaches() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user?.subscriber) {
     return <SignInButton autoSignIn />;
   }

--- a/src/app/deprecated/(authenticated)/user/layout.tsx
+++ b/src/app/deprecated/(authenticated)/user/layout.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ReactNode } from "react";
-import { getServerSession } from "next-auth";
 import Image from "next/image";
 import Script from "next/script";
 
@@ -16,18 +15,18 @@ import AppConstants from "../../../../appConstants.js";
 import MonitorLogo from "../../../../client/images/monitor-logo-transparent@2x.webp";
 import MozillaLogo from "../../../../client/images/moz-logo-1color-white-rgb-01.svg";
 import { getL10n } from "../../../functions/server/l10n";
-import { authOptions } from "../../../api/utils/auth";
 import { getNonce } from "../../functions/server/getNonce";
 import { PageLoadEvent } from "../../../components/client/PageLoadEvent";
 import { getExperiments } from "../../../functions/server/getExperiments";
 import { getEnabledFeatureFlags } from "../../../../db/tables/featureFlags";
+import { getServerSession } from "../../../functions/server/getServerSession";
 
 export type Props = {
   children: ReactNode;
 };
 
 const MainLayout = async (props: Props) => {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session?.user?.subscriber) {
     return <SignInButton autoSignIn />;
   }

--- a/src/app/deprecated/(authenticated)/user/settings/page.tsx
+++ b/src/app/deprecated/(authenticated)/user/settings/page.tsx
@@ -7,8 +7,6 @@ import Image from "next/image";
 import Script from "next/script";
 import AppConstants from "../../../../../appConstants";
 import { getL10n } from "../../../../functions/server/l10n";
-import { getServerSession } from "next-auth";
-import { authOptions } from "../../../../api/utils/auth";
 import ImageIconDelete from "../../../../../client/images/icon-delete.svg";
 import "../../../../../client/css/partials/settings.css";
 import React from "react";
@@ -22,6 +20,7 @@ import { getSha1 } from "../../../../../utils/fxa";
 import { getSubscriberById } from "../../../../../db/tables/subscribers";
 import { getNonce } from "../../../functions/server/getNonce";
 import { CONST_MAX_NUM_ADDRESSES } from "../../../../../constants";
+import { getServerSession } from "../../../../functions/server/getServerSession";
 
 const emailNeedsVerificationSub = (email: EmailRow) => {
   const l10n = getL10n();
@@ -149,7 +148,7 @@ const alertOptions = ({
 
 export default async function Settings() {
   const l10n = getL10n();
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   if (!session || !session.user?.subscriber) {
     return redirect("/");
   }

--- a/src/app/deprecated/(guest)/layout.tsx
+++ b/src/app/deprecated/(guest)/layout.tsx
@@ -12,8 +12,7 @@ import MonitorLogo from "../../../client/images/monitor-logo-transparent@2x.webp
 import MozillaLogo from "../../../client/images/moz-logo-1color-white-rgb-01.svg";
 import { SignInButton } from "../components/client/SignInButton";
 import { getL10n } from "../../functions/server/l10n";
-import { getServerSession } from "next-auth";
-import { authOptions } from "../../api/utils/auth";
+import { getServerSession } from "../../functions/server/getServerSession";
 import { PageLoadEvent } from "../../components/client/PageLoadEvent";
 import { getExperiments } from "../../functions/server/getExperiments";
 import { getEnabledFeatureFlags } from "../../../db/tables/featureFlags";
@@ -27,7 +26,7 @@ const GuestLayout = async (props: Props) => {
   const l10n = getL10n();
 
   // If the user is logged in, use UUID derived from FxA UID as Nimbus user ID.
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
   const userId = getUserId(session);
 
   if (!userId) {

--- a/src/app/functions/server/getServerSession.ts
+++ b/src/app/functions/server/getServerSession.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This ESLint rule is there to get people to use this wrapper - but the wrapper
+// itself needs to access the original, of course:
+/* eslint-disable-next-line no-restricted-imports */
+import * as nextAuth from "next-auth";
+import { authOptions } from "../../api/utils/auth";
+
+export const getServerSession = () => nextAuth.getServerSession(authOptions);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,12 +6,11 @@ import { ReactNode } from "react";
 import { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
-import { getServerSession } from "next-auth";
 import { getL10n, getL10nBundles } from "./functions/server/l10n";
 import { getLocale } from "./functions/universal/getLocale";
 import { PublicEnvProvider } from "../contextProviders/public-env";
 import { SessionProvider } from "../contextProviders/session";
-import { authOptions } from "./api/utils/auth";
+import { getServerSession } from "./functions/server/getServerSession";
 import { metropolis } from "./fonts/Metropolis/metropolis";
 import { CONST_GA4_MEASUREMENT_ID } from "../constants";
 import { headers } from "next/headers";
@@ -58,7 +57,7 @@ export default async function RootLayout({
   children: ReactNode;
 }) {
   const currentLocale = getLocale(getL10nBundles());
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession();
 
   return (
     <html lang={currentLocale}>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2954
Figma: N/A


<!-- When adding a new feature: -->

# Description

Next-Auth's type definitions for getServerSession() don't enforce the first argument, and v5 (aka Auth.js) removes the function altogether, so an upstream fix is probably not in the books. And since the upstream docs recommend a wrapper (see https://next-auth.js.org/configuration/nextjs#getserversession), we can just enforce that through ESLint to avoid future instsances of the auth options not being passed.

# How to test

There should be no behavioural changes.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
