### PR TITLE
Only set max failures for the optional full E2E test suite

### DIFF
--- a/.github/workflows/e2e_cron.yml
+++ b/.github/workflows/e2e_cron.yml
@@ -76,7 +76,7 @@ jobs:
           name: test-results
           path: src/e2e/test-results/
           retention-days: 30
-          
+
       - name: Send GitHub Action trigger data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@v1.27.0

--- a/.github/workflows/e2e_pr_full.yml
+++ b/.github/workflows/e2e_pr_full.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run Playwright tests
         if: github.actor != 'dependabot[bot]'
-        run: npm run e2e -- --update-snapshots
+        run: npm run e2e -- --max-failures=1 --update-snapshots
         timeout-minutes: 20
         env:
           E2E_TEST_ENV: local

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -50,9 +50,6 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
 
-  /* Limit the number of failures */
-  maxFailures: 1,
-
   /* Retry on CI only */
   retries: process.env.CI ? 1 : 0,
 


### PR DESCRIPTION
Let’s keep the default `maxFailures` option for the E2E tests that are running in the daily cronjob against `stage` as well as for the blocking `@smoke` test suite.