### PR TITLE
add docs and a cli flag for testing adm-zip dependency updates

### DIFF
--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -284,5 +284,13 @@ Monitor provides a tool for sending test email at the endpoint `/admin/emails`.
 
 ### `adm-zip`
 
+This is used as part of downloading and unzipping location data for the auto-complete address feature.
+
+Normally this is run by cron and uploads to an S3 bucket, the upload step can be skipped with:
+
+```sh
+npm run create-location-data -- --skip-upload
+```
+
 TODO: Describe how to verify that uploading auto-complete locations still works
 as expected.

--- a/src/scripts/build/uploadAutoCompleteLocations.js
+++ b/src/scripts/build/uploadAutoCompleteLocations.js
@@ -22,7 +22,6 @@ import {
   rmSync,
   writeFileSync,
 } from "fs";
-import { uploadToS3 } from "../s3.js";
 import Sentry from "@sentry/nextjs";
 import os from "os";
 import path from "path";
@@ -325,7 +324,13 @@ try {
   writeFileSync(LOCATIONS_DATA_FILE, JSON.stringify(locationDataFinal));
 
   let readStream = fs.createReadStream(LOCATIONS_DATA_FILE);
-  await uploadToS3(`autocomplete/${LOCATIONS_DATA_FILE}`, readStream);
+
+  if (process.argv.includes("--skip-upload")) {
+    console.debug("Skipping S3 upload");
+  } else {
+    const uploadToS3 = import("../s3.js");
+    await uploadToS3(`autocomplete/${LOCATIONS_DATA_FILE}`, readStream);
+  }
 
   if (CLEANUP_TMP_DATA_AFTER_FINISHED) {
     console.info("Cleaning up data directory");


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3467

<!-- When adding a new feature: -->

# Description

A dependency update for `adm-zip` was opened and I noticed we didn't have docs for this yet. There are two `package.json` scripts related to the auto-complete feature that use this dependency:

1. `create-location-data` - intended to run from cron to download and process location files and upload to S3
2. `get-location-data` - downloads the latest output from (1) from the S3 bucket

Only (1) actually uses `adm-zip`, the S3 part wasn't optional so I added a `--skip-upload` flag.

# How to test

Try following the instructions per the docs :) Note that it takes quite a while to run, at least on my machine.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
