### PR TITLE
Include stripe.js for fraud resistance (MNTOR-1769)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@sentry/nextjs": "^7.100.1",
         "@sentry/node": "^7.58.1",
         "@sentry/tracing": "^7.100.1",
+        "@stripe/stripe-js": "^3.0.3",
         "@types/jsdom": "^21.1.5",
         "@types/node": "^20.11.17",
         "@types/react": "^18.2.48",
@@ -9321,6 +9322,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-3.0.3.tgz",
+      "integrity": "sha512-UrHQ0hvDCZzpJEaOLbTRme1jREFzCuBe6eeHzowLtsS65Ah9pM+8bivXAyQUGHaAE2nPLu4lDvuDHPStPlrZUQ==",
+      "engines": {
+        "node": ">=12.16"
       }
     },
     "node_modules/@swc/core": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@sentry/nextjs": "^7.100.1",
     "@sentry/node": "^7.58.1",
     "@sentry/tracing": "^7.100.1",
+    "@stripe/stripe-js": "^3.0.3",
     "@types/jsdom": "^21.1.5",
     "@types/node": "^20.11.17",
     "@types/react": "^18.2.48",

--- a/src/app/components/client/StripeScript.tsx
+++ b/src/app/components/client/StripeScript.tsx
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use client";
+
+// Load stripe.js for fraud resistance.
+// https://stripe.com/guides/radar-rules-101#importance-of-using-stripejs
+import "@stripe/stripe-js";
+
+export default function StripeScript() {
+  return <></>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,7 @@ import { CONST_GA4_MEASUREMENT_ID } from "../constants";
 import { headers } from "next/headers";
 import { GoogleAnalyticsWorkaround } from "./components/client/GoogleAnalyticsWorkaround";
 import { getNonce } from "./deprecated/functions/server/getNonce";
+import StripeScript from "./components/client/StripeScript";
 
 // DO NOT ADD SECRETS: Env variables added here become public.
 const PUBLIC_ENVS = {
@@ -72,6 +73,7 @@ export default async function RootLayout({
           <SessionProvider session={session}>{children}</SessionProvider>
         </PublicEnvProvider>
       </body>
+      <StripeScript />
       {headers().get("DNT") !== "1" && (
         <GoogleAnalyticsWorkaround
           gaId={CONST_GA4_MEASUREMENT_ID}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -61,10 +61,10 @@ function generateCspData() {
       (process.env.NODE_ENV === "development"
         ? "'unsafe-eval' 'unsafe-inline'"
         : `'nonce-${nonce}'`) +
-      ` https://*.googletagmanager.com`,
+      ` https://*.googletagmanager.com https://js.stripe.com`,
     `connect-src 'self' ${
       process.env.NODE_ENV === "development" ? "webpack://*" : ""
-    } https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.ingest.sentry.io https://incoming.telemetry.mozilla.org`,
+    } https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.ingest.sentry.io https://incoming.telemetry.mozilla.org https://api.stripe.com`,
     // `withSentryConfig` in next.config.js messes up the type, but we know that
     // it's a valid NextConfig with `images.remotePatterns` set:
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -86,6 +86,7 @@ function generateCspData() {
     "font-src 'self'",
     "form-action 'self'",
     "frame-ancestors 'self'",
+    "frame-src 'self' https://js.stripe.com",
     "object-src 'none'",
     "block-all-mixed-content",
     "upgrade-insecure-requests",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-1769](https://mozilla-hub.atlassian.net/browse/MNTOR-1769)

<!-- When adding a new feature: -->

# Description

Include `stripe.js` for fraud resistance as requested in [MNTOR-1769](https://mozilla-hub.atlassian.net/browse/MNTOR-1769).

# How to test

Make sure `<script src="https://js.stripe.com/v3"></script>` is present and `stripe.js` is being loaded without any CSP errors.