### PR TITLE
MNTOR-null: add push to docker

### DIFF
--- a/.github/workflows/release_cron_daily.yml
+++ b/.github/workflows/release_cron_daily.yml
@@ -43,6 +43,10 @@ jobs:
             "generate_release_notes": true
           }'
 
+    # We cannot rely on the release_retag.yaml workflow because of the 
+    # auth scope of the default github token. It's a good security practice
+    # to prevent a github action being triggered by another.
+    # So we will deliberately push to dockerhub below
     - name: Log in to Docker Hub
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/release_cron_daily.yml
+++ b/.github/workflows/release_cron_daily.yml
@@ -49,8 +49,15 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: mozilla/blurts-server
+        tags: type=sha,format=short,prefix=
+
     - name: Tag Docker image with release tag
-      run: docker tag ${{ env.CURRENT_DATE }} mozilla/blurts-server:${{ env.CURRENT_DATE }}
+      run: docker tag ${{ steps.meta.outputs.tags }} mozilla/blurts-server:${{ env.CURRENT_DATE }}
 
     - name: Push Docker image with release tag
       run: docker push mozilla/blurts-server:${{ env.CURRENT_DATE }}

--- a/.github/workflows/release_cron_daily.yml
+++ b/.github/workflows/release_cron_daily.yml
@@ -30,13 +30,27 @@ jobs:
       run: |
         curl -X POST \
           -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/${{ github.repository }}/releases \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/releases \
           -d '{
             "tag_name": "${{ env.CURRENT_DATE }}",
             "target_commitish": "main",
             "name": "${{ env.CURRENT_DATE }}",
             "body": "Daily pre-release for ${{ env.CURRENT_DATE }}.",
             "prerelease": true,
+            "draft": false,
             "generate_release_notes": true
           }'
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Tag Docker image with release tag
+      run: docker tag ${{ env.CURRENT_DATE }} mozilla/blurts-server:${{ env.CURRENT_DATE }}
+
+    - name: Push Docker image with release tag
+      run: docker push mozilla/blurts-server:${{ env.CURRENT_DATE }}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-null

<!-- When adding a new feature: -->

# Description
The github default token cannot trigger another github actions.. it would have to be a personal access token. For best security practices, we wouldn't want to use a personal access token. 

Instead we should just add the docker push at the end of this job, since it shouldn't trigger the retag job


