### PR TITLE
MNTOR-3226 - Breach details pages link to a wrong website URL

### DIFF
--- a/src/app/(proper_react)/(redesign)/(public)/breach-details/[breachName]/BreachDetailView.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/breach-details/[breachName]/BreachDetailView.tsx
@@ -114,7 +114,7 @@ export const BreachDetailsView = (props: Props) => {
         {typeof breach.Domain === "string" && breach.Domain.length > 0 ? (
           <p>
             <TelemetryLink
-              href={`//${breach.Domain}`}
+              href={`https://${breach.Domain}`}
               eventData={{ link_id: breach.Domain }}
               target="_blank"
               rel="noopener noreferrer"

--- a/src/app/(proper_react)/(redesign)/(public)/breach-details/[breachName]/BreachDetailView.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/breach-details/[breachName]/BreachDetailView.tsx
@@ -114,7 +114,7 @@ export const BreachDetailsView = (props: Props) => {
         {typeof breach.Domain === "string" && breach.Domain.length > 0 ? (
           <p>
             <TelemetryLink
-              href={breach.Domain}
+              href={`//${breach.Domain}`}
               eventData={{ link_id: breach.Domain }}
               target="_blank"
               rel="noopener noreferrer"


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3226
Figma:

<!-- When adding a new feature: -->

# Description
Seems like the issue was because href interpreted the given domain as a relative path instead of absolute. Adding a "//" in front seems to have fixed the issue.

# Screenshot (if applicable)

Not applicable.

# How to test
Follow the steps in the jira ticket for any breach that has its 'breach-details' page.

# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
