### PR TITLE
Fix paths to FTL files from cron job l10n loading

### DIFF
--- a/src/app/functions/l10n/cronjobs.ts
+++ b/src/app/functions/l10n/cronjobs.ts
@@ -30,14 +30,17 @@ export type LocaleData = {
 };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const ftlRoot = resolve(__dirname, `../../locales/`);
+const ftlRoot = resolve(__dirname, `../../../../locales/`);
 export const getL10nBundles: GetL10nBundles = createGetL10nBundles({
   availableLocales: readdirSync(ftlRoot),
   // TODO: Make this optional in `createGetL10nBundles`, which would then make
   //       it required in the newly-created function:
   getAcceptLangHeader: () => "en",
   loadLocaleFiles: (locale) => {
-    const referenceStringsPath = resolve(__dirname, `../../locales/${locale}/`);
+    const referenceStringsPath = resolve(
+      __dirname,
+      `../../../../locales/${locale}/`,
+    );
     const ftlPaths = readdirSync(referenceStringsPath).map((filename) =>
       resolve(referenceStringsPath, filename),
     );
@@ -45,7 +48,10 @@ export const getL10nBundles: GetL10nBundles = createGetL10nBundles({
     return ftlPaths.map((filePath) => readFileSync(filePath, "utf-8"));
   },
   loadPendingStrings: () => {
-    const pendingStringsPath = resolve(__dirname, "../../locales-pending/");
+    const pendingStringsPath = resolve(
+      __dirname,
+      "../../../../locales-pending/",
+    );
     const ftlPaths = readdirSync(pendingStringsPath).map((filename) =>
       resolve(pendingStringsPath, filename),
     );


### PR DESCRIPTION
I moved the l10n loading from /src/emails/getEmailL10n.node.ts to /src/app/functions/l10n/cronjobs.ts in
c68110264ef9c687005bd0a7ee0e4f0ffecc98a5, and in doing so, missed that I also had to update the paths to the FTL files. These are loaded at runtime, so I didn't get a build error for that either.
