### PR TITLE
Fix Storybook

### DIFF
--- a/src/appConstants.js
+++ b/src/appConstants.js
@@ -6,7 +6,7 @@
 import path from "path";
 import url from "url";
 
-if (typeof process.env.NEXT_RUNTIME === "undefined") {
+if (typeof process.env.NEXT_RUNTIME === "undefined" && typeof process.env.STORYBOOK === "undefined") {
   // Next.js already loads env vars by itself, and dotenv-flow will throw an
   // error if loaded in that context (about `fs` not existing), so only load
   // it if we're not running in a Next.js-context (e.g. cron jobs):


### PR DESCRIPTION
Don't manually load env vars in Storybook.

This breaks Storybook, and it should already emulate Next.js's env var loading behaviour.

See https://fx-monitor-storybook.netlify.app/?path=/story/pages-logged-in-dashboard--dashboard-non-us-no-breaches for an example of the breakage.

Here's that same page for this PR: https://deploy-preview-4806--fx-monitor-storybook.netlify.app/?path=/story/pages-logged-in-dashboard--dashboard-non-us-no-breaches