### PR TITLE
Cirrus expects ISO-3166 compliant upper-case country code

### DIFF
--- a/src/app/functions/server/getExperiments.ts
+++ b/src/app/functions/server/getExperiments.ts
@@ -45,7 +45,7 @@ export async function getExperiments(params: {
         context: {
           // Nimbus takes a language, rather than a locale, hence the .split:
           language: params.locale.split("-")[0],
-          region: params.countryCode,
+          region: params.countryCode.toUpperCase(),
         },
       }),
     });


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

<!-- When adding a new feature: -->

# Description

Make the `countryCode` upper-case for Cirrus, we should consider changing this throughout the code to be more compliant wiht ISO-3166. I'll file a separate ticket if we decide to do that.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
