### PR TITLE
Break up breach alert template into separate components

### DIFF
--- a/src/emails/templates/breachAlert/BreachAlertEmail.tsx
+++ b/src/emails/templates/breachAlert/BreachAlertEmail.tsx
@@ -75,6 +75,13 @@ export type RedesignedBreachAlertEmailProps = {
   breachedEmail: string;
   utmCampaignId: string;
   subscriber: SubscriberRow;
+  /**
+   * We need to run a bunch of queries to collect this data,
+   * so it's optional; however, make sure to pass it in for
+   * free users who are eligible for Plus (i.e. in the US),
+   * who have run a scan — those are the ones we show a
+   * <DataPointCount> for at the moment.
+   */
   dataSummary?: DashboardSummary;
   enabledFeatureFlags: FeatureFlagName[];
 };


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3014
Figma:

<!-- When adding a new feature: -->

# Description

This scaffolds out `EmailBanner` and `DataPointCount` from the Breach alert email template so that it can be re-used in the monthly report for free users. 

# Screenshot (if applicable)

Not applicable.

# How to test

# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
