### PR TITLE
First data broker removed email adjustments (MNTOR-2700)

### DIFF
--- a/locales-pending/emails-all.ftl
+++ b/locales-pending/emails-all.ftl
@@ -10,6 +10,7 @@ email-header-button-sign-in = Sign in
 email-footer-support-heading = Questions about { -brand-mozilla-monitor }?
 email-footer-support-content = Visit our <support-link>Support Center</support-link> for help
 email-footer-reason-subscriber = You’re receiving this automated email as a subscriber of { -brand-mozilla-monitor }. If you received it in error, no action is required. For more information, please visit <support-link>{ -brand-mozilla } Support</support-link>.
+email-footer-reason-subscriber-one-time = You’ve received this one-time automated email because you are subscribed to { -brand-monitor-plus }. You won’t receive any further emails like this. For more information, please visit <support-link>{ -brand-mozilla } Support</support-link>.
 email-footer-source-hibp = Breach data provided by <hibp-link>{ -brand-HIBP }</hibp-link>
 email-footer-logo-mozilla-alt = { -brand-mozilla }
 

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/actions.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/actions.tsx
@@ -23,6 +23,7 @@ import { getCountryCode } from "../../../../../functions/server/getCountryCode";
 import { headers } from "next/headers";
 import { getLatestOnerepScanResults } from "../../../../../../db/tables/onerep_scans";
 import { FirstDataBrokerRemovalFixed } from "../../../../../../emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed";
+import { createRandomScanResult } from "../../../../../../apiMocks/mockData";
 
 async function getAdminSubscriber(): Promise<SubscriberRow | null> {
   const session = await getServerSession();
@@ -123,15 +124,16 @@ export async function triggerMonthlyActivity(emailAddress: string) {
 
 export async function triggerFirstDataBrokerRemovalFixed(emailAddress: string) {
   const l10n = getL10n();
+  const randomScanResult = createRandomScanResult({ status: "removed" });
 
   await send(
     emailAddress,
     l10n.getString("email-first-broker-removal-fixed-subject"),
     <FirstDataBrokerRemovalFixed
       data={{
-        dataBrokerName: "Data broker name",
-        dataBrokerLink: process.env.SERVER_URL ?? "",
-        removalDate: new Date(Date.now()),
+        dataBrokerName: randomScanResult.data_broker,
+        dataBrokerLink: randomScanResult.link,
+        removalDate: randomScanResult.updated_at,
       }}
       l10n={l10n}
     />,

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/actions.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/actions.tsx
@@ -132,7 +132,7 @@ export async function triggerFirstDataBrokerRemovalFixed(emailAddress: string) {
     <FirstDataBrokerRemovalFixed
       data={{
         dataBrokerName: randomScanResult.data_broker,
-        dataBrokerLink: randomScanResult.link,
+        dataBrokerLink: `${process.env.SERVER_URL}/user/dashboard/fixed`,
         removalDate: randomScanResult.updated_at,
       }}
       l10n={l10n}

--- a/src/emails/templates/EmailFooter.tsx
+++ b/src/emails/templates/EmailFooter.tsx
@@ -11,7 +11,11 @@ import {
   CONST_URL_TERMS,
 } from "../../constants";
 
-export type Props = { l10n: ExtendedReactLocalization; utm_campaign: string };
+export type Props = {
+  l10n: ExtendedReactLocalization;
+  utm_campaign: string;
+  isOneTimeEmail?: boolean;
+};
 
 export const EmailFooter = (props: Props) => {
   const l10n = props.l10n;
@@ -52,16 +56,21 @@ export const EmailFooter = (props: Props) => {
       <mj-section border-top="1px solid #dcdcdc" padding="10px 20px">
         <mj-column>
           <mj-text font-size="14px" font-weight="400" align="center">
-            {l10n.getFragment("email-footer-reason-subscriber", {
-              elems: {
-                "support-link": (
-                  <a
-                    href={CONST_URL_SUMO_MONITOR_SUPPORT}
-                    style={{ color: "#0060DF" }}
-                  />
-                ),
+            {l10n.getFragment(
+              props.isOneTimeEmail
+                ? "email-footer-reason-subscriber-one-time"
+                : "email-footer-reason-subscriber",
+              {
+                elems: {
+                  "support-link": (
+                    <a
+                      href={CONST_URL_SUMO_MONITOR_SUPPORT}
+                      style={{ color: "#0060DF" }}
+                    />
+                  ),
+                },
               },
-            })}
+            )}
           </mj-text>
           <mj-text
             color="#3D3D3D"

--- a/src/emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed.stories.tsx
+++ b/src/emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed.stories.tsx
@@ -31,7 +31,7 @@ export const FirstDataBrokerRemovalFixedStory: Story = {
   args: {
     data: {
       dataBrokerName: "Data broker name",
-      dataBrokerLink: "https://monitor.mozilla.org/",
+      dataBrokerLink: `${process.env.SERVER_URL}/user/dashboard/fixed`,
       removalDate: new Date("5/31/2024"),
     },
   },

--- a/src/emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed.test.tsx
+++ b/src/emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed.test.tsx
@@ -26,6 +26,6 @@ it("has a link that sends user to the dashboard with the correct href attribute"
   const dashboardLink = screen.getByRole("link", { name: "View dashboard" });
   expect(dashboardLink).toHaveAttribute(
     "href",
-    `${process.env.SERVER_URL}/user/dashboard?utm_source=monitor-product&utm_medium=email&utm_campaign=first-removal&utm_content=view-dashboard`,
+    `${process.env.SERVER_URL}/user/dashboard/fixed?utm_source=monitor-product&utm_medium=email&utm_campaign=first-removal&utm_content=view-dashboard`,
   );
 });

--- a/src/emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed.tsx
+++ b/src/emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed.tsx
@@ -82,7 +82,7 @@ export const FirstDataBrokerRemovalFixed = (props: Props) => {
             </mj-button>
           </mj-column>
         </mj-section>
-        <EmailFooter l10n={l10n} utm_campaign={utmCampaign} />
+        <EmailFooter l10n={l10n} utm_campaign={utmCampaign} isOneTimeEmail />
       </mj-body>
     </mjml>
   );

--- a/src/emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed.tsx
+++ b/src/emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed.tsx
@@ -72,7 +72,7 @@ export const FirstDataBrokerRemovalFixed = (props: Props) => {
         <mj-section padding="20px">
           <mj-column>
             <mj-button
-              href={`${process.env.SERVER_URL}/user/dashboard?utm_source=monitor-product&utm_medium=email&utm_campaign=${utmCampaign}&utm_content=view-dashboard`}
+              href={`${process.env.SERVER_URL}/user/dashboard/fixed?utm_source=monitor-product&utm_medium=email&utm_campaign=${utmCampaign}&utm_content=view-dashboard`}
               background-color="#0060DF"
               font-weight="600"
               font-size="15px"

--- a/src/scripts/cronjobs/firstDataBrokerRemovalFixed.tsx
+++ b/src/scripts/cronjobs/firstDataBrokerRemovalFixed.tsx
@@ -124,7 +124,7 @@ async function sendFirstDataBrokerRemovalFixedActivityEmail(
       <FirstDataBrokerRemovalFixed
         data={{
           dataBrokerName: scanResult.data_broker,
-          dataBrokerLink: scanResult.link,
+          dataBrokerLink: `${process.env.SERVER_URL}/user/dashboard/fixed`,
           removalDate: scanResult.updated_at,
         }}
         l10n={l10n}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira:
- [MNTOR-3294](https://mozilla-hub.atlassian.net/browse/MNTOR-3294): Some links in First data broker removal fixed email redirect to the Action needed tab instead of the Fixed tab
- [MNTOR-3296](https://mozilla-hub.atlassian.net/browse/MNTOR-3296): Footer displays standard text instead of custom text referring to a one-time automated email

Figma: https://www.figma.com/design/CaEKIhvSJqf6KNIMzSkt40/Concepts-for-Monitor-MVP-Redesign?t=hTR7PAsYeLpS2V1N-0

<!-- When adding a new feature: -->

# Description

Updates the footer text for one-time emails and the dashboard link target.

# Screenshot

| Footer text (before) | Footer text (after) |
| --- | --- |
| <img width="491" alt="image" src="https://github.com/mozilla/blurts-server/assets/13835474/50f82a36-90c3-4bea-a9ec-464b4c6cc515"> | <img width="480" alt="image" src="https://github.com/mozilla/blurts-server/assets/13835474/204c404b-9d6a-42a5-82e0-91680dfbde64"> |


# How to test

Same steps as for https://github.com/mozilla/blurts-server/pull/4614.

[MNTOR-3294]: https://mozilla-hub.atlassian.net/browse/MNTOR-3294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNTOR-3296]: https://mozilla-hub.atlassian.net/browse/MNTOR-3296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ