### PR TITLE
chore: removes docker latest tag and push

### DIFF
--- a/.github/workflows/docker_build_deploy.yml
+++ b/.github/workflows/docker_build_deploy.yml
@@ -44,8 +44,6 @@ jobs:
           DOCKERHUB_REPO: ${{ env.DOCKERHUB_REPO }}
         run: |
           # deploy main
-          docker tag blurts-server mozilla/blurts-server:latest
-          docker push mozilla/blurts-server:latest
           docker tag blurts-server ${{ steps.meta.outputs.tags }}
           docker push ${{ steps.meta.outputs.tags }}
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-
Figma:

<!-- When adding a new feature: -->

# Description
This will fix the errors in the deploy pipeline from two jobs running at the same time.  latest tag is the same as sha tag as well. 
