### PR TITLE
Make sure experiment code exists during tests

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -15,7 +15,6 @@ jobs:
           node-version: '22.3.x'
       - run: npm ci
       - run: npm run build-glean
-      - run: npm run build-nimbus
       - run: npm test
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "next start",
     "lint": "stylelint '**/*.scss' && prettier --check './src' && next lint --max-warnings=0 && tsc -p tsconfig.json --noEmit",
     "fix": "prettier --write './src' && next lint --fix && stylelint --fix '**/*.scss'",
-    "test": "jest",
+    "test": "npm run build-nimbus && jest",
     "e2e": "playwright test src/e2e/",
     "e2e:debug": "playwright test src/e2e/ --ui",
     "e2e:smoke": "playwright test src/e2e/ --grep @smoke",


### PR DESCRIPTION
It took quite a bit of tracking down when all my tests failed due to my not having generated the Nimbus experiment types. Since the code generation happens basically instantly, it seems fine to just run it every time before running the tests.