### PR TITLE
Use a singleton for the DB connection object

### DIFF
--- a/src/db/connect.ts
+++ b/src/db/connect.ts
@@ -5,6 +5,7 @@
 import knex from "knex";
 import knexConfig from "./knexfile.js";
 
+let connection: knex.Knex;
 export default function createDbConnection(): knex.Knex {
   /* c8 ignore start */
   if (process.env.NODE_ENV === "development") {
@@ -15,9 +16,11 @@ export default function createDbConnection(): knex.Knex {
       );
     }
 
-    return (global as unknown as Record<string, knex.Knex>)[client];
+    connection ??= (global as unknown as Record<string, knex.Knex>)[client];
+    return connection;
   }
   /* c8 ignore stop */
 
-  return knex(knexConfig as knex.Knex.Config);
+  connection ??= knex(knexConfig as knex.Knex.Config);
+  return connection;
 }

--- a/src/scripts/cronjobs/monthlyActivityFree.tsx
+++ b/src/scripts/cronjobs/monthlyActivityFree.tsx
@@ -4,21 +4,23 @@
 
 import { SubscriberRow } from "knex/types/tables";
 import { getFreeSubscribersWaitingForMonthlyEmail } from "../../db/tables/subscribers";
+import { getLatestOnerepScanResults } from "../../db/tables/onerep_scans";
+import { updateEmailPreferenceForSubscriber } from "../../db/tables/subscriber_email_preferences";
 import { initEmail, sendEmail, closeEmailPool } from "../../utils/email";
 import { renderEmail } from "../../emails/renderEmail";
 import { MonthlyActivityFreeEmail } from "../../emails/templates/monthlyActivityFree/MonthlyActivityFreeEmail";
 import { getCronjobL10n } from "../../app/functions/l10n/cronjobs";
 import { sanitizeSubscriberRow } from "../../app/functions/server/sanitize";
 import { getDashboardSummary } from "../../app/functions/server/dashboard";
-import { getLatestOnerepScanResults } from "../../db/tables/onerep_scans";
 import { getSubscriberBreaches } from "../../app/functions/server/getSubscriberBreaches";
 import { refreshStoredScanResults } from "../../app/functions/server/refreshStoredScanResults";
 import { getSignupLocaleCountry } from "../../emails/functions/getSignupLocaleCountry";
-import { updateEmailPreferenceForSubscriber } from "../../db/tables/subscriber_email_preferences";
+import createDbConnection from "../../db/connect";
 import { logger } from "../../app/functions/server/logging";
 import { getMonthlyActivityFreeUnsubscribeLink } from "../../app/functions/cronjobs/unsubscribeLinks";
 
-void run();
+await run();
+await createDbConnection().destroy();
 
 async function run() {
   const batchSize = Number.parseInt(


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3606
Figma:

<!-- When adding a new feature: -->

# Description

This is the riskier sibling to https://github.com/mozilla/blurts-server/pull/5254, where I'm trying to figure out what could be causing the monthly-activity-free cronjob to be hanging.

In this PR, I call `destroy()` on the connection object when it's done - but more importantly, I have every `db/tables` module re-use the same connection object, to avoid having to do this: https://github.com/mozilla/blurts-server/blob/0da029654e65dedffe2b3bd169d1160626f2c11b/src/scripts/cronjobs/emailBreachAlerts.tsx#L427-L429

I think this should be safe, and in practice, the connections should be pooled already, but there might always be unforeseen effects, so please take some time to think about potential problems and/or ways to catch any that might occur.