### PR TITLE
Don't run preview deployments for Dependabot PRs

### DIFF
--- a/.github/workflows/preview_deploy_gcp.yml
+++ b/.github/workflows/preview_deploy_gcp.yml
@@ -14,6 +14,10 @@ jobs:
   deploy:
     permissions: 
       pull-requests: write
+    # Secrets aren't available for Dependabot PR (because the updated
+    # dependencies might abuse them), so they don't have enough rights to
+    # do a preview deployment:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/preview_deploy_gcp_cleanup.yml
+++ b/.github/workflows/preview_deploy_gcp_cleanup.yml
@@ -16,6 +16,10 @@ jobs:
   deploy:
     permissions: 
       pull-requests: write
+    # Secrets aren't available for Dependabot PR (because the updated
+    # dependencies might abuse them), so they don't have enough rights to
+    # do a preview deployment:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
     - name: Setup Cloud SDK


### PR DESCRIPTION
They don't have access to the credentials needed for deployment (because the updated dependencies could exploit those).