### PR TITLE
MNTOR-2995: not having fxa tokens shouldn't return 500

### DIFF
--- a/src/app/api/v1/fxa-rp-events/route.ts
+++ b/src/app/api/v1/fxa-rp-events/route.ts
@@ -254,18 +254,14 @@ export async function POST(request: NextRequest) {
           updateFromEvent,
         });
 
-        const refreshToken = subscriber.fxa_refresh_token;
-        const accessToken = subscriber.fxa_access_token;
-        if (refreshToken === null || accessToken === null) {
+        const refreshToken = subscriber.fxa_refresh_token ?? "";
+        const accessToken = subscriber.fxa_access_token ?? "";
+        if (accessToken === null || refreshToken === null) {
           logger.error("failed_changing_password", {
             subscriber_id: subscriber.id,
             fxa_refresh_token: subscriber.fxa_refresh_token,
             fxa_access_token: subscriber.fxa_access_token,
           });
-          return NextResponse.json(
-            { success: false, message: "failed_changing_password" },
-            { status: 500 },
-          );
         }
 
         // MNTOR-1932: Change password should revoke sessions
@@ -273,6 +269,12 @@ export async function POST(request: NextRequest) {
           fxa_access_token: accessToken,
           fxa_refresh_token: refreshToken,
         });
+
+        return NextResponse.json(
+          { success: true, message: "session_revoked" },
+          { status: 200 },
+        );
+
         break;
       }
       case FXA_SUBSCRIPTION_CHANGE_EVENT: {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2995
Figma: 


<!-- When adding a new feature: -->

# Description
Not having fxa tokens shouldn't be considered a failure and return 500
We will simply revoke tokens if available

# Screenshot (if applicable)

Not applicable.

# How to test



# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
