### PR TITLE
Fix uploadToS3 import path

### DIFF
--- a/src/scripts/build/uploadAutoCompleteLocations.js
+++ b/src/scripts/build/uploadAutoCompleteLocations.js
@@ -27,6 +27,7 @@ import os from "os";
 import path from "path";
 import fs from "fs";
 import AdmZip from "adm-zip";
+import { uploadToS3 } from "../../utils/s3.js";
 
 const REMOTE_DATA_URL = "https://download.geonames.org/export/dump";
 const DATA_COUNTRY_CODE = "US";
@@ -328,7 +329,6 @@ try {
   if (process.argv.includes("--skip-upload")) {
     console.debug("Skipping S3 upload");
   } else {
-    const uploadToS3 = await import("../s3.js");
     await uploadToS3(`autocomplete/${LOCATIONS_DATA_FILE}`, readStream);
   }
 

--- a/src/utils/s3.js
+++ b/src/utils/s3.js
@@ -24,7 +24,11 @@ const s3 = new S3({
   },
 });
 
-export async function uploadToS3(fileName: string, fileStream: Buffer) {
+/**
+ * @param {string} fileName
+ * @param {Buffer} fileStream
+ */
+export async function uploadToS3(fileName, fileStream) {
   console.log("Attempt to upload to s3: ", fileName);
   const uploadParams = {
     Bucket,
@@ -37,7 +41,7 @@ export async function uploadToS3(fileName: string, fileStream: Buffer) {
       params: uploadParams,
     }).done();
     console.log("Successfully uploaded data to " + Bucket + "/" + fileName);
-  } catch (err) {
-    console.error(err, (err as Error).stack);
+  } catch (/** @type {any} */ err) {
+    console.error(err, err.stack);
   }
 }


### PR DESCRIPTION
This potentially fixes MNTOR-3922 as well, since the icon upload imported from the `.js` file: https://github.com/mozilla/blurts-server/blob/d91f5a5242282c7e65ee9d4b3f5180a4f6f68fc4/src/scripts/cronjobs/syncBreaches.ts#L22

I reverted `s3.ts` back to a JS file because it was still being imported from the JS upload script. Or at least, it was supposed to, as that had the wrong path.