### PR TITLE
Remove need to import React in cronjobs

### DIFF
--- a/esbuild.cronjobs.js
+++ b/esbuild.cronjobs.js
@@ -23,4 +23,5 @@ build({
   sourcemap: true,
   target: "node20.9",
   packages: "external",
+  jsx: "automatic",
 });

--- a/src/emails/components/BreachCard.tsx
+++ b/src/emails/components/BreachCard.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { ExtendedReactLocalization } from "../../app/functions/l10n";
 import { formatDate } from "../../utils/formatDate";
 import { HibpLikeDbBreach } from "../../utils/hibp";

--- a/src/emails/components/EmailBanner.tsx
+++ b/src/emails/components/EmailBanner.tsx
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
-
 /* c8 ignore start */
 export const EmailBanner = (props: {
   heading: string;

--- a/src/emails/components/EmailDataPointCount.tsx
+++ b/src/emails/components/EmailDataPointCount.tsx
@@ -4,7 +4,6 @@
 
 /* c8 ignore start */
 
-import React from "react";
 import { ExtendedReactLocalization } from "../../app/functions/l10n";
 import { DashboardSummary } from "../../app/functions/server/dashboard";
 import { SubscriberRow } from "knex/types/tables";

--- a/src/emails/components/EmailHero.tsx
+++ b/src/emails/components/EmailHero.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { ExtendedReactLocalization } from "../../app/functions/l10n";
 
 export type Props = {

--- a/src/emails/templates/EmailFooter.tsx
+++ b/src/emails/templates/EmailFooter.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { ExtendedReactLocalization } from "../../app/functions/l10n";
 import {
   CONST_URL_PRIVACY_POLICY,

--- a/src/emails/templates/EmailHeader.tsx
+++ b/src/emails/templates/EmailHeader.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { ExtendedReactLocalization } from "../../app/functions/l10n";
 
 export type Props = { l10n: ExtendedReactLocalization; utm_campaign: string };

--- a/src/emails/templates/breachAlert/BreachAlertEmail.tsx
+++ b/src/emails/templates/breachAlert/BreachAlertEmail.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import type { SubscriberRow } from "knex/types/tables";
 import { ExtendedReactLocalization } from "../../../app/functions/l10n";
 import { EmailFooter, RedesignedBreachEmailFooter } from "../EmailFooter";

--- a/src/emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed.tsx
+++ b/src/emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { ExtendedReactLocalization } from "../../../app/functions/l10n";
 import { EmailFooter } from "../EmailFooter";
 import { EmailHeader } from "../EmailHeader";

--- a/src/emails/templates/monthlyActivity/MonthlyActivityEmail.tsx
+++ b/src/emails/templates/monthlyActivity/MonthlyActivityEmail.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { DashboardSummary } from "../../../app/functions/server/dashboard";
 import { SanitizedSubscriberRow } from "../../../app/functions/server/sanitize";
 import { ExtendedReactLocalization } from "../../../app/functions/l10n";

--- a/src/emails/templates/monthlyActivity/freeUser/MonthlyActivityFreeUser.tsx
+++ b/src/emails/templates/monthlyActivity/freeUser/MonthlyActivityFreeUser.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import type { SubscriberRow } from "knex/types/tables";
 import { ExtendedReactLocalization } from "../../../../app/functions/l10n";
 import { EmailFooter } from "../../EmailFooter";

--- a/src/emails/templates/signupReport/SignupReportEmail.tsx
+++ b/src/emails/templates/signupReport/SignupReportEmail.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
+import { Fragment } from "react";
 import { ExtendedReactLocalization } from "../../../app/functions/l10n";
 import { EmailFooter } from "../EmailFooter";
 import { EmailHeader } from "../EmailHeader";
@@ -40,7 +40,7 @@ export const SignupReportEmail = (props: Props) => {
           </mj-column>
         </mj-section>
         {props.breaches.map((breach, i) => (
-          <React.Fragment key={breach.Id}>
+          <Fragment key={breach.Id}>
             {i > 0 && (
               // > mj-spacer cannot be used inside mj-body, only inside: mj-attributes, mj-column, mj-hero.
               // And <mj-column>s "must be located under mj-section tags".
@@ -51,7 +51,7 @@ export const SignupReportEmail = (props: Props) => {
               </mj-section>
             )}
             <BreachCard breach={breach} l10n={l10n} />
-          </React.Fragment>
+          </Fragment>
         ))}
         <mj-section padding="20px">
           <mj-column>

--- a/src/scripts/cronjobs/emailBreachAlerts.tsx
+++ b/src/scripts/cronjobs/emailBreachAlerts.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import Sentry from "@sentry/nextjs";
 
 import * as pubsub from "@google-cloud/pubsub";

--- a/src/scripts/cronjobs/firstDataBrokerRemovalFixed.tsx
+++ b/src/scripts/cronjobs/firstDataBrokerRemovalFixed.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { OnerepScanResultRow, SubscriberRow } from "knex/types/tables";
 import {
   getPotentialSubscribersWaitingForFirstDataBrokerRemovalFixedEmail,

--- a/src/scripts/cronjobs/monthlyActivity.tsx
+++ b/src/scripts/cronjobs/monthlyActivity.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from "react";
 import { SubscriberRow } from "knex/types/tables";
 import {
   getSubscribersWaitingForMonthlyEmail,


### PR DESCRIPTION
This caused errors in production, but not in dev, making them easy to slip through. Specifically, the error was just re-introduced via `<HeaderStyles>`.

With this changes, it's no longer possible to forget to add the React import, because it will be added automatically (just like it is for the Next.js site).

See https://esbuild.github.io/api/#jsx.