### PR TITLE
MNTOR-2997: deactivate without onerep id returns 200

### DIFF
--- a/src/app/api/v1/fxa-rp-events/route.ts
+++ b/src/app/api/v1/fxa-rp-events/route.ts
@@ -384,8 +384,8 @@ export async function POST(request: NextRequest) {
                         )}`,
               );
               return NextResponse.json(
-                { success: false, message: "failed_activating_subscription" },
-                { status: 500 },
+                { success: true, message: "failed_deactivating_subscription" },
+                { status: 200 },
               );
             }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2997


<!-- When adding a new feature: -->

# Description
We have a fxa webhook that’s throwing 500 for an edge case:
* a user subscribed
* the user never ran a one rep scan, thus no id
* the user unsubbed

In this case, we are currently throwing 500 and spamming the fxa queue.

We’d want to return a 200


# Screenshot (if applicable)

Not applicable.

# How to test



# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
