### PR TITLE
Increase visibility for the Premium plan selection CTA

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/automatic-remove/AutomaticRemoveView.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/automatic-remove/AutomaticRemoveView.tsx
@@ -248,7 +248,7 @@ export function AutomaticRemoveView(props: Props) {
                     )}
               </span>
               <Button
-                variant="primary"
+                variant="secondary"
                 /* c8 ignore start */
                 onPress={() => {
                   selectedPlanIsYearly

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/dataBrokerProfiles.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/dataBrokerProfiles.module.scss
@@ -197,6 +197,18 @@
       font: $text-title-sm;
       font-weight: 500;
     }
+
+    // Invert color for the plan selection CTA to increase visibility
+    // against the purple background.
+    & > a {
+      color: $color-white;
+      box-shadow: inset 0 0 0 2px $color-white;
+
+      &:hover {
+        background-color: $color-white;
+        color: $color-purple-70;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-3884](https://mozilla-hub.atlassian.net/browse/MNTOR-3884)

<!-- When adding a new feature: -->

# Description

Increases the visibility for the Premium plan selection CTA against the purple background.

# Screenshot

| Before | After |
| --- | --- |
| <img width="378" alt="Screenshot 2024-12-17 at 18 29 11" src="https://github.com/user-attachments/assets/dba797f7-146b-4cc4-9aa1-1b4b6d21bba9" /> | <img width="385" alt="Screenshot 2024-12-17 at 18 28 53" src="https://github.com/user-attachments/assets/ccc2a0ad-5397-4bed-9afd-5d897b65c8fd" /> |

# How to test

The change can be looked at on the `fx-monitor-storybook` deploy preview: [1e. Automatically resolve brokers](https://deploy-preview-5425--fx-monitor-storybook.netlify.app/?path=/story/pages-logged-in-guided-resolution-1e-automatically-resolve-brokers--automatic-remove-view-story).

[MNTOR-3884]: https://mozilla-hub.atlassian.net/browse/MNTOR-3884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ