### PR TITLE
change OAUTH_ACCOUNT_URI to stage to match other OAUTH defaults

### DIFF
--- a/.env
+++ b/.env
@@ -39,8 +39,7 @@ OAUTH_CLIENT_SECRET=get-this-from-groovecoder-or-fxmonitor-engineering
 OAUTH_AUTHORIZATION_URI=https://oauth.stage.mozaws.net/v1/authorization
 OAUTH_PROFILE_URI=https://profile.stage.mozaws.net/v1/profile
 OAUTH_TOKEN_URI=https://oauth.stage.mozaws.net/v1/token
-OAUTH_ACCOUNT_URI = "https://oauth.accounts.firefox.com/v1"
-OAUTH_API_URI="https://api-accounts.stage.mozaws.net/v1"
+OAUTH_ACCOUNT_URI="https://api-accounts.stage.mozaws.net/v1"
 
 # HIBP API for breach data
 # How many seconds to wait before refreshing upstream breach data from HIBP


### PR DESCRIPTION
I just ran into this testing locally, since `OAUTH_API_URI` was removed my local env fell back to `OAUTH_ACCOUNT_URI` default which points to the prod URL and not stage (as the other `OAUTH` examples do)