### PR TITLE
Make QA customs tool usable after account recreation

### DIFF
--- a/src/db/tables/qa_customs.ts
+++ b/src/db/tables/qa_customs.ts
@@ -268,6 +268,15 @@ async function createQaTogglesRow(
     const existingRow = await knex("qa_custom_toggles")
       .where({ email_hash: emailHash })
       .first();
+
+    // If an account was deleted and recreated, it has another
+    // `onerep_profile_id`. Let’s make sure to update it!
+    if (existingRow && existingRow.onerep_profile_id !== onerep_profile_id) {
+      await knex("qa_custom_toggles").where({ email_hash: emailHash }).update({
+        onerep_profile_id,
+      });
+    }
+
     return existingRow as QaToggleRow;
   }
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

## References

Jira: [MNTOR-3843](https://mozilla-hub.atlassian.net/browse/MNTOR-3843)
<!-- When adding a new feature: -->

## Description

When a Monitor account is deleted and recreated a new OneRep profile is created during the initial broker scan. We need to make sure to update the `onerep_profile_id` in the `qa_custom_toggles` table.

## How to test

1. Delete the (admin) account from the settings page
2. Recreate the account
3. Run the initial scan with the recreated account
4. Make sure that custom data brokers can still be added through the QA customs tool

[MNTOR-3843]: https://mozilla-hub.atlassian.net/browse/MNTOR-3843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ