### PR TITLE
MNTOR-3291 - set experimentationId correctly for signed-in users

### DIFF
--- a/src/app/functions/server/getExperimentationId.ts
+++ b/src/app/functions/server/getExperimentationId.ts
@@ -23,7 +23,7 @@ export function getExperimentationId(
   const accountId = user?.subscriber?.id;
   let experimentationId: null | ExperimentationId;
 
-  if (accountId && typeof accountId === "string") {
+  if (accountId && typeof accountId === "number") {
     // If the user is logged in, use the Subscriber ID.
     const namespace = process.env.NIMBUS_UUID_NAMESPACE;
     if (!namespace) {
@@ -31,7 +31,7 @@ export function getExperimentationId(
         "NIMBUS_UUID_NAMESPACE not set, cannot create experimentationId",
       );
     }
-    experimentationId = uuidv5(accountId, namespace) as UUID;
+    experimentationId = uuidv5(accountId.toString(), namespace) as UUID;
   } else {
     // if the user is not logged in, use a cookie with a randomly-generated Nimbus user ID.
     // TODO: could we use client ID for this? There's no supported way to get it from GleanJS.


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3291

<!-- When adding a new feature: -->

# Description

The `experimentationId` is not being set correctly for signed-in users, looks like confusion over the type (it's a `number` but there's a check for `string`).

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
