### PR TITLE
Fix resolving breaches for secondary emails (MNTOR-3495)

### DIFF
--- a/src/utils/breaches.ts
+++ b/src/utils/breaches.ts
@@ -73,7 +73,7 @@ async function getAllEmailsAndBreaches(
       verifiedEmails.push(
         await bundleVerifiedEmails({
           user,
-          email: user.primary_email,
+          email: email.email,
           recordId: email.id,
           recordVerified: email.verified,
           allBreaches,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-3495](https://mozilla-hub.atlassian.net/browse/MNTOR-3495)

<!-- When adding a new feature: -->

# Description

Resolving breaches for secondary emails is currently broken as we are passing the users primary email address to `bundleVerifiedEmails` accidentally by default since [converting `breaches.js` to TS](https://github.com/mozilla/blurts-server/pull/4876).

[MNTOR-3495]: https://mozilla-hub.atlassian.net/browse/MNTOR-3495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ