### PR TITLE
Disabling a flag also dis-allowlists all

### DIFF
--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -68,9 +68,12 @@ export async function getEnabledFeatureFlags(
     .and.where("is_enabled", true);
 
   if (!options.ignoreAllowlist) {
-    query = query.and
-      .whereRaw("ARRAY_LENGTH(allow_list, 1) IS NULL")
-      .orWhereRaw("? = ANY(allow_list)", options.email);
+    query = query.andWhere(
+      (whereBuilder) =>
+        void whereBuilder
+          .whereRaw("ARRAY_LENGTH(allow_list, 1) IS NULL")
+          .orWhereRaw("? = ANY(allow_list)", options.email),
+    );
   }
 
   const enabledFlagNames = await query;


### PR DESCRIPTION
I actually think the previous approach makes more sense, but it wasn't the behaviour that we intended - the allowlists were intended to be a restriction on the `enabled: true` property (i.e. clearing the allowlist enabled it for everyone), rather than a loosening of `enabled: false`. This is also why we have the `ignoreAllowlist` option, to allow the use of feature flags on public pages where we do not have a specific user.

We might still want to consciously choose the previous behaviour (yes please! that will help us avoid bugs like https://github.com/mozilla/blurts-server/pull/4897), but then we should replace the `ignoreAllowlist` option by a `disableAllowlist` option that only removes the ability to expose the flag to specific users.
