### PR TITLE
MNTOR-null: pre release workflow needs to do a pull first

### DIFF
--- a/.github/workflows/release_cron_daily.yml
+++ b/.github/workflows/release_cron_daily.yml
@@ -60,6 +60,9 @@ jobs:
         images: mozilla/blurts-server
         tags: type=sha,format=short,prefix=
 
+    - name: Pull Docker image with commit tag
+      run: docker pull ${{ steps.meta.outputs.tags }}
+
     - name: Tag Docker image with release tag
       run: docker tag ${{ steps.meta.outputs.tags }} mozilla/blurts-server:${{ env.CURRENT_DATE }}
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-null

<!-- When adding a new feature: -->

# Description
pre release workflow needs to do a pull first to get the image

Error from last run: https://github.com/mozilla/blurts-server/actions/runs/11509608474/job/32040015716