### PR TITLE
Move unsubscribe link generation into own module

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/actions.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/actions.tsx
@@ -39,7 +39,7 @@ import { refreshStoredScanResults } from "../../../../../functions/server/refres
 import { hasPremium } from "../../../../../functions/universal/user";
 import { isEligibleForPremium } from "../../../../../functions/universal/premium";
 import { MonthlyActivityFreeEmail } from "../../../../../../emails/templates/monthlyActivityFree/MonthlyActivityFreeEmail";
-import { getMonthlyActivityFreeUnsubscribeLink } from "../../../../../../scripts/cronjobs/monthlyActivityFree";
+import { getMonthlyActivityFreeUnsubscribeLink } from "../../../../../../app/functions/cronjobs/unsubscribeLinks";
 
 async function getAdminSubscriber(): Promise<SubscriberRow | null> {
   const session = await getServerSession();

--- a/src/app/functions/cronjobs/unsubscribeLinks.ts
+++ b/src/app/functions/cronjobs/unsubscribeLinks.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { randomBytes } from "crypto";
+import { SubscriberRow } from "knex/types/tables";
+import { captureException } from "@sentry/node";
+import {
+  addUnsubscribeTokenForSubscriber,
+  getEmailPreferenceForSubscriber,
+  updateEmailPreferenceForSubscriber,
+} from "../../../db/tables/subscriber_email_preferences";
+import { logger } from "../server/logging";
+
+export async function getMonthlyActivityFreeUnsubscribeLink(
+  subscriber: SubscriberRow,
+) {
+  try {
+    const newUnsubToken = randomBytes(64).toString("hex");
+    let sub;
+    const getRes = await getEmailPreferenceForSubscriber(subscriber.id);
+    if (getRes.unsubscribe_token) {
+      // if record has been created and the token exists, return the token
+      return `${process.env.SERVER_URL}/unsubscribe-email/monthly-report-free?token=${getRes.unsubscribe_token}`;
+    } else if (
+      !getRes.monthly_monitor_report_free_at &&
+      !getRes.unsubscribe_token
+    ) {
+      // if record in the new table has not been created
+      sub = await addUnsubscribeTokenForSubscriber(
+        subscriber.id,
+        newUnsubToken,
+      );
+    } else {
+      // if record already exists, but token doesn't exist, add the token
+      sub = await updateEmailPreferenceForSubscriber(subscriber.id, true, {
+        unsubscribe_token: newUnsubToken,
+      });
+    }
+
+    return `${process.env.SERVER_URL}/unsubscribe-email/monthly-report-free?token=${sub.unsubscribe_token}`;
+  } catch (e) {
+    logger.error("generate_unsubscribe_link", {
+      exception: e,
+    });
+    captureException(e);
+    return null;
+  }
+}

--- a/src/scripts/cronjobs/monthlyActivityFree.tsx
+++ b/src/scripts/cronjobs/monthlyActivityFree.tsx
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { SubscriberRow } from "knex/types/tables";
-import { captureException } from "@sentry/node";
-import { randomBytes } from "crypto";
 import { getFreeSubscribersWaitingForMonthlyEmail } from "../../db/tables/subscribers";
 import { initEmail, sendEmail } from "../../utils/email";
 import { renderEmail } from "../../emails/renderEmail";
@@ -16,12 +14,9 @@ import { getLatestOnerepScanResults } from "../../db/tables/onerep_scans";
 import { getSubscriberBreaches } from "../../app/functions/server/getSubscriberBreaches";
 import { refreshStoredScanResults } from "../../app/functions/server/refreshStoredScanResults";
 import { getSignupLocaleCountry } from "../../emails/functions/getSignupLocaleCountry";
-import {
-  addUnsubscribeTokenForSubscriber,
-  getEmailPreferenceForSubscriber,
-  updateEmailPreferenceForSubscriber,
-} from "../../db/tables/subscriber_email_preferences";
+import { updateEmailPreferenceForSubscriber } from "../../db/tables/subscriber_email_preferences";
 import { logger } from "../../app/functions/server/logging";
+import { getMonthlyActivityFreeUnsubscribeLink } from "../../app/functions/cronjobs/unsubscribeLinks";
 
 void run();
 
@@ -112,41 +107,5 @@ async function sendMonthlyActivityEmail(subscriber: SubscriberRow) {
     logger.error("send_monthly_activity_email_free", {
       exception: e,
     });
-  }
-}
-
-export async function getMonthlyActivityFreeUnsubscribeLink(
-  subscriber: SubscriberRow,
-) {
-  try {
-    const newUnsubToken = randomBytes(64).toString("hex");
-    let sub;
-    const getRes = await getEmailPreferenceForSubscriber(subscriber.id);
-    if (getRes.unsubscribe_token) {
-      // if record has been created and the token exists, return the token
-      return `${process.env.SERVER_URL}/unsubscribe-email/monthly-report-free?token=${getRes.unsubscribe_token}`;
-    } else if (
-      !getRes.monthly_monitor_report_free_at &&
-      !getRes.unsubscribe_token
-    ) {
-      // if record in the new table has not been created
-      sub = await addUnsubscribeTokenForSubscriber(
-        subscriber.id,
-        newUnsubToken,
-      );
-    } else {
-      // if record already exists, but token doesn't exist, add the token
-      sub = await updateEmailPreferenceForSubscriber(subscriber.id, true, {
-        unsubscribe_token: newUnsubToken,
-      });
-    }
-
-    return `${process.env.SERVER_URL}/unsubscribe-email/monthly-report-free?token=${sub.unsubscribe_token}`;
-  } catch (e) {
-    logger.error("generate_unsubscribe_link", {
-      exception: e,
-    });
-    captureException(e);
-    return null;
   }
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: N/A
Figma:

<!-- When adding a new feature: -->

# Description

It's not just used by the cronjob, but also by the admin tool on /admin/emails/. Since that is a Next.js page, if the function is imported from a module that also imports the cronjob l10n module, it breaks. Thus, I've moved it into its own module.

# How to test

Try sending an email using the admin email tool (any email). It should no longer fail.