### PR TITLE
Do not run tests of compiled cronjobs

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -193,9 +193,7 @@ const customJestConfig = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: ["/node_modules/", "/dist/"],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],


### PR DESCRIPTION
Without this change, running `npm test` after running `npm run build-cronjobs` will result in failing tests.