### PR TITLE
MNTOR-3857: rework to utilize env var if possible/correct

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,5 +46,3 @@ export const CONST_SETTINGS_TAB_SLUGS = [
   "notifications",
   "manage-account",
 ] as const;
-
-export const MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE = 5;

--- a/src/scripts/cronjobs/monthlyActivityFree.tsx
+++ b/src/scripts/cronjobs/monthlyActivityFree.tsx
@@ -19,13 +19,21 @@ import createDbConnection from "../../db/connect";
 import { logger } from "../../app/functions/server/logging";
 import { getMonthlyActivityFreeUnsubscribeLink } from "../../app/functions/cronjobs/unsubscribeLinks";
 import { hasPremium } from "../../app/functions/universal/user";
-import { MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE } from "../../constants";
 
 await run();
 await createDbConnection().destroy();
 
 async function run() {
-  const batchSize = MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE;
+  let batchSize = Number.parseInt(
+    process.env.MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE ?? "10",
+    10,
+  );
+  if (Number.isNaN(batchSize)) {
+    batchSize = 10;
+    logger.warn(
+      `Could not send monthly activity emails, because the env var MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE has a non-numeric value: [${process.env.MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE}].`,
+    );
+  }
 
   logger.info(`Getting free subscribers with batch size: ${batchSize}`);
   const subscribersToEmail = (await getFreeSubscribersWaitingForMonthlyEmail())


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3857

<!-- When adding a new feature: -->

# Description
Revert the hardcoded value for `MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE` and utilize the env var if available
# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
