### PR TITLE
Only initialise LoggingWinston when used

### DIFF
--- a/src/app/functions/server/glean.ts
+++ b/src/app/functions/server/glean.ts
@@ -8,12 +8,13 @@ import { v4 as uuidv4 } from "uuid";
 
 const GLEAN_EVENT_MOZLOG_TYPE = "glean-server-event";
 
-const loggingWinston = new LoggingWinston({
-  labels: {
-    name: GLEAN_EVENT_MOZLOG_TYPE,
-    version: "0.1.0",
-  },
-});
+const getLoggingWinston = () =>
+  new LoggingWinston({
+    labels: {
+      name: GLEAN_EVENT_MOZLOG_TYPE,
+      version: "0.1.0",
+    },
+  });
 
 export function record(
   category: string,
@@ -26,7 +27,7 @@ export function record(
     // In GCP environments, use cloud logging instead of stdout.
     // FIXME https://mozilla-hub.atlassian.net/browse/MNTOR-2401 - enable for stage and production
     transports: ["gcpdev"].includes(process.env.APP_ENV ?? "local")
-      ? [loggingWinston]
+      ? [getLoggingWinston()]
       : [new transports.Console()],
   });
 

--- a/src/app/functions/server/logging.ts
+++ b/src/app/functions/server/logging.ts
@@ -5,12 +5,15 @@
 import { createLogger, transports } from "winston";
 import { LoggingWinston } from "@google-cloud/logging-winston";
 
-const loggingWinston = new LoggingWinston({
-  labels: {
-    name: "monitor-stats",
-    version: "0.1.0",
-  },
-});
+// Explicitly not run in tests (and other non-gcpdev environments)
+/* c8 ignore next 7 */
+const getLoggingWinston = () =>
+  new LoggingWinston({
+    labels: {
+      name: "monitor-stats",
+      version: "0.1.0",
+    },
+  });
 
 export const logger = createLogger({
   level: "info",
@@ -18,6 +21,6 @@ export const logger = createLogger({
   // FIXME https://mozilla-hub.atlassian.net/browse/MNTOR-2401 - enable for stage and production
   /* c8 ignore next 3 - cannot test this outside of GCP currently */
   transports: ["gcpdev"].includes(process.env.APP_ENV ?? "local")
-    ? [loggingWinston]
+    ? [getLoggingWinston()]
     : [new transports.Console()],
 });


### PR DESCRIPTION
The `gcpdev` env isn't really in use yet according to @rhelmer ("it's intended for GCP-based dev environments"), but at least locally for me, the `LoggingWinston` instantiation seems to contribute some slowdown to the termination of Node scripts, so this change ensures it's only initialised when actually used.

It might not solve the issue we're seeing where the monthly-activity-free cron job is never terminating in stage, but even then at least it saves a few resources.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3606