### PR TITLE
Convert experiment automatic-removal-csat-survey to feature flag

### DIFF
--- a/config/nimbus.yaml
+++ b/config/nimbus.yaml
@@ -33,20 +33,6 @@ features:
         value: { "enabled": false }
       - channel: production
         value: { "enabled": false }
-  automatic-removal-csat-survey:
-    description: Show the CSAT survey for Plus users that have automatically removed broker results
-    variables:
-      enabled:
-        description: If the feature is enabled
-        type: Boolean
-        default: false
-    defaults:
-      - channel: local
-        value: { "enabled": true }
-      - channel: staging
-        value: { "enabled": true }
-      - channel: production
-        value: { "enabled": false }
   data-privacy-petition-banner:
     description: Show the data privacy petition banner to US users
     variables:

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.stories.tsx
@@ -212,15 +212,13 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
             elapsedTimeInDaysSinceInitialScan={
               props.elapsedTimeInDaysSinceInitialScan
             }
-            enabledFeatureFlags={
-              props.enabledFeatureFlags ?? ["HowItWorksPage"]
-            }
+            enabledFeatureFlags={[
+              ...(props.enabledFeatureFlags ?? []),
+              "HowItWorksPage",
+            ]}
             experimentData={
               props.experimentData ?? {
                 ...defaultExperimentData,
-                "automatic-removal-csat-survey": {
-                  enabled: true,
-                },
                 "last-scan-date": {
                   enabled: true,
                 },

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
@@ -3477,12 +3477,7 @@ describe("CSAT survey banner", () => {
     render(
       <ComposedDashboard
         elapsedTimeInDaysSinceInitialScan={1}
-        experimentData={{
-          ...defaultExperimentData,
-          "automatic-removal-csat-survey": {
-            enabled: true,
-          },
-        }}
+        enabledFeatureFlags={["AutomaticRemovalCsatSurvey"]}
       />,
     );
 
@@ -3501,12 +3496,7 @@ describe("CSAT survey banner", () => {
     render(
       <ComposedDashboard
         elapsedTimeInDaysSinceInitialScan={1}
-        experimentData={{
-          ...defaultExperimentData,
-          "automatic-removal-csat-survey": {
-            enabled: true,
-          },
-        }}
+        enabledFeatureFlags={["AutomaticRemovalCsatSurvey"]}
       />,
     );
 
@@ -3528,12 +3518,7 @@ describe("CSAT survey banner", () => {
     render(
       <ComposedDashboard
         elapsedTimeInDaysSinceInitialScan={91}
-        experimentData={{
-          ...defaultExperimentData,
-          "automatic-removal-csat-survey": {
-            enabled: true,
-          },
-        }}
+        enabledFeatureFlags={["AutomaticRemovalCsatSurvey"]}
       />,
     );
 
@@ -3555,12 +3540,7 @@ describe("CSAT survey banner", () => {
     render(
       <ComposedDashboard
         elapsedTimeInDaysSinceInitialScan={1}
-        experimentData={{
-          ...defaultExperimentData,
-          "automatic-removal-csat-survey": {
-            enabled: true,
-          },
-        }}
+        enabledFeatureFlags={["AutomaticRemovalCsatSurvey"]}
       />,
     );
 
@@ -3587,12 +3567,7 @@ describe("CSAT survey banner", () => {
     render(
       <ComposedDashboard
         elapsedTimeInDaysSinceInitialScan={180}
-        experimentData={{
-          ...defaultExperimentData,
-          "automatic-removal-csat-survey": {
-            enabled: true,
-          },
-        }}
+        enabledFeatureFlags={["AutomaticRemovalCsatSurvey"]}
       />,
     );
 
@@ -3620,12 +3595,7 @@ describe("CSAT survey banner", () => {
       <ComposedDashboard
         activeTab="fixed"
         elapsedTimeInDaysSinceInitialScan={185}
-        experimentData={{
-          ...defaultExperimentData,
-          "automatic-removal-csat-survey": {
-            enabled: true,
-          },
-        }}
+        enabledFeatureFlags={["AutomaticRemovalCsatSurvey"]}
       />,
     );
 
@@ -3684,7 +3654,10 @@ describe("CSAT survey banner", () => {
         activeTab="fixed"
         elapsedTimeInDaysSinceInitialScan={90}
         hasFirstMonitoringScan
-        enabledFeatureFlags={["LatestScanDateCsatSurvey"]}
+        enabledFeatureFlags={[
+          "LatestScanDateCsatSurvey",
+          "AutomaticRemovalCsatSurvey",
+        ]}
       />,
     );
 
@@ -3703,7 +3676,10 @@ describe("CSAT survey banner", () => {
         activeTab="fixed"
         elapsedTimeInDaysSinceInitialScan={90}
         hasFirstMonitoringScan
-        enabledFeatureFlags={["LatestScanDateCsatSurvey"]}
+        enabledFeatureFlags={[
+          "LatestScanDateCsatSurvey",
+          "AutomaticRemovalCsatSurvey",
+        ]}
       />,
     );
 

--- a/src/app/components/client/csat_survey/CsatSurvey.tsx
+++ b/src/app/components/client/csat_survey/CsatSurvey.tsx
@@ -35,7 +35,8 @@ export const CsatSurvey = (props: CsatSurveyProps) => {
   // The order of the surveys here matter: If there are multiple matching
   // surveys for the user we dismiss all surveys, but the last one in the list.
   const surveys = [
-    props.elapsedTimeInDaysSinceInitialScan !== null &&
+    props.enabledFeatureFlags.includes("AutomaticRemovalCsatSurvey") &&
+      props.elapsedTimeInDaysSinceInitialScan !== null &&
       getAutomaticRemovalCsatSurvey({
         ...surveyOptions,
         elapsedTimeInDaysSinceInitialScan:

--- a/src/app/components/client/csat_survey/surveys/automaticRemovalCsatSurvey.ts
+++ b/src/app/components/client/csat_survey/surveys/automaticRemovalCsatSurvey.ts
@@ -29,12 +29,7 @@ function isAutomaticRemovalSurvey(
 
 const surveyData: SurveyData = {
   id: "csat_survey",
-  requiredExperiments: [
-    {
-      id: "automatic-removal-csat-survey",
-      statusAllowList: ["enabled"],
-    },
-  ],
+  requiredExperiments: [],
   variations: [
     {
       id: "initial",

--- a/src/app/components/client/csat_survey/surveys/csatSurvey.ts
+++ b/src/app/components/client/csat_survey/surveys/csatSurvey.ts
@@ -64,6 +64,9 @@ export function getRelevantSurveys({
   experimentData,
   user,
 }: SurveyData & CsatSurveyProps): Survey[] | null {
+  // There is currently no CSAT survey that is only shown for enabled
+  // experiments and would trigger the early return.
+  /* c8 ignore start */
   if (
     !requiredExperiments.every((experiment) => {
       return experiment.statusAllowList.includes(
@@ -73,6 +76,7 @@ export function getRelevantSurveys({
   ) {
     return null;
   }
+  /* c8 ignore stop */
 
   const filteredSurveys = variations.filter((surveyVariation) => {
     const isRelevantUser = surveyVariation.showForUser.includes(

--- a/src/app/components/client/stories/CsatSurvey.stories.ts
+++ b/src/app/components/client/stories/CsatSurvey.stories.ts
@@ -20,13 +20,11 @@ export const CsatSurveyAutomaticRemoval: Story = {
   args: {
     activeTab: "fixed",
     user: createUserWithPremiumSubscription(),
-    enabledFeatureFlags: ["LatestScanDateCsatSurvey"],
-    experimentData: {
-      ...defaultExperimentData,
-      "automatic-removal-csat-survey": {
-        enabled: true,
-      },
-    },
+    enabledFeatureFlags: [
+      "LatestScanDateCsatSurvey",
+      "AutomaticRemovalCsatSurvey",
+    ],
+    experimentData: defaultExperimentData,
     hasAutoFixedDataBrokers: true,
     elapsedTimeInDaysSinceInitialScan: 0,
   },

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -47,6 +47,7 @@ export type FeatureFlagName =
   | "FirstDataBrokerRemovalFixedEmail"
   | "DiscountCouponNextThreeMonths"
   | "LatestScanDateCsatSurvey"
+  | "AutomaticRemovalCsatSurvey"
   | "HowItWorksPage"
   | "AdditionalRemovalStatuses";
 


### PR DESCRIPTION
# Description

Converts the experiment `automatic-removal-csat-survey` to use the feature flag `AutomaticRemovalCsatSurvey` instead.