### PR TITLE
MNTOR-3380 - pass nimbus_preview param to Cirrus

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/[[...slug]]/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/[[...slug]]/page.tsx
@@ -51,7 +51,7 @@ type Props = {
     slug: string[] | undefined;
   };
   searchParams: {
-    nimbus_web_preview?: string;
+    nimbus_preview?: string;
     dialog?: "subscriptions";
   };
 };
@@ -126,7 +126,7 @@ export default async function DashboardPage({ params, searchParams }: Props) {
     experimentationId: experimentationId,
     countryCode: countryCode,
     locale: getLocale(getL10n()),
-    previewMode: searchParams.nimbus_web_preview === "true",
+    previewMode: searchParams.nimbus_preview === "true",
   });
 
   const monthlySubscriptionUrl = getPremiumSubscriptionUrl({ type: "monthly" });

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/page.tsx
@@ -28,7 +28,7 @@ import { checkUserHasMonthlySubscription } from "../../../../../../functions/ser
 import { getEmailPreferenceForPrimaryEmail } from "../../../../../../../db/tables/subscriber_email_preferences";
 type Props = {
   searchParams: {
-    nimbus_web_preview?: string;
+    nimbus_preview?: string;
   };
 };
 
@@ -79,7 +79,7 @@ export default async function SettingsPage({ searchParams }: Props) {
     experimentationId: experimentationId,
     countryCode: countryCode,
     locale: getLocale(getL10n()),
-    previewMode: searchParams.nimbus_web_preview === "true",
+    previewMode: searchParams.nimbus_preview === "true",
   });
 
   const lastOneRepScan = await getLatestOnerepScan(

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/[[...slug]]/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/[[...slug]]/page.tsx
@@ -25,7 +25,7 @@ type Props = {
   };
   searchParams: {
     referrer?: string;
-    nimbus_web_preview?: string;
+    nimbus_preview?: string;
   };
 };
 
@@ -67,7 +67,7 @@ export default async function Onboarding({ params, searchParams }: Props) {
     experimentationId,
     countryCode,
     locale: getLocale(getL10n()),
-    previewMode: searchParams.nimbus_web_preview === "true",
+    previewMode: searchParams.nimbus_preview === "true",
   });
 
   return (

--- a/src/app/(proper_react)/(redesign)/(public)/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/page.tsx
@@ -24,7 +24,7 @@ import { AccountsMetricsFlowProvider } from "../../../../contextProviders/accoun
 
 type Props = {
   searchParams: {
-    nimbus_web_preview?: string;
+    nimbus_preview?: string;
   };
 };
 
@@ -41,7 +41,7 @@ export default async function Page({ searchParams }: Props) {
     experimentationId,
     countryCode,
     locale: getLocale(getL10n()),
-    previewMode: searchParams.nimbus_web_preview === "true",
+    previewMode: searchParams.nimbus_preview === "true",
   });
 
   // request the profile stats for the last 30 days

--- a/src/app/api/v1/user/welcome-scan/create/route.ts
+++ b/src/app/api/v1/user/welcome-scan/create/route.ts
@@ -92,7 +92,7 @@ export async function POST(
     experimentationId: experimentationId,
     countryCode: getCountryCode(headers()),
     locale: getLocale(getL10n()),
-    previewMode: searchParams.get("nimbus_web_preview") === "true",
+    previewMode: searchParams.get("nimbus_preview") === "true",
   });
   const optionalInfoExperimentData =
     experimentData["welcome-scan-optional-info"];

--- a/src/app/functions/server/getExperiments.ts
+++ b/src/app/functions/server/getExperiments.ts
@@ -35,13 +35,13 @@ export async function getExperiments(params: {
   if (!process.env.NIMBUS_SIDECAR_URL) {
     throw new Error("env var NIMBUS_SIDECAR_URL not set");
   }
-  const serverUrl = new URL(process.env.NIMBUS_SIDECAR_URL);
+  const serverUrl = new URL(`${process.env.NIMBUS_SIDECAR_URL}/v1/features`);
 
   try {
     if (params.previewMode === true) {
       serverUrl.searchParams.set("nimbus_preview", "true");
     }
-    serverUrl.pathname = "/v1/features";
+
     const response = await fetch(serverUrl, {
       headers: {
         "Content-Type": "application/json",

--- a/src/app/functions/server/getExperiments.ts
+++ b/src/app/functions/server/getExperiments.ts
@@ -28,30 +28,21 @@ export async function getExperiments(params: {
   countryCode: string;
   previewMode: boolean;
 }): Promise<ExperimentData> {
-  // TODO MNTOR-3380 - until Cirrus implements preview mode, set all Nimbus features to `true` for QA purposes.
-  if (params.previewMode === true) {
-    // Clone the `localExperimentData` object so we don't modify the exported data structure.
-    const overriddenExperimentData = Object.fromEntries(
-      Object.entries(localExperimentData).map(
-        ([experimentId, experimentConfig]) => {
-          return [experimentId, { ...experimentConfig, enabled: true }];
-        },
-      ),
-    ) as ExperimentData;
-    return overriddenExperimentData;
-  }
-
   if (["local"].includes(process.env.APP_ENV ?? "local")) {
     return localExperimentData;
   }
 
-  const serverUrl = process.env.NIMBUS_SIDECAR_URL;
-  if (!serverUrl) {
+  if (!process.env.NIMBUS_SIDECAR_URL) {
     throw new Error("env var NIMBUS_SIDECAR_URL not set");
   }
+  const serverUrl = new URL(process.env.NIMBUS_SIDECAR_URL);
 
   try {
-    const response = await fetch(`${serverUrl}/v1/features`, {
+    if (params.previewMode === true) {
+      serverUrl.searchParams.set("nimbus_preview", "true");
+    }
+    serverUrl.pathname = "/v1/features";
+    const response = await fetch(serverUrl, {
       headers: {
         "Content-Type": "application/json",
       },
@@ -70,7 +61,7 @@ export async function getExperiments(params: {
 
     return (experimentData as ExperimentData) ?? defaultExperimentData;
   } catch (ex) {
-    logger.error(`Could not connect to Cirrus on ${serverUrl}`, ex);
+    logger.error("Could not connect to Cirrus", { serverUrl, ex });
     captureException(ex);
     return defaultExperimentData;
   }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3380/

<!-- When adding a new feature: -->

# Description

The Nimbus team came up with an ADR to support enabling preview mode on specific page loads. We previously had a workaround in place that would simply enable all experiments when an HTTP parameter like `?nimbus_web_preview=true` was passed, this change really just removes that and does two things:

1. change the param name to `nimbus_preview`
2. pass the param on to the Cirrus sidecar

This will instruct Cirrus to check which experiments are in preview mode on the server, and only enable these.

# How to test

See ticket. It's probably easiest to merge this to stage and test there, but we can at least verify locally that `nimbus_preview=true` is appended to the URL set in `process.env.NIMBUS_SIDECAR_URL`.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
