### PR TITLE
Update FxA promo silent authentication path to dashboard

### DIFF
--- a/src/app/components/client/PromptNoneAuth.tsx
+++ b/src/app/components/client/PromptNoneAuth.tsx
@@ -21,7 +21,7 @@ export const PromptNoneAuth = (): ReactNode => {
     if (isPromptNoneAuthAttempt) {
       void signIn(
         "fxa",
-        { callbackUrl: "/user/dashboard" },
+        { callbackUrl: "/user/dashboard/action-needed?dialog=subscriptions" },
         { prompt: "none" },
       );
     }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-3492](https://mozilla-hub.atlassian.net/browse/MNTOR-3492)

<!-- When adding a new feature: -->

# Description

Update the dashboard link for FxA silent authentication to link directly to the Premium upsell.

# How to test

1. Enable the feature flag `PromptNoneAuthFlow`
2. Visit http://localhost:6060/?utm_source=moz-account&utm_campaign=settings-promo&utm_content=monitor-free with and without the user authenticated with FxA

[MNTOR-3492]: https://mozilla-hub.atlassian.net/browse/MNTOR-3492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ