### PR TITLE
Add admin email trigger for first data broker removal fixed

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/EmailTrigger.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/EmailTrigger.tsx
@@ -7,7 +7,11 @@
 import { useState } from "react";
 import Link from "next/link";
 import styles from "./EmailTrigger.module.scss";
-import { triggerMonthlyActivity, triggerVerificationEmail } from "./actions";
+import {
+  triggerFirstDataBrokerRemovalFixed,
+  triggerMonthlyActivity,
+  triggerVerificationEmail,
+} from "./actions";
 import { Button } from "../../../../../components/client/Button";
 
 export type Props = {
@@ -23,6 +27,8 @@ export const EmailTrigger = (props: Props) => {
     isSendingMonthlyActivityOverview,
     setIssSendingMonthlyActivityOverview,
   ] = useState(false);
+  const [firstDataBrokerRemovalFixed, setFirstDataBrokerRemovalFixed] =
+    useState(false);
 
   return (
     <main className={styles.wrapper}>
@@ -73,6 +79,20 @@ export const EmailTrigger = (props: Props) => {
           }}
         >
           Monthly activity overview
+        </Button>
+        <Button
+          variant="primary"
+          isLoading={firstDataBrokerRemovalFixed}
+          onPress={() => {
+            setFirstDataBrokerRemovalFixed(true);
+            void triggerFirstDataBrokerRemovalFixed(selectedEmailAddress).then(
+              () => {
+                setFirstDataBrokerRemovalFixed(false);
+              },
+            );
+          }}
+        >
+          First data broker removal fixed
         </Button>
       </div>
     </main>

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/actions.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/actions.tsx
@@ -22,6 +22,7 @@ import { getSubscriberBreaches } from "../../../../../functions/server/getSubscr
 import { getCountryCode } from "../../../../../functions/server/getCountryCode";
 import { headers } from "next/headers";
 import { getLatestOnerepScanResults } from "../../../../../../db/tables/onerep_scans";
+import { FirstDataBrokerRemovalFixed } from "../../../../../../emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed";
 
 async function getAdminSubscriber(): Promise<SubscriberRow | null> {
   const session = await getServerSession();
@@ -116,6 +117,23 @@ export async function triggerMonthlyActivity(emailAddress: string) {
       subscriber={sanitizeSubscriberRow(subscriber)}
       l10n={l10n}
       data={data}
+    />,
+  );
+}
+
+export async function triggerFirstDataBrokerRemovalFixed(emailAddress: string) {
+  const l10n = getL10n();
+
+  await send(
+    emailAddress,
+    l10n.getString("email-first-broker-removal-fixed-subject"),
+    <FirstDataBrokerRemovalFixed
+      data={{
+        dataBrokerName: "Data broker name",
+        dataBrokerLink: process.env.SERVER_URL ?? "",
+        removalDate: new Date(Date.now()),
+      }}
+      l10n={l10n}
     />,
   );
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-2700](https://mozilla-hub.atlassian.net/browse/MNTOR-2700)

<!-- When adding a new feature: -->

# Description

Add the ability to send a test “First data broker removal fixed” email from the admin view.

# How to test

Note: Sending emails locally does not work at the moment.

1. Make sure you are added as an admin
2. Visit `/admin/emails`

[MNTOR-2700]: https://mozilla-hub.atlassian.net/browse/MNTOR-2700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ