### PR TITLE
MNTOR-3183: Generating / cleaning up DB on the fly with each PR open/merge

### DIFF
--- a/.github/workflows/preview_deploy_gcp.yml
+++ b/.github/workflows/preview_deploy_gcp.yml
@@ -54,7 +54,7 @@ jobs:
         image: ${{env.REGION}}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}/${{ env.SERVICE }}:${{ env.TAG }}
         region: ${{ env.REGION }}
         flags: "--allow-unauthenticated --add-cloudsql-instances=${{ env.PROJECT_ID }}:${{env.REGION}}:${{ env.SERVICE }}-${{ env.TAG }}"
-        tag: ${{ env.TAG }}
+        # tag: ${{ env.TAG }}
         env_vars: |
           NEXTAUTH_URL= ${{ secrets.NEXTAUTH_URL }}
           NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }}

--- a/.github/workflows/preview_deploy_gcp.yml
+++ b/.github/workflows/preview_deploy_gcp.yml
@@ -70,10 +70,13 @@ jobs:
           HIBP_API_TOKEN=${{ secrets.HIBP_API_TOKEN }}
           HIBP_KANON_API_TOKEN=${{ secrets.HIBP_KANON_API_TOKEN }}
           AUTH_REDIRECT_PROXY_URL=${{ secrets.AUTH_REDIRECT_PROXY_URL }}
+          PGUSER=postgres
+          PGDATABASE=postgres
+          DB_NAME=blurts
           DB_USER=postgres
-          DB_PASS=postgres
-          DB_NAME=${{ env.SERVICE }}
+          DB_PASSWORD=postgres
           CLOUD_SQL_CONNECTION_NAME=${{ env.PROJECT_ID }}:${{env.REGION}}:${{ env.SERVICE }}-${{ env.TAG }}
+          DATABASE_URL= postgres://postgres:postgres@localhost:5432/blurts 
 
     - name: Comment on Pull Request
       uses: thollander/actions-comment-pull-request@v2

--- a/.github/workflows/preview_deploy_gcp.yml
+++ b/.github/workflows/preview_deploy_gcp.yml
@@ -25,7 +25,7 @@ jobs:
         credentials_json: '${{ secrets.GCP_SA_KEY }}'
   
     - name: Use gcloud CLI
-      run: 'gcloud info'
+      run: gcloud info
 
     - name: Generate database on the fly
       id: db_create

--- a/.github/workflows/preview_deploy_gcp.yml
+++ b/.github/workflows/preview_deploy_gcp.yml
@@ -71,6 +71,10 @@ jobs:
           HIBP_API_TOKEN=${{ secrets.HIBP_API_TOKEN }}
           HIBP_KANON_API_TOKEN=${{ secrets.HIBP_KANON_API_TOKEN }}
           AUTH_REDIRECT_PROXY_URL=${{ secrets.AUTH_REDIRECT_PROXY_URL }}
+          DB_USER=postgres
+          DB_PASS=postgres
+          DB_NAME=${{ env.SERVICE }}
+          CLOUD_SQL_CONNECTION_NAME=${{ env.PROJECT_ID }}:${{env.REGION}}:${{ env.SERVICE }}-${{ env.TAG }}
 
     - name: Comment on Pull Request
       uses: thollander/actions-comment-pull-request@v2

--- a/.github/workflows/preview_deploy_gcp.yml
+++ b/.github/workflows/preview_deploy_gcp.yml
@@ -31,8 +31,14 @@ jobs:
       id: db_create
       # This can fail on the subsequent runs, we can ignore the error (database already exists)
       continue-on-error: true
-      run: 'gcloud sql instances create ${{ env.SERVICE }}-${{ env.TAG }} --tier=db-f1-micro --region=${{ env.REGION }} --database-version=POSTGRES_15 --edition=enterprise'
-
+      run: |
+        gcloud sql instances create ${{ env.SERVICE }}-${{ env.TAG }} --tier=db-f1-micro --region=${{ env.REGION }} --database-version=POSTGRES_15 --edition=enterprise'
+        gcloud sql users set-password postgres --host=% --instance ${{ env.SERVICE }}-${{ env.TAG }} --password postgres 
+        gcloud sql users create postgres --host=% --instance=${{ env.SERVICE }}-${{ env.TAG }}  --password=postgres
+        gcloud sql databases create ${{ env.SERVICE }} --instance=database-external
+        gcloud sql databases list --instance=${{ env.SERVICE }}-${{ env.TAG }}
+        gcloud sql instances list
+  
     - name: Authorize Docker push
       run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
 

--- a/.github/workflows/preview_deploy_gcp.yml
+++ b/.github/workflows/preview_deploy_gcp.yml
@@ -34,8 +34,7 @@ jobs:
       run: |
         gcloud sql instances create ${{ env.SERVICE }}-${{ env.TAG }} --tier=db-f1-micro --region=${{ env.REGION }} --database-version=POSTGRES_15 --edition=enterprise
         gcloud sql users set-password postgres --host=% --instance ${{ env.SERVICE }}-${{ env.TAG }} --password postgres 
-        gcloud sql users create postgres --host=% --instance=${{ env.SERVICE }}-${{ env.TAG }}  --password=postgres
-        gcloud sql databases create ${{ env.SERVICE }} --instance=${{ env.SERVICE }}-${{ env.TAG }}
+        gcloud sql databases create blurts --instance=${{ env.SERVICE }}-${{ env.TAG }}
         gcloud sql databases list --instance=${{ env.SERVICE }}-${{ env.TAG }}
         gcloud sql instances list
   

--- a/.github/workflows/preview_deploy_gcp.yml
+++ b/.github/workflows/preview_deploy_gcp.yml
@@ -54,7 +54,7 @@ jobs:
         service: ${{ env.SERVICE }}-${{ env.TAG }}
         image: ${{env.REGION}}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}/${{ env.SERVICE }}:${{ env.TAG }}
         region: ${{ env.REGION }}
-        flags: "--allow-unauthenticated --set-cloudsql-instances=${{ env.PROJECT_ID }}:${{env.REGION}}:${{ env.SERVICE }}-${{ env.TAG }}"
+        flags: "--allow-unauthenticated --add-cloudsql-instances=${{ env.PROJECT_ID }}:${{env.REGION}}:${{ env.SERVICE }}-${{ env.TAG }}"
         tag: ${{ env.TAG }}
         env_vars: |
           NEXTAUTH_URL= ${{ secrets.NEXTAUTH_URL }}

--- a/.github/workflows/preview_deploy_gcp.yml
+++ b/.github/workflows/preview_deploy_gcp.yml
@@ -35,7 +35,7 @@ jobs:
         gcloud sql instances create ${{ env.SERVICE }}-${{ env.TAG }} --tier=db-f1-micro --region=${{ env.REGION }} --database-version=POSTGRES_15 --edition=enterprise
         gcloud sql users set-password postgres --host=% --instance ${{ env.SERVICE }}-${{ env.TAG }} --password postgres 
         gcloud sql users create postgres --host=% --instance=${{ env.SERVICE }}-${{ env.TAG }}  --password=postgres
-        gcloud sql databases create ${{ env.SERVICE }} --instance=database-external
+        gcloud sql databases create ${{ env.SERVICE }} --instance=${{ env.SERVICE }}-${{ env.TAG }}
         gcloud sql databases list --instance=${{ env.SERVICE }}-${{ env.TAG }}
         gcloud sql instances list
   

--- a/.github/workflows/preview_deploy_gcp.yml
+++ b/.github/workflows/preview_deploy_gcp.yml
@@ -32,7 +32,7 @@ jobs:
       # This can fail on the subsequent runs, we can ignore the error (database already exists)
       continue-on-error: true
       run: |
-        gcloud sql instances create ${{ env.SERVICE }}-${{ env.TAG }} --tier=db-f1-micro --region=${{ env.REGION }} --database-version=POSTGRES_15 --edition=enterprise'
+        gcloud sql instances create ${{ env.SERVICE }}-${{ env.TAG }} --tier=db-f1-micro --region=${{ env.REGION }} --database-version=POSTGRES_15 --edition=enterprise
         gcloud sql users set-password postgres --host=% --instance ${{ env.SERVICE }}-${{ env.TAG }} --password postgres 
         gcloud sql users create postgres --host=% --instance=${{ env.SERVICE }}-${{ env.TAG }}  --password=postgres
         gcloud sql databases create ${{ env.SERVICE }} --instance=database-external

--- a/.github/workflows/preview_deploy_gcp_cleanup.yml
+++ b/.github/workflows/preview_deploy_gcp_cleanup.yml
@@ -28,10 +28,12 @@ jobs:
 
     - name: Delete created database
       id: db_delete
-      # This can fail on the subsequent runs, we can ignore the error (database already exists)
-      continue-on-error: true
       # Delete cloud sql instance
       run: 'gcloud sql instances delete blurts-server-${{ env.TAG }}'
+    
+    - name: Delete created cloud run service
+      id: cloudrun_delete
+      run: gcloud run services delete blurts-server-${{ env.TAG }} --region ${{ env.REGION }} --platform managed --quiet
 
     - name: Comment on Pull Request
       uses: thollander/actions-comment-pull-request@v2

--- a/.github/workflows/preview_deploy_gcp_cleanup.yml
+++ b/.github/workflows/preview_deploy_gcp_cleanup.yml
@@ -39,4 +39,4 @@ jobs:
       uses: thollander/actions-comment-pull-request@v2
       with:
           GITHUB_TOKEN: ${{ github.token }}
-          message: Cleanup completed - database 'blurts-server-${{ env.TAG }}' destroyed
+          message: Cleanup completed - database 'blurts-server-${{ env.TAG }}' destroyed, cloud run service 'blurts-server-${{ env.TAG }}' destroyed


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-3183

<!-- When adding a new feature: -->

# Description
Generating database on the fly as the PR opens, clean up the database when the PR closes or merges
Also cleans up the cloud run service generated that links with the database


# Screenshot (if applicable)

Not applicable.

# How to test



# Checklist (Definition of Done)
- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
