### PR TITLE
Update fallback path for silent authentication error

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -19,7 +19,7 @@ const handler = async (
       `${process.env.SERVER_URL}/api/auth/callback/fxa?error=`,
     )
   ) {
-    return NextResponse.redirect(`${process.env.SERVER_URL}/user/dashboard`);
+    return NextResponse.redirect(process.env.SERVER_URL as string);
   }
 
   return NextAuth(req, res, authOptions) as Promise<Response>;


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Follow-up to address https://github.com/mozilla/blurts-server/pull/5104#discussion_r1799621794.

<!-- When adding a new feature: -->

# Description

Update the fallback path in case of a silent authentication callback error.

# How to test

Same steps as for PR #5104:
- Enable the feature flag `PromptNoneAuthFlow`
- Visit http://localhost:6060/?utm_source=moz-account&utm_campaign=settings-promo&utm_content=monitor-free with and without the user authenticated with FxA