### PR TITLE
chore: upgrade to glean.js 5.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@google-cloud/pubsub": "^4.3.3",
         "@grpc/grpc-js": "1.10.7",
         "@leeoniya/ufuzzy": "^1.0.14",
-        "@mozilla/glean": "5.0.1",
+        "@mozilla/glean": "^5.0.2",
         "@next/third-parties": "^14.2.3",
         "@sentry/nextjs": "^8.2.1",
         "@sentry/node": "^8.0.0",
@@ -5217,9 +5217,10 @@
       }
     },
     "node_modules/@mozilla/glean": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-5.0.1.tgz",
-      "integrity": "sha512-PrIvNGjJsBBzasGMf2QwoxEPK+XNGKu0il3YgiwbXXGJZ6aguFS6dakKkVho+X5Gdckj0QD7P2rjfG3y6IkGfQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-5.0.2.tgz",
+      "integrity": "sha512-NBWNBoPTY0AeLdDiNROECq9Vx84ybKmzdkwSXQ54EgjGUkq7FD4yoo11NqeQKvgnRCgzR/IhuQNiE0HXcAyQxw==",
+      "license": "MPL-2.0",
       "dependencies": {
         "fflate": "^0.8.0",
         "tslib": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@google-cloud/pubsub": "^4.3.3",
     "@grpc/grpc-js": "1.10.7",
     "@leeoniya/ufuzzy": "^1.0.14",
-    "@mozilla/glean": "5.0.1",
+    "@mozilla/glean": "^5.0.2",
     "@next/third-parties": "^14.2.3",
     "@sentry/nextjs": "^8.2.1",
     "@sentry/node": "^8.0.0",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When adding a new feature: -->

# Description

Upgrade to glean.js 5.0.2 to pick up fix for `ModuleNotFoundError: No module named 'pkg_resources'.` error we're seeing in Monitor builds.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
