### PR TITLE
Ensure a subscriber has their first data broker removal before sending email

### DIFF
--- a/src/scripts/cronjobs/firstDataBrokerRemovalFixed.tsx
+++ b/src/scripts/cronjobs/firstDataBrokerRemovalFixed.tsx
@@ -24,7 +24,11 @@ type SubscriberFirstRemovedScanResult = {
 function isFulfilledResult(
   result: PromiseSettledResult<SubscriberFirstRemovedScanResult | undefined>,
 ): result is PromiseFulfilledResult<SubscriberFirstRemovedScanResult> {
-  return typeof result !== "undefined" && result.status === "fulfilled";
+  return (
+    typeof result !== "undefined" &&
+    result.status === "fulfilled" &&
+    typeof result.value !== "undefined"
+  );
 }
 
 void run();


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-3352](https://mozilla-hub.atlassian.net/browse/MNTOR-3352)

<!-- When adding a new feature: -->

# Description

Ensure a subscriber has their first data broker removal before attempting to send the email.

[MNTOR-3352]: https://mozilla-hub.atlassian.net/browse/MNTOR-3352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ