### PR TITLE
disable welcome-scan-optional-info feature on stage for testing Nimbus

### DIFF
--- a/config/nimbus.yaml
+++ b/config/nimbus.yaml
@@ -30,7 +30,7 @@ features:
       - channel: local
         value: { "enabled": true }
       - channel: staging
-        value: { "enabled": true }
+        value: { "enabled": false }
       - channel: production
         value: { "enabled": false }
   automatic-removal-csat-survey:


### PR DESCRIPTION
# Description

We're testing roll-out on stage, we need to set `welcome-scan-optional-info` to `false` by default. 