### PR TITLE
Add a story to test the progress bar

### DIFF
--- a/src/app/components/client/stories/ProgressBar.stories.tsx
+++ b/src/app/components/client/stories/ProgressBar.stories.tsx
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ProgressBar as ProgressBarEl, ProgressBarProps } from "../ProgressBar";
+import { useInterval } from "../../../hooks/useInterval";
+import { useState } from "react";
+
+const ProgressBarDemo = (props: ProgressBarProps) => {
+  const [val, setValue] = useState(0);
+  useInterval(
+    () =>
+      setValue((prev) => Math.min(prev + Math.round(Math.random() * 10), 100)),
+    1000,
+  );
+
+  return <ProgressBarEl label="Progress bar demo" value={val} {...props} />;
+};
+
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
+const meta: Meta<typeof ProgressBarEl> = {
+  title: "Progress bar",
+  component: ProgressBarDemo,
+};
+export default meta;
+type Story = StoryObj<typeof ProgressBarEl>;
+
+export const ProgressBar: Story = {
+  name: "Progress bar",
+};


### PR DESCRIPTION
It's a bit hard to test since you have to run the manual scan to get to the progress bar, so with a separate story, we can at least see what it looks like when loading.

I added this to try and verify https://github.com/mozilla/blurts-server/pull/4271, but though it probably isn't the best way to verify that specific case, I figured the story might still be useful.

View it live at https://deploy-preview-4272--fx-monitor-storybook.netlify.app/?path=/story/progress-bar--progress-bar.