### PR TITLE
Redirect users from leaked password step if nothing to resolve

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/LeakedPasswordsLayout.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/LeakedPasswordsLayout.tsx
@@ -69,6 +69,15 @@ export function LeakedPasswordsLayout(props: LeakedPasswordsLayoutProps) {
   /* c8 ignore start */
   const emailsAffected = unresolvedPasswordBreach?.emailsAffected ?? [];
   const nextStep = getNextGuidedStep(props.data, stepMap[props.type]);
+
+  // If there are no unresolved breaches for the ”leaked passwords” step:
+  // Go to the next step in the guided resolution or back to the dashboard.
+  useEffect(() => {
+    if (!unresolvedPasswordBreach) {
+      router.push(nextStep.href);
+    }
+  }, [nextStep.href, router, unresolvedPasswordBreach]);
+
   const pageData = getLeakedPasswords({
     dataType: props.type,
     breaches: guidedExperienceBreaches,

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/[type]/LeakedPasswordsLayout.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/[type]/LeakedPasswordsLayout.test.tsx
@@ -17,7 +17,9 @@ import { useTelemetry } from "../../../../../../../../../hooks/useTelemetry";
 
 jest.mock("../../../../../../../../../hooks/useTelemetry");
 jest.mock("next/navigation", () => ({
-  useRouter: jest.fn(),
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
   usePathname: jest.fn(),
 }));
 


### PR DESCRIPTION

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: [MNTOR-2956](https://mozilla-hub.atlassian.net/browse/MNTOR-2956)


<!-- When adding a new feature: -->

# Description

Prevent users from visiting the “leaked passwords” step in the guided resolution flow.

# How to test

- There are two scenarios where users can land on an empty “leaked passwords” breach resolution step. Both require a user to have an account with unresolved breaches that include passwords:
1. Fix resolve guided resolution step ”leaked passwords”  and go back in the browser history.
2. Directly navigate to `/user/dashboard/fix/leaked-passwords/passwords`.

[MNTOR-2956]: https://mozilla-hub.atlassian.net/browse/MNTOR-2956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ