### PR TITLE
Increase E2E auth timeout

### DIFF
--- a/src/e2e/pages/landingPage.ts
+++ b/src/e2e/pages/landingPage.ts
@@ -264,7 +264,7 @@ export class LandingPage {
   async goToSignIn() {
     await this.signInButton.click();
     // FxA can take a while to load on stage:
-    await this.page.waitForURL("**/oauth/**", { timeout: 60_000 });
+    await this.page.waitForURL("**/oauth/**", { timeout: 120_000 });
   }
 
   async enterFreeScanEmail(email: string) {


### PR DESCRIPTION
We have regular E2E cronjob failures. These are mostly caused by authentication attempts timing out. Let’s see if increasing the timeout even more resolves the issue.