### PR TITLE
Explicitly provide env file path

### DIFF
--- a/src/appConstants.js
+++ b/src/appConstants.js
@@ -8,8 +8,13 @@ if (typeof process.env.NEXT_RUNTIME === "undefined") {
   // Next.js already loads env vars by itself, and dotenv-flow will throw an
   // error if loaded in that context (about `fs` not existing), so only load
   // it if we're not running in a Next.js-context (e.g. cron jobs):
+  const path = await import("path");
+  const url = await import("url");
+  const __filename = url.fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+
   const dotenvFlow = await import("dotenv-flow");
-  dotenvFlow.config();
+  dotenvFlow.config({ path: path.resolve(__dirname, "../") });
 }
 
 const requiredEnvVars = [

--- a/src/appConstants.js
+++ b/src/appConstants.js
@@ -3,13 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // TODO: these vars were copy/pasted from the old app-constants.js and should be cleaned up
+import path from "path";
+import url from "url";
 
 if (typeof process.env.NEXT_RUNTIME === "undefined") {
   // Next.js already loads env vars by itself, and dotenv-flow will throw an
   // error if loaded in that context (about `fs` not existing), so only load
   // it if we're not running in a Next.js-context (e.g. cron jobs):
-  const path = await import("path");
-  const url = await import("url");
   const __filename = url.fileURLToPath(import.meta.url);
   const __dirname = path.dirname(__filename);
 


### PR DESCRIPTION
We need to explicitly provide the [option.path](https://github.com/kerimdzhanov/dotenv-flow?tab=readme-ov-file#optionspath) in [appConstants.js](https://github.com/mozilla/blurts-server/blob/main/src/appConstants.js#L12) when running scripts like `npm run db:migrate` which change the `CWD`.