### PR TITLE
MNTOR-3857 - move locale filtering from TS to SQL for monthly free activity report

### DIFF
--- a/src/db/tables/subscribers.ts
+++ b/src/db/tables/subscribers.ts
@@ -515,7 +515,7 @@ async function getFreeSubscribersWaitingForMonthlyEmail(
   }
 
   const wrappedQuery = knex
-    // @ts-ignore TODO update our knex types
+    // @ts-ignore TODO MNTOR-3890 Move away from this approach and simplify query.
     .from({ base_query: query }) // Use the existing query as a subquery
     .select("*")
     .whereIn("country_code", countryCodes)

--- a/src/db/tables/subscribers.ts
+++ b/src/db/tables/subscribers.ts
@@ -520,7 +520,6 @@ async function getFreeSubscribersWaitingForMonthlyEmail(
     .whereIn("country_code", countryCodes)
     .limit(batchSize);
 
-  console.debug(wrappedQuery.toQuery());
   const rows = await wrappedQuery;
 
   return rows;

--- a/src/db/tables/subscribers.ts
+++ b/src/db/tables/subscribers.ts
@@ -417,9 +417,10 @@ async function getPlusSubscribersWaitingForMonthlyEmail(
 
 // Not covered by tests; mostly side-effects. See test-coverage.md#mock-heavy
 /* c8 ignore start */
-async function getFreeSubscribersWaitingForMonthlyEmail(): Promise<
-  SubscriberRow[]
-> {
+async function getFreeSubscribersWaitingForMonthlyEmail(
+  batchSize: number,
+  countryCodes: string[],
+): Promise<SubscriberRow[]> {
   const flag = await getFeatureFlagData("MonthlyReportFreeUser");
   const accountCutOffDate = parseIso8601Datetime(
     process.env.MONTHLY_ACTIVITY_FREE_EMAIL_ACCOUNT_CUTOFF_DATE ??
@@ -438,6 +439,24 @@ async function getFreeSubscribersWaitingForMonthlyEmail(): Promise<
 
   let query = knex("subscribers")
     .select<SubscriberRow[]>("subscribers.*")
+    .select(
+      knex.raw(
+        `CASE
+        WHEN (fxa_profile_json->>'locale') ~ ',' THEN
+          CASE
+            WHEN split_part(fxa_profile_json->>'locale', ',', 1) ~ '-' THEN
+              split_part(split_part(fxa_profile_json->>'locale', ',', 1), '-', 2) -- Extract country code from first part
+            ELSE
+              split_part(fxa_profile_json->>'locale', ',', 1) -- Fallback to the language code
+          END
+        WHEN (fxa_profile_json->>'locale') ~ '-' THEN
+          split_part(fxa_profile_json->>'locale', '-', 2) -- Extract country code if present
+        ELSE
+          fxa_profile_json->>'locale' -- Fallback to the language code
+      END AS country_code`,
+      ),
+    )
+
     .leftJoin(
       "subscriber_email_preferences",
       "subscribers.id",
@@ -494,14 +513,15 @@ async function getFreeSubscribersWaitingForMonthlyEmail(): Promise<
     // https://github.com/knex/knex/issues/1881#issuecomment-275433906
     query = query.whereIn("subscribers.primary_email", flag.allow_list);
   }
-  // One thing to note as being absent from this query: a LIMIT clause.
-  // The reason for this is that we want to filter out people who had
-  // a language other than `en-US` set when signing up, but to do so,
-  // we need to parse the `accept-language` field, which we can only
-  // do after we have the query results. Thus, if we were to limit
-  // the result of this query, we would at some point end up filtering
-  // every returned row, and then never moving on to the rows after that.
-  const rows = await query;
+
+  const wrappedQuery = knex
+    .from({ base_query: query }) // Use the existing query as a subquery
+    .select("*")
+    .whereIn("country_code", countryCodes)
+    .limit(batchSize);
+
+  console.debug(wrappedQuery.toQuery());
+  const rows = await wrappedQuery;
 
   return rows;
 }

--- a/src/db/tables/subscribers.ts
+++ b/src/db/tables/subscribers.ts
@@ -523,7 +523,7 @@ async function getFreeSubscribersWaitingForMonthlyEmail(
 
   const rows = await wrappedQuery;
 
-  return rows;
+  return rows as SubscriberRow[];
 }
 /* c8 ignore stop */
 

--- a/src/db/tables/subscribers.ts
+++ b/src/db/tables/subscribers.ts
@@ -515,6 +515,7 @@ async function getFreeSubscribersWaitingForMonthlyEmail(
   }
 
   const wrappedQuery = knex
+    // @ts-ignore TODO update our knex types
     .from({ base_query: query }) // Use the existing query as a subquery
     .select("*")
     .whereIn("country_code", countryCodes)

--- a/src/scripts/cronjobs/monthlyActivityFree.tsx
+++ b/src/scripts/cronjobs/monthlyActivityFree.tsx
@@ -28,12 +28,10 @@ async function run() {
   const batchSize = MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE;
 
   logger.info(`Getting free subscribers with batch size: ${batchSize}`);
-  const subscribersToEmail = (await getFreeSubscribersWaitingForMonthlyEmail())
-    .filter((subscriber) => {
-      const assumedCountryCode = getSignupLocaleCountry(subscriber);
-      return assumedCountryCode === "us";
-    })
-    .slice(0, batchSize);
+  const subscribersToEmail = await getFreeSubscribersWaitingForMonthlyEmail(
+    batchSize,
+    ["US"],
+  );
   await initEmail();
 
   for (const subscriber of subscribersToEmail) {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3857

<!-- When adding a new feature: -->

# Description

Our cronjob container is running out of memory trying to fetch data and filter in the application side, specifically it wants to extract the country code (if present) from the [locale header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) which can be pretty complex.

We can have the database do this filtering in a much more efficient way, I think it's worth revisiting this to simplify the query but the minimally-invasive fix I could figure out is:

1. use nested `CASE / ELSE` to split the locale into `country_code`
2. use a subquery so we can do a `WHERE IN` on `country_code`

The `batchSize` is now passed as an argument to the DB function and used directly as a `LIMIT` in the query, and the list of acceptable country codes is also passed as a `string[]` argument.

# How to test

Moving this to SQL makes it more difficult to unit test, I ended up modifying my local database and testing that way.

We should continue to explore ways to test our SQL in controlled environments, especially as it gets more complicated. This probably should be refactored into a stored procedure, for instance, which we could more feasibly unit test.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).