### PR TITLE
MNTOR-2781 - Fix pricing toggle colour contrast in upsell dialog

### DIFF
--- a/src/app/components/client/UpsellDialog.module.scss
+++ b/src/app/components/client/UpsellDialog.module.scss
@@ -34,21 +34,31 @@
     }
 
     [role="tablist"] {
-      background: $color-grey-10;
+      width: auto;
+      display: inline-flex;
+      gap: $spacing-sm;
+      background-color: $color-grey-10;
       border-radius: $border-radius-xl;
-      gap: 0;
-      padding: $spacing-xs;
+      padding: $spacing-sm $spacing-sm;
+      font: $text-body-sm;
+      margin-bottom: $spacing-md;
     }
 
     [role="tab"] {
-      border-radius: $border-radius-xl;
-      color: $color-grey-40;
+      cursor: pointer;
+      appearance: none;
+      background-color: transparent;
+      border: 0;
+      color: $color-grey-50;
       padding: $spacing-xs $spacing-md;
+      font-weight: 500;
 
       &[aria-selected="true"] {
-        background: white;
-        color: $color-blue-50;
+        background-color: $color-white;
+        border-radius: $border-radius-xl;
+        color: $color-informational;
       }
+
       &::after {
         display: none;
       }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2781



<!-- When adding a new feature: -->

# Description

The pricing toggle on the upsell dialog should match that of the landing page and the automatic removal data broker page in the resolution flow.
<img width="1000" alt="image" src="https://github.com/mozilla/blurts-server/assets/13066134/f258daf4-33b2-4e0f-9c1c-df1e90e45cc2">






# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
