### PR TITLE
Enable data estimated removal time experiment by default

### DIFF
--- a/config/nimbus.yaml
+++ b/config/nimbus.yaml
@@ -98,9 +98,9 @@ features:
       - channel: local
         value: { "enabled": true }
       - channel: staging
-        value: { "enabled": false }
+        value: { "enabled": true }
       - channel: production
-        value: { "enabled": false }
+        value: { "enabled": true }
 enums:
   OptionalBrokerScanInfoFields:
     description: An enum of optional broker scan info fields


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-3733](https://mozilla-hub.atlassian.net/browse/MNTOR-3733)

<!-- When adding a new feature: -->

# Description

Enable the experiment `data-broker-removal-time-estimates` by default.

# How to test

1. Enable the following feature flags: `DataBrokerRemovalTimeEstimateLabel`
2. (Re)build experiments: `npm run build-nimbus`
3. Add the environment variable `DATA_BROKER_REMOVAL_ESTIMATES_DATA` to `.env.local`. The data can be found in the [JIRA ticket](https://mozilla-hub.atlassian.net/browse/MNTOR-3618) under “Data for testing”.

[MNTOR-3733]: https://mozilla-hub.atlassian.net/browse/MNTOR-3733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ