### PR TITLE
MNTOR-2934/sentry sourcemap docker secret

### DIFF
--- a/.github/workflows/docker_build_deploy.yml
+++ b/.github/workflows/docker_build_deploy.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           docker build --tag blurts-server \
             --build-arg SENTRY_RELEASE="$GITHUB_REF_NAME" \
+            --secret id=SENTRY_AUTH_TOKEN \
             .
 
 # FIXME temporarily disable push while testing

--- a/.github/workflows/docker_build_deploy.yml
+++ b/.github/workflows/docker_build_deploy.yml
@@ -2,7 +2,7 @@ name: Build Docker image and publish
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, MNTOR-2934/sentry-sourcemap-docker-secret ] # FIXME remove after testing
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
@@ -39,11 +39,12 @@ jobs:
             --build-arg SENTRY_RELEASE="$GITHUB_REF_NAME" \
             .
 
-      - name: Deploy to Dockerhub
-        env:
-          DOCKERHUB_REPO: ${{ env.DOCKERHUB_REPO }}
-        run: |
-          # deploy main
-          docker tag blurts-server ${{ steps.meta.outputs.tags }}
-          docker push ${{ steps.meta.outputs.tags }}
+# FIXME temporarily disable push while testing
+#      - name: Deploy to Dockerhub
+#        env:
+#          DOCKERHUB_REPO: ${{ env.DOCKERHUB_REPO }}
+#        run: |
+#          # deploy main
+#          docker tag blurts-server ${{ steps.meta.outputs.tags }}
+#          docker push ${{ steps.meta.outputs.tags }}
 

--- a/.github/workflows/docker_build_deploy.yml
+++ b/.github/workflows/docker_build_deploy.yml
@@ -45,7 +45,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build --tag blurts-server \
-            --build-arg SENTRY_RELEASE="rhelmer-test" \ # FIXME
+            --build-arg SENTRY_RELEASE="rhelmer-test" \
             --secret id=SENTRY_AUTH_TOKEN \
             .
 

--- a/.github/workflows/docker_build_deploy.yml
+++ b/.github/workflows/docker_build_deploy.yml
@@ -2,7 +2,7 @@ name: Build Docker image and publish
 
 on:
   push:
-    branches: [ main, MNTOR-2934/sentry-sourcemap-docker-secret ] # FIXME remove after testing
+    branches: [ main ]
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
@@ -45,16 +45,15 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build --tag blurts-server \
-            --build-arg SENTRY_RELEASE="rhelmer-test" \
+            --build-arg SENTRY_RELEASE="$SENTRY_RELEASE" \
             --secret id=SENTRY_AUTH_TOKEN \
             .
 
-# FIXME temporarily disable push while testing
-#      - name: Deploy to Dockerhub
-#        env:
-#          DOCKERHUB_REPO: ${{ env.DOCKERHUB_REPO }}
-#        run: |
-#          # deploy main
-#          docker tag blurts-server ${{ steps.meta.outputs.tags }}
-#          docker push ${{ steps.meta.outputs.tags }}
+      - name: Deploy to Dockerhub
+        env:
+          DOCKERHUB_REPO: ${{ env.DOCKERHUB_REPO }}
+        run: |
+          # deploy main
+          docker tag blurts-server ${{ steps.meta.outputs.tags }}
+          docker push ${{ steps.meta.outputs.tags }}
 

--- a/.github/workflows/docker_build_deploy.yml
+++ b/.github/workflows/docker_build_deploy.yml
@@ -30,6 +30,15 @@ jobs:
         run: |
           echo "{\"commit\":\"$GITHUB_SHA\",\"version\":\"$GITHUB_REF\",\"source\":\"https://github.com/$GITHUB_REPOSITORY\",\"build\":\"$GITHUB_RUN_ID\"}" > version.json
 
+      - name: Check Docker Version
+        run: docker --version
+      - name: Install Latest Docker
+        run: |
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
+          sudo apt-get update
+          sudo apt-get install docker-ce
+
       - name: Build Docker image
         env:
           UPLOAD_SENTRY_SOURCEMAPS: true

--- a/.github/workflows/docker_build_deploy.yml
+++ b/.github/workflows/docker_build_deploy.yml
@@ -45,7 +45,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build --tag blurts-server \
-            --build-arg SENTRY_RELEASE="$GITHUB_REF_NAME" \
+            --build-arg SENTRY_RELEASE="rhelmer-test" \ # FIXME
             --secret id=SENTRY_AUTH_TOKEN \
             .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:20.9-alpine
+RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN
 
 RUN addgroup -g 10001 app && \
     adduser -D -G app -h /app -u 10001 app
@@ -31,8 +32,5 @@ RUN GLEAN_PYTHON=python GLEAN_PIP=pip npm run build
 
 ARG SENTRY_RELEASE
 ENV SENTRY_RELEASE=$SENTRY_RELEASE
-
-ARG SENTRY_AUTH_TOKEN
-ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:20.9-alpine
-RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN
 
 RUN addgroup -g 10001 app && \
     adduser -D -G app -h /app -u 10001 app
@@ -28,9 +27,10 @@ ENV NEXT_PUBLIC_GA4_DEBUG_MODE=false
 ARG S3_BUCKET
 ENV S3_BUCKET=$S3_BUCKET
 
-RUN GLEAN_PYTHON=python GLEAN_PIP=pip npm run build
-
 ARG SENTRY_RELEASE
 ENV SENTRY_RELEASE=$SENTRY_RELEASE
+
+RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \
+    GLEAN_PYTHON=python GLEAN_PIP=pip npm run build
 
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ ARG SENTRY_RELEASE
 ENV SENTRY_RELEASE=$SENTRY_RELEASE
 
 RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \
-    GLEAN_PYTHON=python GLEAN_PIP=pip npm run build
+    GLEAN_PYTHON=python \
+    GLEAN_PIP=pip \
+    npm run build
 
 CMD ["npm", "start"]


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-2934

<!-- When adding a new feature: -->

# Description

Pass `SENTRY_AUTH_TOKEN` as secret to docker build. Note that this also upgrades to the latest official Docker (Community Edition) in the GitHub Action container, so we can pass Docker secrets via environment variable (the
version of Docker that ships with the version of Ubuntu that GHA ships by default only supports files, which is a lot
more cumbersome to deal with).

# How to test

See the commit history on this branch, I temporarily modified the "build and push" docker GHA to run on this branch and I see that artifacts were successfully uploaded to Sentry.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
