### PR TITLE
Show any CSAT survey only after the petition banner has been dismissed

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
@@ -3610,6 +3610,40 @@ describe("CSAT survey banner", () => {
     });
     expect(answerButton).toBeInTheDocument();
   });
+
+  it("does not display any CSAT survey alongside the Petition banner", () => {
+    const ComposedDashboard = composeStory(
+      DashboardUsPremiumResolvedScanNoBreaches,
+      Meta,
+    );
+    render(
+      <ComposedDashboard
+        activeTab="fixed"
+        elapsedTimeInDaysSinceInitialScan={90}
+        hasFirstMonitoringScan
+        enabledFeatureFlags={[
+          "LatestScanDateCsatSurvey",
+          "AutomaticRemovalCsatSurvey",
+        ]}
+        experimentData={{
+          ...defaultExperimentData,
+          "data-privacy-petition-banner": {
+            enabled: true,
+          },
+        }}
+      />,
+    );
+
+    const petitionCta = screen.queryByRole("link", {
+      name: "Sign petition",
+    });
+    expect(petitionCta).toBeInTheDocument();
+
+    const answerButton = screen.queryByRole("button", {
+      name: "Neutral",
+    });
+    expect(answerButton).not.toBeInTheDocument();
+  });
 });
 
 describe("Data privacy petition banner", () => {

--- a/src/app/components/client/csat_survey/CsatSurvey.tsx
+++ b/src/app/components/client/csat_survey/CsatSurvey.tsx
@@ -89,14 +89,11 @@ export const CsatSurvey = (props: CsatSurveyProps) => {
     }
   });
 
-  const isPetitionCsatBanner =
-    currentSurvey.localDismissalId.includes("petition_banner");
   // Only show the petition CSAT banner for users that are part of
   // the `data-privacy-petition-banner` experiment if the petition has
   // already been interacted with.
   if (
     props.experimentData["data-privacy-petition-banner"].enabled &&
-    isPetitionCsatBanner &&
     !props.localDismissalPetitionBanner.isDismissed
   ) {
     return;


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-3657](https://mozilla-hub.atlassian.net/browse/MNTOR-3657)

<!-- When adding a new feature: -->

# Description

After disabling the follow-up CSAT survey for the Petition banner, the condition guarding the CSAT banners did not evaluate to `true` for CSAT surveys with a lower priority. The change ensures that we do not show any CSAT survey if the Petition banner is displayed.


[MNTOR-3657]: https://mozilla-hub.atlassian.net/browse/MNTOR-3657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ