### PR TITLE
Use normal Plus Monthly mail subject in test mails

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/actions.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/actions.tsx
@@ -109,7 +109,7 @@ export async function triggerMonthlyActivity(emailAddress: string) {
 
   await send(
     emailAddress,
-    l10n.getString("email-monthly-plus-manual-subject", {
+    l10n.getString("email-monthly-plus-auto-subject", {
       month: dateFormatter.format(new Date(Date.now())),
     }),
     <MonthlyActivityEmail


### PR DESCRIPTION
We removed the special-casing for users who had done manual removals, so that string no longer exists.

Looks like https://github.com/mozilla/blurts-server/pull/4537 strikes again :facepalm: 