### PR TITLE
MNTOR-3344: use account uri

### DIFF
--- a/src/utils/fxa.js
+++ b/src/utils/fxa.js
@@ -126,7 +126,7 @@ async function getSubscriptions(bearerToken) {
  */
 
 async function getBillingAndSubscriptions(bearerToken) {
-  const subscriptionIdUrl = `${process.env.OAUTH_API_URI}/oauth/mozilla-subscriptions/customer/billing-and-subscriptions`
+  const subscriptionIdUrl = `${process.env.OAUTH_ACCOUNT_URI}/oauth/mozilla-subscriptions/customer/billing-and-subscriptions`
   
   try {
     const getResp = await fetch(subscriptionIdUrl, {

--- a/src/utils/fxa.js
+++ b/src/utils/fxa.js
@@ -126,7 +126,7 @@ async function getSubscriptions(bearerToken) {
  */
 
 async function getBillingAndSubscriptions(bearerToken) {
-  const subscriptionIdUrl = `${process.env.OAUTH_ACCOUNT_URI}/oauth/mozilla-subscriptions/customer/billing-and-subscriptions`
+  const subscriptionIdUrl = `${AppConstants.OAUTH_ACCOUNT_URI}/oauth/mozilla-subscriptions/customer/billing-and-subscriptions`
   
   try {
     const getResp = await fetch(subscriptionIdUrl, {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3344


<!-- When adding a new feature: -->

# Description
use account uri instead of api uri (not set in prod)
