### PR TITLE
MNTOR-3219 - sendEmail function should logs sends and errors

### DIFF
--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -85,6 +85,7 @@ async function sendEmail (recipient, subject, html) {
   } catch (e) {
     if (e instanceof Error) {
       console.error("error_sending_email", { message: e.message, stack: e.stack });
+    /* c8 ignore next 3 */
     } else {
       console.error("error_sending_email", { message: JSON.stringify(e) })
     }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-3219

<!-- When adding a new feature: -->

# Description

The `sendEmail` function doesn't currently log sends and errors on its own, this leaves it up to the caller but it's an important function that we should be logging. It made some recent SES configuration changes more difficult to track down than we would've liked.

# How to test

Sending email locally or on stage/prod should now log when an email is sent or an error occurs, in addition to returning info to the caller.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
