### PR TITLE
MNTOR-2849 - Make each breach badge a list item

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/ResolutionContent.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/ResolutionContent.module.scss
@@ -18,9 +18,6 @@
 }
 
 .breachItemsWrapper {
-  margin: 0;
-  padding: 0;
-  list-style: none;
   display: flex;
   flex-wrap: wrap;
   gap: $spacing-xs;

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/ResolutionContent.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/ResolutionContent.tsx
@@ -48,7 +48,9 @@ export const ResolutionContent = ({
     <>
       <p>{summary}</p>
       {exposedData && (
-        <ul className={styles.breachItemsWrapper}>{listOfBreaches}</ul>
+        <ul className={`${styles.breachItemsWrapper} noList`}>
+          {listOfBreaches}
+        </ul>
       )}
       {description}
       {recommendations && (


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-2849



<!-- When adding a new feature: -->

# Description

Previously, all breach items were stored within the same `<div>` wrapper, resulting in all breaches being announced as one large block of information. This made it impossible to track which date applied to which breach. To address this, the new approach utilizes `ul` and `li` elements, which are more semantically correct. This allows assistive technologies to list out one breach at a time, enhancing accessibility and clarity.


# Screenshot (if applicable)


https://github.com/mozilla/blurts-server/assets/13066134/b4c3e3d3-37fa-4ad4-9493-dec5c9814fc3



# How to test



# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
