### PR TITLE
Allow inline styles via the style attribute

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -80,7 +80,16 @@ function generateCspData() {
       )
       .join(" ")}`,
     "child-src 'self'",
-    "style-src 'self'",
+    `style-src 'self' 'nonce=${nonce}'`,
+    // We sometimes add styles via the `style` attribute, most notably the
+    // `--sliceLength` custom property in <DoughtnutChart>. The style attribute
+    // can't receive a `nonce`; we could work around it by moving those to an
+    // inline <style> tag and passing it a nonce, but we've already forgotten
+    // that quite a few times. Since the risk of attribute styles seem pretty
+    // low, given that they can only be set by code we've already given control
+    // over that particular element, 'unsafe-inline' for just `style-src-attr`
+    // feels like a fine compromise.
+    "style-src-attr 'self' 'unsafe-inline'",
     "font-src 'self'",
     "form-action 'self'",
     "frame-ancestors 'self'",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-3154
Figma: N/A


<!-- When adding a new feature: -->

# Description

Currently, the doughnut chart on the dashboard doesn't render the individual slices on first load, although they do display on a re-render (e.g. after switching  tabs and back). The reason for this is that our Content Security Policy forbids styles defined via the style attribute, although it does allow our client-side JS to set it (which is why it works on re-render).

Since you can't set a nonce for the attribute, the only CSP config we can set for it to work is `unsafe-inline`. The risk seems fairly low, since styles in the attribute don't apply to other elements, and if code can set it, it already has control over the element. Thus, I figured the easiest resolution would be to add that.

An alternative solution would be to move the styles to an inline `<style>` element with the nonce, but that both has quite a bit of overhead (passing down the `nonce`'s, adding a separate `<style>` element, and coordinating the IDs of the elements-to-style to ensure the styles only apply to that element), in addition to us still being very likely to forget that we need to do that in the future. But let me know if you prefer that approach.

# How to test

Visit the dashboard by directlying entering the `/user/dashboard` URL. The doughnut chart should have more than a single colour.

# Checklist (Definition of Done)
- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
