### PR TITLE
add logging when free scan is created

### DIFF
--- a/src/app/api/v1/user/welcome-scan/create/route.ts
+++ b/src/app/api/v1/user/welcome-scan/create/route.ts
@@ -99,6 +99,12 @@ export async function POST(
         const scan = await createScan(profileId);
         const scanId = scan.id;
         await setOnerepScan(profileId, scanId, scan.status, "manual");
+        // TODO MNTOR-2686 - refactor onerep.ts and centralize logging.
+        logger.info("scan_created", {
+          onerepScanId: scanId,
+          onerepScanStatus: scan.status,
+          onerepScanReason: "manual",
+        });
 
         return NextResponse.json({ success: true }, { status: 200 });
       }

--- a/src/app/functions/server/onerep.ts
+++ b/src/app/functions/server/onerep.ts
@@ -161,6 +161,9 @@ export async function createProfile(
     updated_at: ISO8601DateString;
     url: string;
   } = await response.json();
+
+  logger.info("onerep_profile_created", { onerepProfileId: savedProfile.id });
+
   return savedProfile.id;
 }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2686


<!-- When adding a new feature: -->

# Description

It's pretty difficult to generate reports right now about how long free scans are taking. This PR just adds a bit of logging when scans are created that we can get in ASAP, I have a branch that refactors `onerep.ts` but it's a much larger change that we should spend some time testing on stage.