### PR TITLE
Adjust CSAT banner button layout (MNTOR-3317)

### DIFF
--- a/src/app/components/client/csat_survey/CsatSurveyBanner.module.scss
+++ b/src/app/components/client/csat_survey/CsatSurveyBanner.module.scss
@@ -22,12 +22,8 @@
 .answers {
   align-items: center;
   display: flex;
-  flex-direction: column;
+  flex-flow: row wrap;
   gap: $spacing-sm;
-
-  @media screen and (min-width: $screen-md) {
-    flex-direction: row;
-  }
 
   .answer {
     background-color: $color-purple-40;

--- a/src/app/components/client/csat_survey/CsatSurveyBanner.tsx
+++ b/src/app/components/client/csat_survey/CsatSurveyBanner.tsx
@@ -96,7 +96,6 @@ export const CsatSurveyBanner = ({
                 <Button
                   className={styles.answer}
                   variant="primary"
-                  small
                   onPress={() => submit(response)}
                 >
                   {l10n.getString(`survey-csat-answer-${response}`)}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-3317](https://mozilla-hub.atlassian.net/browse/MNTOR-3317)
Figma: https://www.figma.com/design/DTbmXzCQCw2PxXpHQW8yfW/Monitor-MVP-Enhancements?node-id=329-6723&t=oWtFX5z5dIEj8Iii-0

<!-- When adding a new feature: -->

# Description

Adjusts the CSAT banner layout to be more fluid for smaller viewports.

# Screenshot

| Desktop | Mobile |
| --- | --- |
| <img width="761" alt="image" src="https://github.com/mozilla/blurts-server/assets/13835474/ad34b12f-210d-4c3a-8dec-5b234fbb02c7"> | <img width="422" alt="image" src="https://github.com/mozilla/blurts-server/assets/13835474/764f3357-e22a-4962-bbe4-460fb875e748"> |

[MNTOR-3317]: https://mozilla-hub.atlassian.net/browse/MNTOR-3317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ