### PR TITLE
Only show cancellation link if deletion is hidden

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPage.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPage.test.tsx
@@ -813,7 +813,7 @@ describe("to learn about usage", () => {
           yearlySubscriptionUrl=""
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
-          enabledFeatureFlags={["MonitorAccountDeletion"]}
+          enabledFeatureFlags={[]}
         />
       </TestComponentWrapper>,
     );

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/View.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/View.tsx
@@ -116,28 +116,28 @@ export const SettingsView = (props: Props) => {
             </>
           )}
           <hr />
-          <div className={styles.deactivateSection}>
-            <h3>{l10n.getString("settings-deactivate-account-title")}</h3>
-            <p>{l10n.getString("settings-deactivate-account-info-2")}</p>
-            <TelemetryLink
-              href={props.fxaSettingsUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              eventData={{
-                link_id: "deactivate_account",
-              }}
-            >
-              {l10n.getString("settings-fxa-link-label-3")}
-              <OpenInNew
-                alt={l10n.getString("open-in-new-tab-alt")}
-                width="13"
-                height="13"
-              />
-            </TelemetryLink>
-          </div>
-          {props.enabledFeatureFlags.includes("MonitorAccountDeletion") && (
+          {!props.enabledFeatureFlags.includes("MonitorAccountDeletion") ? (
+            <div className={styles.deactivateSection}>
+              <h3>{l10n.getString("settings-deactivate-account-title")}</h3>
+              <p>{l10n.getString("settings-deactivate-account-info-2")}</p>
+              <TelemetryLink
+                href={props.fxaSettingsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                eventData={{
+                  link_id: "deactivate_account",
+                }}
+              >
+                {l10n.getString("settings-fxa-link-label-3")}
+                <OpenInNew
+                  alt={l10n.getString("open-in-new-tab-alt")}
+                  width="13"
+                  height="13"
+                />
+              </TelemetryLink>
+            </div>
+          ) : (
             <>
-              <hr />
               <div className={styles.deleteAccountSection}>
                 {hasPremium(props.user) ? (
                   <>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: https://mozilla-hub.atlassian.net/browse/MNTOR-1371?focusedCommentId=857676


<!-- When adding a new feature: -->

# Description

When the `MonitorAccountDeletion` flag is enabled, don't show the link to SubPlat to cancel the subscription (that's what's replaced by the deletion flow).

# Screenshot (if applicable)

![image](https://github.com/mozilla/blurts-server/assets/4251/e27ee349-6fc0-479c-b20d-01c972b60bcc)

vs

![image](https://github.com/mozilla/blurts-server/assets/4251/8b21dc9b-ab98-4d5a-bc1f-e297382d373c)


# How to test

Visit settings with the flag enabled and disabled.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
