### PR TITLE
Revert "Import translations from l10n repository (2024-05-28)"

### DIFF
--- a/locales/nn-NO/fix.ftl
+++ b/locales/nn-NO/fix.ftl
@@ -24,18 +24,14 @@ fix-flow-celebration-next-dashboard-label = Gå til ditt oversyn
 
 # High Risk Data Breaches
 
-high-risk-breach-heading = Dette er det du skal gjere
 high-risk-breach-mark-as-fixed = Merk som løyst
 high-risk-breach-skip = Hopp over no
 
 # Credit Card Breaches
 
-high-risk-breach-credit-card-title = Betalingskortnummeret ditt er eksponert
-high-risk-breach-credit-card-step-two = Be om eit nytt kort med eit nytt nummer.
 
 # Bank Account Breaches
 
-high-risk-breach-bank-account-step-two = Endre kontonummeret ditt.
 
 # Social Security Number Breaches
 
@@ -49,7 +45,6 @@ ssn-modal-ok = OK
 
 # No high risk breaches found
 
-high-risk-breach-none-sub-description-bank-account = Bankkontoinformasjon
 high-risk-breach-none-sub-description-cc-number = Nummer på betalingskort
 high-risk-breach-none-sub-description-pin = PIN-kodar
 high-risk-breach-none-continue = Hald fram


### PR DESCRIPTION
Reverts mozilla/blurts-server#4600

We are investigating an unexpected spike in out-of-memory errors that started on stage right after this was landed. It seems unlikely this patch would cause the problem by itself, unless there's an existing bug in Fluent or its dependencies but we want to try rolling back things in the regression range.