### PR TITLE
MNTOR-null: fix preview-deploy-pr-comments changes

### DIFF
--- a/.github/workflows/preview_deploy_gcp.yml
+++ b/.github/workflows/preview_deploy_gcp.yml
@@ -88,5 +88,5 @@ jobs:
           message: |
             Preview URL :rocket: : ${{ steps.deploy.outputs.url }}
           comment_tag: preview_url
-          create_if_not_exists: true
+          create-if-not-exists: true
           


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-null
Figma:

<!-- When adding a new feature: -->

# Description
Caused by this upgrade: https://github.com/mozilla/blurts-server/pull/5172
Migrate from v2 to v3 to prevent comment spamming in preview deployment
