### PR TITLE
use structured logging for email utils

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -113,7 +113,10 @@ const customJestConfig = {
   // ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    // Force module uuid to resolve with the CJS entry point, because Jest does not support package.json.exports. See https://github.com/uuidjs/uuid/issues/451
+    uuid: require.resolve("uuid"),
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   modulePathIgnorePatterns: ["e2e/"],

--- a/src/app/functions/server/logging.ts
+++ b/src/app/functions/server/logging.ts
@@ -16,6 +16,7 @@ export const logger = createLogger({
   level: "info",
   // In GCP environments, use cloud logging instead of stdout.
   // FIXME https://mozilla-hub.atlassian.net/browse/MNTOR-2401 - enable for stage and production
+  /* c8 ignore next 3 - cannot test this outside of GCP currently */
   transports: ["gcpdev"].includes(process.env.APP_ENV ?? "local")
     ? [loggingWinston]
     : [new transports.Console()],

--- a/src/utils/email.test.ts
+++ b/src/utils/email.test.ts
@@ -12,6 +12,25 @@ jest.mock("nodemailer", () => {
   };
 });
 
+jest.mock("../app/functions/server/logging", () => {
+  class Logging {
+    info(message: string, details: object) {
+      console.info(message, details);
+    }
+    warn(message: string, details: object) {
+      console.warn(message, details);
+    }
+    error(message: string, details: object) {
+      console.error(message, details);
+    }
+  }
+
+  const logger = new Logging();
+  return {
+    logger,
+  };
+});
+
 test("EmailUtils.sendEmail before .init() fails", async () => {
   expect.assertions(1);
 

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -7,6 +7,7 @@ import crypto from "crypto";
 
 import { SentMessageInfo } from "nodemailer/lib/smtp-transport/index.js";
 import { getEnvVarsOrThrow } from "../envVars";
+import { logger } from "../app/functions/server/logging";
 
 // The SMTP transport object. This is initialized to a nodemailer transport
 // object while reading SMTP credentials, or to a dummy function in debug mode.
@@ -17,7 +18,7 @@ const envVars = getEnvVarsOrThrow(["SMTP_URL", "EMAIL_FROM", "SES_CONFIG_SET"]);
 async function initEmail(smtpUrl = envVars.SMTP_URL) {
   // Allow a debug mode that will log JSON instead of sending emails.
   if (!smtpUrl) {
-    console.info("smtpUrl-empty", {
+    logger.info("smtpUrl-empty", {
       message: "EmailUtils will log a JSON response instead of sending emails.",
     });
     gTransporter = createTransport({ jsonTransport: true });
@@ -62,24 +63,24 @@ async function sendEmail(
     /* c8 ignore next 5 */
     if (gTransporter.transporter.name === "JSONTransport") {
       // @ts-ignore Added typing later, but it disagrees with actual use:
-      console.info("JSONTransport", { message: info.message.toString() });
+      logger.info("JSONTransport", { message: info.message.toString() });
       return info;
     }
 
-    console.info("sent_email", {
+    logger.info("sent_email", {
       messageId: info.messageId,
       response: info.response,
     });
     return info;
   } catch (e) {
     if (e instanceof Error) {
-      console.error("error_sending_email", {
+      logger.error("error_sending_email", {
         message: e.message,
         stack: e.stack,
       });
       /* c8 ignore next 3 */
     } else {
-      console.error("error_sending_email", { message: JSON.stringify(e) });
+      logger.error("error_sending_email", { message: JSON.stringify(e) });
     }
     throw e;
   }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3713

<!-- When adding a new feature: -->

# Description

Use the Winston logging library from the email utils so we get [structured logging](https://cloud.google.com/logging/docs/structured-logging) in GCP. Right now log messages are split across several lines which makes it difficult to locate and link to problems.

# How to test

Our logging library automatically falls back to console logging in local environments, so the output can be inspected that way. We'll want to check on stage that the output looks acceptable.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
