### PR TITLE
Remove rebrand banner check in e2e tests

### DIFF
--- a/src/e2e/specs/landing.spec.ts
+++ b/src/e2e/specs/landing.spec.ts
@@ -94,23 +94,12 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page content`, (
 
   test('Observe "Choose your level of protection" section', async ({
     landingPage,
-    page,
   }) => {
     test.info().annotations.push({
       type: "testrail",
       description:
         "https://testrail.stage.mozaws.net/index.php?/cases/view/2463517",
     });
-
-    // temp fix to clear rebrand banner before image comparison
-    try {
-      const rebrandBanner = page.getByTitle("dismiss");
-      if (rebrandBanner) {
-        await rebrandBanner.click();
-      }
-    } catch (error) {
-      console.log("[E2E_Log - No Rebrand Banner, continuing...]");
-    }
 
     await expect(landingPage.chooseLevelSection).toHaveScreenshot(
       `${process.env.E2E_TEST_ENV}-chooseLevelSection.png`,


### PR DESCRIPTION
# Description

The rebrand banner flag was removed in https://github.com/mozilla/blurts-server/pull/4586 so this test is failing. Removed the part this is causing the failiure

Passing job: https://github.com/mozilla/blurts-server/actions/runs/9230359512

# Screenshot (if applicable)

Not applicable.