### PR TITLE
Close the SMTP connection pool when done

### DIFF
--- a/src/scripts/cronjobs/emailBreachAlerts.tsx
+++ b/src/scripts/cronjobs/emailBreachAlerts.tsx
@@ -22,7 +22,7 @@ import {
   addEmailNotification,
   markEmailAsNotified,
 } from "../../db/tables/email_notifications";
-import { initEmail, sendEmail } from "../../utils/email";
+import { initEmail, sendEmail, closeEmailPool } from "../../utils/email";
 
 import {
   getAddressesAndLanguageForEmail,
@@ -427,6 +427,7 @@ if (process.env.NODE_ENV !== "test") {
       await knexSubscribers.destroy();
       await knexEmailAddresses.destroy();
       await knexHibp.destroy();
+      closeEmailPool();
       Sentry.captureCheckIn({
         checkInId,
         monitorSlug: SENTRY_SLUG,

--- a/src/scripts/cronjobs/firstDataBrokerRemovalFixed.tsx
+++ b/src/scripts/cronjobs/firstDataBrokerRemovalFixed.tsx
@@ -7,7 +7,7 @@ import {
   getPotentialSubscribersWaitingForFirstDataBrokerRemovalFixedEmail,
   markFirstDataBrokerRemovalFixedEmailAsJustSent,
 } from "../../db/tables/subscribers";
-import { initEmail, sendEmail } from "../../utils/email";
+import { initEmail, sendEmail, closeEmailPool } from "../../utils/email";
 import { renderEmail } from "../../emails/renderEmail";
 import { FirstDataBrokerRemovalFixed } from "../../emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed";
 import { getCronjobL10n } from "../../app/functions/l10n/cronjobs";
@@ -103,6 +103,9 @@ async function run() {
       );
     }),
   );
+
+  closeEmailPool();
+
   console.log(
     `[${new Date(Date.now()).toISOString()}] Sent [${subscribersToEmailWithData.length}] first data broker removal fixed emails.`,
   );

--- a/src/scripts/cronjobs/monthlyActivityFree.tsx
+++ b/src/scripts/cronjobs/monthlyActivityFree.tsx
@@ -4,7 +4,7 @@
 
 import { SubscriberRow } from "knex/types/tables";
 import { getFreeSubscribersWaitingForMonthlyEmail } from "../../db/tables/subscribers";
-import { initEmail, sendEmail } from "../../utils/email";
+import { initEmail, sendEmail, closeEmailPool } from "../../utils/email";
 import { renderEmail } from "../../emails/renderEmail";
 import { MonthlyActivityFreeEmail } from "../../emails/templates/monthlyActivityFree/MonthlyActivityFreeEmail";
 import { getCronjobL10n } from "../../app/functions/l10n/cronjobs";
@@ -43,6 +43,8 @@ async function run() {
       sendMonthlyActivityEmail(subscriber),
     ),
   );
+
+  closeEmailPool();
   console.log(
     `[${new Date(Date.now()).toISOString()}] Sent [${subscribersToEmail.length}] monthly activity emails to free users.`,
   );

--- a/src/scripts/cronjobs/monthlyActivityPlus.tsx
+++ b/src/scripts/cronjobs/monthlyActivityPlus.tsx
@@ -7,7 +7,7 @@ import {
   getPlusSubscribersWaitingForMonthlyEmail,
   markMonthlyActivityPlusEmailAsJustSent,
 } from "../../db/tables/subscribers";
-import { initEmail, sendEmail } from "../../utils/email";
+import { initEmail, sendEmail, closeEmailPool } from "../../utils/email";
 import { renderEmail } from "../../emails/renderEmail";
 import { MonthlyActivityPlusEmail } from "../../emails/templates/monthlyActivityPlus/MonthlyActivityPlusEmail";
 import { getCronjobL10n } from "../../app/functions/l10n/cronjobs";
@@ -40,6 +40,8 @@ async function run() {
       return sendMonthlyActivityEmail(subscriber);
     }),
   );
+
+  closeEmailPool();
   console.log(
     `[${new Date(Date.now()).toISOString()}] Sent [${subscribersToEmail.length}] monthly activity emails to Plus users.`,
   );

--- a/src/utils/email.test.ts
+++ b/src/utils/email.test.ts
@@ -154,6 +154,16 @@ test("EmailUtils.init with empty host uses jsonTransport. logs messages", async 
   );
 });
 
+test("EmailUtils.closeEmailPool before .init() fails", async () => {
+  expect.assertions(1);
+
+  const { closeEmailPool } = await import("./email");
+
+  const expectedError = "`closeEmailPool` called before `initEmail`";
+
+  expect(() => closeEmailPool()).toThrow(expectedError);
+});
+
 test("randomToken returns a random token of 2xlength (because of hex)", () => {
   const token = randomToken(32);
   expect(token).toHaveLength(64);

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -15,7 +15,7 @@ let gTransporter: Transporter<SentMessageInfo>;
 
 const envVars = getEnvVarsOrThrow(["SMTP_URL", "EMAIL_FROM", "SES_CONFIG_SET"]);
 
-async function initEmail(smtpUrl = envVars.SMTP_URL) {
+export async function initEmail(smtpUrl = envVars.SMTP_URL) {
   // Allow a debug mode that will log JSON instead of sending emails.
   if (!smtpUrl) {
     logger.info("smtpUrl-empty", {
@@ -30,6 +30,17 @@ async function initEmail(smtpUrl = envVars.SMTP_URL) {
   return gTransporterVerification;
 }
 
+/** See https://nodemailer.com/smtp/pooled/ */
+export function closeEmailPool() {
+  if (!gTransporter) {
+    throw new Error("`closeEmailPool` called before `initEmail`");
+    /* c8 ignore next 5 */
+  }
+  // Not covered by tests because it involves a lot of mocks to basically check
+  // that we called this function. See test-coverage.md#mock-heavy
+  gTransporter.close();
+}
+
 /**
  * Send Email
  *
@@ -37,7 +48,7 @@ async function initEmail(smtpUrl = envVars.SMTP_URL) {
  * @param subject
  * @param html
  */
-async function sendEmail(
+export async function sendEmail(
   recipient: string,
   subject: string,
   html: string,
@@ -86,8 +97,6 @@ async function sendEmail(
   }
 }
 
-function randomToken(length: number = 64) {
+export function randomToken(length: number = 64) {
   return crypto.randomBytes(length).toString("hex");
 }
-
-export { initEmail, sendEmail, randomToken };


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3606

This closes the SMTP pool at the end of the cron job. Together with https://github.com/mozilla/blurts-server/pull/5257 and https://github.com/mozilla/blurts-server/pull/5254, this at least makes the cron job terminate immediately once it finishes locally for me, and hopefully on stage as well.

