### PR TITLE
MNTOR-3920: add new reactivate endpoint wrapper

### DIFF
--- a/src/utils/fxa.ts
+++ b/src/utils/fxa.ts
@@ -306,6 +306,50 @@ async function deleteSubscription(bearerToken: string): Promise<boolean> {
 
 // Not covered by tests; mostly side-effects. See test-coverage.md#mock-heavy
 /* c8 ignore start */
+async function reactivate(bearerToken: string): Promise<void> {
+  try {
+    const subs = (await getSubscriptions(bearerToken)) ?? [];
+    let subscriptionId;
+    for (const sub of subs) {
+      if (
+        sub &&
+        sub.productId &&
+        sub.productId === process.env.PREMIUM_PRODUCT_ID
+      ) {
+        subscriptionId = sub.subscriptionId;
+      }
+    }
+    if (subscriptionId) {
+      const reactivateSubscriptionUrl = `${envVars.OAUTH_ACCOUNT_URI}/oauth/subscriptions/reactivate`;
+      const response = await fetch(reactivateSubscriptionUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          Authorization: `Bearer ${bearerToken}`,
+        },
+        body: JSON.stringify({
+          subscriptionId,
+        }),
+      });
+      const responseJson = await response.json();
+      if (!response.ok) throw new Error(responseJson);
+      logger.info("reactivate_fxa_subscription_success");
+    }
+  } catch (e) {
+    if (e instanceof Error) {
+      logger.error("reactivate_fxa_subscription", {
+        stack: e.stack,
+        message: e.message,
+      });
+    }
+    throw e;
+  }
+}
+/* c8 ignore stop */
+
+// Not covered by tests; mostly side-effects. See test-coverage.md#mock-heavy
+/* c8 ignore start */
 async function applyCoupon(
   bearerToken: string,
   couponCodeId: string,
@@ -418,6 +462,7 @@ export {
   getSubscriptions,
   getBillingAndSubscriptions,
   deleteSubscription,
+  reactivate,
   applyCoupon,
   getAttachedClients,
 };


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3920

<!-- When adding a new feature: -->

# Description
POST call for reactivating a user's subscription via FxA

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
