### PR TITLE
hrefs added to DataBreaches CTA buttons

### DIFF
--- a/src/app/(proper_react)/(redesign)/(public)/how-it-works/HowItWorksView.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/how-it-works/HowItWorksView.module.scss
@@ -194,7 +194,6 @@
     }
     &.breachesCTAButton {
       padding-inline: $spacing-md;
-      margin-top: -$spacing-2xl;
       margin-bottom: $spacing-xl;
     }
     @media screen and (min-width: $screen-md) {

--- a/src/app/(proper_react)/(redesign)/(public)/how-it-works/HowItWorksView.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/how-it-works/HowItWorksView.test.tsx
@@ -62,12 +62,17 @@ describe("How it works page", () => {
 
     const user = userEvent.setup();
 
-    const [getFreeScanBtn1, getFreeScanBtn2] = screen.getAllByRole("button", {
+    const [getFreeScanBtn1, getFreeScanBtn2] = screen.getAllByRole("link", {
       name: "Get free scan",
     });
 
     expect(getFreeScanBtn1).toBeInTheDocument();
     expect(getFreeScanBtn2).toBeInTheDocument();
+    // jsdom will complain about not being able to navigate to a different page
+    // after clicking the link; suppress that error, as it's not relevant to the
+    // test:
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+
     await user.click(getFreeScanBtn1);
     expect(mockedRecord).toHaveBeenCalledWith(
       "ctaButton",
@@ -79,7 +84,7 @@ describe("How it works page", () => {
     expect(mockedRecord).toHaveBeenCalledWith(
       "ctaButton",
       "click",
-      expect.objectContaining({ button_id: "free_scan_first" }),
+      expect.objectContaining({ button_id: "free_scan_second" }),
     );
   });
 

--- a/src/app/(proper_react)/(redesign)/(public)/how-it-works/components/DataBreaches.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/how-it-works/components/DataBreaches.tsx
@@ -36,6 +36,7 @@ export const DataBreaches = () => {
           </h3>
           <div className={styles.sectionCTAButton}>
             <TelemetryButton
+              href="/user/dashboard"
               variant="primary"
               onPress={() => {
                 void signIn("fxa");
@@ -109,6 +110,7 @@ export const DataBreaches = () => {
       </div>
       <div className={`${styles.sectionCTAButton} ${styles.breachesCTAButton}`}>
         <TelemetryButton
+          href="/user/dashboard"
           variant="primary"
           onPress={() => {
             void signIn("fxa");


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3310
Figma:

<!-- When adding a new feature: -->

# Description
Also resolves MNTOR-3311
Users (new and returning) clicking Get Free Scan buttons on How it works page stuck in loop that returns them to the  page after login, rather than taking them to the dashboard

# How to test
1. Have VPN location set to USA
2. Be signed in to Monitor;
3. Be on the https://stage.firefoxmonitor.nonprod.cloudops.mozgcp.net/how-it-works 
4. Scroll down to the “Get free scan” CTA;
5. Click on the CTA;
6. Observe behavior;

# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
