### PR TITLE
comment out test broken by MNTOR-3341 until experiment concludes

### DIFF
--- a/src/e2e/specs/landing.spec.ts
+++ b/src/e2e/specs/landing.spec.ts
@@ -41,7 +41,7 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page content`, (
     await expect(landingPage.monitorHeroSubtitle).toHaveText(
       "We scan to see if your phone number, passwords or home address have been leaked, and help you make it private again.",
     );
-    await expect(landingPage.monitorHeroFormEmailInputField).toBeVisible();
+    // TODO MNTOR-3341: await expect(landingPage.monitorHeroFormEmailInputField).toBeVisible();
     await expect(landingPage.monitorHeroFormInputSubmitButton).toBeVisible();
     await expect(landingPage.monitorLandingMidHeading).toBeVisible();
   });
@@ -73,7 +73,7 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page content`, (
 
     await expect(landingPage.couldBeAtRiskTitle).toBeVisible();
     await expect(landingPage.couldBeAtRiskSubtitle).toBeVisible();
-    await expect(landingPage.couldBeAtRiskFormEmailInputField).toBeVisible();
+    // TODO MNTOR-3341: await expect(landingPage.couldBeAtRiskFormEmailInputField).toBeVisible();
     await expect(landingPage.couldBeAtRiskFormInputSubmitButton).toBeVisible();
     await expect(landingPage.couldBeAtRiskGraphic).toBeVisible();
   });
@@ -88,7 +88,7 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page content`, (
     });
 
     await expect(landingPage.getStartedScanTitle).toBeVisible();
-    await expect(landingPage.getStartedScanFormEmailInputField).toBeVisible();
+    // TODO MNTOR-3341: await expect(landingPage.getStartedScanFormEmailInputField).toBeVisible();
     await expect(landingPage.getStartedScanFormSubmitButton).toBeVisible();
   });
 
@@ -130,7 +130,7 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page content`, (
     });
 
     await expect(landingPage.takeBackControlTitle).toBeVisible();
-    await expect(landingPage.takeBackControlFormEmailInputField).toBeVisible();
+    // await expect(landingPage.takeBackControlFormEmailInputField).toBeVisible();
     await expect(landingPage.takeBackControlFormSubmitButton).toBeVisible();
   });
 
@@ -173,6 +173,7 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page content`, (
     await purchasePage.verifyYearlyPlanDetails();
   });
 
+  /* TODO MNTOR-3341
   test('Verify the "Get free scan" corresponding email fields', async ({
     landingPage,
     authPage,
@@ -194,6 +195,7 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page content`, (
     await authPage.passwordInputField.waitFor();
     await expect(authPage.passwordInputField).toBeVisible();
   });
+  */
 
   test('Verify manual/automatic removal "more info" tips from "Choose your level of protection" section', async ({
     landingPage,

--- a/src/e2e/specs/landing.spec.ts
+++ b/src/e2e/specs/landing.spec.ts
@@ -57,7 +57,7 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page content`, (
 
     await expect(landingPage.fixExposuresTitle).toBeVisible();
     await expect(landingPage.fixExposuresSubtitle).toBeVisible();
-    await expect(landingPage.fixExposuresFormEmailInputField).toBeVisible();
+    // TODO MNTOR-3341 await expect(landingPage.fixExposuresFormEmailInputField).toBeVisible();
     await expect(landingPage.fixExposuresFormInputSubmitButton).toBeVisible();
     await expect(landingPage.fixExposuresGraphic).toBeVisible();
   });
@@ -130,7 +130,7 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page content`, (
     });
 
     await expect(landingPage.takeBackControlTitle).toBeVisible();
-    // await expect(landingPage.takeBackControlFormEmailInputField).toBeVisible();
+    // TODO MNTOR-3341 await expect(landingPage.takeBackControlFormEmailInputField).toBeVisible();
     await expect(landingPage.takeBackControlFormSubmitButton).toBeVisible();
   });
 
@@ -173,8 +173,8 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page content`, (
     await purchasePage.verifyYearlyPlanDetails();
   });
 
-  /* TODO MNTOR-3341
-  test('Verify the "Get free scan" corresponding email fields', async ({
+  // TODO MNTOR-3341
+  test.skip('Verify the "Get free scan" corresponding email fields', async ({
     landingPage,
     authPage,
   }) => {
@@ -195,7 +195,6 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page content`, (
     await authPage.passwordInputField.waitFor();
     await expect(authPage.passwordInputField).toBeVisible();
   });
-  */
 
   test('Verify manual/automatic removal "more info" tips from "Choose your level of protection" section', async ({
     landingPage,
@@ -232,8 +231,9 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page Functionali
 
     // fill out free scan form
     const randomEmail = `${Date.now()}_tstact@restmail.net`;
-    await landingPage.monitorHeroFormEmailInputField.fill(randomEmail);
-    await landingPage.monitorHeroFormInputSubmitButton.click();
+    // TODO MNTOR-3341 await landingPage.monitorHeroFormEmailInputField.fill(randomEmail);
+    // await landingPage.monitorHeroFormInputSubmitButton.click();
+    await landingPage.signInButton.click();
     await page.waitForURL("**/oauth/**");
 
     // complete registration form
@@ -301,10 +301,13 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page Functionali
     });
 
     // fill out free scan form
+    /* TODO MNTOR-3341
     await landingPage.monitorHeroFormEmailInputField.fill(
       process.env.E2E_TEST_ACCOUNT_EMAIL as string,
     );
     await landingPage.monitorHeroFormInputSubmitButton.click();
+    */
+    await landingPage.signInButton.click();
     await page.waitForURL("**/oauth/**");
 
     // complete sign in form


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3420

<!-- When adding a new feature: -->

# Description

The e2e tests expect the email form fields on the landing page which is removed by the experiment in MNTOR-3341. This comments them out until the experiment concludes and we decide if those fields are being removed permanently.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
