### PR TITLE
ongoing incident: catch and log profile stats being down

### DIFF
--- a/src/app/functions/server/onerep.ts
+++ b/src/app/functions/server/onerep.ts
@@ -482,10 +482,21 @@ export async function getProfilesStats(
     // );
   }
 
-  const profileStats: ProfileStats = await response.json();
+  try {
+    const profileStats: ProfileStats = await response.json();
 
-  // cache results in map, with a flush hack to keep the size low
-  if (profileStatsCache.size > 5) profileStatsCache.clear();
-  profileStatsCache.set(queryParamsString, profileStats);
-  return profileStats;
+    // cache results in map, with a flush hack to keep the size low
+    if (profileStatsCache.size > 5) profileStatsCache.clear();
+    profileStatsCache.set(queryParamsString, profileStats);
+    return profileStats;
+  } catch (e) {
+    if (e instanceof Error) {
+      logger.error("failed_fetching_stats", {
+        stack: e.stack,
+        message: e.message,
+      });
+    } else {
+      logger.error("failed_fetching_stats", { e });
+    }
+  }
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

<!-- When adding a new feature: -->

# Description

Catch and log if stats API result cannot be parsed. `undefined` being return will cause the waitlist functionality to activate.
