### PR TITLE
Always output the coverage report

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -29,6 +29,7 @@ jobs:
       - run: npm test -- --coverageThreshold='{"global":{"branches":80,"functions":80,"lines":80,"statements":80}}'
         if: github.event_name == 'schedule'
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: coverage-report
           path: coverage/


### PR DESCRIPTION
I intended to do this in 647e95ede6f61628d73c136b6eb4afb506e2c0f4 (#5155), but the `failure()` call that I remove didn't limit it to failures — it explicitly enabled it for failing jobs, where the default is to skip subsequent jobs after a failure. However, if we want a job to run after both failed and successful runs, we need the `always()` call.