### PR TITLE
use the ref_name not the full ref for SENTRY_RELEASE

### DIFF
--- a/.github/workflows/docker_build_deploy.yml
+++ b/.github/workflows/docker_build_deploy.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           UPLOAD_SENTRY_SOURCEMAPS: true
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_RELEASE: ${{ github.ref }}
+          SENTRY_RELEASE: ${{ github.ref_name }}
           NEXT_PUBLIC_SENTRY_DSN: ${{ env.NEXT_PUBLIC_SENTRY_DSN }}
         run: |
           docker build --tag blurts-server \


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3853

<!-- When adding a new feature: -->

# Description

Small followup to PR #5369 - Sentry does not want to use the full path from `github.ref` as `SENTRY_RELEASE`, I think `github.ref_name` is what is intended anyway.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
