### PR TITLE
Remove invalid OAuth parameter service

### DIFF
--- a/src/app/(proper_react)/(redesign)/(public)/FreeScanCta.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/FreeScanCta.tsx
@@ -41,7 +41,6 @@ export function getAttributionSearchParams({
     {
       entrypoint: "monitor.mozilla.org-monitor-product-page",
       form_type: typeof emailInput === "string" ? "email" : "button",
-      service: process.env.OAUTH_CLIENT_ID as string,
       ...(emailInput && { email: emailInput }),
       ...(experimentData &&
         experimentData["landing-page-free-scan-cta"].enabled && {

--- a/src/app/(proper_react)/(redesign)/(public)/LandingView.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingView.test.tsx
@@ -1015,7 +1015,6 @@ describe("Free scan CTA experiment", () => {
         [
           "entrypoint=monitor.mozilla.org-monitor-product-page",
           "form_type=email",
-          "service=edd29a80019d61a1",
           "email=mail%40example.com",
           "entrypoint_experiment=landing-page-free-scan-cta",
           "entrypoint_variation=ctaWithEmail",


### PR DESCRIPTION
Passing the UTM parameter to Mozilla accounts endpoint `/authorization` results in an `Invalid OAuth parameter: service` error.