### PR TITLE
MNTOR-3812 - switch to Cirrus v2 output

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/page.tsx
@@ -68,7 +68,7 @@ export default async function FeatureFlagPage() {
             lastScanDate={null}
             // We're not going to run experiments on the feature flag page (it's
             // not user-visible), so no need to fetch experiment data:
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
           />
         </div>
       </nav>

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.stories.tsx
@@ -56,7 +56,7 @@ export type DashboardWrapperProps = (
   totalNumberOfPerformedScans?: number;
   activeTab?: TabType;
   enabledFeatureFlags?: FeatureFlagName[];
-  experimentData?: ExperimentData;
+  experimentData?: ExperimentData["Features"];
   hasFirstMonitoringScan?: boolean;
   signInCount?: number;
   autoOpenUpsellDialog?: boolean;
@@ -227,7 +227,7 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
             enabledFeatureFlags={props.enabledFeatureFlags ?? []}
             experimentData={
               props.experimentData ?? {
-                ...defaultExperimentData,
+                ...defaultExperimentData["Features"],
                 "last-scan-date": {
                   enabled: true,
                 },

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
@@ -3487,7 +3487,7 @@ describe("CSAT survey banner", () => {
         activeTab="fixed"
         enabledFeatureFlags={["PetitionBannerCsatSurvey"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-privacy-petition-banner": {
             enabled: false,
           },
@@ -3515,7 +3515,7 @@ describe("CSAT survey banner", () => {
         activeTab="action-needed"
         enabledFeatureFlags={["PetitionBannerCsatSurvey"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-privacy-petition-banner": {
             enabled: false,
           },
@@ -3539,7 +3539,7 @@ describe("CSAT survey banner", () => {
         activeTab="fixed"
         enabledFeatureFlags={["PetitionBannerCsatSurvey"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-privacy-petition-banner": {
             enabled: true,
           },
@@ -3564,7 +3564,7 @@ describe("CSAT survey banner", () => {
         activeTab="fixed"
         enabledFeatureFlags={["PetitionBannerCsatSurvey"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-privacy-petition-banner": {
             enabled: true,
           },
@@ -3595,7 +3595,7 @@ describe("CSAT survey banner", () => {
         activeTab="fixed"
         enabledFeatureFlags={["PetitionBannerCsatSurvey"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-privacy-petition-banner": {
             enabled: true,
           },
@@ -3630,7 +3630,7 @@ describe("CSAT survey banner", () => {
           "AutomaticRemovalCsatSurvey",
         ]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-privacy-petition-banner": {
             enabled: true,
           },
@@ -3659,7 +3659,7 @@ describe("CSAT survey banner", () => {
         activeTab="fixed"
         enabledFeatureFlags={["DataBrokerRemovalTimeEstimateCsat"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-broker-removal-time-estimates": {
             enabled: true,
           },
@@ -3683,7 +3683,7 @@ describe("CSAT survey banner", () => {
         activeTab="fixed"
         enabledFeatureFlags={["DataBrokerRemovalTimeEstimateCsat"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-broker-removal-time-estimates": {
             enabled: false,
           },
@@ -3707,7 +3707,7 @@ describe("CSAT survey banner", () => {
         activeTab="action-needed"
         enabledFeatureFlags={["DataBrokerRemovalTimeEstimateCsat"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-broker-removal-time-estimates": {
             enabled: true,
           },
@@ -3731,7 +3731,7 @@ describe("CSAT survey banner", () => {
         activeTab="fixed"
         enabledFeatureFlags={["DataBrokerRemovalTimeEstimateCsat"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-broker-removal-time-estimates": {
             enabled: true,
           },
@@ -3756,7 +3756,7 @@ describe("Data privacy petition banner", () => {
       <ComposedDashboard
         enabledFeatureFlags={["PetitionBannerCsatSurvey"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-privacy-petition-banner": {
             enabled: true,
           },
@@ -3780,7 +3780,7 @@ describe("Data privacy petition banner", () => {
         activeTab="fixed"
         enabledFeatureFlags={["PetitionBannerCsatSurvey"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-privacy-petition-banner": {
             enabled: true,
           },
@@ -3804,7 +3804,7 @@ describe("Data privacy petition banner", () => {
         activeTab="fixed"
         enabledFeatureFlags={["PetitionBannerCsatSurvey"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-privacy-petition-banner": {
             enabled: true,
           },
@@ -3827,7 +3827,7 @@ describe("Data privacy petition banner", () => {
       <ComposedDashboard
         enabledFeatureFlags={["PetitionBannerCsatSurvey"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-privacy-petition-banner": {
             enabled: true,
           },
@@ -3847,7 +3847,7 @@ describe("Data privacy petition banner", () => {
       <ComposedDashboard
         enabledFeatureFlags={["PetitionBannerCsatSurvey"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-privacy-petition-banner": {
             enabled: true,
           },
@@ -3882,7 +3882,7 @@ describe("Data privacy petition banner", () => {
         activeTab="fixed"
         enabledFeatureFlags={["PetitionBannerCsatSurvey"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-privacy-petition-banner": {
             enabled: true,
           },
@@ -3914,7 +3914,7 @@ describe("Data privacy petition banner", () => {
         activeTab="fixed"
         enabledFeatureFlags={["PetitionBannerCsatSurvey"]}
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "data-privacy-petition-banner": {
             enabled: true,
           },

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardNonUSUsers.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardNonUSUsers.stories.tsx
@@ -194,7 +194,7 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
             enabledFeatureFlags={props.enabledFeatureFlags ?? []}
             experimentData={
               props.experimentData ?? {
-                ...defaultExperimentData,
+                ...defaultExperimentData["Features"],
                 "last-scan-date": {
                   enabled: true,
                 },

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardPlusUsers.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardPlusUsers.stories.tsx
@@ -193,7 +193,7 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
             enabledFeatureFlags={props.enabledFeatureFlags ?? []}
             experimentData={
               props.experimentData ?? {
-                ...defaultExperimentData,
+                ...defaultExperimentData["Features"],
                 "last-scan-date": {
                   enabled: true,
                 },

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardUSUsers.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardUSUsers.stories.tsx
@@ -194,7 +194,7 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
             enabledFeatureFlags={props.enabledFeatureFlags ?? []}
             experimentData={
               props.experimentData ?? {
-                ...defaultExperimentData,
+                ...defaultExperimentData["Features"],
                 "last-scan-date": {
                   enabled: true,
                 },

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/View.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/View.tsx
@@ -62,7 +62,7 @@ export type TabType = "action-needed" | "fixed";
 
 export type Props = {
   enabledFeatureFlags: FeatureFlagName[];
-  experimentData: ExperimentData;
+  experimentData: ExperimentData["Features"];
   user: Session["user"];
   userBreaches: SubscriberBreach[];
   userScanData: LatestOnerepScanData;

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/CancelFlow.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/CancelFlow.tsx
@@ -25,7 +25,7 @@ import { OpenInNew } from "../../../../../../components/server/Icons";
 export type Props = {
   fxaSubscriptionsUrl: string;
   enableDiscountCoupon: boolean;
-  experimentData?: ExperimentData;
+  experimentData?: ExperimentData["Features"];
   isMonthlySubscriber: boolean;
 };
 

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPage.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPage.test.tsx
@@ -264,7 +264,7 @@ it("passes the axe accessibility audit", async () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
       />
     </TestComponentWrapper>,
@@ -305,7 +305,7 @@ it("Add email address button is not shown when email limit of five reached", () 
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -350,7 +350,7 @@ it("Add email address button is shown when fewer than five emails", () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -387,7 +387,7 @@ it("preselects 'Send all breach alerts to the primary email address' if that's t
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -432,7 +432,7 @@ it("preselects 'Send breach alerts to the affected email address' if that's the 
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -477,7 +477,7 @@ it("disables breach alert notification options if a user opts out of breach aler
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={["UpdatedEmailPreferencesOption"]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -532,7 +532,7 @@ it("preselects primary email alert option", () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={["UpdatedEmailPreferencesOption"]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -573,7 +573,7 @@ it("unselects the breach alerts checkbox and sends a null value to the API", asy
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={["UpdatedEmailPreferencesOption"]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -630,7 +630,7 @@ it("preselects the affected email comms option after a user decides to enable br
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={["UpdatedEmailPreferencesOption"]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -678,7 +678,7 @@ it("sends a call to the API to change the email alert preferences when changing 
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={["UpdatedEmailPreferencesOption"]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -733,7 +733,7 @@ it("checks that monthly monitor report is available to free users", () => {
           "UpdatedEmailPreferencesOption",
           "MonthlyReportFreeUser",
         ]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={false}
         data={mockedFreeSubscriberEmailPreferences}
       />
@@ -775,7 +775,7 @@ it("checks that monthly monitor report is enabled", () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={["UpdatedEmailPreferencesOption"]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -820,7 +820,7 @@ it("sends an API call to disable monthly monitor reports", async () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={["UpdatedEmailPreferencesOption"]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -872,7 +872,7 @@ it("calls the right telemetry event if a user opts out of monthly report", async
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={["UpdatedEmailPreferencesOption"]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -929,7 +929,7 @@ it("refreshes the session token after changing email alert preferences, to ensur
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -966,7 +966,7 @@ it("marks unverified email addresses as such", () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1004,7 +1004,7 @@ it("calls the API to resend a verification email if requested to", async () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1052,7 +1052,7 @@ it("calls the 'remove' action when clicking the rubbish bin icon", async () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1090,7 +1090,7 @@ it("hides the Plus cancellation link if the user doesn't have Plus", () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1127,7 +1127,7 @@ it("shows the Plus cancellation link if the user has Plus", () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1171,7 +1171,7 @@ it("takes you through the cancellation dialog flow all the way to subplat", asyn
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={["ConfirmCancellation", "CancellationFlow"]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1250,7 +1250,7 @@ it("closes the cancellation survey if the user selects nevermind, take me back",
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={["ConfirmCancellation", "CancellationFlow"]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1308,7 +1308,7 @@ it("closes the cancellation dialog", async () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={["CancellationFlow"]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1359,7 +1359,7 @@ it("shows the account deletion button if the user does not have Plus", () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1401,7 +1401,7 @@ it("warns about the consequences before deleting a free user's account", async (
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1445,7 +1445,7 @@ it("shows a loading state while account deletion is in progress", async () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1490,7 +1490,7 @@ it("shows the account deletion button if the user has Plus", () => {
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1532,7 +1532,7 @@ it("warns about the consequences before deleting a Plus user's account", async (
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1585,7 +1585,7 @@ it.skip("calls the 'add' action when adding another email address", async () => 
         monthlySubscriptionUrl=""
         subscriptionBillingAmount={mockedSubscriptionBillingAmount}
         enabledFeatureFlags={[]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -1621,7 +1621,7 @@ describe("to learn about usage", () => {
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
           enabledFeatureFlags={[]}
-          experimentData={defaultExperimentData}
+          experimentData={defaultExperimentData["Features"]}
           isMonthlySubscriber={true}
           data={mockedPlusSubscriberEmailPreferences}
         />
@@ -1666,7 +1666,7 @@ describe("to learn about usage", () => {
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
           enabledFeatureFlags={[]}
-          experimentData={defaultExperimentData}
+          experimentData={defaultExperimentData["Features"]}
           isMonthlySubscriber={true}
           data={mockedPlusSubscriberEmailPreferences}
         />
@@ -1711,7 +1711,7 @@ describe("to learn about usage", () => {
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
           enabledFeatureFlags={[]}
-          experimentData={defaultExperimentData}
+          experimentData={defaultExperimentData["Features"]}
           isMonthlySubscriber={true}
           data={mockedPlusSubscriberEmailPreferences}
         />
@@ -1757,7 +1757,7 @@ describe("to learn about usage", () => {
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
           enabledFeatureFlags={[]}
-          experimentData={defaultExperimentData}
+          experimentData={defaultExperimentData["Features"]}
           isMonthlySubscriber={true}
           data={mockedPlusSubscriberEmailPreferences}
         />
@@ -1802,7 +1802,7 @@ describe("to learn about usage", () => {
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
           enabledFeatureFlags={[]}
-          experimentData={defaultExperimentData}
+          experimentData={defaultExperimentData["Features"]}
           isMonthlySubscriber={true}
           data={mockedPlusSubscriberEmailPreferences}
         />
@@ -1852,7 +1852,7 @@ describe("to learn about usage", () => {
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
           enabledFeatureFlags={[]}
-          experimentData={defaultExperimentData}
+          experimentData={defaultExperimentData["Features"]}
           isMonthlySubscriber={true}
           data={mockedPlusSubscriberEmailPreferences}
         />
@@ -1898,7 +1898,7 @@ describe("to learn about usage", () => {
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
           enabledFeatureFlags={[]}
-          experimentData={defaultExperimentData}
+          experimentData={defaultExperimentData["Features"]}
           isMonthlySubscriber={true}
           data={mockedPlusSubscriberEmailPreferences}
         />
@@ -1948,7 +1948,7 @@ describe("to learn about usage", () => {
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
           enabledFeatureFlags={[]}
-          experimentData={defaultExperimentData}
+          experimentData={defaultExperimentData["Features"]}
           isMonthlySubscriber={true}
           data={mockedPlusSubscriberEmailPreferences}
         />
@@ -1993,7 +1993,7 @@ describe("to learn about usage", () => {
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
           enabledFeatureFlags={[]}
-          experimentData={defaultExperimentData}
+          experimentData={defaultExperimentData["Features"]}
           isMonthlySubscriber={true}
           data={mockedPlusSubscriberEmailPreferences}
         />
@@ -2043,7 +2043,7 @@ describe("to learn about usage", () => {
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
           enabledFeatureFlags={[]}
-          experimentData={defaultExperimentData}
+          experimentData={defaultExperimentData["Features"]}
           isMonthlySubscriber={true}
           data={mockedPlusSubscriberEmailPreferences}
         />
@@ -2105,7 +2105,7 @@ it("selects the coupon code discount cta and shows the all-set dialog step", asy
           "ConfirmCancellation",
           "DiscountCouponNextThreeMonths",
         ]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -2192,7 +2192,7 @@ it("shows error message if the applying the coupon code function was unsuccessfu
           "ConfirmCancellation",
           "DiscountCouponNextThreeMonths",
         ]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />
@@ -2259,7 +2259,7 @@ it("does not show the coupon code if a user already has a coupon set", async () 
           "ConfirmCancellation",
           "DiscountCouponNextThreeMonths",
         ]}
-        experimentData={defaultExperimentData}
+        experimentData={defaultExperimentData["Features"]}
         isMonthlySubscriber={true}
         data={mockedPlusSubscriberEmailPreferences}
       />

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPageRedesign.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPageRedesign.test.tsx
@@ -295,7 +295,7 @@ describe("Settings page redesign", () => {
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
           enabledFeatureFlags={[]}
-          experimentData={defaultExperimentData}
+          experimentData={defaultExperimentData["Features"]}
           isMonthlySubscriber={true}
           data={mockedPlusSubscriberEmailPreferences}
         />
@@ -333,7 +333,7 @@ describe("Settings page redesign", () => {
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
           enabledFeatureFlags={["SettingsPageRedesign"]}
-          experimentData={defaultExperimentData}
+          experimentData={defaultExperimentData["Features"]}
           isMonthlySubscriber={true}
           data={mockedPlusSubscriberEmailPreferences}
         />
@@ -370,7 +370,7 @@ describe("Settings page redesign", () => {
           monthlySubscriptionUrl=""
           subscriptionBillingAmount={mockedSubscriptionBillingAmount}
           enabledFeatureFlags={["SettingsPageRedesign"]}
-          experimentData={defaultExperimentData}
+          experimentData={defaultExperimentData["Features"]}
           isMonthlySubscriber={true}
           data={mockedPlusSubscriberEmailPreferences}
         />
@@ -408,7 +408,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
           />
         </SettingsWrapper>,
@@ -442,7 +442,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -496,7 +496,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -542,7 +542,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -577,7 +577,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -616,7 +616,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -665,7 +665,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -710,7 +710,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -749,7 +749,7 @@ describe("Settings page redesign", () => {
               monthlySubscriptionUrl=""
               subscriptionBillingAmount={mockedSubscriptionBillingAmount}
               enabledFeatureFlags={["SettingsPageRedesign"]}
-              experimentData={defaultExperimentData}
+              experimentData={defaultExperimentData["Features"]}
               isMonthlySubscriber={true}
               data={mockedPlusSubscriberEmailPreferences}
             />
@@ -795,7 +795,7 @@ describe("Settings page redesign", () => {
               monthlySubscriptionUrl=""
               subscriptionBillingAmount={mockedSubscriptionBillingAmount}
               enabledFeatureFlags={["SettingsPageRedesign"]}
-              experimentData={defaultExperimentData}
+              experimentData={defaultExperimentData["Features"]}
               isMonthlySubscriber={true}
               data={mockedPlusSubscriberEmailPreferences}
             />
@@ -841,7 +841,7 @@ describe("Settings page redesign", () => {
               monthlySubscriptionUrl=""
               subscriptionBillingAmount={mockedSubscriptionBillingAmount}
               enabledFeatureFlags={["SettingsPageRedesign"]}
-              experimentData={defaultExperimentData}
+              experimentData={defaultExperimentData["Features"]}
               isMonthlySubscriber={true}
               data={mockedPlusSubscriberEmailPreferences}
             />
@@ -891,7 +891,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -928,7 +928,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -966,7 +966,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1015,7 +1015,7 @@ describe("Settings page redesign", () => {
               "CancellationFlow",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1099,7 +1099,7 @@ describe("Settings page redesign", () => {
               "CancellationFlow",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1158,7 +1158,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["CancellationFlow", "SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1210,7 +1210,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1253,7 +1253,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1298,7 +1298,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1344,7 +1344,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1387,7 +1387,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1436,7 +1436,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1482,7 +1482,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1533,7 +1533,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1580,7 +1580,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1631,7 +1631,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1677,7 +1677,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1728,7 +1728,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1793,7 +1793,7 @@ describe("Settings page redesign", () => {
               "DiscountCouponNextThreeMonths",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1884,7 +1884,7 @@ describe("Settings page redesign", () => {
               "DiscountCouponNextThreeMonths",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1953,7 +1953,7 @@ describe("Settings page redesign", () => {
               "DiscountCouponNextThreeMonths",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -1996,7 +1996,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -2042,7 +2042,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -2091,7 +2091,7 @@ describe("Settings page redesign", () => {
               "UpdatedEmailPreferencesOption",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -2156,7 +2156,7 @@ describe("Settings page redesign", () => {
               "UpdatedEmailPreferencesOption",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -2201,7 +2201,7 @@ describe("Settings page redesign", () => {
               "UpdatedEmailPreferencesOption",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -2265,7 +2265,7 @@ describe("Settings page redesign", () => {
               "UpdatedEmailPreferencesOption",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -2317,7 +2317,7 @@ describe("Settings page redesign", () => {
               "UpdatedEmailPreferencesOption",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -2380,7 +2380,7 @@ describe("Settings page redesign", () => {
               "MonthlyReportFreeUser",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={false}
             data={mockedFreeSubscriberEmailPreferences}
           />
@@ -2426,7 +2426,7 @@ describe("Settings page redesign", () => {
               "UpdatedEmailPreferencesOption",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -2475,7 +2475,7 @@ describe("Settings page redesign", () => {
               "UpdatedEmailPreferencesOption",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -2534,7 +2534,7 @@ describe("Settings page redesign", () => {
               "UpdatedEmailPreferencesOption",
               "SettingsPageRedesign",
             ]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />
@@ -2592,7 +2592,7 @@ describe("Settings page redesign", () => {
             monthlySubscriptionUrl=""
             subscriptionBillingAmount={mockedSubscriptionBillingAmount}
             enabledFeatureFlags={["SettingsPageRedesign"]}
-            experimentData={defaultExperimentData}
+            experimentData={defaultExperimentData["Features"]}
             isMonthlySubscriber={true}
             data={mockedPlusSubscriberEmailPreferences}
           />

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/View.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/View.tsx
@@ -46,7 +46,7 @@ export type Props = {
   emailAddresses: EmailAddressRow[];
   breachCountByEmailAddress: Record<string, number>;
   enabledFeatureFlags: FeatureFlagName[];
-  experimentData: ExperimentData;
+  experimentData: ExperimentData["Features"];
   lastScanDate?: Date;
   isMonthlySubscriber: boolean;
   activeTab?: TabType;

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelManageAccount.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelManageAccount.tsx
@@ -17,7 +17,7 @@ import { DeleteAccountButton } from "../DeleteAccountButton";
 
 export type SettingsPanelManageAccountProps = {
   enabledFeatureFlags: FeatureFlagName[];
-  experimentData: ExperimentData;
+  experimentData: ExperimentData["Features"];
   fxaSubscriptionsUrl: string;
   isMonthlySubscriber: boolean;
   user: Session["user"];

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/EnterInfo.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/EnterInfo.tsx
@@ -63,7 +63,7 @@ export type Props = {
   user: Session["user"];
   skipInitialStep: boolean;
   previousRoute: string | null;
-  experimentData: ExperimentData;
+  experimentData: ExperimentData["Features"];
 };
 
 export const EnterInfo = ({

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/Onboarding.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/Onboarding.stories.tsx
@@ -23,7 +23,7 @@ export const Onboarding: Story = {
       breachesTotalCount={678}
       previousRoute={props.previousRoute}
       experimentData={{
-        ...defaultExperimentData,
+        ...defaultExperimentData["Features"],
         "welcome-scan-optional-info": {
           enabled: true,
           variant: "suffixAndMiddleName",

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/View.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/View.tsx
@@ -30,7 +30,7 @@ export type Props = {
   breachesTotalCount: number;
   stepId?: StepId;
   previousRoute: string | null;
-  experimentData: ExperimentData;
+  experimentData: ExperimentData["Features"];
 };
 
 export const View = ({

--- a/src/app/(proper_react)/(redesign)/(public)/FreeScanCta.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/FreeScanCta.tsx
@@ -19,7 +19,7 @@ import { useViewTelemetry } from "../../../hooks/useViewTelemetry";
 
 export const FreeScanCta = (
   props: Props & {
-    experimentData: ExperimentData;
+    experimentData: ExperimentData["Features"];
   },
 ) => {
   const l10n = useL10n();

--- a/src/app/(proper_react)/(redesign)/(public)/LandingView.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingView.stories.tsx
@@ -13,7 +13,8 @@ import { CONST_URL_MONITOR_LANDING_PAGE_ID } from "../../../../constants";
 const meta: Meta<typeof View> = {
   title: "Pages/Public/Landing page",
   component: (props: ViewProps) => {
-    const experimentData = props.experimentData ?? defaultExperimentData;
+    const experimentData =
+      props.experimentData ?? defaultExperimentData["Features"];
     return (
       <AccountsMetricsFlowProvider
         enabled={experimentData["landing-page-free-scan-cta"].enabled}

--- a/src/app/(proper_react)/(redesign)/(public)/LandingView.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingView.test.tsx
@@ -860,9 +860,9 @@ describe("Free scan CTA experiment", () => {
     render(
       <ComposedDashboard
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "landing-page-free-scan-cta": {
-            ...defaultExperimentData["landing-page-free-scan-cta"],
+            ...defaultExperimentData["Features"]["landing-page-free-scan-cta"],
             enabled: false,
           },
         }}
@@ -893,7 +893,7 @@ describe("Free scan CTA experiment", () => {
     render(
       <ComposedDashboard
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "landing-page-free-scan-cta": {
             enabled: true,
             variant: "ctaWithEmail",
@@ -928,7 +928,7 @@ describe("Free scan CTA experiment", () => {
     render(
       <ComposedDashboard
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "landing-page-free-scan-cta": {
             enabled: true,
             variant: "ctaOnly",
@@ -961,7 +961,7 @@ describe("Free scan CTA experiment", () => {
     render(
       <ComposedDashboard
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "landing-page-free-scan-cta": {
             enabled: true,
             variant: "ctaOnlyAlternativeLabel",
@@ -994,7 +994,7 @@ describe("Free scan CTA experiment", () => {
     render(
       <ComposedDashboard
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "landing-page-free-scan-cta": {
             enabled: true,
             variant: "ctaOnly",
@@ -1027,7 +1027,7 @@ describe("Free scan CTA experiment", () => {
     render(
       <ComposedDashboard
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "landing-page-free-scan-cta": {
             enabled: true,
             variant: "ctaOnly",
@@ -1067,7 +1067,7 @@ describe("Free scan CTA experiment", () => {
     render(
       <ComposedDashboard
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "landing-page-free-scan-cta": {
             enabled: true,
             variant: "ctaOnly",
@@ -1100,7 +1100,7 @@ describe("Free scan CTA experiment", () => {
     render(
       <ComposedDashboard
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "landing-page-free-scan-cta": {
             enabled: true,
             variant: "ctaWithEmail",
@@ -1155,7 +1155,7 @@ describe("Free scan CTA experiment", () => {
     render(
       <ComposedDashboard
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "landing-page-free-scan-cta": {
             enabled: true,
             variant: "ctaWithEmail",
@@ -1220,7 +1220,7 @@ describe("Free scan CTA experiment", () => {
     render(
       <ComposedDashboard
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "landing-page-free-scan-cta": {
             enabled: true,
             variant: "ctaWithEmail",

--- a/src/app/(proper_react)/(redesign)/(public)/LandingView.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingView.tsx
@@ -35,7 +35,7 @@ export type Props = {
   l10n: ExtendedReactLocalization;
   countryCode: string;
   scanLimitReached: boolean;
-  experimentData: ExperimentData;
+  experimentData: ExperimentData["Features"];
 };
 
 export const View = (props: Props) => {

--- a/src/app/(proper_react)/(redesign)/(public)/SignUpForm.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/SignUpForm.tsx
@@ -33,7 +33,7 @@ export type Props = {
   };
   scanLimitReached: boolean;
   signUpCallbackUrl: string;
-  experimentData?: ExperimentData;
+  experimentData?: ExperimentData["Features"];
   isHero?: boolean;
   placeholder?: string;
 };

--- a/src/app/components/client/ExposuresFilter.test.tsx
+++ b/src/app/components/client/ExposuresFilter.test.tsx
@@ -53,7 +53,7 @@ it("shows and hides the removal time explainer dialog by clicking the â€œGot itâ
       isPlusSubscriber
       enabledFeatureFlags={["DataBrokerRemovalTimeEstimateLabel"]}
       experimentData={{
-        ...defaultExperimentData,
+        ...defaultExperimentData["Features"],
         "data-broker-removal-time-estimates": {
           enabled: true,
         },
@@ -84,7 +84,7 @@ it("shows and hides the removal time explainer dialog by clicking the close butt
       isPlusSubscriber
       enabledFeatureFlags={["DataBrokerRemovalTimeEstimateLabel"]}
       experimentData={{
-        ...defaultExperimentData,
+        ...defaultExperimentData["Features"],
         "data-broker-removal-time-estimates": {
           enabled: true,
         },

--- a/src/app/components/client/ExposuresFilter.tsx
+++ b/src/app/components/client/ExposuresFilter.tsx
@@ -50,7 +50,7 @@ export type FilterState = {
 
 type ExposuresFilterProps = {
   enabledFeatureFlags: FeatureFlagName[];
-  experimentData: ExperimentData;
+  experimentData: ExperimentData["Features"];
   initialFilterValues: FilterState;
   filterValues: FilterState;
   setFilterValues: React.Dispatch<React.SetStateAction<FilterState>>;

--- a/src/app/components/client/csat_survey/CsatSurvey.test.tsx
+++ b/src/app/components/client/csat_survey/CsatSurvey.test.tsx
@@ -297,7 +297,7 @@ describe("CSAT survey banner: Latest scan date", () => {
     render(
       <ComposedCsatSurvey
         experimentData={{
-          ...defaultExperimentData,
+          ...defaultExperimentData["Features"],
           "last-scan-date": {
             enabled: false,
           },

--- a/src/app/components/client/csat_survey/CsatSurvey.tsx
+++ b/src/app/components/client/csat_survey/CsatSurvey.tsx
@@ -22,7 +22,7 @@ import { getRemovalTimeEstimatesCsatSurvey } from "./surveys/removalTimeEstimate
 export type CsatSurveyProps = {
   activeTab: TabType;
   user: Session["user"];
-  experimentData: ExperimentData;
+  experimentData: ExperimentData["Features"];
   enabledFeatureFlags: FeatureFlagName[];
   hasAutoFixedDataBrokers: boolean;
   hasFirstMonitoringScan: boolean;

--- a/src/app/components/client/csat_survey/surveys/csatSurvey.ts
+++ b/src/app/components/client/csat_survey/surveys/csatSurvey.ts
@@ -26,7 +26,7 @@ export type SurveyLinks = Record<SurveyResponse, string>;
 type RequiredExperimentStatus = "enabled" | "disabled";
 
 type RequiredExperiment = {
-  id: keyof ExperimentData;
+  id: keyof ExperimentData["Features"];
   statusAllowList: RequiredExperimentStatus[];
 };
 
@@ -50,7 +50,7 @@ export type Survey = AutomaticRemovalVariation | LatestScanDateVariation;
 
 export type CsatSurveyProps = {
   activeTab: TabType;
-  experimentData: ExperimentData;
+  experimentData: ExperimentData["Features"];
   user: Session["user"];
 };
 

--- a/src/app/components/client/exposure_card/ExposureCard.stories.tsx
+++ b/src/app/components/client/exposure_card/ExposureCard.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof ExposureCard> = {
   args: {
     enabledFeatureFlags: [],
     experimentData: {
-      ...defaultExperimentData,
+      ...defaultExperimentData["Features"],
       "data-broker-removal-time-estimates": {
         enabled: true,
       },

--- a/src/app/components/client/exposure_card/ExposureCard.tsx
+++ b/src/app/components/client/exposure_card/ExposureCard.tsx
@@ -34,7 +34,7 @@ export type ExposureCardProps = {
   resolutionCta: ReactNode;
   isExpanded: boolean;
   enabledFeatureFlags: FeatureFlagName[];
-  experimentData: ExperimentData;
+  experimentData: ExperimentData["Features"];
   removalTimeEstimate?: number;
   onToggleExpanded: () => void;
 };

--- a/src/app/components/client/exposure_card/ScanResultCard.tsx
+++ b/src/app/components/client/exposure_card/ScanResultCard.tsx
@@ -26,7 +26,7 @@ export type ScanResultCardProps = {
   isExpanded: boolean;
   isOnManualRemovePage?: boolean;
   enabledFeatureFlags?: FeatureFlagName[];
-  experimentData?: ExperimentData;
+  experimentData?: ExperimentData["Features"];
   removalTimeEstimate?: number;
   onToggleExpanded: () => void;
 };

--- a/src/app/components/client/exposure_card/SubscriberBreachCard.tsx
+++ b/src/app/components/client/exposure_card/SubscriberBreachCard.tsx
@@ -30,7 +30,7 @@ export type SubscriberBreachCardProps = {
   isPremiumUser: boolean;
   isExpanded: boolean;
   enabledFeatureFlags: FeatureFlagName[];
-  experimentData: ExperimentData;
+  experimentData: ExperimentData["Features"];
   onToggleExpanded: () => void;
 };
 

--- a/src/app/components/client/stories/CsatSurvey.stories.ts
+++ b/src/app/components/client/stories/CsatSurvey.stories.ts
@@ -24,7 +24,7 @@ export const CsatSurveyAutomaticRemoval: Story = {
       "LatestScanDateCsatSurvey",
       "AutomaticRemovalCsatSurvey",
     ],
-    experimentData: defaultExperimentData,
+    experimentData: defaultExperimentData["Features"],
     hasAutoFixedDataBrokers: true,
     elapsedTimeInDaysSinceInitialScan: 0,
   },
@@ -40,7 +40,7 @@ export const CsatSurveyLatestScanDate: Story = {
     lastScanDate: new Date(Date.UTC(2024, 6, 31)),
     enabledFeatureFlags: ["LatestScanDateCsatSurvey"],
     experimentData: {
-      ...defaultExperimentData,
+      ...defaultExperimentData["Features"],
       "last-scan-date": {
         enabled: true,
       },

--- a/src/app/components/client/stories/UpsellCta.stories.tsx
+++ b/src/app/components/client/stories/UpsellCta.stories.tsx
@@ -38,7 +38,7 @@ const UpsellCtaWrapper = (props: UpsellCtaWrapperProps) => {
             subscriptionBillingAmount={subscriptionBillingAmount}
             lastScanDate={new Date(Date.UTC(1998, 2, 31))}
             experimentData={{
-              ...defaultExperimentData,
+              ...defaultExperimentData["Features"],
               "last-scan-date": {
                 enabled: true,
               },

--- a/src/app/components/client/toolbar/Toolbar.tsx
+++ b/src/app/components/client/toolbar/Toolbar.tsx
@@ -22,7 +22,7 @@ export type Props = {
   };
   fxaSettingsUrl: string;
   lastScanDate: Date | null;
-  experimentData: ExperimentData;
+  experimentData: ExperimentData["Features"];
   children?: ReactNode;
   autoOpenUpsellDialog?: boolean;
 };

--- a/src/app/components/client/toolbar/UpsellBadge.tsx
+++ b/src/app/components/client/toolbar/UpsellBadge.tsx
@@ -169,7 +169,7 @@ export type UpsellBadgeProps = UpsellButtonProps & {
    * at more experiments in the future, make sure to remove the `?` so that
    * they're actually passed everywhere.
    */
-  experimentData?: ExperimentData;
+  experimentData?: ExperimentData["Features"];
   autoOpenUpsellDialog?: boolean;
 };
 export function UpsellBadge(props: UpsellBadgeProps) {

--- a/src/app/functions/server/getExperiments.ts
+++ b/src/app/functions/server/getExperiments.ts
@@ -59,7 +59,6 @@ export async function getExperiments(params: {
 
     const experimentData = await response.json();
 
-    console.debug("experimentData:", experimentData);
     return (
       (experimentData as ExperimentData["Features"]) ??
       defaultExperimentData["Features"]

--- a/src/app/functions/server/getExperiments.ts
+++ b/src/app/functions/server/getExperiments.ts
@@ -69,9 +69,9 @@ export async function getExperiments(params: {
 
     let experimentData;
     if (flags.includes("CirrusV2")) {
-      experimentData = json;
-    } else {
       experimentData = json["Features"];
+    } else {
+      experimentData = json;
     }
 
     return (

--- a/src/app/functions/server/getExperiments.ts
+++ b/src/app/functions/server/getExperiments.ts
@@ -35,7 +35,7 @@ export async function getExperiments(params: {
   if (!process.env.NIMBUS_SIDECAR_URL) {
     throw new Error("env var NIMBUS_SIDECAR_URL not set");
   }
-  const serverUrl = new URL(`${process.env.NIMBUS_SIDECAR_URL}/v1/features`);
+  const serverUrl = new URL(`${process.env.NIMBUS_SIDECAR_URL}/v2/features`);
 
   try {
     if (params.previewMode === true) {

--- a/src/app/functions/server/getExperiments.ts
+++ b/src/app/functions/server/getExperiments.ts
@@ -27,9 +27,9 @@ export async function getExperiments(params: {
   locale: string;
   countryCode: string;
   previewMode: boolean;
-}): Promise<ExperimentData> {
+}): Promise<ExperimentData["Features"]> {
   if (["local"].includes(process.env.APP_ENV ?? "local")) {
-    return localExperimentData;
+    return localExperimentData["Features"];
   }
 
   if (!process.env.NIMBUS_SIDECAR_URL) {
@@ -59,10 +59,14 @@ export async function getExperiments(params: {
 
     const experimentData = await response.json();
 
-    return (experimentData as ExperimentData) ?? defaultExperimentData;
+    console.debug("experimentData:", experimentData);
+    return (
+      (experimentData as ExperimentData["Features"]) ??
+      defaultExperimentData["Features"]
+    );
   } catch (ex) {
     logger.error("Could not connect to Cirrus", { serverUrl, ex });
     captureException(ex);
-    return defaultExperimentData;
+    return defaultExperimentData["Features"];
   }
 }

--- a/src/app/functions/universal/getFreeScanSearchParams.ts
+++ b/src/app/functions/universal/getFreeScanSearchParams.ts
@@ -39,7 +39,7 @@ export function getFreeScanSearchParams({
   experimentData,
 }: SearchParamArgs &
   Omit<MetricFlowParams, "entrypointExperiment" | "entrypointVariation"> & {
-    experimentData?: ExperimentData;
+    experimentData?: ExperimentData["Features"];
   }) {
   const attributionSearchParams = modifyAttributionsForUrlSearchParams(
     new URLSearchParams(cookies.attributionsFirstTouch ?? FREE_SCAN_UTM_PARAMS),

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -55,6 +55,7 @@ export const featureFlagNames = [
   "DataBrokerRemovalTimeEstimateCsat",
   "SettingsPageRedesign",
   "EnableRemovalUnderMaintenanceStep",
+  "CirrusV2",
 ] as const;
 export type FeatureFlagName = (typeof featureFlagNames)[number];
 

--- a/src/db/tables/subscribers.ts
+++ b/src/db/tables/subscribers.ts
@@ -417,9 +417,10 @@ async function getPlusSubscribersWaitingForMonthlyEmail(
 
 // Not covered by tests; mostly side-effects. See test-coverage.md#mock-heavy
 /* c8 ignore start */
-async function getFreeSubscribersWaitingForMonthlyEmail(): Promise<
-  SubscriberRow[]
-> {
+async function getFreeSubscribersWaitingForMonthlyEmail(
+  batchSize: number,
+  countryCodes: string[],
+): Promise<SubscriberRow[]> {
   const flag = await getFeatureFlagData("MonthlyReportFreeUser");
   const accountCutOffDate = parseIso8601Datetime(
     process.env.MONTHLY_ACTIVITY_FREE_EMAIL_ACCOUNT_CUTOFF_DATE ??
@@ -438,6 +439,24 @@ async function getFreeSubscribersWaitingForMonthlyEmail(): Promise<
 
   let query = knex("subscribers")
     .select<SubscriberRow[]>("subscribers.*")
+    .select(
+      knex.raw(
+        `CASE
+        WHEN (fxa_profile_json->>'locale') ~ ',' THEN
+          CASE
+            WHEN split_part(fxa_profile_json->>'locale', ',', 1) ~ '-' THEN
+              split_part(split_part(fxa_profile_json->>'locale', ',', 1), '-', 2) -- Extract country code from first part
+            ELSE
+              split_part(fxa_profile_json->>'locale', ',', 1) -- Fallback to the language code
+          END
+        WHEN (fxa_profile_json->>'locale') ~ '-' THEN
+          split_part(fxa_profile_json->>'locale', '-', 2) -- Extract country code if present
+        ELSE
+          fxa_profile_json->>'locale' -- Fallback to the language code
+      END AS country_code`,
+      ),
+    )
+
     .leftJoin(
       "subscriber_email_preferences",
       "subscribers.id",
@@ -494,16 +513,17 @@ async function getFreeSubscribersWaitingForMonthlyEmail(): Promise<
     // https://github.com/knex/knex/issues/1881#issuecomment-275433906
     query = query.whereIn("subscribers.primary_email", flag.allow_list);
   }
-  // One thing to note as being absent from this query: a LIMIT clause.
-  // The reason for this is that we want to filter out people who had
-  // a language other than `en-US` set when signing up, but to do so,
-  // we need to parse the `accept-language` field, which we can only
-  // do after we have the query results. Thus, if we were to limit
-  // the result of this query, we would at some point end up filtering
-  // every returned row, and then never moving on to the rows after that.
-  const rows = await query;
 
-  return rows;
+  const wrappedQuery = knex
+    // @ts-ignore TODO MNTOR-3890 Move away from this approach and simplify query.
+    .from({ base_query: query }) // Use the existing query as a subquery
+    .select("*")
+    .whereIn("country_code", countryCodes)
+    .limit(batchSize);
+
+  const rows = await wrappedQuery;
+
+  return rows as SubscriberRow[];
 }
 /* c8 ignore stop */
 

--- a/src/scripts/build/nimbusTypes.js
+++ b/src/scripts/build/nimbusTypes.js
@@ -4,6 +4,7 @@
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { parse } from "yaml";
+import * as prettier from "prettier";
 
 run();
 
@@ -68,7 +69,10 @@ async function run() {
     "\n" +
     getLocalOverrides(nimbusConfig);
   await mkdir("src/telemetry/generated/nimbus/", { recursive: true });
-  await writeFile("src/telemetry/generated/nimbus/experiments.ts", typedef);
+  await writeFile(
+    "src/telemetry/generated/nimbus/experiments.ts",
+    await prettier.format(typedef, { parser: "typescript" }),
+  );
 }
 
 /**

--- a/src/scripts/build/nimbusTypes.js
+++ b/src/scripts/build/nimbusTypes.js
@@ -91,7 +91,19 @@ function getFallbackObject(nimbusConfig) {
     },
   );
 
-  return `export const defaultExperimentData: ExperimentData = {\n${featureFallbackDefs.join("\n")}};\n`;
+  const defaultExperimentData = `
+    "Features": {
+      ${featureFallbackDefs.join("\n")}
+    },
+    "Enrollments": {
+      "nimbus_user_id": "-1",
+      "app_id": "-1",
+      "experiment": "-1",
+      "branch": "-1",
+      "experiment_type": "-1",
+      "is_preview": false
+    }`;
+  return `export const defaultExperimentData: ExperimentData = {\n${defaultExperimentData}};\n`;
 }
 
 /**
@@ -108,11 +120,24 @@ function getLocalOverrides(nimbusConfig) {
         typeof localOverrides === "undefined"
           ? ""
           : `    ...${JSON.stringify(localOverrides.value, null, 2).replaceAll("\n", "\n    ")}\n`;
-      return `  "${featureId}": {\n    ...defaultExperimentData["${featureId}"],\n${overriddenValuesDef}  },\n`;
+      return `  "${featureId}": {\n    ...defaultExperimentData["Features"]["${featureId}"],\n${overriddenValuesDef}  },\n`;
     },
   );
 
-  return `export const localExperimentData: ExperimentData = {\n${featureLocalOverridesDefs.join("\n")}};\n`;
+  const localExperimentData = `
+  "Features": {
+    ${featureLocalOverridesDefs.join("\n")}
+  },
+  "Enrollments": {
+    "nimbus_user_id": "-1",
+    "app_id": "-1",
+    "experiment": "-1",
+    "branch": "-1",
+    "experiment_type": "-1",
+    "is_preview": false
+  }`;
+
+  return `export const localExperimentData: ExperimentData = {\n${localExperimentData}};\n`;
 }
 
 /**
@@ -129,7 +154,20 @@ function getFeaturesTypeDef(nimbusConfig) {
     });
     return `  "${featureId}": {\n${variableDefs.join("")}  };\n`;
   });
-  const experimentDataTypeDef = `/** Status of experiments, as setup in Experimenter */\nexport type ExperimentData = {\n${featureDefs.join("")}};\n`;
+
+  const experimentDataType = `{
+  "Features": {${featureDefs.join("")}};
+  "Enrollments": {
+    "nimbus_user_id": string,
+    "app_id": string,
+    "experiment": string,
+    "branch": string,
+    "experiment_type": string,
+    "is_preview": boolean
+    };
+  };`;
+
+  const experimentDataTypeDef = `/** Status of experiments, as setup in Experimenter */\nexport type ExperimentData = ${experimentDataType}`;
   const featureTypeDef =
     getStringAliases(nimbusConfig) +
     "\n\n" +

--- a/src/scripts/cronjobs/monthlyActivityFree.tsx
+++ b/src/scripts/cronjobs/monthlyActivityFree.tsx
@@ -28,12 +28,10 @@ async function run() {
   const batchSize = MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE;
 
   logger.info(`Getting free subscribers with batch size: ${batchSize}`);
-  const subscribersToEmail = (await getFreeSubscribersWaitingForMonthlyEmail())
-    .filter((subscriber) => {
-      const assumedCountryCode = getSignupLocaleCountry(subscriber);
-      return assumedCountryCode === "us";
-    })
-    .slice(0, batchSize);
+  const subscribersToEmail = await getFreeSubscribersWaitingForMonthlyEmail(
+    batchSize,
+    ["US"],
+  );
   await initEmail();
 
   for (const subscriber of subscribersToEmail) {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3812

<!-- When adding a new feature: -->

# Description

Switch to the Cirrus v2 output. This requires changing the code that generates types based on the `nimbus.yaml`.

This is a bit cumbersome to do by hand, we should consider using some pre-existing code-generation tool for
this, but I think it works well enough for now. I can file a followup tech debt ticket for that.

# How to test

Cirrus is used by just about every part of Monitor including the front page, so it's hard to miss. We also have unit test coverage.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
