### PR TITLE
Exposure card info for manually fixed results (MNTOR-3329)

### DIFF
--- a/src/app/components/client/exposure_card/ExposureCard.stories.ts
+++ b/src/app/components/client/exposure_card/ExposureCard.stories.ts
@@ -20,7 +20,10 @@ const meta: Meta<typeof ExposureCard> = {
 export default meta;
 type Story = StoryObj<typeof ExposureCard>;
 
-const ScanMockItemRemoved = createRandomScanResult({ status: "removed" });
+const ScanMockItemRemoved = createRandomScanResult({
+  status: "removed",
+  manually_resolved: false,
+});
 const ScanMockItemManualRemoved = createRandomScanResult({
   status: "new",
   manually_resolved: true,
@@ -35,6 +38,7 @@ const ScanMockItemNew = createRandomScanResult({
 });
 const ScanMockItemInProgress = createRandomScanResult({
   status: "optout_in_progress",
+  manually_resolved: false,
 });
 const BreachMockItemRemoved = createRandomBreach({ isResolved: true });
 const BreachMockItemNew = createRandomBreach({ isResolved: false });

--- a/src/app/components/client/exposure_card/ScanResultCard.tsx
+++ b/src/app/components/client/exposure_card/ScanResultCard.tsx
@@ -121,10 +121,33 @@ export const ScanResultCard = (props: ScanResultCardProps) => {
   );
 
   const dataBrokerDescription = () => {
+    // Data broker cards manually resolved do not change their status to "removed";
+    // instead, we track them using the "manually_resolved" property.
+    if (scanResult.manually_resolved) {
+      return l10n.getFragment(
+        "exposure-card-description-info-for-sale-fixed-manually-fixed",
+        {
+          elems: {
+            data_broker_profile: dataBrokerProfileLink,
+          },
+        },
+      );
+    }
+
     switch (scanResult.status) {
       case "waiting_for_verification":
+        if (props.enabledFeatureFlags?.includes("AdditionalRemovalStatuses")) {
+          return l10n.getFragment(
+            "exposure-card-description-info-for-sale-requested-removal-dashboard",
+            {
+              elems: {
+                data_broker_profile: dataBrokerProfileLink,
+              },
+            },
+          );
+        }
         return l10n.getFragment(
-          "exposure-card-description-info-for-sale-requested-removal-dashboard",
+          "exposure-card-description-info-for-sale-in-progress-dashboard",
           {
             elems: {
               data_broker_profile: dataBrokerProfileLink,
@@ -141,37 +164,16 @@ export const ScanResultCard = (props: ScanResultCardProps) => {
           },
         );
       case "new":
-        // Data broker cards manually resolved do not change their status to "removed";
-        // instead, we track them using the "manually_resolved" property.
-        if (scanResult.manually_resolved) {
+        /* c8 ignore start */
+        if (props.isOnManualRemovePage) {
           return l10n.getFragment(
-            "exposure-card-description-info-for-sale-fixed-manually-fixed",
+            "exposure-card-description-info-for-sale-action-needed-manual-fix-page",
             {
               elems: {
                 data_broker_profile: dataBrokerProfileLink,
               },
             },
           );
-        }
-        /* c8 ignore start */
-        if (props.isOnManualRemovePage) {
-          return scanResult.manually_resolved
-            ? l10n.getFragment(
-                "exposure-card-description-info-for-sale-fixed-manually-fixed",
-                {
-                  elems: {
-                    data_broker_profile: dataBrokerProfileLink,
-                  },
-                },
-              )
-            : l10n.getFragment(
-                "exposure-card-description-info-for-sale-action-needed-manual-fix-page",
-                {
-                  elems: {
-                    data_broker_profile: dataBrokerProfileLink,
-                  },
-                },
-              );
         }
         /* c8 ignore stop */
         return l10n.getFragment(
@@ -197,7 +199,10 @@ export const ScanResultCard = (props: ScanResultCardProps) => {
 
   const attemptCount = scanResult.optout_attempts ?? 0;
   const statusPillNote =
-    scanResult.status === "waiting_for_verification" && attemptCount >= 1
+    props.enabledFeatureFlags?.includes("AdditionalRemovalStatuses") &&
+    !scanResult.manually_resolved &&
+    scanResult.status === "waiting_for_verification" &&
+    attemptCount >= 1
       ? l10n.getString("status-pill-requested-removal-info", {
           attempt_count: attemptCount,
           last_attempt_date: new Intl.DateTimeFormat(locale).format(
@@ -251,9 +256,7 @@ export const ScanResultCard = (props: ScanResultCardProps) => {
               <StatusPill
                 exposure={scanResult}
                 note={statusPillNote}
-                additionalRemovalStatusesEnabled={props.enabledFeatureFlags?.includes(
-                  "AdditionalRemovalStatuses",
-                )}
+                enabledFeatureFlags={props.enabledFeatureFlags}
               />
             </dd>
           </dl>

--- a/src/app/components/server/StatusPill.module.scss
+++ b/src/app/components/server/StatusPill.module.scss
@@ -4,18 +4,21 @@
   font: $text-body-2xs;
   display: inline-block;
   line-height: 1;
-  min-width: 140px; // keep the width fixed
   text-align: center;
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-sm) {
     font: $text-body-xs;
-    min-width: 160px; // keep the width fixed
+    min-width: 145px; // keep the width fixed
   }
 
   .pill {
-    padding: $spacing-xs 0;
+    padding: $spacing-xs $spacing-sm;
     border-radius: $border-radius-sm;
     font-weight: 600;
+
+    @media screen and (min-width: $screen-sm) {
+      padding: $spacing-xs 0;
+    }
 
     &.actionNeeded {
       background: $color-red-10;

--- a/src/app/components/server/StatusPill.tsx
+++ b/src/app/components/server/StatusPill.tsx
@@ -7,6 +7,7 @@ import styles from "./StatusPill.module.scss";
 import { useL10n } from "../../hooks/l10n";
 import { Exposure, isScanResult } from "../client/exposure_card/ExposureCard";
 import { ExtendedReactLocalization } from "../../functions/l10n";
+import { FeatureFlagName } from "../../../db/tables/featureFlags";
 
 type StatusPillType =
   | "actionNeeded"
@@ -26,7 +27,7 @@ export const StatusPillTypeMap: Record<string, StatusPillType> = {
 type DirectTypeProps = { type: StatusPillType };
 type ExposureProps = { exposure: Exposure };
 export type Props = (DirectTypeProps | ExposureProps) & {
-  additionalRemovalStatusesEnabled?: boolean;
+  enabledFeatureFlags?: FeatureFlagName[];
   note?: string;
 };
 
@@ -38,7 +39,8 @@ export const StatusPill = (props: Props) => {
     ? props.type
     : getExposureStatus(
         props.exposure,
-        props.additionalRemovalStatusesEnabled ?? false,
+        props.enabledFeatureFlags?.includes("AdditionalRemovalStatuses") ??
+          false,
       );
 
   return (
@@ -46,7 +48,7 @@ export const StatusPill = (props: Props) => {
       <div className={`${styles.pill} ${styles[pillType]}`}>
         {getStatusLabel({ pillType, l10n })}
       </div>
-      {props.additionalRemovalStatusesEnabled && props.note ? props.note : null}
+      {props.note}
     </div>
   );
 };


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira:
- [MNTOR-3201](https://mozilla-hub.atlassian.net/browse/MNTOR-3201)
- [MNTOR-3329](https://mozilla-hub.atlassian.net/browse/MNTOR-3329)

<!-- When adding a new feature: -->

# Description

Fixes the exposure card content for manually fixed results as well as the status pill layout for mobile.

# Screenshot

| Before | After |
| --- | --- |
| <img width="294" alt="image" src="https://github.com/mozilla/blurts-server/assets/13835474/b3efad68-765d-465a-a85d-833b236c58f4"> | <img width="284" alt="image" src="https://github.com/mozilla/blurts-server/assets/13835474/3a2a6088-d56a-48be-a2c0-c0e191a65ae3"> |


# How to test

Step to reproduce from QA:

1. Navigate to the Monitor dashboard.
2. Manually mark some of the Data Brokers as fixed/removed.
3. Upgrade to Monitor Plus.
4. Return to the “fixed tab” and observe the previously manually fixed cards.

[MNTOR-3201]: https://mozilla-hub.atlassian.net/browse/MNTOR-3201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MNTOR-3329]: https://mozilla-hub.atlassian.net/browse/MNTOR-3329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ