### PR TITLE
MNTOR-3648: Don't send page load events on every re-render

### DIFF
--- a/src/app/hooks/useGlean.ts
+++ b/src/app/hooks/useGlean.ts
@@ -4,6 +4,7 @@
 
 "use client";
 
+import { useCallback } from "react";
 import EventMetricType from "@mozilla/glean/private/metrics/event";
 import type { GleanMetricMap } from "../../telemetry/generated/_map";
 import { useSession } from "next-auth/react";
@@ -13,31 +14,34 @@ export const useGlean = () => {
   const session = useSession();
   const isPremiumUser = hasPremium(session.data?.user);
 
-  const record = async <
-    EventModule extends keyof GleanMetricMap,
-    EventName extends keyof GleanMetricMap[EventModule],
-  >(
-    eventModule: EventModule,
-    event: keyof GleanMetricMap[EventModule],
-    data: GleanMetricMap[EventModule][EventName],
-  ) => {
-    const mod = (await import(
-      `../../telemetry/generated/${eventModule}`
-    )) as Record<keyof GleanMetricMap[EventModule], EventMetricType>;
-    // Instead of the specific type definitions we generated in the npm script
-    // `build-glean-types`, Glean takes a non-specific "ExtraArgs" type as
-    // parameter to `record`.
+  const record = useCallback(
+    async <
+      EventModule extends keyof GleanMetricMap,
+      EventName extends keyof GleanMetricMap[EventModule],
+    >(
+      eventModule: EventModule,
+      event: keyof GleanMetricMap[EventModule],
+      data: GleanMetricMap[EventModule][EventName],
+    ) => {
+      const mod = (await import(
+        `../../telemetry/generated/${eventModule}`
+      )) as Record<keyof GleanMetricMap[EventModule], EventMetricType>;
+      // Instead of the specific type definitions we generated in the npm script
+      // `build-glean-types`, Glean takes a non-specific "ExtraArgs" type as
+      // parameter to `record`.
 
-    // Record the `plan_tier` key on all events.
-    // `plan_tier` is set on every metric, but it's too much work for TypeScript
-    // to infer that — hence the type assertion.
-    (data as GleanMetricMap["button"]["click"]).plan_tier = isPremiumUser
-      ? "Plus"
-      : "Free";
+      // Record the `plan_tier` key on all events.
+      // `plan_tier` is set on every metric, but it's too much work for TypeScript
+      // to infer that — hence the type assertion.
+      (data as GleanMetricMap["button"]["click"]).plan_tier = isPremiumUser
+        ? "Plus"
+        : "Free";
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mod[event].record(data as any);
-  };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mod[event].record(data as any);
+    },
+    [isPremiumUser],
+  );
 
   return record;
 };

--- a/src/app/hooks/useTelemetry.ts
+++ b/src/app/hooks/useTelemetry.ts
@@ -5,6 +5,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import { useCallback } from "react";
 // Imports for the `useGlean` and `useGa` hooks are restricted.
 /* eslint-disable-next-line no-restricted-imports */
 import { useGlean } from "./useGlean";
@@ -22,31 +23,34 @@ export const useTelemetry = () => {
   const recordGlean = useGlean();
 
   const { Glean, Ga } = TelemetryPlatforms;
-  const recordTelemetry = <
-    EventModule extends keyof GleanMetricMap,
-    EventName extends keyof GleanMetricMap[EventModule],
-  >(
-    eventModule: EventModule,
-    event: EventName,
-    data: GleanMetricMap[EventModule][EventName],
-    platforms: Array<
-      (typeof TelemetryPlatforms)[keyof typeof TelemetryPlatforms]
-    > = [Glean, Ga],
-  ) => {
-    if (platforms.includes(Glean)) {
-      void recordGlean(eventModule, event, {
-        path: path,
-        ...data,
-      });
-    }
-    if (platforms.includes(Ga)) {
-      sendGAEvent("event", convertCamelToSnakeCase(eventModule), {
-        ...data,
-        action: event,
-        page_location: path,
-      });
-    }
-  };
+  const recordTelemetry = useCallback(
+    <
+      EventModule extends keyof GleanMetricMap,
+      EventName extends keyof GleanMetricMap[EventModule],
+    >(
+      eventModule: EventModule,
+      event: EventName,
+      data: GleanMetricMap[EventModule][EventName],
+      platforms: Array<
+        (typeof TelemetryPlatforms)[keyof typeof TelemetryPlatforms]
+      > = [Glean, Ga],
+    ) => {
+      if (platforms.includes(Glean)) {
+        void recordGlean(eventModule, event, {
+          path: path,
+          ...data,
+        });
+      }
+      if (platforms.includes(Ga)) {
+        sendGAEvent("event", convertCamelToSnakeCase(eventModule), {
+          ...data,
+          action: event,
+          page_location: path,
+        });
+      }
+    },
+    [Ga, Glean, path, recordGlean],
+  );
 
   return recordTelemetry;
 };


### PR DESCRIPTION
In <PageLoadEvent>, the call to `recordTelemetry` currently has a dependency on the current path name (which is fine), and on the `recordTelemetry` function. However, that function gets recreated whenever the component that includes <PageLoadEvent> gets re- rendered, which is more often than that a particular page is actually loaded. This means that we're sending more page view events than that pages are actually being viewed.

By memoizing the `recordTelemetry` function (using `useCallback`), it should stay stable during re-renders, and thus not send the pageview events multiple times.
(Note that in local development, the effect does run twice, because we have strict mode enabled. This makes sure that errors in which we forget to clean up effects are surfaced in development, and does not happen in production.)

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3648