### PR TITLE
MNTOR-3494: Upload Sentry source maps by default

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -205,7 +205,7 @@ const sentryOptions = {
   hideSourceMaps: false,
 
   sourcemaps: {
-    disable: process.env.UPLOAD_SENTRY_SOURCEMAPS !== "true",
+    disable: process.env.UPLOAD_SENTRY_SOURCEMAPS === "false",
   },
 };
 


### PR DESCRIPTION
Alternatively, I could make sure that we're passing in `UPLOAD_SENTRY_SOURCEMAPS` in CI, but since I assume we'll generally want to upload the source maps always, doing so by default seems more natural.