### PR TITLE
Guard breach resolution steps if already resolved (MNTOR-2956)

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/HighRiskBreachLayout.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/HighRiskBreachLayout.tsx
@@ -4,7 +4,7 @@
 
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ResolutionContainer } from "../ResolutionContainer";
 import { ResolutionContent } from "../ResolutionContent";
@@ -67,6 +67,14 @@ export function HighRiskBreachLayout(props: HighRiskBreachLayoutProps) {
   const isHighRiskBreachesStep = type !== "none";
   const isStepDone = type === "done";
   const hasExposedData = exposedData.length > 0;
+
+  // If there are no unresolved high risk breach:
+  // Go to the next step in the guided resolution or back to the dashboard.
+  useEffect(() => {
+    if (!hasExposedData && !isStepDone) {
+      router.push(nextStep.href);
+    }
+  }, [nextStep.href, router, hasExposedData, isStepDone]);
 
   // TODO: Write unit tests MNTOR-2560
   /* c8 ignore start */

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/[type]/HighRiskBreachLayout.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/[type]/HighRiskBreachLayout.test.tsx
@@ -18,7 +18,9 @@ import Meta, {
 
 jest.mock("../../../../../../../../../hooks/useTelemetry");
 jest.mock("next/navigation", () => ({
-  useRouter: jest.fn(),
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
   usePathname: jest.fn(),
 }));
 

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/LeakedPasswordsLayout.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/LeakedPasswordsLayout.tsx
@@ -73,10 +73,10 @@ export function LeakedPasswordsLayout(props: LeakedPasswordsLayoutProps) {
   // If there are no unresolved breaches for the ”leaked passwords” step:
   // Go to the next step in the guided resolution or back to the dashboard.
   useEffect(() => {
-    if (!unresolvedPasswordBreach) {
+    if (!unresolvedPasswordBreach && !isStepDone) {
       router.push(nextStep.href);
     }
-  }, [nextStep.href, router, unresolvedPasswordBreach]);
+  }, [nextStep.href, router, unresolvedPasswordBreach, isStepDone]);
 
   const pageData = getLeakedPasswords({
     dataType: props.type,

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/SecurityRecommendationsLayout.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/SecurityRecommendationsLayout.tsx
@@ -4,7 +4,7 @@
 
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   SecurityRecommendationTypes,
@@ -67,6 +67,14 @@ export function SecurityRecommendationsLayout(
   // in `./[type]/page.tsx`:
   const { title, illustration, content, exposedData } = pageData!;
   const hasExposedData = exposedData.length > 0;
+
+  // If there are no unresolved security recommendations:
+  // Go to the next step in the guided resolution or back to the dashboard.
+  useEffect(() => {
+    if (!hasExposedData && !isStepDone) {
+      router.push(nextStep.href);
+    }
+  }, [nextStep.href, router, hasExposedData, isStepDone]);
 
   // TODO: Write unit tests MNTOR-2560
   /* c8 ignore start */

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/[type]/SecurityRecommendations.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/[type]/SecurityRecommendations.test.tsx
@@ -16,7 +16,9 @@ import Meta, {
 
 jest.mock("../../../../../../../../../hooks/useTelemetry");
 jest.mock("next/navigation", () => ({
-  useRouter: jest.fn(),
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
   usePathname: jest.fn(),
 }));
 


### PR DESCRIPTION
# References: 
Jira: [MNTOR-2956](https://mozilla-hub.atlassian.net/browse/MNTOR-2956)

<!-- When adding a new feature: -->

# Description

Prevent users from visiting or navigating back to an already resolved step in the guided resolution flow.

# How to test

1. Fix a breach category, for example, “high-risk data breaches”
2. Directly navigate to `/user/dashboard/fix/high-risk-data-breaches`.

[MNTOR-2956]: https://mozilla-hub.atlassian.net/browse/MNTOR-2956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ