### PR TITLE
MNTOR-2247: circleCI - take out deploy to dockerhub step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,12 +132,6 @@ jobs:
 workflows:
     deploy-only:
         jobs:
-            - deploy:
-                filters:
-                    tags:
-                        only: /.*/
-                    branches:
-                        only: main
 
             - deploy_heroku:
                 name: Deploy main to Heroku


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2247


<!-- When adding a new feature: -->

# Description
Take out the `deploy to dockerhub` step in CircleCI. We already do that via GHA
