### PR TITLE
Disable parallel test execution for E2E cronjob

### DIFF
--- a/.github/workflows/e2e_cron.yml
+++ b/.github/workflows/e2e_cron.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Run Playwright tests - ${{ inputs.environment != null && inputs.environment || 'stage' }}
         if: github.actor != 'dependabot[bot]'
-        run: npm run e2e
-        timeout-minutes: 20
+        run: npm run e2e -- --fully-parallel=false --workers=1
+        timeout-minutes: 40
         env:
           E2E_TEST_ENV: ${{ inputs.environment != null && inputs.environment || 'stage' }}
           E2E_TEST_BASE_URL: ${{ secrets.E2E_TEST_BASE_URL }}


### PR DESCRIPTION
Let’s disable parallel E2E test execution again for the [Monitor Cron e2e Tests](https://github.com/mozilla/blurts-server/actions/workflows/e2e_cron.yml) until they run more stable. We can keep improving and debugging the E2E test suite with new the optional [Monitor E2E Test Suite (full)](https://github.com/mozilla/blurts-server/actions/workflows/e2e_pr_full.yml) that is running no every PR.