### PR TITLE
Block the use of !important in our CSS

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -6,6 +6,7 @@
     "stylelint-scss"
   ],
   "rules": {
+    "declaration-no-important": true,
     "selector-class-pattern": [
       "^[a-z][a-zA-Z0-9]+$",
       {

--- a/src/app/components/client/CsatSurvey.module.scss
+++ b/src/app/components/client/CsatSurvey.module.scss
@@ -28,13 +28,13 @@
   @media screen and (min-width: $screen-md) {
     flex-direction: row;
   }
-}
 
-.answer {
-  background-color: $color-purple-40 !important;
+  .answer {
+    background-color: $color-purple-40;
 
-  &:hover {
-    background-color: $color-purple-50 !important;
+    &:hover {
+      background-color: $color-purple-50;
+    }
   }
 }
 


### PR DESCRIPTION
!important can never be overridden, which is almost never what you
want. Better is to provide either a more specific selector, or
potentially a CSS @layer.

For more information, see
https://developer.mozilla.org/en-US/docs/Web/CSS/important#best_practices

(Not sure why this isn't in stylelint's recommended set; maybe for the rare exceptions, e.g. user styles?)