### PR TITLE
Fix data loading logic on admin email page

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/actions.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/actions.tsx
@@ -203,7 +203,7 @@ export async function triggerBreachAlert(
           utmCampaignId="breach-alert"
           l10n={l10n}
           dataSummary={
-            isEligibleForPremium(assumedCountryCode) && hasPremium(subscriber)
+            isEligibleForPremium(assumedCountryCode) && !hasPremium(subscriber)
               ? getDashboardSummary(scanData.results, allSubscriberBreaches)
               : undefined
           }


### PR DESCRIPTION
We need the user's scan and breach data when that user is eligible for Plus (i.e. is in the US), does not have Plus already, and has run a scan - that's when we show the number of data points found.

The actual email sending logic (in
src/scripts/cronjobs/emailBreachAlerts.tsx) [does this correctly](https://github.com/mozilla/blurts-server/blob/df0207dd3063b8d522ccd836955c408f6ae755ca/src/scripts/cronjobs/emailBreachAlerts.tsx#L283), but the admin page inadvertently checked that the user *did* have Plus, making QA unable to test that variant.
