### PR TITLE
updated styles to add padding to intro sections

### DIFF
--- a/src/app/(proper_react)/(redesign)/(public)/how-it-works/HowItWorksView.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/how-it-works/HowItWorksView.module.scss
@@ -56,6 +56,7 @@
       gap: $spacing-md;
       display: flex;
       flex-direction: column;
+      padding: 0 $spacing-md;
       h2 {
         color: $color-grey-60;
         font: $text-title-md;


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3308
# Description
Added horizontal padding for intro of brokers and breaches sections on mobile

# Screenshot (if applicable)
<img width="572" alt="Screenshot 2024-06-13 at 12 12 20 PM" src="https://github.com/mozilla/blurts-server/assets/31937894/405543f3-fbe4-4f80-bed5-3ce304754dfe">
<img width="519" alt="Screenshot 2024-06-13 at 12 12 03 PM" src="https://github.com/mozilla/blurts-server/assets/31937894/541dde48-5f9d-409e-b3ca-4298e614dc6d">

# How to test

# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
