### PR TITLE
Only require token when unsubscribing

### DIFF
--- a/src/app/api/utils/email.tsx
+++ b/src/app/api/utils/email.tsx
@@ -12,10 +12,7 @@ import { getL10n } from "../../functions/l10n/serverComponents";
 import { BadRequestError } from "../../../utils/error";
 import { captureException } from "@sentry/node";
 import crypto from "crypto";
-import {
-  addEmailPreferenceForSubscriber,
-  getEmailPreferenceForPrimaryEmail,
-} from "../../../db/tables/subscriber_email_preferences";
+import { addEmailPreferenceForSubscriber } from "../../../db/tables/subscriber_email_preferences";
 import { SerializedSubscriber } from "../../../next-auth.js";
 
 export async function sendVerificationEmail(
@@ -81,25 +78,6 @@ export async function generateUnsubscribeLinkForSubscriber(
     });
     captureException(e);
     return null;
-  }
-}
-
-export async function verifyUnsubscribeToken(
-  email: string,
-  unsubToken: string,
-) {
-  try {
-    const preference = await getEmailPreferenceForPrimaryEmail(email);
-    if (!preference || !preference.unsubscribe_token) {
-      return false;
-    }
-    return unsubToken === preference.unsubscribe_token;
-  } catch (e) {
-    console.error("verify_unsubscribe_token", {
-      exception: e as string,
-    });
-    captureException(e);
-    return false;
   }
 }
 

--- a/src/app/api/v1/user/unsubscribe-email/route.ts
+++ b/src/app/api/v1/user/unsubscribe-email/route.ts
@@ -5,40 +5,26 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { logger } from "../../../../functions/server/logging";
-import { verifyUnsubscribeToken } from "../../../utils/email";
-import { unsubscribeMonthlyMonitorReportForEmail } from "../../../../../db/tables/subscriber_email_preferences";
+import { unsubscribeMonthlyMonitorReportForUnsubscribeToken } from "../../../../../db/tables/subscriber_email_preferences";
 
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
-    const email = searchParams.get("email");
     const unsubToken = searchParams.get("token");
 
-    if (!email || !unsubToken) {
+    if (!unsubToken) {
       return NextResponse.json(
         {
           success: false,
-          message: "email and token are required url parameters.",
+          message: "token is a required url parameter.",
         },
         { status: 400 },
       );
     }
 
-    const tokenVerified = await verifyUnsubscribeToken(email, unsubToken);
-    if (tokenVerified) {
-      await unsubscribeMonthlyMonitorReportForEmail(email);
-      logger.debug("unsubscribe_email_success");
-      return NextResponse.json({ success: true }, { status: 200 });
-    } else {
-      logger.warn("unsubscribe_email_unauthorized_token", {
-        email,
-        unsubToken,
-      });
-      return NextResponse.json(
-        { success: false, message: "Unauthorized unsubscribe token" },
-        { status: 401 },
-      );
-    }
+    await unsubscribeMonthlyMonitorReportForUnsubscribeToken(unsubToken);
+    logger.debug("unsubscribe_email_success");
+    return NextResponse.json({ success: true }, { status: 200 });
   } catch (e) {
     logger.error("unsubscribe_email", {
       exception: e as string,

--- a/src/db/migrations/20240904120545_email_preference_token_index.js
+++ b/src/db/migrations/20240904120545_email_preference_token_index.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export async function up(knex) {
+  await knex.schema
+    .table('subscriber_email_preferences', function(table) {
+      table.index("unsubscribe_token");
+    })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  return knex.schema.table('subscriber_email_preferences', function(table) {
+    table.dropIndex("unsubscribe_token");
+  })
+}


### PR DESCRIPTION
Since the user is not logged in, there is no extra information given by passing in the email address, but it does add PII to our request logs. Hence, just accepting the unsubscribe token might be enough.

Merges into https://github.com/mozilla/blurts-server/pull/4988. /cc @codemist 