### PR TITLE
Rename Monthly Monitor report to *Plus report

### DIFF
--- a/locales-pending/settings-premium.ftl
+++ b/locales-pending/settings-premium.ftl
@@ -2,6 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+## Email preferences
+
+settings-alert-preferences-allow-monthly-monitor-plus-report-title = Monthly { -brand-monitor-plus } report
+settings-alert-preferences-allow-monthly-monitor-plus-report-subtitle = A monthly update of new exposures, what’s been fixed, and what needs your attention.
+
 ## Cancel Plus subscription
 
 settings-cancel-plus-title = Cancel { -brand-monitor-plus } subscription

--- a/locales/en/settings.ftl
+++ b/locales/en/settings.ftl
@@ -14,8 +14,6 @@ settings-alert-preferences-allow-breach-alerts-title = Instant breach alerts
 settings-alert-preferences-allow-breach-alerts-subtitle = These alerts are sent immediately once a data breach is detected
 settings-alert-preferences-option-one = Send breach alerts to the affected email address
 settings-alert-preferences-option-two = Send all breach alerts to the primary email address
-settings-alert-preferences-allow-monthly-monitor-report-title = Monthly { -brand-monitor } report
-settings-alert-preferences-allow-monthly-monitor-report-subtitle = A monthly update of new exposures, what’s been fixed, and what needs your attention.
 
 ## Monitored email addresses
 

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/AlertAddressForm.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/AlertAddressForm.tsx
@@ -185,12 +185,12 @@ export const AlertAddressForm = (props: Props) => {
               <div>
                 <b>
                   {l10n.getString(
-                    "settings-alert-preferences-allow-monthly-monitor-report-title",
+                    "settings-alert-preferences-allow-monthly-monitor-plus-report-title",
                   )}
                 </b>
                 <p>
                   {l10n.getString(
-                    "settings-alert-preferences-allow-monthly-monitor-report-subtitle",
+                    "settings-alert-preferences-allow-monthly-monitor-plus-report-subtitle",
                   )}
                 </p>
               </div>

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPage.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPage.test.tsx
@@ -703,7 +703,7 @@ it("checks that monthly monitor report is enabled", () => {
   );
 
   const monthlyMonitorReportBtn = screen.getByLabelText(
-    "Monthly ⁨Monitor⁩ report",
+    "Monthly ⁨Monitor Plus⁩ report",
     { exact: false },
   );
   expect(monthlyMonitorReportBtn).toHaveAttribute("aria-checked", "true");
@@ -749,7 +749,7 @@ it("sends an API call to disable monthly monitor reports", async () => {
     </TestComponentWrapper>,
   );
   const monthlyMonitorReportBtn = screen.getByLabelText(
-    "Monthly ⁨Monitor⁩ report",
+    "Monthly ⁨Monitor Plus⁩ report",
     { exact: false },
   );
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3512
Figma: N/A

<!-- When adding a new feature: -->

# Description

Also, since that setting only applies to Plus users, moved the string to the non-localised strings. (The previous string might come back in a future feature, but as I understand it, Pontoon will remember it for easy re-translation.)

# Screenshot (if applicable)

![image](https://github.com/user-attachments/assets/b976da13-b6b5-472a-a70b-e3e1cf837f16)

# How to test

Visit the Settings page with a Plus account.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, string change
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
