### PR TITLE
Don't ignore allowlist on "Welcome to Plus" page, remove "HowItWorksPage" flag

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/components/FlagEditor.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/components/FlagEditor.tsx
@@ -72,7 +72,11 @@ export const FlagEditor = (props: { flag: FeatureFlagRow }) => {
           {(props.flag.allow_list?.length ?? 0) -
             unAllowlistedAddresses.length ===
             0 && newAllowlistedAddresses.length === 0 ? (
-            <>Enabled for everyone</>
+            <>
+              {props.flag.is_enabled
+                ? "Enabled for everyone"
+                : "Would be enabled for everyone"}
+            </>
           ) : (
             <>Only enable for:</>
           )}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.stories.tsx
@@ -190,7 +190,6 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
           session={mockedSession}
           nonce=""
           countryCode={props.countryCode}
-          howItWorksFlagEnabled
         >
           <DashboardEl
             user={user}
@@ -214,7 +213,6 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
             }
             enabledFeatureFlags={[
               ...(props.enabledFeatureFlags ?? []),
-              "HowItWorksPage",
               "SetExpectationsForUsers",
             ]}
             experimentData={

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
@@ -264,22 +264,20 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
                 </>
               )}
             </div>
-            {enabledFeatureFlags.includes("HowItWorksPage") && (
-              <Link
-                data-testid="learn-more-link-to-how-it-works"
-                href="/how-it-works"
-                target="_blank"
-                onClick={() =>
-                  recordTelemetry("link", "click", {
-                    link_id: "learn_more",
-                  })
-                }
-              >
-                {l10n.getString(
-                  "dashboard-top-banner-monitor-protects-your-even-more-learn-more",
-                )}
-              </Link>
-            )}
+            <Link
+              data-testid="learn-more-link-to-how-it-works"
+              href="/how-it-works"
+              target="_blank"
+              onClick={() =>
+                recordTelemetry("link", "click", {
+                  link_id: "learn_more",
+                })
+              }
+            >
+              {l10n.getString(
+                "dashboard-top-banner-monitor-protects-your-even-more-learn-more",
+              )}
+            </Link>
           </>
         );
       case "UsUserNonPremiumNoExposures":

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/automatic-remove/AutomaticRemove.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/automatic-remove/AutomaticRemove.stories.tsx
@@ -50,13 +50,7 @@ export const AutomaticRemoveViewStory: Story = {
   name: "1d. Automatically resolve brokers",
   render: () => {
     return (
-      <Shell
-        l10n={getL10n()}
-        session={mockedSession}
-        nonce=""
-        countryCode="us"
-        howItWorksFlagEnabled
-      >
+      <Shell l10n={getL10n()} session={mockedSession} nonce="" countryCode="us">
         <AutomaticRemoveView
           data={{
             countryCode: "us",

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/manual-remove/ManualRemove.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/manual-remove/ManualRemove.stories.tsx
@@ -51,13 +51,7 @@ export const ManualRemoveViewStory: Story = {
   name: "1c. Manually resolve brokers",
   render: () => {
     return (
-      <Shell
-        l10n={getL10n()}
-        session={mockedSession}
-        nonce=""
-        countryCode="us"
-        howItWorksFlagEnabled
-      >
+      <Shell l10n={getL10n()} session={mockedSession} nonce="" countryCode="us">
         <ManualRemoveView
           scanData={mockedScanData}
           breaches={mockedBreaches}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/start-free-scan/StartFreeScan.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/start-free-scan/StartFreeScan.stories.tsx
@@ -50,13 +50,7 @@ export const StartFreeScanViewStory: Story = {
   name: "1a. Free scan",
   render: () => {
     return (
-      <Shell
-        l10n={getL10n()}
-        session={mockedSession}
-        nonce=""
-        countryCode="us"
-        howItWorksFlagEnabled
-      >
+      <Shell l10n={getL10n()} session={mockedSession} nonce="" countryCode="us">
         <StartFreeScanView
           data={{
             countryCode: "us",

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/ViewDataBrokers.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/ViewDataBrokers.stories.tsx
@@ -94,13 +94,7 @@ const ViewWrapper = (props: ViewWrapperProps) => {
   const l10n = getL10n();
 
   return (
-    <Shell
-      l10n={l10n}
-      session={mockedSession}
-      nonce=""
-      countryCode="us"
-      howItWorksFlagEnabled
-    >
+    <Shell l10n={l10n} session={mockedSession} nonce="" countryCode="us">
       <ViewDataBrokersView
         data={{
           latestScanData: scanData,

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/WelcomeToPlus.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/WelcomeToPlus.stories.tsx
@@ -58,13 +58,7 @@ const mockedSession = {
 
 const WelcomeToPlusViewWrapper = (props: { brokerScanCount: number }) => {
   return (
-    <Shell
-      l10n={l10n}
-      session={mockedSession}
-      nonce=""
-      countryCode="us"
-      howItWorksFlagEnabled
-    >
+    <Shell l10n={l10n} session={mockedSession} nonce="" countryCode="us">
       <WelcomeToPlusView
         data={{
           countryCode: "us",
@@ -77,7 +71,7 @@ const WelcomeToPlusViewWrapper = (props: { brokerScanCount: number }) => {
         }}
         l10n={l10n}
         subscriberEmails={[]}
-        enabledFeatureFlags={["HowItWorksPage", "SetExpectationsForUsers"]}
+        enabledFeatureFlags={["SetExpectationsForUsers"]}
       />
     </Shell>
   );

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/WelcomeToPlusView.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/WelcomeToPlusView.tsx
@@ -90,8 +90,7 @@ export function WelcomeToPlusView(props: Props) {
                 )}
           </p>
           <p>
-            {hasRelevantScanResults &&
-            props.enabledFeatureFlags.includes("HowItWorksPage")
+            {hasRelevantScanResults
               ? /* c8 ignore next 23 */
                 // As the `SetExpectationsForUsers` feature flag is removed, the
                 // branch will be covered again:

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/page.tsx
@@ -56,7 +56,8 @@ export default async function WelcomeToPlusPage() {
   };
 
   const enabledFeatureFlags = await getEnabledFeatureFlags({
-    ignoreAllowlist: true,
+    ignoreAllowlist: false,
+    email: session.user.email,
   });
 
   // If the current user is a subscriber and their OneRep profile is not

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/[type]/HighRiskDataBreach.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/[type]/HighRiskDataBreach.stories.tsx
@@ -107,7 +107,6 @@ const HighRiskBreachWrapper = (props: {
       session={mockedSession}
       nonce=""
       countryCode={data.countryCode}
-      howItWorksFlagEnabled
     >
       <HighRiskBreachLayout
         subscriberEmails={[]}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/[type]/LeakedPasswords.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/[type]/LeakedPasswords.stories.tsx
@@ -64,13 +64,7 @@ const LeakedPasswordsWrapper = (props: {
   }
 
   return (
-    <Shell
-      l10n={getL10n()}
-      session={mockedSession}
-      nonce=""
-      countryCode="nl"
-      howItWorksFlagEnabled
-    >
+    <Shell l10n={getL10n()} session={mockedSession} nonce="" countryCode="nl">
       <LeakedPasswordsLayout
         subscriberEmails={[]}
         type={props.type}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/[type]/SecurityRecommendations.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/[type]/SecurityRecommendations.stories.tsx
@@ -42,13 +42,7 @@ const SecurityRecommendationsWrapper = (props: {
   type: SecurityRecommendationTypes;
 }) => {
   return (
-    <Shell
-      l10n={getL10n()}
-      session={mockedSession}
-      nonce=""
-      countryCode="nl"
-      howItWorksFlagEnabled
-    >
+    <Shell l10n={getL10n()} session={mockedSession} nonce="" countryCode="nl">
       <SecurityRecommendationsLayout
         subscriberEmails={[]}
         type={props.type}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/layout.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/layout.tsx
@@ -12,7 +12,6 @@ import { Shell } from "../../../Shell";
 import { headers } from "next/headers";
 import { AutoSignIn } from "../../../../../components/client/AutoSignIn";
 import { getCountryCode } from "../../../../../functions/server/getCountryCode";
-import { getEnabledFeatureFlags } from "../../../../../../db/tables/featureFlags";
 
 export default async function Layout({ children }: { children: ReactNode }) {
   const l10nBundles = getL10nBundles();
@@ -20,10 +19,6 @@ export default async function Layout({ children }: { children: ReactNode }) {
   const session = await getServerSession();
   const headersList = headers();
   const countryCode = getCountryCode(headersList);
-  const enabledFeatureFlags = await getEnabledFeatureFlags({
-    ignoreAllowlist: true,
-  });
-  const howItWorksFlagEnabled = enabledFeatureFlags.includes("HowItWorksPage");
 
   if (!session) {
     return <AutoSignIn />;
@@ -37,7 +32,6 @@ export default async function Layout({ children }: { children: ReactNode }) {
       session={session}
       nonce={nonce}
       countryCode={countryCode}
-      howItWorksFlagEnabled={howItWorksFlagEnabled}
     >
       {children}
     </Shell>

--- a/src/app/(proper_react)/(redesign)/(public)/PublicShell.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/PublicShell.tsx
@@ -35,11 +35,7 @@ export const PublicShell = (props: Props) => {
         </nav>
       </header>
       <div className={styles.content}>{props.children}</div>
-      <Footer
-        l10n={props.l10n}
-        countryCode={props.countryCode}
-        howItWorksFlagEnabled
-      />
+      <Footer l10n={props.l10n} countryCode={props.countryCode} />
     </div>
   );
 };

--- a/src/app/(proper_react)/(redesign)/(public)/how-it-works/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/how-it-works/page.tsx
@@ -13,7 +13,6 @@ import {
   monthlySubscribersQuota,
 } from "../../../../functions/server/onerep";
 import { CONST_DAY_MILLISECONDS } from "../../../../../constants";
-import { getEnabledFeatureFlags } from "../../../../../db/tables/featureFlags";
 
 export default async function Page() {
   const headersList = headers();
@@ -30,11 +29,7 @@ export default async function Page() {
     typeof oneRepActivations === "undefined" ||
     oneRepActivations > monthlySubscribersQuota;
 
-  const featureFlags = await getEnabledFeatureFlags({
-    ignoreAllowlist: true,
-  });
-
-  if (countryCode !== "us" || !featureFlags.includes("HowItWorksPage")) {
+  if (countryCode !== "us") {
     return redirect("/");
   }
 

--- a/src/app/(proper_react)/(redesign)/Footer.tsx
+++ b/src/app/(proper_react)/(redesign)/Footer.tsx
@@ -20,12 +20,10 @@ export const Footer = ({
   l10n,
   session,
   countryCode,
-  howItWorksFlagEnabled,
 }: {
   l10n: ExtendedReactLocalization;
   session?: Session;
   countryCode: string;
-  howItWorksFlagEnabled: boolean;
 }) => {
   return (
     <footer className={styles.footer}>
@@ -47,7 +45,7 @@ export const Footer = ({
             {l10n.getString("footer-nav-all-breaches")}
           </TelemetryLink>
         </li>
-        {countryCode === "us" && !session && howItWorksFlagEnabled && (
+        {countryCode === "us" && !session && (
           <li>
             <TelemetryLink
               href="/how-it-works"

--- a/src/app/(proper_react)/(redesign)/MobileShell.tsx
+++ b/src/app/(proper_react)/(redesign)/MobileShell.tsx
@@ -29,7 +29,6 @@ export type Props = {
   };
   fxaSettingsUrl: string;
   children: ReactNode;
-  howItWorksFlagEnabled: boolean;
 };
 
 export const MobileShell = (props: Props) => {
@@ -144,7 +143,7 @@ export const MobileShell = (props: Props) => {
                   {l10n.getString("main-nav-link-settings-label")}
                 </PageLink>
               </li>
-              {props.countryCode === "us" && props.howItWorksFlagEnabled && (
+              {props.countryCode === "us" && (
                 <li key="how-it-works">
                   <PageLink
                     href="/how-it-works"

--- a/src/app/(proper_react)/(redesign)/Shell.tsx
+++ b/src/app/(proper_react)/(redesign)/Shell.tsx
@@ -24,7 +24,6 @@ export type Props = {
   children: ReactNode;
   nonce: string;
   countryCode: string;
-  howItWorksFlagEnabled: boolean;
 };
 
 export const Shell = (props: Props) => {
@@ -45,7 +44,6 @@ export const Shell = (props: Props) => {
         yearlySubscriptionUrl={yearlySubscriptionUrl}
         fxaSettingsUrl={process.env.FXA_SETTINGS_URL!}
         subscriptionBillingAmount={getSubscriptionBillingAmount()}
-        howItWorksFlagEnabled={props.howItWorksFlagEnabled}
       >
         <div className={styles.wrapper}>
           <nav
@@ -79,7 +77,7 @@ export const Shell = (props: Props) => {
                   {l10n.getString("main-nav-link-settings-label")}
                 </PageLink>
               </li>
-              {props.countryCode === "us" && props.howItWorksFlagEnabled && (
+              {props.countryCode === "us" && (
                 <li key="how-it-works">
                   <PageLink
                     href="/how-it-works"
@@ -109,7 +107,6 @@ export const Shell = (props: Props) => {
               l10n={props.l10n}
               session={props.session}
               countryCode={props.countryCode}
-              howItWorksFlagEnabled={props.howItWorksFlagEnabled}
             />
           </div>
         </div>

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -47,7 +47,6 @@ export type FeatureFlagName =
   | "DiscountCouponNextThreeMonths"
   | "LatestScanDateCsatSurvey"
   | "AutomaticRemovalCsatSurvey"
-  | "HowItWorksPage"
   | "AdditionalRemovalStatuses"
   | "PetitionBannerCsatSurvey"
   /** Set clear expectations about auto-removal finishing in time for *most*, not *all* data brokers: */


### PR DESCRIPTION
https://github.com/mozilla/blurts-server/pull/4666/files#diff-a54be8bc10c4d286b8f42676102b87a3d78308578c01609682cef692b1d812b9 ignored the allowlist for the Welcome to Plus page when determining whether to link to the "How it works" page, and although that made sense for the public pages, when I now used that same list of enabled flags for the removal time estimation, all of a sudden the allowlist didn't work.

I also removed the `HowItWorksPage` flag, since it's now enabled, and had a couple of other allowlist-free feature flag fetches.