### PR TITLE
MNTOR-3672: fix unique contraints violation

### DIFF
--- a/src/app/api/utils/email.tsx
+++ b/src/app/api/utils/email.tsx
@@ -4,14 +4,13 @@
 
 import { SubscriberRow } from "knex/types/tables";
 import { resetUnverifiedEmailAddress } from "../../../db/tables/emailAddresses";
-import { sendEmail } from "../../../utils/email";
+import { sendEmail, randomToken } from "../../../utils/email";
 import { renderEmail } from "../../../emails/renderEmail";
 import { VerifyEmailAddressEmail } from "../../../emails/templates/verifyEmailAddress/VerifyEmailAddressEmail";
 import { sanitizeSubscriberRow } from "../../functions/server/sanitize";
 import { getL10n } from "../../functions/l10n/serverComponents";
 import { BadRequestError } from "../../../utils/error";
 import { captureException } from "@sentry/node";
-import crypto from "crypto";
 import {
   addUnsubscribeTokenForSubscriber,
   getEmailPreferenceForSubscriber,
@@ -67,7 +66,7 @@ export async function unsubscribeLinkForSubscriber(
   subscriber: SerializedSubscriber,
 ) {
   try {
-    const newUnsubToken = randomString();
+    const newUnsubToken = randomToken();
     let sub;
     const getRes = await getEmailPreferenceForSubscriber(subscriber.id);
     if (getRes.unsubscribe_token) {
@@ -97,8 +96,4 @@ export async function unsubscribeLinkForSubscriber(
     captureException(e);
     return null;
   }
-}
-
-function randomString(length: number = 64) {
-  return crypto.randomBytes(length).toString("hex");
 }

--- a/src/db/tables/subscriber_email_preferences.ts
+++ b/src/db/tables/subscriber_email_preferences.ts
@@ -5,6 +5,7 @@
 import createDbConnection from "../connect";
 import { logger } from "../../app/functions/server/logging";
 import { captureException } from "@sentry/node";
+import { randomToken } from "../../utils/email";
 
 const knex = createDbConnection();
 
@@ -47,7 +48,7 @@ async function addEmailPreferenceForSubscriber(
     res = await knex("subscriber_email_preferences")
       .insert({
         subscriber_id: subscriberId,
-        unsubscribe_token: preference.unsubscribe_token || "",
+        unsubscribe_token: preference.unsubscribe_token || randomToken(),
         monthly_monitor_report_free:
           preference.monthly_monitor_report_free ?? true,
         // @ts-ignore knex.fn.now() results in it being set to a date,

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { createTransport, Transporter } from "nodemailer";
+import crypto from "crypto";
 
 import { SentMessageInfo } from "nodemailer/lib/smtp-transport/index.js";
 import { getEnvVarsOrThrow } from "../envVars";
@@ -84,4 +85,8 @@ async function sendEmail(
   }
 }
 
-export { initEmail, sendEmail };
+function randomToken(length: number = 64) {
+  return crypto.randomBytes(length).toString("hex");
+}
+
+export { initEmail, sendEmail, randomToken };


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3672

<!-- When adding a new feature: -->

# Description
Another issue (hopefully last). Getting the following error in stage:
```
error_add_subscriber_email_preference insert into "subscriber_email_preferences" ("monthly_monitor_report_free", "monthly_monitor_report_free_at", "subscriber_id", "unsubscribe_token") values ($1, CURRENT_TIMESTAMP, $2, $3) returning * - duplicate key value violates unique constraint "subscriber_email_preferences_unsubscribe_token_unique"
```

The reason we are getting this violation is because we are using "" as a fallback, the way to mitigate this is to actually generate a token if it's not provided.

# Screenshot (if applicable)

Not applicable.

# How to test

# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
