### PR TITLE
Fix cron jobs not finding FTL files

### DIFF
--- a/src/app/functions/l10n/cronjobs.ts
+++ b/src/app/functions/l10n/cronjobs.ts
@@ -29,18 +29,14 @@ export type LocaleData = {
   bundleSources: string[];
 };
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const ftlRoot = resolve(__dirname, `../../../../locales/`);
+const rootDir = getRootDir();
 export const getL10nBundles: GetL10nBundles = createGetL10nBundles({
-  availableLocales: readdirSync(ftlRoot),
+  availableLocales: readdirSync(resolve(rootDir, `./locales/`)),
   // TODO: Make this optional in `createGetL10nBundles`, which would then make
   //       it required in the newly-created function:
   getAcceptLangHeader: () => "en",
   loadLocaleFiles: (locale) => {
-    const referenceStringsPath = resolve(
-      __dirname,
-      `../../../../locales/${locale}/`,
-    );
+    const referenceStringsPath = resolve(rootDir, `./locales/${locale}/`);
     const ftlPaths = readdirSync(referenceStringsPath).map((filename) =>
       resolve(referenceStringsPath, filename),
     );
@@ -48,10 +44,7 @@ export const getL10nBundles: GetL10nBundles = createGetL10nBundles({
     return ftlPaths.map((filePath) => readFileSync(filePath, "utf-8"));
   },
   loadPendingStrings: () => {
-    const pendingStringsPath = resolve(
-      __dirname,
-      "../../../../locales-pending/",
-    );
+    const pendingStringsPath = resolve(rootDir, "./locales-pending/");
     const ftlPaths = readdirSync(pendingStringsPath).map((filename) =>
       resolve(pendingStringsPath, filename),
     );
@@ -59,6 +52,25 @@ export const getL10nBundles: GetL10nBundles = createGetL10nBundles({
     return ftlPaths.map((filePath) => readFileSync(filePath, "utf-8"));
   },
 });
+
+/**
+ * Find the directory that contains the `locales` directory
+ *
+ * Cronjobs get bundled by esbuild, which inlines all required modules,
+ * including this one. This means that the directory this code runs in depends
+ * on the location of the calling code, and hence the relative path to the FTL
+ * files does so too. This function traverses up the paths to find the directory
+ * that contains the FTL files, regardless of where it is executed.
+ *
+ * @param currentDir
+ */
+function getRootDir(currentDir = dirname(fileURLToPath(import.meta.url))) {
+  const dirContents = readdirSync(currentDir);
+  if (dirContents.includes("locales")) {
+    return currentDir;
+  }
+  return getRootDir(resolve(currentDir, "../"));
+}
 
 export const getL10n: GetL10n = createGetL10n({
   getL10nBundles: getL10nBundles,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-3067
Figma: N/A


<!-- When adding a new feature: -->

# Description

When the cronjob l10n loading code gets included from a cronjob file, it gets inlined by esbuild. This means that paths that were relative to that specific module, all of a sudden are relative to the calling module.

In Next.js, Storybook, and Jest, this is resolved by using Webpack's `require.context`. In esbuild, however, this isn't available, thus, this simply walks up the tree until it finds the directory that contains `locales`.

This fixes the following error when running the monthly activity cronjob:

```
Error: ENOENT: no such file or directory, scandir '/locales'
```

# How to test

Run `npm run build-cronjobs; npm run cron:monthly-activity`. You should not get the above error, and instead, the cronjob should just run.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - This was specific to built code, so that's a different setting from unit tests.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
