### PR TITLE
Update Monitor CTA experiment copy (MNTOR-3429)

### DIFF
--- a/config/nimbus.yaml
+++ b/config/nimbus.yaml
@@ -83,4 +83,4 @@ enums:
       ctaOnly:
         description: Only show a CTA button with the label “Get free scan”
       ctaOnlyAlternativeLabel:
-        description: Only show a CTA button with the label “Sign in to get free scan”
+        description: Only show a CTA button with the label “Sign up to get free scan”

--- a/locales/en/landing-all.ftl
+++ b/locales/en/landing-all.ftl
@@ -10,7 +10,7 @@ landing-all-hero-lead = We scan data breaches to see if your data has been leake
 landing-all-hero-emailform-input-placeholder = yourname@example.com
 landing-all-hero-emailform-input-label = Enter your email address to check for data breach exposures.
 landing-all-hero-emailform-submit-label = Get free scan
-landing-all-hero-emailform-submit-sign-in-label = Sign in to get free scan
+landing-all-hero-emailform-submit-sign-up-label = Sign up to get free scan
 
 # This is a label underneath a big number "14" - it's an image that demos Monitor.
 landing-all-hero-image-chart-label = exposures

--- a/src/app/(proper_react)/(redesign)/(public)/FreeScanCta.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/FreeScanCta.tsx
@@ -106,7 +106,7 @@ export const FreeScanCta = (
           props.experimentData["landing-page-free-scan-cta"].variant ===
             "ctaOnly"
             ? "landing-all-hero-emailform-submit-label"
-            : "landing-all-hero-emailform-submit-sign-in-label",
+            : "landing-all-hero-emailform-submit-sign-up-label",
         )}
       </TelemetryButton>
     </div>

--- a/src/app/(proper_react)/(redesign)/(public)/LandingView.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingView.test.tsx
@@ -928,7 +928,7 @@ describe("Free scan CTA experiment", () => {
     expect(inputField.length).toBe(0);
 
     const submitButton = screen.getAllByRole("button", {
-      name: "Sign in to get free scan",
+      name: "Sign up to get free scan",
     });
     expect(submitButton[0]).toBeInTheDocument();
   });


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-3429](https://mozilla-hub.atlassian.net/browse/MNTOR-3429)
Figma: https://www.figma.com/design/YqpVpUbSTzZMj9Jbp2po8Q/Mozilla-Monitor-Premium-LP?node-id=3562-11693&t=WW3B3g07hmf6qdsB-4

<!-- When adding a new feature: -->

# Description

Update the landing page CTA label for experiment variation B. From the Jira ticket:

> On Variation B: we have the CTA as “Sign in to get free scan”. After reviewing on stage we believe this should be changed to “Sign up to get free scan” as “Sign in” might cause confusion for users because they might not see a clear path forward to sign up.

[MNTOR-3429]: https://mozilla-hub.atlassian.net/browse/MNTOR-3429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ