### PR TITLE
Fix condition for showing the email resent indicator

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelEditInfo.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelEditInfo.tsx
@@ -90,7 +90,7 @@ function MonitoredEmail(props: {
             }}
           >
             {l10n.getString("settings-resend-email-verification-link")}
-            {!isVerificationEmailResent && (
+            {isVerificationEmailResent && (
               <CheckIcon alt="" width={14} height={14} />
             )}
           </Button>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-3849](https://mozilla-hub.atlassian.net/browse/MNTOR-3849)

<!-- When adding a new feature: -->

# Description

Show the “email resent” indicator only after initiating the sending of the email.

# Screenshot

| Before sending | After sending |
| --- | --- |
| <img width="421" alt="image" src="https://github.com/user-attachments/assets/a30254c9-b83b-4264-b473-1622e1bddd14"> | <img width="424" alt="image" src="https://github.com/user-attachments/assets/89ddb731-0b5c-4ece-87cf-bd00b2d2a451"> |

# How to test

1. Enable the feature flag `SettingsPageRedesign`
2. Visit the settings page: `/user/settings`
3. Add a new email
4. Resend a verification email

[MNTOR-3849]: https://mozilla-hub.atlassian.net/browse/MNTOR-3849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ