### PR TITLE
MNTOR-3391: node 22.5.1 fixes an error with npm build

### DIFF
--- a/.github/workflows/e2e_cron.yml
+++ b/.github/workflows/e2e_cron.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.5
+          node-version: 22.5.x
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.5
+          node-version: 22.5.x
 
       - name: Install dependencies
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "homepage": "https://github.com/mozilla/blurts-server",
   "license": "MPL-2.0",
   "volta": {
-    "node": "22.5.0",
+    "node": "22.5.1",
     "npm": "10.8.1"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3391

<!-- When adding a new feature: -->

# Description
Some people might get an error with 22.5.0 when using Volta and `npm run build`
Ref: https://github.com/nodejs/node/issues/53902

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
