### PR TITLE
Add floating labels to InputField

### DIFF
--- a/src/app/components/client/InputField.module.scss
+++ b/src/app/components/client/InputField.module.scss
@@ -7,14 +7,46 @@
   flex-direction: column;
   position: relative;
 
+  .inputFieldWrapper {
+    position: relative;
+  }
+
+  .placeholder {
+    background: $color-white;
+    border-radius: $border-radius-sm;
+    color: $color-grey-40;
+    display: inline-block;
+    left: calc($spacing-sm + $spacing-xs);
+    line-height: 1em;
+    padding: 0 calc($spacing-xs * 0.5);
+    pointer-events: none;
+    position: absolute;
+    top: 50%;
+    transform-origin: top left;
+    transform: translateY(-50%) scale(1);
+    transition: transform 0.2s ease-in-out;
+    user-select: none;
+  }
+
+  &:focus-within,
+  &:not(:has(:placeholder-shown)) {
+    .placeholder {
+      transform: translateY(-205%) scale(0.875);
+    }
+  }
+
   .inputField {
     border: 1px solid $color-grey-30;
     border-radius: $border-radius-sm;
     color: $color-black;
     // Add a bit more vertical space: The next spacing step is too much.
     padding: calc($spacing-sm * 1.5) $spacing-md;
+    width: 100%;
 
-    &::placeholder,
+    &::placeholder {
+      @include visually-hidden;
+    }
+
     &.noValue {
       color: $color-grey-40;
     }

--- a/src/app/components/client/InputField.module.scss
+++ b/src/app/components/client/InputField.module.scss
@@ -16,7 +16,7 @@
     border-radius: $border-radius-sm;
     color: $color-black;
     display: inline-block;
-    left: calc($spacing-sm + $spacing-xs);
+    left: $spacing-md;
     line-height: 1em;
     padding: 0 calc($spacing-xs * 0.5);
     pointer-events: none;
@@ -28,13 +28,6 @@
     user-select: none;
   }
 
-  &:focus-within,
-  &:not(:has(:placeholder-shown)) {
-    .floatingLabel {
-      transform: translateY(-205%) scale(0.875);
-    }
-  }
-
   .inputField {
     border: 1px solid $color-grey-30;
     border-radius: $border-radius-sm;
@@ -42,10 +35,6 @@
     // Add a bit more vertical space: The next spacing step is too much.
     padding: calc($spacing-sm * 1.5) $spacing-md;
     width: 100%;
-
-    &::placeholder {
-      @include visually-hidden;
-    }
 
     &.noValue {
       color: $color-grey-40;
@@ -68,6 +57,29 @@
     &:disabled {
       background: none;
       border: 1px solid $color-grey-10;
+    }
+  }
+
+  &:has(.floatingLabel) {
+    &::placeholder {
+      @include visually-hidden;
+    }
+
+    .inputField {
+      padding: $spacing-md;
+    }
+  }
+
+  &:focus-within,
+  &:not(:has(:placeholder-shown)) {
+    &:has(.floatingLabel) {
+      .inputField {
+        padding: calc($spacing-md + $spacing-sm) $spacing-md $spacing-sm;
+      }
+    }
+
+    .floatingLabel {
+      transform: translateY(-125%) scale(0.75);
     }
   }
 

--- a/src/app/components/client/InputField.module.scss
+++ b/src/app/components/client/InputField.module.scss
@@ -11,10 +11,10 @@
     position: relative;
   }
 
-  .placeholder {
+  .floatingLabel {
     background: $color-white;
     border-radius: $border-radius-sm;
-    color: $color-grey-40;
+    color: $color-black;
     display: inline-block;
     left: calc($spacing-sm + $spacing-xs);
     line-height: 1em;
@@ -30,7 +30,7 @@
 
   &:focus-within,
   &:not(:has(:placeholder-shown)) {
-    .placeholder {
+    .floatingLabel {
       transform: translateY(-205%) scale(0.875);
     }
   }

--- a/src/app/components/client/InputField.module.scss
+++ b/src/app/components/client/InputField.module.scss
@@ -16,14 +16,15 @@
     border-radius: $border-radius-sm;
     color: $color-black;
     display: inline-block;
-    left: $spacing-md;
+    // Add a bit more space: The next spacing step is too much.
+    left: calc($spacing-sm * 1.5);
     line-height: 1em;
     padding: 0 calc($spacing-xs * 0.5);
     pointer-events: none;
     position: absolute;
     top: 50%;
     transform-origin: top left;
-    transform: translateY(-50%) scale(1);
+    transform: translate(-0.05em, -50%) scale(1);
     transition: transform 0.2s ease-in-out;
     user-select: none;
   }
@@ -32,8 +33,8 @@
     border: 1px solid $color-grey-30;
     border-radius: $border-radius-sm;
     color: $color-black;
-    // Add a bit more vertical space: The next spacing step is too much.
-    padding: calc($spacing-sm * 1.5) $spacing-md;
+    // Add a bit more space: The next spacing step is too much.
+    padding: calc($spacing-sm * 1.5);
     width: 100%;
 
     &.noValue {
@@ -61,25 +62,21 @@
   }
 
   &:has(.floatingLabel) {
-    &::placeholder {
+    ::placeholder {
       @include visually-hidden;
     }
-
     .inputField {
-      padding: $spacing-md;
+      // Move the value string off-center.
+      padding: calc($spacing-md * 1.25) calc($spacing-sm * 1.5) $spacing-xs;
     }
   }
 
   &:focus-within,
   &:not(:has(:placeholder-shown)) {
-    &:has(.floatingLabel) {
-      .inputField {
-        padding: calc($spacing-md + $spacing-sm) $spacing-md $spacing-sm;
-      }
-    }
-
     .floatingLabel {
-      transform: translateY(-125%) scale(0.75);
+      color: $color-grey-40;
+      // Make the floating label visually align with the input value.
+      transform: translate(-0.05em, -115%) scale(0.75);
     }
   }
 

--- a/src/app/components/client/InputField.test.tsx
+++ b/src/app/components/client/InputField.test.tsx
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect } from "@jest/globals";
+import { render } from "@testing-library/react";
+import { composeStory } from "@storybook/react";
+import { axe } from "jest-axe";
+import Meta, {
+  TextInputFieldEmpty,
+  TextInputFieldEmptyFloatingLabel,
+  TextInputFieldFilled,
+  TextInputFieldFilledFloatingLabel,
+} from "./stories/InputField.stories";
+
+describe("InputField", () => {
+  test.each([
+    TextInputFieldEmpty,
+    TextInputFieldFilled,
+    TextInputFieldEmptyFloatingLabel,
+    TextInputFieldFilledFloatingLabel,
+  ])("passes the axe accessibility test suite for %s", async (component) => {
+    const ComposedInput = composeStory(component, Meta);
+    const { container } = render(<ComposedInput hasFloatingLabel />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/src/app/components/client/InputField.tsx
+++ b/src/app/components/client/InputField.tsx
@@ -38,13 +38,20 @@ export const InputField = (
           }
         </label>
       )}
-      <input
-        {...inputProps}
-        ref={inputRef}
-        className={`${styles.inputField} ${!value ? styles.noValue : ""} ${
-          isInvalid ? styles.hasError : ""
-        }`}
-      />
+      <span className={styles.inputFieldWrapper}>
+        <input
+          {...inputProps}
+          ref={inputRef}
+          className={`${styles.inputField} ${!value ? styles.noValue : ""} ${
+            isInvalid ? styles.hasError : ""
+          }`}
+        />
+        {inputProps.placeholder && (
+          <span aria-hidden className={styles.placeholder}>
+            {inputProps.placeholder}
+          </span>
+        )}
+      </span>
       {props.iconButton && (
         <div className={styles.buttonIcon}>{props.iconButton}</div>
       )}

--- a/src/app/components/client/InputField.tsx
+++ b/src/app/components/client/InputField.tsx
@@ -13,6 +13,7 @@ import { useL10n } from "../../hooks/l10n";
 export const InputField = (
   props: AriaTextFieldProps & {
     iconButton?: ReactNode;
+    hasFloatingLabel?: boolean;
   },
 ) => {
   const { isRequired, label, isInvalid, value, description } = props;
@@ -29,29 +30,23 @@ export const InputField = (
   return (
     <div className={styles.input}>
       {label && (
-        <label {...labelProps} className={styles.inputLabel}>
-          {label}
-          {
-            // TODO: Add unit test when changing this code:
-            /* c8 ignore next */
-            isRequired ? <span aria-hidden="true">*</span> : ""
+        <label
+          {...labelProps}
+          className={
+            props.hasFloatingLabel ? styles.floatingLabel : styles.inputLabel
           }
+        >
+          {label}
+          {isRequired ? <span aria-hidden="true">*</span> : ""}
         </label>
       )}
-      <span className={styles.inputFieldWrapper}>
-        <input
-          {...inputProps}
-          ref={inputRef}
-          className={`${styles.inputField} ${!value ? styles.noValue : ""} ${
-            isInvalid ? styles.hasError : ""
-          }`}
-        />
-        {inputProps.placeholder && (
-          <span aria-hidden className={styles.placeholder}>
-            {inputProps.placeholder}
-          </span>
-        )}
-      </span>
+      <input
+        {...inputProps}
+        ref={inputRef}
+        className={`${styles.inputField} ${!value ? styles.noValue : ""} ${
+          isInvalid ? styles.hasError : ""
+        }`}
+      />
       {props.iconButton && (
         <div className={styles.buttonIcon}>{props.iconButton}</div>
       )}

--- a/src/app/components/client/stories/InputField.stories.ts
+++ b/src/app/components/client/stories/InputField.stories.ts
@@ -81,3 +81,22 @@ export const DateInputFieldInvalidWithMessage: Story = {
     errorMessage: "Select a date",
   },
 };
+
+export const TextInputFieldEmptyFloatingLabel: Story = {
+  args: {
+    label: "Text input floating label",
+    placeholder: "Type here",
+    type: "text",
+    hasFloatingLabel: true,
+  },
+};
+
+export const TextInputFieldFilledFloatingLabel: Story = {
+  args: {
+    label: "Text input floating label",
+    placeholder: "Type here",
+    type: "text",
+    value: "Input is filled",
+    hasFloatingLabel: true,
+  },
+};


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-3823](https://mozilla-hub.atlassian.net/browse/MNTOR-3823)
Figma: https://www.figma.com/design/xa533LXIOuK6KG6vXGyysr/Landing-pages?node-id=778-24195&node-type=frame&t=2xnIBF0BzRra5ktH-0

<!-- When adding a new feature: -->

# Description

Introduces an option to have floating labels for the `InputField`. We are going to use them for the landing page redesign and ultimately update them on existing views.

# Screenshot

| Empty | Filled |
| --- | --- |
| <img width="392" alt="image" src="https://github.com/user-attachments/assets/311db5ff-1422-4f36-9db9-454c69657332" /> | <img width="391" alt="image" src="https://github.com/user-attachments/assets/e11fb93d-4229-4039-a981-fc73e25810f5" /> |

# How to test

They can be seen and tested in Storybook: `/?path=/story/design-systems-molecules-input-field--text-input-field-empty-floating-label`.
