### PR TITLE
Prevent breach cards from overflowing on mobile

### DIFF
--- a/src/app/(proper_react)/(redesign)/(public)/breaches/BreachIndexView.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/breaches/BreachIndexView.module.scss
@@ -5,7 +5,11 @@
   flex-direction: column;
   align-items: center;
   gap: $spacing-lg;
-  padding: $spacing-lg;
+  padding: $spacing-xs;
+
+  @media (min-width: $screen-md) {
+    padding: $spacing-lg;
+  }
 
   header {
     padding: $spacing-2xl $spacing-xl;
@@ -51,10 +55,13 @@
   display: grid;
   align-items: start;
   grid-gap: $spacing-2xl;
-  grid-template-columns: repeat(auto-fit, minmax($content-xs, 1fr));
   list-style-type: none;
   margin: 0;
   padding: 0;
+
+  @media (min-width: $screen-md) {
+    grid-template-columns: repeat(auto-fit, minmax($content-xs, 1fr));
+  }
 
   li {
     height: 100%;
@@ -88,9 +95,12 @@
       flex-direction: column;
       gap: $spacing-md;
       padding: $spacing-lg $spacing-md;
-      // `.breachCard h2` padding + breach logo width + `.breachCard h2` gap,
-      // to align the content to the title in the header:
-      padding-inline-start: calc($spacing-md + 32px + $spacing-md);
+
+      @media (min-width: $screen-sm) {
+        // `.breachCard h2` padding + breach logo width + `.breachCard h2` gap,
+        // to align the content to the title in the header:
+        padding-inline-start: calc($spacing-md + 32px + $spacing-md);
+      }
 
       dt {
         font: $text-body-sm;
@@ -104,11 +114,14 @@
 
     .linkDescription {
       padding: $spacing-md;
-      // `.breachCard h2` padding + breach logo width + `.breachCard h2` gap,
-      // to align the content to the title in the header:
-      padding-inline-start: calc($spacing-md + 32px + $spacing-md);
       color: $color-blue-50;
       font-weight: 700;
+
+      @media (min-width: $screen-sm) {
+        // `.breachCard h2` padding + breach logo width + `.breachCard h2` gap,
+        // to align the content to the title in the header:
+        padding-inline-start: calc($spacing-md + 32px + $spacing-md);
+      }
 
       &:hover {
         text-decoration: underline;


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3510
Figma: N/A

<!-- When adding a new feature: -->

# Description

The minimum breach card size of $content-xs caused the breach cards from overflowing on small screens. Removing that and reducing some padding elsewhere, the cards are able to take up the space they need on mobile.

# Screenshot (if applicable)

After:

![image](https://github.com/user-attachments/assets/08bf9bb5-17d2-4148-9acc-bd66b0b5d81d)

Before:

![image](https://github.com/user-attachments/assets/3caacedc-4c38-45dc-9d0d-0523777f1f93)

# How to test

Visit https://blurts-server-pr-4971-mgjlpikfea-uk.a.run.app/breaches. Compare to https://monitor.mozilla.org/breaches on small screens.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual change
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
