### PR TITLE
Don't crash when SubPlat doesn't know a user

### DIFF
--- a/src/app/functions/universal/user.ts
+++ b/src/app/functions/universal/user.ts
@@ -51,28 +51,22 @@ export async function checkUserHasYearlySubscription(user: Session["user"]) {
     console.error("FXA token not set");
     return false;
   }
-  let hasYearlyPlanId: boolean = false;
 
-  const getBillingAndSubscriptionInfo = await getBillingAndSubscriptions(
+  const billingAndSubscriptionInfo = await getBillingAndSubscriptions(
     user.subscriber.fxa_access_token,
   );
+  if (billingAndSubscriptionInfo === null) {
+    return false;
+  }
+
   const yearlyPlanId: string = process.env.PREMIUM_PLAN_ID_YEARLY_US;
-
-  const parsedBillingAndSubscriptionInfo = JSON.parse(
-    JSON.stringify(getBillingAndSubscriptionInfo),
-  );
-
-  const subscriptions = parsedBillingAndSubscriptionInfo.subscriptions;
+  const subscriptions = billingAndSubscriptionInfo.subscriptions;
 
   const planIds: string[] = [];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  subscriptions.forEach((subscription: any) => {
+  subscriptions.forEach((subscription) => {
     planIds.push(subscription.plan_id);
   });
 
-  if (planIds.includes(yearlyPlanId)) {
-    hasYearlyPlanId = true;
-  }
-  return hasYearlyPlanId;
+  return planIds.includes(yearlyPlanId);
 }
 /* c8 ignore stop */

--- a/src/utils/fxa.js
+++ b/src/utils/fxa.js
@@ -104,8 +104,25 @@ async function getSubscriptions(bearerToken) {
 }
 
 /**
+ * Calls https://mozilla.github.io/ecosystem-platform/api#tag/Subscriptions/operation/getOauthMozillasubscriptionsCustomerBillingandsubscriptions
+ *
+ * Note that we currently only look at the subscriptions and their plan IDs, so
+ * the return type definition isn't exhaustive yet. If you need more data, look
+ * at the above docs to expand the return type definition.
+ *
  * @param {string} bearerToken
- * @returns {Promise<Array<any> | null>}
+ * @returns {Promise<
+ *   null
+ *   | {
+ *       subscriptions: Array<{
+ *         plan_id: string;
+ *         product_id: string;
+ *         current_period_end: number;
+ *         cancel_at_period_end: boolean;
+ *         status: "active" | "canceled" | "trialing" | "unpaid" | string;
+ *       }>
+ *     }
+ * >}
  */
 
 async function getBillingAndSubscriptions(bearerToken) {
@@ -120,7 +137,7 @@ async function getBillingAndSubscriptions(bearerToken) {
     })
 
     if (!getResp.ok) {
-      throw new InternalServerError(`bad response: ${getResp.status}`)
+      throw new InternalServerError(`bad response: [${getResp.status}] [${getResp.statusText}]`)
     } else {
       console.info(`get_fxa_subscriptions: success`)
       return await getResp.json()


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3359
Figma: N/A

<!-- When adding a new feature: -->

# Description

The settings page would refuse to load since https://github.com/mozilla/blurts-server/pull/4731 because we threw an error after SubPlat's API returned a 404, which it always does for free users.

TypeScript didn't catch this, because we didn't define the type for the SubPlat API response, and instead "laundered" it through JSON.parse(JSON.stringify()) to mark it as `any`. So I've added a minimal type definition that includes the data we use (plan_id), and a bit of data that we might use later, but it's not unlikely that we'll need to update it as we read more data from this API.

# How to test

Create a new free account, then visit the settings page. This results in a server error on `main`, but should no longer do so on this branch.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - No, but the type definitions should catch regressions.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
