### PR TITLE
MNTOR-3433: Correctly detect the lack of scan

### DIFF
--- a/esbuild.cronjobs.js
+++ b/esbuild.cronjobs.js
@@ -23,5 +23,4 @@ build({
   sourcemap: true,
   target: "node20.9",
   packages: "external",
-  jsx: "automatic",
 });

--- a/src/emails/templates/breachAlert/BreachAlertEmail.stories.tsx
+++ b/src/emails/templates/breachAlert/BreachAlertEmail.stories.tsx
@@ -70,6 +70,10 @@ export const RedesignedBreachAlertEmailUsFreeNoScanStory: Story = {
     breach: createRandomHibpListing(),
     breachedEmail: "example@example.com",
     enabledFeatureFlags: ["BreachEmailRedesign"],
+    dataSummary: getDashboardSummary(
+      [],
+      Array.from({ length: 5 }, () => createRandomBreach()),
+    ),
   },
 };
 

--- a/src/emails/templates/breachAlert/BreachAlertEmail.tsx
+++ b/src/emails/templates/breachAlert/BreachAlertEmail.tsx
@@ -113,7 +113,7 @@ export const RedesignedBreachAlertEmail = (
     if (hasPremium(props.subscriber)) {
       utmCampaignId = "breach-alert-plus";
     } else {
-      if (typeof props.dataSummary === "undefined") {
+      if (!hasRunFreeScan) {
         utmCampaignId = "breach-alert-free-us-no-scan";
       } else {
         utmCampaignId = "breach-alert-free-us-scanned";
@@ -274,7 +274,7 @@ export const RedesignedBreachAlertEmail = (
           )}
         {isEligibleForPremium(assumedCountryCode) &&
           !hasPremium(props.subscriber) &&
-          (typeof props.dataSummary === "undefined" ? (
+          (!hasRunFreeScan ? (
             <EmailBanner
               variant="dark"
               heading={l10n.getString(

--- a/src/scripts/cronjobs/emailBreachAlerts.test.ts
+++ b/src/scripts/cronjobs/emailBreachAlerts.test.ts
@@ -37,7 +37,7 @@ jest.mock("../../utils/hibp", () => {
 
 jest.mock("../../db/tables/subscribers", () => {
   return {
-    getSubscribersByHashes: jest.fn(() => [""]),
+    getSubscribersByHashes: jest.fn(() => [{ onerep_profile_id: 42 }]),
   };
 });
 

--- a/src/scripts/cronjobs/emailBreachAlerts.tsx
+++ b/src/scripts/cronjobs/emailBreachAlerts.tsx
@@ -279,7 +279,8 @@ export async function poll(
               let dataSummary: DashboardSummary | undefined;
               if (
                 isEligibleForPremium(assumedCountryCode) &&
-                !hasPremium(recipient)
+                !hasPremium(recipient) &&
+                typeof recipient.onerep_profile_id === "number"
               ) {
                 const scanData = await getLatestOnerepScanResults(
                   recipient.onerep_profile_id,

--- a/tsconfig.cronjobs.json
+++ b/tsconfig.cronjobs.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/scripts/cronjobs/**/*.ts", "src/scripts/cronjobs/**/*.tsx"],
+  "include": ["src/scripts/cronjobs/**/*.ts", "src/scripts/cronjobs/**/*.tsx", "src/emails/**/*.ts",  "src/emails/**/*.tsx"],
   "outDir": "dist/scripts/cronjobs/",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ES2020",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3433
Figma:

<!-- When adding a new feature: -->

# Description

There was a bug where the email template didn't correctly check if a scan had run - to fix this, I'm now looking at the `hasRunFreeScan` variable that @codemist added for exactly that purpose 😅 Note that that specific fix is in 86ef22453; I also added 229673769308707d6aea9ff6457add1a65fd7bea which fixes a "React is not defined" error when running cronjobs locally (basically, also applying the fix from https://github.com/mozilla/blurts-server/pull/5153 to dev mode).

# How to test

I've updated the storybook to pass in the dashboard summary even if no scan was run (i.e. `onerep_profile_id` is `null`), so you should see the correct UTM parameters in Storybook, and the tests still succeed (whereas they fail with _only_ the Storybook change, without the code change).

You can also follow the instructions in the README to send a breach alert, but that's fairly involved.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
