### PR TITLE
MNTOR-null: add e2e cron badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Firefox Monitor Server
 
+[![Monitor Cron e2e Tests](https://github.com/mozilla/blurts-server/actions/workflows/e2e_cron.yml/badge.svg)](https://github.com/mozilla/blurts-server/actions/workflows/e2e_cron.yml)
+
 ## Summary
 
 Firefox Monitor notifies users when their credentials have been compromised in a data breach.


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-null

<!-- When adding a new feature: -->

# Description
Add the badge for better way to check for daily e2e daily cron status
