### PR TITLE
MNTOR-3354 - Last Get free scan button can trigger an extra field focused telemetry ping

### DIFF
--- a/src/app/(proper_react)/(redesign)/(public)/SignUpForm.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/SignUpForm.tsx
@@ -57,9 +57,6 @@ export const SignUpForm = (props: Props) => {
       { callbackUrl: props.signUpCallbackUrl },
       attributionSearchParams.toString(),
     );
-    record("ctaButton", "click", {
-      button_id: props.eventId.cta,
-    });
   };
 
   const labelContent = (
@@ -95,7 +92,16 @@ export const SignUpForm = (props: Props) => {
           l10n.getString("landing-all-hero-emailform-input-placeholder")
         }
       />
-      <Button type="submit" variant="primary" wide>
+      <Button
+        type="submit"
+        variant="primary"
+        wide
+        onPress={() => {
+          record("ctaButton", "click", {
+            button_id: props.eventId.cta,
+          });
+        }}
+      >
         {l10n.getString("landing-all-hero-emailform-submit-label")}
       </Button>
       {props.isHero ? (


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3354

# How to test
    Navigate to the Monitor “How it works” page;

    Scroll down to the last Get free scan button;

    Click on the email field and observe the telemetry pings;

    Click on the Get free scan button and observe the telemetry pings;

    Refresh the page and repeat only step 4, observing the telemetry pings;

Expected result:

    Clicking the Get free scan button triggers only a ping for clicking the button;

Actual result:

    Clicking the Get free scan button after interacting with the field triggers both a field focus ping and a clicking the button ping;

Note: [Comments in Jira ticket](https://mozilla-hub.atlassian.net/browse/MNTOR-3354?focusedCommentId=905069) include how to observe telemetry pings when running locally
# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
