### PR TITLE
Port the signup report email to the new template

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/EmailTrigger.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/EmailTrigger.tsx
@@ -11,6 +11,7 @@ import {
   triggerBreachAlert,
   triggerFirstDataBrokerRemovalFixed,
   triggerMonthlyActivity,
+  triggerSignupReportEmail,
   triggerVerificationEmail,
 } from "./actions";
 import { Button } from "../../../../../components/client/Button";
@@ -23,6 +24,7 @@ export const EmailTrigger = (props: Props) => {
   const [selectedEmailAddress, setSelectedEmailAddress] = useState(
     props.emailAddresses[0],
   );
+  const [isSendingSignupReport, setIsSendingSignupReport] = useState(false);
   const [isSendingVerification, setIsSendingVerification] = useState(false);
   const [isSendingBreachAlert, setIsSendingBreachAlert] = useState(false);
   const [
@@ -58,6 +60,18 @@ export const EmailTrigger = (props: Props) => {
         </small>
       </div>
       <div className={styles.triggers}>
+        <Button
+          variant="primary"
+          isLoading={isSendingSignupReport}
+          onPress={() => {
+            setIsSendingSignupReport(true);
+            void triggerSignupReportEmail(selectedEmailAddress).then(() => {
+              setIsSendingSignupReport(false);
+            });
+          }}
+        >
+          Signup report
+        </Button>
         <Button
           variant="primary"
           isLoading={isSendingVerification}

--- a/src/emails/components/BreachCard.tsx
+++ b/src/emails/components/BreachCard.tsx
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ExtendedReactLocalization } from "../../app/functions/l10n";
+import { formatDate } from "../../utils/formatDate";
+import { HibpLikeDbBreach } from "../../utils/hibp";
+import { getLocale } from "../../app/functions/universal/getLocale";
+
+export type Props = {
+  breach: HibpLikeDbBreach;
+  l10n: ExtendedReactLocalization;
+};
+
+export const BreachCard = (props: Props) => {
+  const listFormatter = new Intl.ListFormat(getLocale(props.l10n));
+
+  return (
+    <mj-wrapper border="1px solid #eee" text-align="center" padding="0">
+      <mj-section background-color="#eee">
+        <mj-column vertical-align="middle">
+          <mj-text
+            font-size="18px"
+            line-height="24px"
+            align="center"
+            height="32px"
+          >
+            <BreachLogo breach={props.breach} />
+            <span style={{ paddingInlineStart: "4px" }}>
+              {props.breach.Title}
+            </span>
+          </mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-section padding="20px">
+        <mj-column>
+          <mj-text align="center" font-size="16px" padding="24px">
+            <p style={{ color: "#5e5e72" }}>
+              {props.l10n.getString("breach-added-label")}
+            </p>
+            <p>
+              <b>{formatDate(props.breach.AddedDate, getLocale(props.l10n))}</b>
+            </p>
+            {
+              // These lines get covered by the BreachAlertEmail.test.tsx tests,
+              // but for some reason get marked as uncovered again once the
+              // `src/scripts/cronjobs/emailBreachAlerts.test.ts` tests are run:
+              /* c8 ignore next 2 */
+              Array.isArray(props.breach.DataClasses) &&
+                props.breach.DataClasses.length > 0 && (
+                  <>
+                    <p style={{ color: "#5e5e72" }}>
+                      {props.l10n.getString("compromised-data")}
+                    </p>
+                    <p>
+                      <b>
+                        {listFormatter.format(
+                          props.breach.DataClasses.map((classKey) =>
+                            props.l10n.getString(classKey),
+                          ),
+                        )}
+                      </b>
+                    </p>
+                  </>
+                )
+            }
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+  );
+};
+
+const BreachLogo = (props: { breach: HibpLikeDbBreach }) => {
+  // These lines get covered by the BreachAlertEmail.test.tsx tests,
+  // but for some reason get marked as uncovered again once the
+  // `src/scripts/cronjobs/emailBreachAlerts.test.ts` tests are run:
+  /* c8 ignore next 12 */
+  if (props.breach.FaviconUrl) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={props.breach.FaviconUrl}
+        alt=""
+        width="32px"
+        height="32px"
+        style={{ display: "inline-block" }}
+      />
+    );
+  }
+
+  return null;
+};

--- a/src/emails/templates/signupReport/SignupReportEmail.stories.tsx
+++ b/src/emails/templates/signupReport/SignupReportEmail.stories.tsx
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { FC } from "react";
+import { Props, SignupReportEmail } from "./SignupReportEmail";
+import { StorybookEmailRenderer } from "../../StorybookEmailRenderer";
+import { getL10n } from "../../../app/functions/l10n/storybookAndJest";
+import { createRandomHibpListing } from "../../../apiMocks/mockData";
+
+const meta: Meta<FC<Props>> = {
+  title: "Emails/Signup Report",
+  component: (props: Props) => (
+    <StorybookEmailRenderer>
+      <SignupReportEmail {...props} />
+    </StorybookEmailRenderer>
+  ),
+  args: {
+    l10n: getL10n("en"),
+  },
+};
+
+export default meta;
+type Story = StoryObj<FC<Props>>;
+
+export const SignupReportEmailNoBreachesStory: Story = {
+  name: "No breaches detected",
+  args: {
+    breaches: [],
+    breachedEmailAddress: "example@example.com",
+  },
+};
+
+export const SignupReportEmailOneBreachStory: Story = {
+  name: "One breach found",
+  args: {
+    breaches: [createRandomHibpListing()],
+    breachedEmailAddress: "example@example.com",
+  },
+};
+
+export const SignupReportEmailSomeBreachesStory: Story = {
+  name: "Multiple breaches found",
+  args: {
+    breaches: [
+      createRandomHibpListing(),
+      createRandomHibpListing(),
+      createRandomHibpListing(),
+    ],
+    breachedEmailAddress: "example@example.com",
+  },
+};
+
+export const SignupReportEmailManyBreachesStory: Story = {
+  name: "Lots of breaches found",
+  args: {
+    breaches: Array.from({ length: 42 }, () => createRandomHibpListing()),
+    breachedEmailAddress: "example@example.com",
+  },
+};

--- a/src/emails/templates/signupReport/SignupReportEmail.test.tsx
+++ b/src/emails/templates/signupReport/SignupReportEmail.test.tsx
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { it, expect } from "@jest/globals";
+import { composeStory } from "@storybook/react";
+import { render, screen } from "@testing-library/react";
+import Meta, {
+  SignupReportEmailNoBreachesStory,
+  SignupReportEmailSomeBreachesStory,
+} from "./SignupReportEmail.stories";
+
+it("lets you know when no breaches were found so far", () => {
+  const ComposedEmail = composeStory(SignupReportEmailNoBreachesStory, Meta);
+  render(<ComposedEmail />);
+
+  const introduction = screen.getByText(
+    "So far, no breaches were found. We’ll send you an alert if your email address appears in a new breach.",
+    { exact: false },
+  );
+  expect(introduction).toBeInTheDocument();
+});
+
+it("lets you know when your email was found in known breaches", () => {
+  const ComposedEmail = composeStory(SignupReportEmailSomeBreachesStory, Meta);
+  render(<ComposedEmail />);
+
+  const introduction = screen.getByText(
+    "Search results for your ⁨example@example.com⁩ account have detected that your email may have been exposed. We recommend you act now to resolve this breach.",
+  );
+  expect(introduction).toBeInTheDocument();
+});

--- a/src/emails/templates/signupReport/SignupReportEmail.tsx
+++ b/src/emails/templates/signupReport/SignupReportEmail.tsx
@@ -11,36 +11,42 @@ import { BreachCard } from "../../components/BreachCard";
 
 export type Props = {
   l10n: ExtendedReactLocalization;
-  breach: HibpLikeDbBreach;
-  breachedEmail: string;
-  utmCampaignId: string;
+  breaches: HibpLikeDbBreach[];
+  breachedEmailAddress: string;
 };
 
-export const BreachAlertEmail = (props: Props) => {
+export const SignupReportEmail = (props: Props) => {
   const l10n = props.l10n;
+  const utmCampaign = "signup-report";
 
   return (
     <mjml>
       <mj-head>
-        <mj-preview>{l10n.getString("email-spotted-new-breach")}</mj-preview>
+        <mj-preview>{l10n.getString("email-breach-summary")}</mj-preview>
       </mj-head>
       <mj-body>
-        <EmailHeader l10n={l10n} utm_campaign={props.utmCampaignId} />
+        <EmailHeader l10n={l10n} utm_campaign={utmCampaign} />
         <mj-section padding="20px">
           <mj-column>
             <mj-text align="center" font-size="16px" line-height="24px">
-              {l10n.getFragment("email-breach-detected-2", {
-                vars: { "email-address": props.breachedEmail },
-                elems: { b: <b /> },
-              })}
+              {props.breaches.length > 0
+                ? l10n.getString("email-breach-detected", {
+                    "email-address": props.breachedEmailAddress,
+                  })
+                : l10n.getString("fxm-warns-you-no-breaches")}
             </mj-text>
           </mj-column>
         </mj-section>
-        <BreachCard breach={props.breach} l10n={l10n} />
+        {props.breaches.map((breach, i) => (
+          <React.Fragment key={breach.Id}>
+            {i > 0 && <mj-spacer height="20px" />}
+            <BreachCard breach={breach} l10n={l10n} />
+          </React.Fragment>
+        ))}
         <mj-section padding="20px">
           <mj-column>
             <mj-button
-              href={`${process.env.SERVER_URL}/user/dashboard/action-needed?utm_source=monitor-product&utm_medium=email&utm_campaign=${props.utmCampaignId}&utm_content=view-your-dashboard-us`}
+              href={`${process.env.SERVER_URL}/user/dashboard/action-needed?utm_source=monitor-product&utm_medium=email&utm_campaign=${utmCampaign}&utm_content=view-your-dashboard-us`}
               background-color="#0060DF"
               font-weight={600}
               font-size="15px"
@@ -50,7 +56,7 @@ export const BreachAlertEmail = (props: Props) => {
             </mj-button>
           </mj-column>
         </mj-section>
-        <EmailFooter l10n={l10n} utm_campaign={props.utmCampaignId} />
+        <EmailFooter l10n={l10n} utm_campaign={utmCampaign} />
       </mj-body>
     </mjml>
   );


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3449
Figma: N/A

<!-- When adding a new feature: -->

# Description

Note that the old template includes code to render data from a variable `emailBreachStats`, but that variable is always unset. Thus, we're never rendering that anymore, so I didn't port it. For what was originally in that variable, see
https://github.com/mozilla/blurts-server/blob/870cca305e2e52ddfe7e0ea5ff5611a58537b70f/template-helpers/emails.js#L8-L33

# Screenshot (if applicable)

Before:

![image](https://github.com/user-attachments/assets/f9175e9e-1530-4e91-8745-8c4d5af02853)

and without breaches:

![image](https://github.com/user-attachments/assets/e3c470d1-8246-4204-bec0-9b963f858a77)

After:

![image](https://github.com/user-attachments/assets/a67126a1-b922-47d1-b1ac-8f30936b57e5)

and without breaches:

![image](https://github.com/user-attachments/assets/1fed826a-ea6d-452e-8621-7a50069207e1)

# How to test

From easy to hard, aka from superficial to more thorough:

1. Open it [in Storybook](https://deploy-preview-4922--fx-monitor-storybook.netlify.app/?path=/story/emails-signup-report)
2. Send it to yourself via `/admin/emails`
3. Enable the `RedesignedEmails` feature flag. Create a new account with an email that has/has not been breached.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
