### PR TITLE
MNTOR-3606: Respect allowlist of disabled flag

### DIFF
--- a/src/db/tables/subscribers.ts
+++ b/src/db/tables/subscribers.ts
@@ -425,7 +425,10 @@ async function getFreeSubscribersWaitingForMonthlyEmail(): Promise<
       "2022-01-01T00:00:00.000Z",
   );
 
-  if (!flag?.is_enabled) {
+  if (
+    !flag?.is_enabled &&
+    !(Array.isArray(flag?.allow_list) && flag.allow_list.length > 0)
+  ) {
     return [];
   }
 

--- a/src/db/tables/subscribers.ts
+++ b/src/db/tables/subscribers.ts
@@ -9,6 +9,7 @@ import { SerializedSubscriber } from "../../next-auth.js";
 import { getFeatureFlagData } from "./featureFlags";
 import { getEnvVarsOrThrow } from "../../envVars";
 import { parseIso8601Datetime } from "../../utils/parse";
+import { logger } from "../../app/functions/server/logging";
 
 const knex = createDbConnection();
 const { DELETE_UNVERIFIED_SUBSCRIBERS_TIMER } = getEnvVarsOrThrow([
@@ -429,6 +430,9 @@ async function getFreeSubscribersWaitingForMonthlyEmail(): Promise<
     !flag?.is_enabled &&
     !(Array.isArray(flag?.allow_list) && flag.allow_list.length > 0)
   ) {
+    logger.info("monthly_free_report_disabled", {
+      flag: flag,
+    });
     return [];
   }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3606
Figma: N/A

<!-- When adding a new feature: -->

# Description

While the query that selected free users to send the monthly report to had a clause to select subscribers who were in the flag's allowlist, it never ran that query if the flag is disabled (which is the only case in which the allowlist applies) :unamused: 

# How to test

Disable the `MonthlyReportFreeUser` flag, add the email address of a free user whose `fxa_profile_json.locale` has `en-US` as the main locale, then run `npm run dev:cron:monthly-activity-free`. It should send an email to that user.

If you want to ensure that the locale is correct for your user, at least until they next login, you can use this query:

```sql
UPDATE subscribers SET fxa_profile_json = jsonb_set(fxa_profile_json, '{locale}', '"en-US;q=0.8,en;q=0.5,nl;q=0.3"') WHERE primary_email='<email address>';
```

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, side-effect-heavy code
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
