### PR TITLE
Fix e2e: Disable landing page experiment locally

### DIFF
--- a/config/nimbus.yaml
+++ b/config/nimbus.yaml
@@ -61,8 +61,8 @@ features:
     defaults:
       - channel: local
         value: {
-          "enabled": true,
-          "variant": ctaOnly,
+          "enabled": false,
+          "variant": ctaWithEmail,
         }
       - channel: staging
         value: {


### PR DESCRIPTION
Disable the experiment also for local environments so it does not [break the Monitor Cron e2e tests](https://github.com/mozilla/blurts-server/actions/runs/9953077903).