### PR TITLE
Only (re)send verification emails for current user

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/actions.ts
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/actions.ts
@@ -97,16 +97,7 @@ export async function onAddEmail(
     );
 
     await initEmail();
-    await sendVerificationEmail(
-      // This first parameter is unused, so the type assertion is safe.
-      // When non-TS invocations of this function are removed, we should remove
-      // the unused parameter:
-      session.user.subscriber as unknown as Parameters<
-        typeof sendVerificationEmail
-      >[0],
-      unverifiedSubscriber.id,
-      getL10n(),
-    );
+    await sendVerificationEmail(subscriber, unverifiedSubscriber.id, getL10n());
     revalidatePath("/user/settings");
 
     return {

--- a/src/app/api/utils/email.ts
+++ b/src/app/api/utils/email.ts
@@ -18,6 +18,7 @@ export async function sendVerificationEmail(
   const getMessage = getStringLookup(l10n);
   const unverifiedEmailAddressRecord = await resetUnverifiedEmailAddress(
     emailId,
+    user,
     l10n,
   );
   const recipientEmail = unverifiedEmailAddressRecord.email;

--- a/src/db/tables/emailAddresses.js
+++ b/src/db/tables/emailAddresses.js
@@ -90,11 +90,12 @@ async function addSubscriberUnverifiedEmailHash (user, email) {
 
 /**
  * @param {number | string} emailAddressId
+ * @param {import('knex/types/tables').SubscriberRow} subscriber
  * @param {import("@fluent/react").ReactLocalization} l10n
  */
 // Not covered by tests; mostly side-effects. See test-coverage.md#mock-heavy
 /* c8 ignore start */
-async function resetUnverifiedEmailAddress (emailAddressId, l10n) {
+async function resetUnverifiedEmailAddress (emailAddressId, subscriber, l10n) {
   const newVerificationToken = uuidv4()
 
   // Time in ms to require between verification reset.
@@ -118,6 +119,7 @@ async function resetUnverifiedEmailAddress (emailAddressId, l10n) {
       updated_at: knex.fn.now()
     })
     .where('id', emailAddressId)
+    .andWhere("subscriber_id", subscriber.id)
     .returning('*')
   return res[0]
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2988
Figma: N/A


<!-- When adding a new feature: -->

# Description

It was possible to trigger re-sending any verification email by simply modifying the email ID passed in to the /resend-email/ endpoint. With this change, we also verify that the email is actually linked to the current subscriber - and enforce that for any route calling sendVerificationEmail /
resetUnverifiedEmailAddress.

# How to test

See ticket.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, enforced by type definitions, mostly DB interaction
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
