### PR TITLE
MNTOR-3155 - look up users by fxa uid not primary sha1 hash of email

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/UserAdmin.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/UserAdmin.tsx
@@ -12,7 +12,7 @@ import {
   type UserStateAction,
   type PutUserStateRequestBody,
   GetUserStateResponseBody,
-} from "../../../../../api/v1/admin/users/[primarySha1]/route";
+} from "../../../../../api/v1/admin/users/[fxaUid]/route";
 
 export const UserAdmin = () => {
   const session = useSession();


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-3155

<!-- When adding a new feature: -->

# Description

This is mostly just removing code, since internally this code turned a sha1 hash of the primary email address into a fxa UID for lookup. I also noticed that the error handling wasn't logging exceptions correctly so I corrected that.

# How to test

`GET` of a valid `fxa_uid` from `subscribers` table should return relevant IDs.

`PUT` with the following should take the appropriate action:

```
{
  "actions":[
    "subscribe",
    "unsubscribe",
    "delete_onerep_profile",
    "delete_onerep_scans",
    "delete_onerep_scan_results",
    "delete_subscriber"
  ]
}
```

http://localhost:6060/admin/dev provides a convenient dev-only web UI to manage this.


# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
