### PR TITLE
fix client import, move checkUserHasMonthlySubscription from universal to server function

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/page.tsx
@@ -24,7 +24,7 @@ import { getLocale } from "../../../../../../functions/universal/getLocale";
 import { getCountryCode } from "../../../../../../functions/server/getCountryCode";
 import { getSubscriberById } from "../../../../../../../db/tables/subscribers";
 import { checkSession } from "../../../../../../functions/server/checkSession";
-import { checkUserHasMonthlySubscription } from "../../../../../../functions/universal/user";
+import { checkUserHasMonthlySubscription } from "../../../../../../functions/server/user";
 
 type Props = {
   searchParams: {

--- a/src/app/functions/server/user.ts
+++ b/src/app/functions/server/user.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Session } from "next-auth";
+import { getBillingAndSubscriptions } from "../../../utils/fxa";
+
+/* c8 ignore start */
+export async function checkUserHasMonthlySubscription(user: Session["user"]) {
+  if (!user.subscriber?.fxa_access_token) {
+    console.error("FXA token not set");
+    return false;
+  }
+
+  if (!process.env.PREMIUM_PLAN_ID_MONTHLY_US) {
+    console.error("Monthly Plan ID not set");
+    return false;
+  }
+
+  const billingAndSubscriptionInfo = await getBillingAndSubscriptions(
+    user.subscriber.fxa_access_token,
+  );
+
+  if (billingAndSubscriptionInfo === null) {
+    return false;
+  }
+
+  const monthlyPlanId = process.env.PREMIUM_PLAN_ID_MONTHLY_US;
+  const yearlyPlanId = process.env.PREMIUM_PLAN_ID_YEARLY_US ?? "";
+
+  const subscriptions = billingAndSubscriptionInfo.subscriptions;
+
+  const planIds: string[] = [];
+  subscriptions.forEach((subscription) => {
+    planIds.push(subscription.plan_id);
+  });
+
+  if (planIds.includes(yearlyPlanId)) {
+    console.error("User has yearly plan set");
+    return false;
+  }
+
+  return planIds.includes(monthlyPlanId);
+}
+/* c8 ignore stop */

--- a/src/app/functions/universal/user.ts
+++ b/src/app/functions/universal/user.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Session } from "next-auth";
-import { getBillingAndSubscriptions } from "../../../utils/fxa";
 import { ISO8601DateString } from "../../../utils/parse";
 
 // TODO: Add unit test when changing this code:
@@ -41,42 +40,3 @@ export function meetsAgeRequirement(dateOfBirth: ISO8601DateString): boolean {
 
   return age >= USER_MIN_AGE;
 }
-
-/* c8 ignore start */
-export async function checkUserHasMonthlySubscription(user: Session["user"]) {
-  if (!user.subscriber?.fxa_access_token) {
-    console.error("FXA token not set");
-    return false;
-  }
-
-  if (!process.env.PREMIUM_PLAN_ID_MONTHLY_US) {
-    console.error("Monthly Plan ID not set");
-    return false;
-  }
-
-  const billingAndSubscriptionInfo = await getBillingAndSubscriptions(
-    user.subscriber.fxa_access_token,
-  );
-
-  if (billingAndSubscriptionInfo === null) {
-    return false;
-  }
-
-  const monthlyPlanId = process.env.PREMIUM_PLAN_ID_MONTHLY_US;
-  const yearlyPlanId = process.env.PREMIUM_PLAN_ID_YEARLY_US ?? "";
-
-  const subscriptions = billingAndSubscriptionInfo.subscriptions;
-
-  const planIds: string[] = [];
-  subscriptions.forEach((subscription) => {
-    planIds.push(subscription.plan_id);
-  });
-
-  if (planIds.includes(yearlyPlanId)) {
-    console.error("User has yearly plan set");
-    return false;
-  }
-
-  return planIds.includes(monthlyPlanId);
-}
-/* c8 ignore stop */


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3460

<!-- When adding a new feature: -->

# Description

`fxa` module can only be used by server components, the import from a client component is causing confusing messages to be logged to the browser.

# How to test

Browser devtools console should not log messages such as:

```
Required environment variable was not set
```

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
