### PR TITLE
MNTOR-2879 - explicit order-by for getLatestOnerepScanResults

### DIFF
--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -88,7 +88,9 @@ async function getLatestOnerepScanResults(
             "onerep_scans",
             "onerep_scan_results.onerep_scan_id",
             "onerep_scans.onerep_scan_id",
-          )) as OnerepScanResultRow[]);
+          )
+          .orderBy("link")
+          .orderBy("onerep_scan_result_id", "desc")) as OnerepScanResultRow[]);
 
   return {
     scan: scan ?? null,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-2879

<!-- When adding a new feature: -->

# Description

Duplicate `link` columns are currently filtered out using `DISTINCT` in the `SELECT` statement, but since the `ORDER BY` isn't consistent different the result set can be slightly different, which throws off our calculations.

This might be a OneRep-specific problem, but if it persists in the future we may want to figure out how to merge these sorts of scan results instead of just picking one.

# How to test

Create two or more scan results with the same link, and change the `updated_at` record on them. We also have a test account in production with over 1k results, I think it's just more likely to happen there but could conceivably happen on as few as two scan results in production.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
