### PR TITLE
use language and region for Nimbus/Cirrus

### DIFF
--- a/src/app/functions/server/getExperiments.ts
+++ b/src/app/functions/server/getExperiments.ts
@@ -44,8 +44,8 @@ export async function getExperiments(params: {
         client_id: params.experimentationId,
         context: {
           // Nimbus takes a language, rather than a locale, hence the .split:
-          locale: params.locale.split("-")[0],
-          countryCode: params.countryCode,
+          language: params.locale.split("-")[0],
+          region: params.countryCode,
         },
       }),
     });


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References: 
Jira: MNTOR-3239

<!-- When adding a new feature: -->

# Description

Per the Nimbus team, they are expecting `language` and `region` for the parameter names of targeting criteria. We're currently passing `locale` and `countryCode` respectively so it's not matching.

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
