### PR TITLE
MNTOR-3271: add table and util functions for subscriber coupon code

### DIFF
--- a/src/db/migrations/20240604053111_subscriber_coupons.js
+++ b/src/db/migrations/20240604053111_subscriber_coupons.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export async function up(knex) {
+  return knex.schema
+    .createTable("subscriber_coupons", table => {
+      table.increments('id').primary()
+      table.integer("subscriber_id").references("subscribers.id").notNullable().onDelete("CASCADE").onUpdate("CASCADE");
+      table.string("coupon_code").notNullable()
+      table.timestamp("created_at").defaultTo(knex.fn.now())
+      table.unique(["subscriber_id", "coupon_code"])
+    })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema
+    .dropTableIfExists("subscriber_coupons")
+}

--- a/src/db/tables/subscriber_coupons.ts
+++ b/src/db/tables/subscriber_coupons.ts
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import createDbConnection from "../connect.js";
+import { logger } from "../../app/functions/server/logging";
+import { SubscriberCouponRow } from "knex/types/tables";
+
+const knex = createDbConnection();
+
+async function checkCouponForSubscriber(
+  subscriberId: number,
+  couponCode: string,
+) {
+  logger.info("checkCouponForSubscriber", subscriberId);
+  return (
+    (
+      await knex("subscriber_coupons")
+        .orderBy("created_at")
+        .where("subscriber_id", subscriberId)
+        .andWhere("coupon_code", couponCode)
+        .returning("*")
+    ).length > 0
+  );
+}
+
+async function addCouponForSubscriber(
+  subscriberId: number,
+  couponCode: string,
+) {
+  logger.info("addCouponForSubscriber", { subscriberId, couponCode });
+
+  let res;
+  try {
+    res = await knex("subscribers_coupon")
+      .insert({
+        subscriber_id: subscriberId,
+        coupon_code: couponCode,
+      })
+      .returning("*");
+  } catch (e) {
+    if ((e as Error).message.includes("violates unique constraint")) {
+      logger.info("addCouponForSubscriber", {
+        subscriberId,
+        error: (e as Error).message,
+      });
+    } else {
+      logger.error(e);
+    }
+  }
+  return res?.[0] as SubscriberCouponRow;
+}
+
+export { checkCouponForSubscriber, addCouponForSubscriber };

--- a/src/knex-tables.d.ts
+++ b/src/knex-tables.d.ts
@@ -174,6 +174,17 @@ declare module "knex/types/tables" {
     "id" | "created_at" | "updated_at"
   >;
 
+  interface SubscriberCouponRow {
+    id: number;
+    subscriber_id: number;
+    coupon_code: string;
+    created_at: Date;
+  }
+  type SubscriberCouponAutoInsertedColumns = Extract<
+    keyof SubscriberCouponRow,
+    "id" | "subscriber_id" | "created_at"
+  >;
+
   interface BreachRow {
     id: number;
     name: string;
@@ -335,6 +346,14 @@ declare module "knex/types/tables" {
       // otherfields are optional, except updated_at:
       Partial<Omit<SubscriberRow, "id" | "created_at">> &
         Pick<SubscriberRow, "updated_at">
+    >;
+
+    subscriber_coupons: Knex.CompositeTableType<
+      SubscriberCouponRow,
+      // On updates, auto-generated columns cannot be set, and nullable columns are optional:
+      Omit<SubscriberCouponRow, SubscriberAutoInsertedColumns>,
+      // On updates, don't allow updating the ID; all other fields are optional:
+      Partial<Omit<SubscriberCouponRow, "id">>
     >;
 
     email_addresses: Knex.CompositeTableType<


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3271

<!-- When adding a new feature: -->

# Description
For cancellation discounts, we need a way to store the discount for record

# How to test
`npm run db:migrate`

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
