### PR TITLE
Run sass-migrator

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/UserAdmin.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/UserAdmin.module.scss
@@ -1,20 +1,20 @@
-@import "../../../../../tokens";
+@use "../../../../../tokens";
 
 .wrapper {
   display: flex;
   flex-direction: column;
-  gap: $spacing-2xl;
-  background-color: $color-grey-05;
+  gap: tokens.$spacing-2xl;
+  background-color: tokens.$color-grey-05;
   height: 100%;
-  padding: $layout-lg $layout-2xl;
+  padding: tokens.$layout-lg tokens.$layout-2xl;
 
-  @media screen and (max-width: $screen-lg) {
-    padding: $spacing-lg;
+  @media screen and (max-width: tokens.$screen-lg) {
+    padding: tokens.$spacing-lg;
   }
 }
 
 .header {
-  font: $text-title-xs;
+  font: tokens.$text-title-xs;
   font-weight: normal;
 
   b {
@@ -25,33 +25,33 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: $spacing-2xl;
+  gap: tokens.$spacing-2xl;
 
   .userPicker {
     flex: 1 0 auto;
     align-items: center;
     display: flex;
     flex-wrap: wrap;
-    gap: $spacing-2xl;
-    min-height: $layout-2xl;
+    gap: tokens.$spacing-2xl;
+    min-height: tokens.$layout-2xl;
 
     label {
       display: flex;
       flex-direction: column;
-      gap: $spacing-sm;
+      gap: tokens.$spacing-sm;
       min-width: 50%;
     }
 
     input {
-      padding: $spacing-sm;
-      font: $text-body-md;
+      padding: tokens.$spacing-sm;
+      font: tokens.$text-body-md;
     }
   }
 
   .actions {
     display: flex;
     flex-wrap: wrap;
-    gap: $spacing-xl;
+    gap: tokens.$spacing-xl;
 
     button {
       flex: 1 1 25%;
@@ -60,9 +60,9 @@
 }
 
 .status {
-  background-color: $color-yellow-05;
-  border: 2px solid $color-yellow-20;
-  border-radius: $border-radius-sm;
-  padding: $spacing-md $spacing-lg;
-  font: $text-body-md;
+  background-color: tokens.$color-yellow-05;
+  border: 2px solid tokens.$color-yellow-20;
+  border-radius: tokens.$border-radius-sm;
+  padding: tokens.$spacing-md tokens.$spacing-lg;
+  font: tokens.$text-body-md;
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/EmailTrigger.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/EmailTrigger.module.scss
@@ -1,35 +1,35 @@
-@import "../../../../../tokens";
+@use "../../../../../tokens";
 
 .wrapper {
   display: flex;
   flex-direction: column;
-  gap: $spacing-2xl;
-  background-color: $color-grey-05;
+  gap: tokens.$spacing-2xl;
+  background-color: tokens.$color-grey-05;
   height: 100%;
-  padding: $layout-lg $layout-2xl;
+  padding: tokens.$layout-lg tokens.$layout-2xl;
 
-  @media screen and (max-width: $screen-lg) {
-    padding: $spacing-lg;
+  @media screen and (max-width: tokens.$screen-lg) {
+    padding: tokens.$spacing-lg;
   }
 }
 
 .addressSection {
   display: flex;
   flex-direction: column;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
 
   .addressPicker {
     display: flex;
     align-items: center;
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
 
     label {
-      font: $text-body-lg;
+      font: tokens.$text-body-lg;
       font-weight: 700;
     }
 
     select {
-      padding: $spacing-sm;
+      padding: tokens.$spacing-sm;
     }
   }
 }
@@ -37,5 +37,5 @@
 .triggers {
   display: flex;
   flex-wrap: wrap;
-  gap: $spacing-lg;
+  gap: tokens.$spacing-lg;
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/components/FlagEditor.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/components/FlagEditor.module.scss
@@ -1,32 +1,32 @@
-@import "../../../../../../tokens";
+@use "../../../../../../tokens";
 
 .flagWrapper {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
-  background-color: $color-white;
-  padding: $spacing-lg;
-  border-radius: $border-radius-md;
-  max-width: $content-sm;
+  gap: tokens.$spacing-lg;
+  background-color: tokens.$color-white;
+  padding: tokens.$spacing-lg;
+  border-radius: tokens.$border-radius-md;
+  max-width: tokens.$content-sm;
 }
 
 .flagName {
-  font: $text-title-3xs;
+  font: tokens.$text-title-3xs;
 }
 
 .enabledControl {
   display: flex;
-  gap: $spacing-xs;
-  font: $text-body-lg;
+  gap: tokens.$spacing-xs;
+  font: tokens.$text-body-lg;
 }
 
 .allowListWrapper {
   display: flex;
   flex-direction: column;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
   h4 {
-    font: $text-body-md;
+    font: tokens.$text-body-md;
     font-weight: bold;
   }
 }
@@ -35,7 +35,7 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  gap: $spacing-xs;
+  gap: tokens.$spacing-xs;
   padding: 0;
   list-style-type: none;
 }
@@ -43,8 +43,8 @@
 .addressListing {
   display: flex;
   align-items: center;
-  gap: $spacing-xs;
-  font: $text-body-md;
+  gap: tokens.$spacing-xs;
+  font: tokens.$text-body-md;
   font-family: monospace;
 
   :first-child {
@@ -54,25 +54,25 @@
   button {
     background-color: transparent;
     border: none;
-    border-radius: $border-radius-xl;
+    border-radius: tokens.$border-radius-xl;
     aspect-ratio: 1;
 
     &:hover {
       cursor: pointer;
-      background-color: $color-red-70;
-      color: $color-white;
+      background-color: tokens.$color-red-70;
+      color: tokens.$color-white;
     }
   }
 
   &:has(button:hover) {
-    color: $color-red-70;
+    color: tokens.$color-red-70;
   }
 }
 
 .addressAdder {
   display: flex;
   align-items: center;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
 
   input[type="email"] {
     flex-grow: 1;
@@ -87,15 +87,15 @@
     align-items: center;
     height: 100%;
     background-color: transparent;
-    color: $color-blue-50;
+    color: tokens.$color-blue-50;
     border: none;
-    border-radius: $border-radius-sm;
-    padding: $spacing-sm;
+    border-radius: tokens.$border-radius-sm;
+    padding: tokens.$spacing-sm;
 
     &:hover {
       cursor: pointer;
-      background-color: $color-blue-50;
-      color: $color-white;
+      background-color: tokens.$color-blue-50;
+      color: tokens.$color-white;
     }
   }
   /* stylelint-enable no-descending-specificity */

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/page.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/page.module.scss
@@ -1,14 +1,14 @@
-@import "../../../../../tokens";
+@use "../../../../../tokens";
 
 .wrapper {
   width: 100%;
   height: 100%;
-  background-color: $color-grey-05;
+  background-color: tokens.$color-grey-05;
   overflow: auto;
 
   .tabBar {
-    height: $tab-bar-height;
-    border-bottom: 1px solid $color-grey-20;
+    height: tokens.$tab-bar-height;
+    border-bottom: 1px solid tokens.$color-grey-20;
     display: flex;
     align-items: center;
 
@@ -16,14 +16,14 @@
       flex: 1 0 auto;
       display: flex;
       align-items: center;
-      padding-inline: $spacing-2xl;
+      padding-inline: tokens.$spacing-2xl;
     }
 
     .end {
-      padding-inline: $spacing-xl;
+      padding-inline: tokens.$spacing-xl;
     }
 
-    @media screen and (max-width: $screen-md) {
+    @media screen and (max-width: tokens.$screen-md) {
       .start {
         justify-content: center;
       }
@@ -35,7 +35,7 @@
   }
 
   .main {
-    padding: $spacing-lg 0;
+    padding: tokens.$spacing-lg 0;
   }
 
   th,
@@ -45,15 +45,15 @@
   }
 
   h3 {
-    padding: 0 $spacing-2xl;
-    font: $text-title-2xs;
+    padding: 0 tokens.$spacing-2xl;
+    font: tokens.$text-title-2xs;
   }
 }
 
 .flagList {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax($content-xs, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(tokens.$content-xs, 1fr));
   justify-content: flex-start;
-  gap: $spacing-lg;
-  padding: $spacing-2xl;
+  gap: tokens.$spacing-lg;
+  padding: tokens.$spacing-2xl;
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/qa-customs/ConfigPage.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/qa-customs/ConfigPage.module.scss
@@ -1,12 +1,12 @@
-@import "../../../../../tokens";
+@use "../../../../../tokens";
 
 .wrapper {
   display: grid;
   grid-template-rows: 120px min-content;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
   height: 100%;
-  padding: $layout-sm;
-  background-color: $color-grey-05;
+  padding: tokens.$layout-sm;
+  background-color: tokens.$color-grey-05;
   align-items: center;
   justify-content: center;
 }
@@ -17,7 +17,7 @@
 }
 
 .header {
-  font: $text-title-xs;
+  font: tokens.$text-title-xs;
   font-weight: normal;
   margin: auto;
   width: 100%;
@@ -28,8 +28,8 @@
 }
 
 .formAndListWrapper {
-  gap: $spacing-md;
-  margin-top: $spacing-lg;
+  gap: tokens.$spacing-md;
+  margin-top: tokens.$spacing-lg;
   display: grid;
   grid-template-rows: 1fr;
   grid-template-columns: 1fr 1fr;
@@ -63,7 +63,7 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
 }
 
 .searchBox {
@@ -134,7 +134,7 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
   align-items: center;
   width: min-content;
 
@@ -143,20 +143,20 @@
     align-items: center;
     display: flex;
     flex-wrap: wrap;
-    gap: $spacing-md;
-    min-height: $layout-md;
+    gap: tokens.$spacing-md;
+    min-height: tokens.$layout-md;
 
     label {
       display: flex;
       flex-direction: column;
-      gap: $spacing-sm;
+      gap: tokens.$spacing-sm;
       min-width: 50%;
       width: 350px;
     }
 
     input {
-      padding: $spacing-sm;
-      font: $text-body-md;
+      padding: tokens.$spacing-sm;
+      font: tokens.$text-body-md;
       transition: border-color 0.3s ease;
     }
   }
@@ -196,7 +196,7 @@
 
 .configContainer {
   display: flex;
-  background-color: $color-grey-05;
+  background-color: tokens.$color-grey-05;
 }
 
 .configLeft {

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/removals/Removals.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/removals/Removals.module.scss
@@ -1,20 +1,20 @@
-@import "../../../../../tokens";
+@use "../../../../../tokens";
 
 .wrapper {
   display: flex;
   flex-direction: column;
-  gap: $spacing-2xl;
-  background-color: $color-grey-05;
+  gap: tokens.$spacing-2xl;
+  background-color: tokens.$color-grey-05;
   height: 100%;
-  padding: $layout-lg $layout-2xl;
+  padding: tokens.$layout-lg tokens.$layout-2xl;
 
-  @media screen and (max-width: $screen-lg) {
-    padding: $spacing-lg;
+  @media screen and (max-width: tokens.$screen-lg) {
+    padding: tokens.$spacing-lg;
   }
 }
 
 .header {
-  font: $text-title-xs;
+  font: tokens.$text-title-xs;
   font-weight: normal;
 
   b {

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBanner.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBanner.module.scss
@@ -1,19 +1,19 @@
-@import "../../../../../../../tokens";
+@use "../../../../../../../tokens";
 
 .container {
-  background-color: $color-white;
+  background-color: tokens.$color-white;
   background-image: url("../images/dashboard-top-banner-wave.svg");
   background-position: center;
   background-size: cover;
-  border-radius: $border-radius-md;
-  border: 1px solid rgba($color-purple-50, 0.2);
+  border-radius: tokens.$border-radius-md;
+  border: 1px solid rgba(tokens.$color-purple-50, 0.2);
   display: flex;
   flex-direction: column-reverse;
-  gap: $layout-sm;
-  padding: $layout-xs;
+  gap: tokens.$layout-sm;
+  padding: tokens.$layout-xs;
 
-  @media screen and (min-width: $screen-lg) {
-    padding: $layout-md;
+  @media screen and (min-width: tokens.$screen-lg) {
+    padding: tokens.$layout-md;
     flex-direction: row;
     align-items: center;
   }
@@ -22,7 +22,7 @@
     display: flex;
     justify-content: center;
 
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: tokens.$screen-md) {
       flex: 1 1 0%;
     }
   }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBannerContent.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBannerContent.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../../../../tokens";
+@use "../../../../../../../tokens";
 
 .explainerContentWrapper {
   align-items: center;
@@ -6,7 +6,7 @@
   justify-content: center;
   flex: 1 1 0%;
 
-  @media screen and (min-width: $screen-sm) and (max-width: calc($screen-md - 1px)) {
+  @media screen and (min-width: tokens.$screen-sm) and (max-width: calc(tokens.$screen-md - 1px)) {
     justify-content: center;
     flex: 0.5 1 0%;
     text-align: center;
@@ -14,27 +14,27 @@
 
   .explainerContent {
     display: flex;
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
     flex-direction: column;
 
-    @media screen and (min-width: $screen-md) {
-      max-width: $content-sm;
+    @media screen and (min-width: tokens.$screen-md) {
+      max-width: tokens.$content-sm;
     }
 
     h3 {
-      font: $text-title-2xs;
+      font: tokens.$text-title-2xs;
     }
 
     .cta {
       align-self: start;
 
-      @media screen and (min-width: $screen-sm) and (max-width: calc($screen-md - 1px)) {
+      @media screen and (min-width: tokens.$screen-sm) and (max-width: calc(tokens.$screen-md - 1px)) {
         align-self: center;
       }
 
-      @media screen and (max-width: calc($screen-md - 1px)) {
+      @media screen and (max-width: calc(tokens.$screen-md - 1px)) {
         display: grid;
-        max-width: $content-sm;
+        max-width: tokens.$content-sm;
         width: 100%;
       }
     }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/View.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/View.module.scss
@@ -1,35 +1,35 @@
-@import "../../../../../../tokens";
+@use "../../../../../../tokens";
 
 .wrapper {
   width: 100%;
   height: 100%;
-  background-color: $color-grey-05;
+  background-color: tokens.$color-grey-05;
 }
 
 .dashboardContent {
-  padding-block: $spacing-2xl;
-  padding-inline: $spacing-xl;
+  padding-block: tokens.$spacing-2xl;
+  padding-inline: tokens.$spacing-xl;
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
+  gap: tokens.$spacing-lg;
 }
 
 .exposuresArea {
   display: flex;
   flex-direction: column;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
 
   .exposuresAreaHeadline {
-    font: $text-body-xl;
+    font: tokens.$text-body-xl;
     font-weight: 600;
   }
 
   .exposuresAreaDescription {
-    font: $text-body-md;
+    font: tokens.$text-body-md;
   }
 
   .exposuresFilterWrapper {
-    padding-block: $spacing-md;
+    padding-block: tokens.$spacing-md;
   }
 }
 
@@ -38,17 +38,17 @@
   padding-inline: 0;
   display: flex;
   flex-direction: column;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 }
 
 .zeroStateIndicator {
   display: flex;
   align-items: center;
   flex-direction: column;
-  gap: $spacing-sm;
-  padding: $spacing-md;
+  gap: tokens.$spacing-sm;
+  padding: tokens.$spacing-md;
 }
 
 .visuallyHidden {
-  @include visually-hidden;
+  @include tokens.visually-hidden;
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/ResolutionContainer.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/ResolutionContainer.module.scss
@@ -1,16 +1,16 @@
-@import "../../../../../../../tokens";
+@use "../../../../../../../tokens";
 
 .container {
   display: grid;
-  grid-gap: $layout-lg;
+  grid-gap: tokens.$layout-lg;
   flex-direction: row;
 
-  @media screen and (min-width: $screen-xl) {
-    padding-inline: $layout-lg;
+  @media screen and (min-width: tokens.$screen-xl) {
+    padding-inline: tokens.$layout-lg;
   }
 
   &.hasIllustration {
-    @media screen and (min-width: $screen-xl) {
+    @media screen and (min-width: tokens.$screen-xl) {
       grid-template-columns: 2fr 1fr;
     }
   }
@@ -18,55 +18,55 @@
   .breachContentWrapper {
     display: flex;
     flex-direction: column;
-    gap: $spacing-sm;
+    gap: tokens.$spacing-sm;
 
     .label {
       align-self: flex-start;
-      background: rgba($color-blue-50, 0.3);
-      border-radius: $border-radius-sm;
-      color: $color-blue-90;
+      background: rgba(tokens.$color-blue-50, 0.3);
+      border-radius: tokens.$border-radius-sm;
+      color: tokens.$color-blue-90;
       display: inline-flex;
-      font: $text-body-xs;
+      font: tokens.$text-body-xs;
       font-weight: 600;
       line-height: 1;
-      padding: $spacing-sm;
+      padding: tokens.$spacing-sm;
     }
 
     h3 {
-      font: $text-title-2xs;
-      padding: $spacing-sm 0 $spacing-xs;
+      font: tokens.$text-title-2xs;
+      padding: tokens.$spacing-sm 0 tokens.$spacing-xs;
     }
 
     .recommendations {
       p {
-        font: $text-body-sm;
+        font: tokens.$text-body-sm;
       }
       ol {
-        padding-top: $spacing-md;
+        padding-top: tokens.$spacing-md;
         list-style-position: inside;
         padding-left: 0;
       }
-      padding-top: $spacing-md;
+      padding-top: tokens.$spacing-md;
     }
 
     .buttons {
-      padding-top: $spacing-md;
+      padding-top: tokens.$spacing-md;
       display: flex;
-      gap: $spacing-md;
+      gap: tokens.$spacing-md;
       align-items: center;
     }
 
     .breachItemsWrapper {
       display: flex;
       flex-wrap: wrap;
-      gap: $spacing-xs;
+      gap: tokens.$spacing-xs;
 
       .breachItem {
-        font: $text-body-sm;
+        font: tokens.$text-body-sm;
         font-weight: 600;
-        background: $color-grey-10;
-        padding: $spacing-xs $spacing-sm;
-        border-radius: $border-radius-md;
+        background: tokens.$color-grey-10;
+        padding: tokens.$spacing-xs tokens.$spacing-sm;
+        border-radius: tokens.$border-radius-md;
 
         .date {
           font-weight: 400;
@@ -76,8 +76,8 @@
   }
 
   .estimatedTime {
-    @include estimated-time;
-    padding-top: $layout-xs;
+    @include tokens.estimated-time;
+    padding-top: tokens.$layout-xs;
   }
 
   .illustrationWrapper {
@@ -86,7 +86,7 @@
     &.hideOnMobile {
       display: none;
 
-      @media screen and (min-width: $screen-xl) {
+      @media screen and (min-width: tokens.$screen-xl) {
         display: flex;
       }
     }
@@ -98,10 +98,10 @@
 
   .doneContentWrapper {
     display: grid;
-    gap: $layout-xs;
+    gap: tokens.$layout-xs;
     grid-template-columns: 1fr;
 
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: tokens.$screen-md) {
       grid-template-columns: 1fr 1fr;
     }
 
@@ -109,7 +109,7 @@
       align-items: flex-start;
       display: flex;
       flex-direction: column;
-      gap: $spacing-md;
+      gap: tokens.$spacing-md;
     }
   }
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/ResolutionContent.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/ResolutionContent.module.scss
@@ -1,17 +1,17 @@
-@import "../../../../../../../tokens";
+@use "../../../../../../../tokens";
 
 .recommendations {
-  padding-top: $spacing-md;
+  padding-top: tokens.$spacing-md;
   p {
-    font: $text-body-sm;
+    font: tokens.$text-body-sm;
   }
   ul,
   ol {
-    padding-top: $spacing-md;
-    padding-left: $spacing-lg;
+    padding-top: tokens.$spacing-md;
+    padding-left: tokens.$spacing-lg;
 
     li {
-      margin-bottom: $spacing-xs;
+      margin-bottom: tokens.$spacing-xs;
       align-items: flex-start;
     }
   }
@@ -20,14 +20,14 @@
 .breachItemsWrapper {
   display: flex;
   flex-wrap: wrap;
-  gap: $spacing-xs;
+  gap: tokens.$spacing-xs;
 
   .breachItem {
-    font: $text-body-sm;
+    font: tokens.$text-body-sm;
     font-weight: 600;
-    background: $color-grey-10;
-    padding: $spacing-xs $spacing-sm;
-    border-radius: $border-radius-md;
+    background: tokens.$color-grey-10;
+    padding: tokens.$spacing-xs tokens.$spacing-sm;
+    border-radius: tokens.$border-radius-md;
 
     .date {
       font-weight: 400;

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/dataBrokerProfiles.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/dataBrokerProfiles.module.scss
@@ -1,11 +1,11 @@
-@import "../../../../../../../../tokens";
+@use "../../../../../../../../tokens";
 
 .main {
   flex-direction: column;
 }
 
 .contentWrapper {
-  max-width: $content-md;
+  max-width: tokens.$content-md;
   margin: 0 auto;
   text-align: center;
 }
@@ -14,13 +14,13 @@
   display: flex;
   flex-direction: column;
   text-align: center;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
   a {
     display: block;
   }
 
-  @media screen and (min-width: $screen-sm) {
+  @media screen and (min-width: tokens.$screen-sm) {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -30,7 +30,7 @@
 
 .upgradeToggleWrapper {
   display: block;
-  margin-bottom: $spacing-lg;
+  margin-bottom: tokens.$spacing-lg;
 
   > span {
     display: block;
@@ -38,21 +38,21 @@
 }
 
 .removalStepsList {
-  font: $text-body-md;
+  font: tokens.$text-body-md;
   text-align: left;
 
   li {
-    margin-bottom: $spacing-md;
+    margin-bottom: tokens.$spacing-md;
 
     > strong {
       display: block;
-      margin-bottom: $spacing-xs;
+      margin-bottom: tokens.$spacing-xs;
       font-weight: 700;
     }
 
     // The subhead/bullet content is wrapped in a span to style to OL marker (1.)
     > span {
-      font: $text-body-sm;
+      font: tokens.$text-body-sm;
       font-weight: normal;
     }
   }
@@ -60,20 +60,20 @@
 
 .content {
   text-align: center;
-  max-width: $content-md;
-  margin: 0 auto $spacing-2xl;
+  max-width: tokens.$content-md;
+  margin: 0 auto tokens.$spacing-2xl;
 
   h3 {
-    font: $text-title-2xs;
+    font: tokens.$text-title-2xs;
   }
 
   h4 {
-    font: $text-title-3xs;
+    font: tokens.$text-title-3xs;
   }
 
   p,
   h3 {
-    margin-block-end: $spacing-md;
+    margin-block-end: tokens.$spacing-md;
   }
 
   h3 + p {
@@ -81,14 +81,14 @@
   }
 
   > a {
-    color: $color-blue-60;
+    color: tokens.$color-blue-60;
     display: inline-block;
-    margin-inline-start: $spacing-sm;
+    margin-inline-start: tokens.$spacing-sm;
   }
 }
 
 .cityScape {
-  margin: 0 auto $spacing-2xl;
+  margin: 0 auto tokens.$spacing-2xl;
   display: block;
   max-width: 100%;
 }
@@ -97,31 +97,31 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: $spacing-xs;
-  font: $text-title-3xs;
+  gap: tokens.$spacing-xs;
+  font: tokens.$text-title-3xs;
 }
 
 .questionTooltip {
-  @include question-mark-circle-btn;
+  @include tokens.question-mark-circle-btn;
 }
 
 .contentAutomaticRemove {
   h3 {
-    @include no-focus-outline;
+    @include tokens.no-focus-outline;
     text-align: left;
   }
 }
 
 .featuresList {
   text-align: left;
-  max-width: $content-sm;
-  margin-bottom: $spacing-lg;
+  max-width: tokens.$content-sm;
+  margin-bottom: tokens.$spacing-lg;
 
   ul {
     padding: 0;
     li {
       background: url("../images/icon-check-mark.svg") no-repeat left center;
-      padding: $spacing-sm 0 $spacing-sm $spacing-xl;
+      padding: tokens.$spacing-sm 0 tokens.$spacing-sm tokens.$spacing-xl;
       list-style: none;
       margin: 0;
       vertical-align: middle;
@@ -132,40 +132,40 @@
 .upgradeToggle {
   width: auto;
   display: inline-flex;
-  gap: $spacing-sm;
-  background-color: $color-grey-10;
-  border-radius: $border-radius-xl;
-  padding: $spacing-sm $spacing-sm;
-  font: $text-body-sm;
-  margin-bottom: $spacing-md;
+  gap: tokens.$spacing-sm;
+  background-color: tokens.$color-grey-10;
+  border-radius: tokens.$border-radius-xl;
+  padding: tokens.$spacing-sm tokens.$spacing-sm;
+  font: tokens.$text-body-sm;
+  margin-bottom: tokens.$spacing-md;
 
   .toggleBtn {
     cursor: pointer;
     appearance: none;
     background-color: transparent;
     border: 0;
-    color: $color-grey-50;
-    padding: $spacing-xs $spacing-md;
+    color: tokens.$color-grey-50;
+    padding: tokens.$spacing-xs tokens.$spacing-md;
     font-weight: 500;
 
     &.isActive,
     &:hover {
-      background-color: $color-white;
-      border-radius: $border-radius-xl;
-      color: $color-informational;
+      background-color: tokens.$color-white;
+      border-radius: tokens.$border-radius-xl;
+      color: tokens.$color-informational;
     }
 
     &.isFocused {
-      outline: 2px solid $color-purple-70;
-      background-color: $color-purple-10;
+      outline: 2px solid tokens.$color-purple-70;
+      background-color: tokens.$color-purple-10;
     }
   }
 }
 
 .upgradeContentWrapper {
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: tokens.$screen-md) {
     display: flex;
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
     justify-content: space-between;
     // Used to stop purple box from stretching full width
     align-items: flex-start;
@@ -177,36 +177,36 @@
     justify-content: space-between;
     flex-direction: column;
     width: 100%;
-    background-color: $color-purple-70;
-    color: $color-white;
-    padding: $spacing-lg;
+    background-color: tokens.$color-purple-70;
+    color: tokens.$color-white;
+    padding: tokens.$spacing-lg;
     // Note: Confirmed with design to only round the top-right corner
-    border-top-right-radius: $border-radius-xl;
+    border-top-right-radius: tokens.$border-radius-xl;
     > strong {
       text-align: center;
       display: block;
-      font: $text-body-xl;
+      font: tokens.$text-body-xl;
       small {
         display: block;
-        font: $text-body-md;
+        font: tokens.$text-body-md;
       }
     }
     // Price block
     > span {
-      margin: $spacing-xl 0;
-      font: $text-title-sm;
+      margin: tokens.$spacing-xl 0;
+      font: tokens.$text-title-sm;
       font-weight: 500;
     }
 
     // Invert color for the plan selection CTA to increase visibility
     // against the purple background.
     & > a {
-      color: $color-white;
-      box-shadow: inset 0 0 0 2px $color-white;
+      color: tokens.$color-white;
+      box-shadow: inset 0 0 0 2px tokens.$color-white;
 
       &:hover {
-        background-color: $color-white;
-        color: $color-purple-70;
+        background-color: tokens.$color-white;
+        color: tokens.$color-purple-70;
       }
     }
   }
@@ -215,15 +215,15 @@
 .dataBrokerResolutionStats {
   display: flex;
   flex-direction: column;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
   justify-content: center;
-  padding-top: $layout-sm;
+  padding-top: tokens.$layout-sm;
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: tokens.$screen-md) {
     flex-direction: row;
   }
   div {
-    @include estimated-time;
+    @include tokens.estimated-time;
     justify-content: center;
   }
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/manual-remove/ManualRemoveView.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/manual-remove/ManualRemoveView.module.scss
@@ -1,23 +1,23 @@
-@import "../../../../../../../../../tokens";
+@use "../../../../../../../../../tokens";
 
 .main {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $spacing-lg;
+  gap: tokens.$spacing-lg;
 }
 
 .buttonsWrapper {
   display: flex;
   flex-direction: column;
   text-align: center;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
   a {
     display: block;
   }
 
-  @media screen and (min-width: $screen-sm) {
+  @media screen and (min-width: tokens.$screen-sm) {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -26,66 +26,66 @@
 }
 
 .removalStepsList {
-  font: $text-body-md;
+  font: tokens.$text-body-md;
   text-align: left;
 
   li {
-    margin-bottom: $spacing-md;
+    margin-bottom: tokens.$spacing-md;
 
     > strong {
       display: block;
-      margin-bottom: $spacing-xs;
+      margin-bottom: tokens.$spacing-xs;
       font-weight: 700;
     }
 
     // The subhead/bullet content is wrapped in a span to style to OL marker (1.)
     > span {
-      font: $text-body-sm;
+      font: tokens.$text-body-sm;
       font-weight: normal;
     }
   }
 }
 
 .content {
-  max-width: $content-md;
+  max-width: tokens.$content-md;
 
   h3 {
-    font: $text-title-2xs;
+    font: tokens.$text-title-2xs;
     text-align: center;
   }
 
   h4 {
-    font: $text-title-3xs;
+    font: tokens.$text-title-3xs;
   }
 
   p,
   h3 {
-    margin-block-end: $spacing-md;
+    margin-block-end: tokens.$spacing-md;
   }
 
   > a {
-    color: $color-blue-60;
+    color: tokens.$color-blue-60;
     display: inline-block;
-    margin-inline-start: $spacing-sm;
+    margin-inline-start: tokens.$spacing-sm;
   }
 }
 
 .exposureListing {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
+  gap: tokens.$spacing-lg;
 
   h3 {
-    font: $text-title-2xs;
+    font: tokens.$text-title-2xs;
   }
 
   .exposureList {
     display: flex;
     flex-direction: column;
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
 
-    @media screen and (min-width: $screen-md) {
-      padding-inline: $spacing-lg;
+    @media screen and (min-width: tokens.$screen-md) {
+      padding-inline: tokens.$spacing-lg;
     }
   }
 }
@@ -94,22 +94,22 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: $spacing-xs;
-  font: $text-title-3xs;
+  gap: tokens.$spacing-xs;
+  font: tokens.$text-title-3xs;
 }
 
 .dataBrokerResolutionStats {
   display: flex;
   flex-direction: column;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
   justify-content: center;
-  padding-top: $layout-sm;
+  padding-top: tokens.$layout-sm;
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: tokens.$screen-md) {
     flex-direction: row;
   }
   div {
-    @include estimated-time;
+    @include tokens.estimated-time;
     justify-content: center;
   }
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/removal-under-maintenance/RemovalUnderMaintenance.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/removal-under-maintenance/RemovalUnderMaintenance.module.scss
@@ -1,24 +1,25 @@
-@import "../../../../../../../../../tokens";
+@use "../../../../../../../../../tokens";
 
 .dataBrokerInformationWrapper {
   .exposureCardWrapper {
-    margin-top: $spacing-md;
-    padding-bottom: $spacing-lg;
+    margin-top: tokens.$spacing-md;
+    padding-bottom: tokens.$spacing-lg;
 
     .exposureCard {
       display: flex;
       flex-direction: column;
-      background-color: $color-white;
-      border: 2px solid rgba($color-purple-70, 0.2);
-      border-radius: $border-radius-lg;
-      padding: $layout-sm $layout-sm $layout-xs $layout-sm;
+      background-color: tokens.$color-white;
+      border: 2px solid rgba(tokens.$color-purple-70, 0.2);
+      border-radius: tokens.$border-radius-lg;
+      padding: tokens.$layout-sm tokens.$layout-sm tokens.$layout-xs
+        tokens.$layout-sm;
 
       .dataClassesList {
         justify-content: space-between;
         margin-left: 0;
         display: grid;
         grid-template-columns: 1fr;
-        grid-row-gap: $spacing-sm;
+        grid-row-gap: tokens.$spacing-sm;
         transition: opacity 0.35s ease-in-out;
         opacity: 1;
 
@@ -26,38 +27,38 @@
           opacity: 0;
         }
 
-        @media screen and (min-width: $screen-md) {
+        @media screen and (min-width: tokens.$screen-md) {
           grid-template-columns: 1fr 1fr 1fr;
-          gap: $spacing-sm;
+          gap: tokens.$spacing-sm;
         }
 
-        @media screen and (min-width: $screen-lg) {
+        @media screen and (min-width: tokens.$screen-lg) {
           display: flex;
           flex-direction: row;
           align-items: flex-start;
-          gap: $layout-xs;
+          gap: tokens.$layout-xs;
           flex-wrap: wrap;
           justify-content: flex-start;
         }
       }
 
       .buttonsWrapper {
-        margin-top: $spacing-lg;
-        border-top: 2px solid $color-grey-10;
-        padding-top: $spacing-lg;
+        margin-top: tokens.$spacing-lg;
+        border-top: 2px solid tokens.$color-grey-10;
+        padding-top: tokens.$spacing-lg;
         display: flex;
-        gap: $spacing-sm;
+        gap: tokens.$spacing-sm;
       }
 
       .estimatedTime {
-        @include estimated-time;
-        padding-top: $spacing-sm;
+        @include tokens.estimated-time;
+        padding-top: tokens.$spacing-sm;
       }
     }
   }
 
   .header {
-    font: $text-body-lg;
+    font: tokens.$text-body-lg;
     font-weight: 700;
     transition: opacity 0.35s ease-in-out;
     opacity: 1;
@@ -74,44 +75,44 @@
     cursor: pointer;
   }
   .headerRemovalGuide {
-    padding-top: $spacing-lg;
-    font: $text-body-xl;
+    padding-top: tokens.$spacing-lg;
+    font: tokens.$text-body-xl;
     font-weight: 700;
   }
 
   .buttonWrapper {
     display: flex;
     justify-content: center;
-    padding-top: $spacing-lg;
+    padding-top: tokens.$spacing-lg;
   }
 }
 
 .removalContentSection {
-  margin-top: $layout-md;
+  margin-top: tokens.$layout-md;
 
   dt {
-    font: $text-body-lg;
+    font: tokens.$text-body-lg;
     font-weight: 600;
 
     &.removalGuideInstructions {
-      font: $text-body-md;
+      font: tokens.$text-body-md;
       font-weight: 700;
     }
   }
 
   dd {
-    padding-top: $spacing-sm;
+    padding-top: tokens.$spacing-sm;
   }
 
   ol {
-    padding-top: $spacing-sm;
+    padding-top: tokens.$spacing-sm;
 
     li {
-      margin-bottom: $spacing-xs;
+      margin-bottom: tokens.$spacing-xs;
     }
   }
 
   button {
-    margin-top: $spacing-lg;
+    margin-top: tokens.$spacing-lg;
   }
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/AboutBrokersIcon.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/AboutBrokersIcon.module.scss
@@ -1,9 +1,9 @@
-@import "../../../../../../../../../tokens";
+@use "../../../../../../../../../tokens";
 
 .triggerButton {
   border-style: none;
   background-color: transparent;
-  color: $color-purple-70;
+  color: tokens.$color-purple-70;
   aspect-ratio: 1 / 1;
   cursor: pointer;
 }
@@ -11,14 +11,14 @@
 .dialogContents {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
-  color: $color-grey-50;
+  gap: tokens.$spacing-lg;
+  color: tokens.$color-grey-50;
 
   .confirmButtonWrapper {
     align-self: center;
     display: flex;
     flex-direction: column;
-    min-width: $content-xs;
-    padding-block-start: $spacing-md;
+    min-width: tokens.$content-xs;
+    padding-block-start: tokens.$spacing-md;
   }
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/welcomeToPlus.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/welcomeToPlus.module.scss
@@ -1,13 +1,13 @@
-@import "../../../../../../../../../tokens";
+@use "../../../../../../../../../tokens";
 
 .contentWrapper {
-  max-width: $content-md;
+  max-width: tokens.$content-md;
   margin: 0 auto;
   text-align: center;
   display: flex;
   align-items: center;
-  gap: $spacing-xl;
-  @media screen and (max-width: $screen-xl) {
+  gap: tokens.$spacing-xl;
+  @media screen and (max-width: tokens.$screen-xl) {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -18,13 +18,13 @@
   display: flex;
   flex-direction: column;
   text-align: center;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
   a {
     display: block;
   }
 
-  @media screen and (min-width: $screen-sm) {
+  @media screen and (min-width: tokens.$screen-sm) {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -33,23 +33,23 @@
 
 .content {
   text-align: left;
-  max-width: $content-sm;
+  max-width: tokens.$content-sm;
   margin: 0 auto;
 
   h3 {
-    font: $text-title-2xs;
+    font: tokens.$text-title-2xs;
   }
 
   p,
   h3 {
-    margin-block-end: $spacing-md;
+    margin-block-end: tokens.$spacing-md;
     text-align: left;
   }
 
   > a {
-    color: $color-blue-60;
+    color: tokens.$color-blue-60;
     display: inline-block;
-    margin-inline-start: $spacing-sm;
+    margin-inline-start: tokens.$spacing-sm;
   }
 }
 
@@ -63,7 +63,7 @@
   &.hideOnMobile {
     display: none;
 
-    @media screen and (min-width: $screen-xl) {
+    @media screen and (min-width: tokens.$screen-xl) {
       display: flex;
     }
   }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/fix.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/fix.module.scss
@@ -1,7 +1,7 @@
-@import "../../../../../../../tokens";
+@use "../../../../../../../tokens";
 
 .fixContainer {
-  background-color: $color-grey-05;
+  background-color: tokens.$color-grey-05;
   height: 100%;
   display: flex;
   align-items: center;
@@ -9,17 +9,17 @@
   // Set position relative so the child <Confetti> canvas can overlay <FixView>
   position: relative;
 
-  @media screen and (min-width: $screen-md) {
-    padding: $layout-sm;
+  @media screen and (min-width: tokens.$screen-md) {
+    padding: tokens.$layout-sm;
   }
 
   .fixWrapper {
-    box-shadow: $box-shadow-xs;
-    border-radius: $border-radius-md;
-    max-width: $content-xl;
+    box-shadow: tokens.$box-shadow-xs;
+    border-radius: tokens.$border-radius-md;
+    max-width: tokens.$content-xl;
     width: 100%;
-    padding: $layout-xs;
-    background-color: $color-white;
+    padding: tokens.$layout-xs;
+    background-color: tokens.$color-white;
     background-size: cover;
     background-position: center;
     position: relative;
@@ -27,7 +27,7 @@
     display: flex;
     justify-content: center;
     flex-direction: column;
-    min-height: $content-sm;
+    min-height: tokens.$content-sm;
 
     &.contentBackgroundImage {
       background-image: url("./images/high-risk-breaches-content-background.svg");
@@ -36,23 +36,24 @@
 
   .navClose {
     position: absolute;
-    right: $spacing-md;
-    top: $spacing-md;
+    right: tokens.$spacing-md;
+    top: tokens.$spacing-md;
   }
 
   .fixSection {
     display: flex;
     justify-content: stretch;
     align-items: center;
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
 
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: tokens.$screen-md) {
       // Add horizontal padding to account for next/prev arrow placement on larger screens
-      padding: $spacing-lg $spacing-2xl;
+      padding: tokens.$spacing-lg tokens.$spacing-2xl;
     }
 
-    @media screen and (min-width: $screen-xl) {
-      padding: $spacing-xl $spacing-lg $spacing-md $spacing-lg;
+    @media screen and (min-width: tokens.$screen-xl) {
+      padding: tokens.$spacing-xl tokens.$spacing-lg tokens.$spacing-md
+        tokens.$spacing-lg;
     }
 
     .navArrow {
@@ -61,15 +62,15 @@
       position: absolute;
       align-items: center;
       justify-content: center;
-      padding: $spacing-md;
-      border-radius: $border-radius-sm;
-      right: $spacing-md;
+      padding: tokens.$spacing-md;
+      border-radius: tokens.$border-radius-sm;
+      right: tokens.$spacing-md;
 
       &:hover {
-        background-color: $color-violet-20;
+        background-color: tokens.$color-violet-20;
       }
 
-      @media screen and (min-width: $screen-md) {
+      @media screen and (min-width: tokens.$screen-md) {
         display: flex;
       }
     }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/FraudAlertModal.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/FraudAlertModal.module.scss
@@ -1,20 +1,20 @@
-@import "../../../../../../../../tokens";
+@use "../../../../../../../../tokens";
 
 .triggerButton {
-  @include question-mark-circle-btn;
+  @include tokens.question-mark-circle-btn;
 }
 
 .dialogContents {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
-  color: $color-grey-50;
+  gap: tokens.$spacing-lg;
+  color: tokens.$color-grey-50;
 
   .confirmButtonWrapper {
     align-self: center;
     display: flex;
     flex-direction: column;
-    min-width: $content-xs;
-    padding-block-start: $spacing-md;
+    min-width: tokens.$content-xs;
+    padding-block-start: tokens.$spacing-md;
   }
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/AlertAddressForm.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/AlertAddressForm.module.scss
@@ -1,39 +1,39 @@
-@import "../../../../../../tokens";
+@use "../../../../../../tokens";
 
 .wrapper {
   display: flex;
   flex-direction: column;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
   .sectionTitle {
     h3 {
-      font: $text-title-3xs;
+      font: tokens.$text-title-3xs;
     }
 
     p {
-      color: $color-grey-40;
+      color: tokens.$color-grey-40;
     }
   }
 
   .radioGroup {
     display: flex;
     flex-direction: column;
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
 
     .emailAlertsOptions {
-      padding-inline-start: $spacing-lg;
+      padding-inline-start: tokens.$spacing-lg;
       display: flex;
       flex-direction: column;
-      gap: $spacing-sm;
+      gap: tokens.$spacing-sm;
     }
 
     .radioButton {
-      stroke: $color-black;
+      stroke: tokens.$color-black;
     }
 
     label {
       display: flex;
-      gap: $spacing-xs;
+      gap: tokens.$spacing-xs;
       div {
         display: flex;
         flex-direction: column;
@@ -43,7 +43,7 @@
         }
 
         p {
-          color: $color-grey-40;
+          color: tokens.$color-grey-40;
         }
       }
 
@@ -53,11 +53,11 @@
     }
 
     .focusRing {
-      stroke: $color-blue-50;
+      stroke: tokens.$color-blue-50;
     }
 
     .selectedFill {
-      fill: $color-black;
+      fill: tokens.$color-black;
     }
   }
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/CancelFlow.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/CancelFlow.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../../../tokens";
+@use "../../../../../../tokens";
 
 // The attribute selector makes this more specific that <Button>'s direct styles,
 // so we can overwrite the font weight. Maybe it should just not be a <Button>…
@@ -10,30 +10,30 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $spacing-xs;
+  gap: tokens.$spacing-xs;
   text-align: center;
 
   button {
     &.primaryCta {
-      margin-top: $spacing-sm;
+      margin-top: tokens.$spacing-sm;
       font-weight: 600;
     }
 
     &.discountCta {
-      background-color: $color-purple-60;
+      background-color: tokens.$color-purple-60;
       width: 100%;
 
-      @media screen and (min-width: $screen-sm) {
-        width: $content-sm;
+      @media screen and (min-width: tokens.$screen-sm) {
+        width: tokens.$content-sm;
       }
 
       &:hover {
-        background-color: $color-purple-70;
+        background-color: tokens.$color-purple-70;
       }
     }
 
     &.tertiaryCta {
-      margin-top: $spacing-lg;
+      margin-top: tokens.$spacing-lg;
       font-weight: 500;
     }
   }
@@ -43,13 +43,13 @@
   }
 
   .limitationsApplyLink {
-    text-decoration-color: $color-grey-30;
+    text-decoration-color: tokens.$color-grey-30;
     .limitationsApplyText {
       display: flex;
-      gap: $spacing-xs;
+      gap: tokens.$spacing-xs;
       align-items: center;
       justify-content: center;
-      text-decoration-color: $color-grey-30;
+      text-decoration-color: tokens.$color-grey-30;
 
       svg {
         width: 13px; // width of open in new tab icon
@@ -58,18 +58,18 @@
   }
 
   .errorApplyingCoupon {
-    padding-top: $spacing-sm;
-    color: $color-red-60;
+    padding-top: tokens.$spacing-sm;
+    color: tokens.$color-red-60;
     font-weight: 500;
 
     button {
-      color: $color-red-60;
+      color: tokens.$color-red-60;
       font-weight: 500;
     }
   }
 
   small {
-    color: $color-grey-30;
+    color: tokens.$color-grey-30;
     font-weight: 400;
   }
 
@@ -79,26 +79,26 @@
 }
 
 .goToDashboardCta {
-  margin-top: $spacing-lg;
-  font: $text-body-md;
+  margin-top: tokens.$spacing-lg;
+  font: tokens.$text-body-md;
   font-weight: 500;
   border: 0;
-  padding: $spacing-md $spacing-lg;
-  border-radius: $border-radius-md;
+  padding: tokens.$spacing-md tokens.$spacing-lg;
+  border-radius: tokens.$border-radius-md;
   cursor: pointer;
   display: inline-block;
   line-height: 1;
   text-align: center;
   text-decoration: none;
-  color: $color-white;
-  background-color: $color-blue-50;
+  color: tokens.$color-white;
+  background-color: tokens.$color-blue-50;
 
   &:hover {
-    background-color: $color-blue-60;
+    background-color: tokens.$color-blue-60;
   }
 
   &:focus {
-    outline: $border-focus-width solid $color-blue-30;
+    outline: tokens.$border-focus-width solid tokens.$color-blue-30;
   }
 }
 
@@ -109,7 +109,7 @@
 .cancellationIllustrationWrapper {
   height: 200px; // height of illustration;
   width: 100%;
-  padding-bottom: $spacing-lg;
+  padding-bottom: tokens.$spacing-lg;
 
   img {
     height: 100%;
@@ -128,7 +128,7 @@
   height: 280px; //height of iframe
 }
 
-@media (min-width: $content-lg) {
+@media (min-width: tokens.$content-lg) {
   .iframeWrapper {
     height: 260px;
   }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/EmailAddressAdder.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/EmailAddressAdder.module.scss
@@ -1,9 +1,9 @@
-@import "../../../../../../tokens";
+@use "../../../../../../tokens";
 
 .dialogContents {
   display: flex;
   flex-direction: column;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
   .description {
     text-align: center;
@@ -14,7 +14,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
   label {
     font-weight: 600;
@@ -22,10 +22,10 @@
   }
 
   input {
-    border: 1px solid $color-grey-30;
-    border-radius: $border-radius-sm;
-    color: $color-black;
-    padding: $spacing-sm $spacing-md;
+    border: 1px solid tokens.$color-grey-30;
+    border-radius: tokens.$border-radius-sm;
+    color: tokens.$color-black;
+    padding: tokens.$spacing-sm tokens.$spacing-md;
     width: 100%;
   }
 

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/EmailListing.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/EmailListing.module.scss
@@ -1,10 +1,10 @@
-@import "../../../../../../tokens";
+@use "../../../../../../tokens";
 
 .emailListing {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
   div {
     display: flex;
@@ -12,33 +12,33 @@
     align-items: flex-start;
 
     small {
-      font: $text-body-sm;
-      color: $color-grey-40;
+      font: tokens.$text-body-sm;
+      color: tokens.$color-grey-40;
     }
 
     .verificationCallout {
       display: flex;
       align-items: center;
-      gap: $spacing-sm;
-      padding: $spacing-sm $spacing-xs;
-      color: $color-red-60;
+      gap: tokens.$spacing-sm;
+      padding: tokens.$spacing-sm tokens.$spacing-xs;
+      color: tokens.$color-red-60;
       font-weight: 600;
     }
 
     .reverifyButton {
       display: flex;
       align-items: center;
-      gap: $spacing-sm;
+      gap: tokens.$spacing-sm;
       padding: 0;
       text-decoration: underline;
-      color: $color-blue-50;
+      color: tokens.$color-blue-50;
 
       &:hover {
-        color: $color-blue-70;
+        color: tokens.$color-blue-70;
       }
 
       &:disabled {
-        color: $color-grey-50;
+        color: tokens.$color-grey-50;
         text-decoration: none;
         cursor: default;
       }
@@ -49,13 +49,13 @@
     flex: 0 0 auto;
     background-color: transparent;
     border-style: none;
-    border-radius: $border-radius-sm;
+    border-radius: tokens.$border-radius-sm;
     text-decoration: underline;
     font-weight: 600;
     cursor: pointer;
 
     &:hover {
-      color: $color-blue-50;
+      color: tokens.$color-blue-50;
     }
   }
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsConfirmationDialog.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsConfirmationDialog.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../../../tokens";
+@use "../../../../../../tokens";
 
 // The attribute selector makes this more specific that <Button>'s direct styles,
 // so we can overwrite the font weight. Maybe it should just not be a <Button>…
@@ -10,7 +10,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
   .dismissLink {
     font-weight: 600;

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsContent.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsContent.module.scss
@@ -1,49 +1,49 @@
-@import "../../../../../../tokens";
+@use "../../../../../../tokens";
 
 .main {
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
-  gap: $spacing-lg;
-  padding: $layout-2xs;
+  gap: tokens.$spacing-lg;
+  padding: tokens.$layout-2xs;
 
-  @media screen and (min-width: $screen-lg) {
+  @media screen and (min-width: tokens.$screen-lg) {
     flex-direction: row;
-    padding: $layout-lg;
+    padding: tokens.$layout-lg;
   }
 
-  @media screen and (min-width: $screen-sm) {
-    padding: $layout-sm;
+  @media screen and (min-width: tokens.$screen-sm) {
+    padding: tokens.$layout-sm;
   }
 }
 
 .header {
   display: flex;
   flex-direction: column;
-  gap: $layout-xs;
+  gap: tokens.$layout-xs;
 
   h2 {
-    font: $text-title-xs;
+    font: tokens.$text-title-xs;
   }
 
   & [role="tab"]::after {
-    width: calc(100% - 24px - $spacing-xs);
+    width: calc(100% - 24px - tokens.$spacing-xs);
   }
 
-  @media screen and (min-width: $screen-lg) {
-    flex: 0 0 $content-xs;
+  @media screen and (min-width: tokens.$screen-lg) {
+    flex: 0 0 tokens.$content-xs;
   }
 }
 
 .content {
   align-items: flex-start;
-  background-color: $color-white;
-  border-radius: $border-radius-md;
-  box-shadow: $box-shadow-xs;
+  background-color: tokens.$color-white;
+  border-radius: tokens.$border-radius-md;
+  box-shadow: tokens.$box-shadow-xs;
   display: flex;
   flex-direction: column;
   flex: 1 0 0;
-  gap: $spacing-lg;
+  gap: tokens.$spacing-lg;
   overflow: hidden;
-  padding: $spacing-lg;
+  padding: tokens.$spacing-lg;
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/View.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/View.module.scss
@@ -1,23 +1,23 @@
-@import "../../../../../../tokens";
+@use "../../../../../../tokens";
 
 .wrapper {
   width: 100%;
   height: 100%;
-  background-color: $color-grey-05;
+  background-color: tokens.$color-grey-05;
 }
 
 .wrapper .main {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  gap: $spacing-2xl;
-  padding: $spacing-2xl;
+  gap: tokens.$spacing-2xl;
+  padding: tokens.$spacing-2xl;
 
   .title {
-    flex: 0 0 $content-xs;
+    flex: 0 0 tokens.$content-xs;
 
     h2 {
-      font: $text-title-xs;
+      font: tokens.$text-title-xs;
     }
   }
 
@@ -26,20 +26,20 @@
     display: flex;
     align-items: flex-start;
     flex-direction: column;
-    gap: $spacing-lg;
+    gap: tokens.$spacing-lg;
 
     h3 {
-      font: $text-title-3xs;
+      font: tokens.$text-title-3xs;
     }
 
     .description {
-      color: $color-grey-40;
+      color: tokens.$color-grey-40;
     }
 
     hr {
       align-self: stretch;
       border-style: none;
-      border-top: 1px solid $color-grey-10;
+      border-top: 1px solid tokens.$color-grey-10;
     }
   }
 }
@@ -51,7 +51,7 @@
   align-self: stretch;
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
+  gap: tokens.$spacing-lg;
 }
 
 .cancelSection,
@@ -59,17 +59,17 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
 
   a {
     display: flex;
     align-items: center;
-    gap: $spacing-xs;
-    color: $color-blue-50;
+    gap: tokens.$spacing-xs;
+    color: tokens.$color-blue-50;
     font-weight: 600;
 
     &:hover {
-      color: $color-blue-70;
+      color: tokens.$color-blue-70;
     }
   }
 }
@@ -77,6 +77,6 @@
 .dialogLead {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
+  gap: tokens.$spacing-lg;
   text-align: center;
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/Panel.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/Panel.module.scss
@@ -1,25 +1,25 @@
-@import "../../../../../../../tokens";
+@use "../../../../../../../tokens";
 
 .panel {
   align-items: flex-start;
   display: flex;
   flex-direction: column;
-  gap: $layout-xs;
+  gap: tokens.$layout-xs;
   width: 100%;
 
   hr {
     border-style: none;
-    border-top: 1px solid $color-grey-30;
+    border-top: 1px solid tokens.$color-grey-30;
     width: 100%;
   }
 
   h3 {
-    font: $text-body-xl;
+    font: tokens.$text-body-xl;
     font-weight: 600;
 
     & + p {
-      color: $color-grey-40;
-      font: $text-body-md;
+      color: tokens.$color-grey-40;
+      font: tokens.$text-body-md;
     }
   }
 
@@ -28,20 +28,20 @@
     display: flex;
     flex-direction: column;
     font-weight: 600;
-    gap: $spacing-xs;
+    gap: tokens.$spacing-xs;
     width: 100%;
 
     h4 {
-      font: $text-body-lg;
+      font: tokens.$text-body-lg;
       font-weight: 600;
     }
 
     p {
-      color: $color-grey-40;
+      color: tokens.$color-grey-40;
       font-weight: 400;
 
-      @media screen and (min-width: $content-md) {
-        padding-right: $layout-xl;
+      @media screen and (min-width: tokens.$content-md) {
+        padding-right: tokens.$layout-xl;
       }
     }
   }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelEditInfo.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelEditInfo.module.scss
@@ -1,22 +1,22 @@
-@import "../../../../../../../tokens";
+@use "../../../../../../../tokens";
 
 .emailList {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
+  gap: tokens.$spacing-lg;
   width: 100%;
 }
 
 .resendButtonWrapper {
-  font: $text-body-sm;
-  padding: $spacing-sm $spacing-md;
+  font: tokens.$text-body-sm;
+  padding: tokens.$spacing-sm tokens.$spacing-md;
 
   .resendButton {
     align-items: center;
     display: flex;
     font-weight: 500;
-    gap: $spacing-xs;
-    margin-top: $spacing-sm;
+    gap: tokens.$spacing-xs;
+    margin-top: tokens.$spacing-sm;
   }
 }
 

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelNotifications.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelNotifications.module.scss
@@ -1,31 +1,31 @@
-@import "../../../../../../../tokens";
+@use "../../../../../../../tokens";
 
 .wrapper {
   display: flex;
   flex-direction: column;
-  gap: $layout-xs;
+  gap: tokens.$layout-xs;
 
   .radioGroup {
     display: flex;
     flex-direction: column;
-    gap: $layout-xs;
+    gap: tokens.$layout-xs;
     justify-content: space-between;
     width: 100%;
 
     label {
       align-items: center;
       display: flex;
-      gap: $layout-xs;
+      gap: tokens.$layout-xs;
       justify-content: space-between;
 
-      @media screen and (min-width: $content-md) {
-        gap: $layout-md;
+      @media screen and (min-width: tokens.$content-md) {
+        gap: tokens.$layout-md;
       }
 
       div {
         display: flex;
         flex-direction: column;
-        gap: $spacing-xs;
+        gap: tokens.$spacing-xs;
       }
 
       svg {
@@ -36,8 +36,8 @@
     .radioInputs {
       display: flex;
       flex-direction: column;
-      font: $text-body-sm;
-      gap: $spacing-sm;
+      font: tokens.$text-body-sm;
+      gap: tokens.$spacing-sm;
     }
   }
 

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/EnterInfo.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/EnterInfo.module.scss
@@ -1,16 +1,16 @@
-@import "../../../../../tokens";
+@use "../../../../../tokens";
 
 .stepContent {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
   h1 {
-    font: $text-title-2xs;
+    font: tokens.$text-title-2xs;
 
-    @media screen and (min-width: $screen-md) {
-      font: $text-title-xs;
+    @media screen and (min-width: tokens.$screen-md) {
+      font: tokens.$text-title-xs;
     }
   }
 
@@ -21,12 +21,12 @@
   .explainerTrigger {
     background-color: transparent;
     border-style: none;
-    color: $color-blue-50;
+    color: tokens.$color-blue-50;
     text-decoration: underline;
     cursor: pointer;
 
     &:hover {
-      color: $color-blue-70;
+      color: tokens.$color-blue-70;
     }
   }
 }
@@ -34,23 +34,23 @@
 .dialogContents {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
-  font: $text-body-md;
-  color: $color-grey-50;
+  gap: tokens.$spacing-lg;
+  font: tokens.$text-body-md;
+  color: tokens.$color-grey-50;
 
   .confirmButtonWrapper {
     align-self: center;
     display: flex;
     flex-direction: column;
-    min-width: $content-xs;
-    padding-block-start: $spacing-md;
+    min-width: tokens.$content-xs;
+    padding-block-start: tokens.$spacing-md;
   }
 
   .list {
     list-style-position: inside;
     display: flex;
     flex-direction: column;
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
     padding: 0;
 
     li::marker {
@@ -63,13 +63,13 @@
 .stepButtonWrapper {
   align-items: center;
   display: flex;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
   justify-content: flex-end;
-  padding-block: $layout-xs;
+  padding-block: tokens.$layout-xs;
   width: 100%;
 
-  @media screen and (min-width: $screen-sm) {
-    padding-block-start: $layout-sm;
+  @media screen and (min-width: tokens.$screen-sm) {
+    padding-block-start: tokens.$layout-sm;
     flex-direction: row;
     align-items: center;
     justify-content: flex-end;
@@ -80,10 +80,10 @@
   align-items: flex-start;
   display: grid;
   grid-template-columns: repeat(6, 1fr);
-  gap: $spacing-lg $spacing-xl;
-  padding: $spacing-lg 0;
+  gap: tokens.$spacing-lg tokens.$spacing-xl;
+  padding: tokens.$spacing-lg 0;
 
-  @media screen and (min-width: $screen-lg) {
+  @media screen and (min-width: tokens.$screen-lg) {
     // The child items in the grid are input fields. Whether items marked as
     // “optional” are shown depends on the enabled variants in the
     // `welcome-scan-optional-info` experiment.
@@ -118,7 +118,7 @@
     }
   }
 
-  @media screen and (max-width: calc($screen-lg - 1px)) {
+  @media screen and (max-width: calc(tokens.$screen-lg - 1px)) {
     grid-template-columns: 1fr;
   }
 
@@ -143,22 +143,22 @@
 .infoList {
   align-items: center;
   columns: 2;
-  font: $text-body-lg;
-  gap: $spacing-lg;
+  font: tokens.$text-body-lg;
+  gap: tokens.$spacing-lg;
   list-style: none;
   margin: 0;
   padding-inline-start: var(--exposureDetailsIconWidth);
   padding: 0;
 
-  @media screen and (max-width: $screen-md) {
+  @media screen and (max-width: tokens.$screen-md) {
     columns: 1;
   }
 }
 
 .infoItem {
   display: flex;
-  gap: $spacing-sm;
-  padding: $spacing-sm 0;
+  gap: tokens.$spacing-sm;
+  padding: tokens.$spacing-sm 0;
 
   // Force all fields related to the users name to be listed in the left column.
   &.isNameRelatedField {

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/FindExposures.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/FindExposures.module.scss
@@ -1,14 +1,14 @@
-@import "../../../../../tokens";
+@use "../../../../../tokens";
 
 .progressLabel {
-  margin: $spacing-xl 0 $spacing-lg;
+  margin: tokens.$spacing-xl 0 tokens.$spacing-lg;
 
   &Indicator {
-    font: $text-title-sm;
-    margin-top: $spacing-sm;
+    font: tokens.$text-title-sm;
+    margin-top: tokens.$spacing-sm;
 
     span {
-      color: $color-purple-70;
+      color: tokens.$color-purple-70;
     }
   }
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/GetStarted.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/GetStarted.module.scss
@@ -1,16 +1,16 @@
-@import "../../../../../tokens";
+@use "../../../../../tokens";
 
 .stepContent {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
   h1 {
-    font: $text-title-2xs;
+    font: tokens.$text-title-2xs;
 
-    @media screen and (min-width: $screen-md) {
-      font: $text-title-xs;
+    @media screen and (min-width: tokens.$screen-md) {
+      font: tokens.$text-title-xs;
     }
   }
 
@@ -21,12 +21,12 @@
   .explainerTrigger {
     background-color: transparent;
     border-style: none;
-    color: $color-blue-50;
+    color: tokens.$color-blue-50;
     text-decoration: underline;
     cursor: pointer;
 
     &:hover {
-      color: $color-blue-70;
+      color: tokens.$color-blue-70;
     }
   }
 }
@@ -34,23 +34,23 @@
 .dialogContents {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
-  font: $text-body-md;
-  color: $color-grey-50;
+  gap: tokens.$spacing-lg;
+  font: tokens.$text-body-md;
+  color: tokens.$color-grey-50;
 
   .confirmButtonWrapper {
     align-self: center;
     display: flex;
     flex-direction: column;
-    min-width: $content-xs;
-    padding-block-start: $spacing-md;
+    min-width: tokens.$content-xs;
+    padding-block-start: tokens.$spacing-md;
   }
 
   .list {
     list-style-position: inside;
     display: flex;
     flex-direction: column;
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
     padding: 0;
 
     li::marker {
@@ -63,13 +63,13 @@
 .stepButtonWrapper {
   align-items: center;
   display: flex;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
   justify-content: flex-end;
-  padding-block: $layout-xs;
+  padding-block: tokens.$layout-xs;
   width: 100%;
 
-  @media screen and (min-width: $screen-sm) {
-    padding-block-start: $layout-sm;
+  @media screen and (min-width: tokens.$screen-sm) {
+    padding-block-start: tokens.$layout-sm;
     flex-direction: row;
     align-items: center;
     justify-content: flex-end;

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/View.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/View.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../../tokens";
+@use "../../../../../tokens";
 
 .wrapper {
   --backgroundImageWidth: 400px;
@@ -11,7 +11,7 @@
     --backgroundImageWidth: 200px;
     --sidebarWidth: 300px;
   }
-  @media screen and (max-width: $screen-md) {
+  @media screen and (max-width: tokens.$screen-md) {
     --sidebarWidth: 0;
   }
 
@@ -19,9 +19,9 @@
   background-image: url("./images/Scanning.svg"),
     linear-gradient(
       to right,
-      $color-grey-05,
-      $color-grey-05 var(--sidebarWidth),
-      $color-white calc(var(--sidebarWidth) + 1px)
+      tokens.$color-grey-05,
+      tokens.$color-grey-05 var(--sidebarWidth),
+      tokens.$color-white calc(var(--sidebarWidth) + 1px)
     );
   background-repeat: no-repeat;
   background-position-y: center;
@@ -35,15 +35,15 @@
   padding-inline-start: var(--sidebarWidth);
   display: flex;
   flex-direction: column;
-  gap: $spacing-xl;
+  gap: tokens.$spacing-xl;
 
   .homeLink {
     margin-inline-start: calc(-1 * var(--sidebarWidth));
     display: block;
-    padding: $spacing-md;
+    padding: tokens.$spacing-md;
 
-    @media screen and (min-width: $screen-md) {
-      padding-inline: $spacing-xl;
+    @media screen and (min-width: tokens.$screen-md) {
+      padding-inline: tokens.$spacing-xl;
     }
   }
 
@@ -52,34 +52,34 @@
     align-items: center;
     justify-content: center;
 
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: tokens.$screen-md) {
       // Gives the steps indicator some extra white-space to match the designs
       // on desktop
       height: 20vh;
     }
 
     .steps {
-      @include no-focus-outline;
+      @include tokens.no-focus-outline;
     }
   }
 
   .stepsWrapper,
   .contentWrapper {
-    padding-inline: $spacing-lg;
+    padding-inline: tokens.$spacing-lg;
 
-    @media screen and (min-width: $screen-md) {
-      padding-inline: $spacing-2xl;
+    @media screen and (min-width: tokens.$screen-md) {
+      padding-inline: tokens.$spacing-2xl;
     }
 
-    @media screen and (min-width: $screen-lg) {
-      padding-inline: $layout-xl;
+    @media screen and (min-width: tokens.$screen-lg) {
+      padding-inline: tokens.$layout-xl;
     }
   }
 
-  @media screen and (max-width: $screen-md) {
+  @media screen and (max-width: tokens.$screen-md) {
     .contentWrapper {
       $backgroundImageHeight: 200px;
-      padding-top: $backgroundImageHeight + $spacing-lg;
+      padding-top: $backgroundImageHeight + tokens.$spacing-lg;
       background-image: url("./images/Scanning.svg");
       background-repeat: no-repeat;
       background-position-x: center;
@@ -88,15 +88,15 @@
   }
 }
 
-@media screen and (min-width: $screen-md) {
+@media screen and (min-width: tokens.$screen-md) {
   .steps {
-    $stepGap: $spacing-2xl;
+    $stepGap: tokens.$spacing-2xl;
     padding-inline-start: 0;
     list-style-type: none;
     display: flex;
     justify-content: space-evenly;
     gap: $stepGap;
-    max-width: $content-sm;
+    max-width: tokens.$content-sm;
     position: relative;
 
     li {
@@ -106,14 +106,14 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: $spacing-xs;
+      gap: tokens.$spacing-xs;
       text-align: center;
-      font: $text-body-xs;
+      font: tokens.$text-body-xs;
       font-weight: 600;
-      color: $color-grey-30;
+      color: tokens.$color-grey-30;
 
       img {
-        background-color: $color-grey-30;
+        background-color: tokens.$color-grey-30;
         padding: 5px;
         margin-block: $iconBorderWidth;
         width: $iconDiameter;
@@ -132,7 +132,7 @@
       // 1-indexed, i.e. it doesn't start at 0.
       &:nth-child(n + 2)::before {
         content: "";
-        background-color: $color-grey-30;
+        background-color: tokens.$color-grey-30;
         // Since the step indicators are justified using space-evenly above, and
         // since there are three of them, they are positioned at 25%, 50% and
         // 75% of the width of the container. So to draw a line between two of
@@ -165,20 +165,20 @@
       &[aria-current="step"] {
         img {
           margin-block: 0;
-          border: $iconBorderWidth solid $color-purple-10;
+          border: $iconBorderWidth solid tokens.$color-purple-10;
         }
       }
 
       &.isCompleted,
       &[aria-current="step"] {
-        color: $color-purple-70;
+        color: tokens.$color-purple-70;
 
         &::before {
-          background-color: $color-purple-10;
+          background-color: tokens.$color-purple-10;
         }
 
         img {
-          background-color: $color-purple-70;
+          background-color: tokens.$color-purple-70;
         }
       }
     }
@@ -195,13 +195,13 @@
     }
   }
 }
-@media screen and (max-width: calc($screen-md - 1px)) {
+@media screen and (max-width: calc(tokens.$screen-md - 1px)) {
   .steps {
     padding-inline-start: 0;
     list-style-type: none;
     display: flex;
     justify-content: space-evenly;
-    gap: $spacing-sm;
+    gap: tokens.$spacing-sm;
 
     li {
       img {
@@ -210,32 +210,32 @@
         // a 0 height and a border. The images are <1kB in size, so that
         // shouldn't matter too much.
         height: 0;
-        border: 3px solid $color-grey-30;
+        border: 3px solid tokens.$color-grey-30;
         border-radius: 3px;
-        min-width: $layout-sm;
+        min-width: tokens.$layout-sm;
         width: 100%;
         pointer-events: none;
         user-select: none;
       }
 
       &[aria-current="step"] img {
-        border-color: $color-purple-10;
+        border-color: tokens.$color-purple-10;
       }
 
       &.isCompleted img {
-        border-color: $color-purple-70;
+        border-color: tokens.$color-purple-70;
       }
 
       .stepLabel {
-        padding-block: $spacing-sm;
-        padding-inline: $spacing-md;
-        color: $color-purple-70;
-        font: $text-body-xs;
+        padding-block: tokens.$spacing-sm;
+        padding-inline: tokens.$spacing-md;
+        color: tokens.$color-purple-70;
+        font: tokens.$text-body-xs;
         font-weight: 600;
       }
 
       &:not([aria-current="step"]) .stepLabel {
-        @include visually-hidden;
+        @include tokens.visually-hidden;
       }
     }
   }

--- a/src/app/(proper_react)/(redesign)/(public)/AccountDeletionNotification.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/AccountDeletionNotification.module.scss
@@ -1,35 +1,35 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .notification[role="alert"] {
   position: absolute;
-  top: $spacing-xs;
+  top: tokens.$spacing-xs;
   left: 50%;
   transform: translateX(-50%);
   display: flex;
   align-items: center;
-  gap: $spacing-md;
-  padding: $spacing-xs;
-  min-width: $content-sm;
-  background-color: $color-blue-50;
-  color: $color-white;
-  border-radius: $border-radius-sm;
-  box-shadow: $box-shadow-sm;
+  gap: tokens.$spacing-md;
+  padding: tokens.$spacing-xs;
+  min-width: tokens.$content-sm;
+  background-color: tokens.$color-blue-50;
+  color: tokens.$color-white;
+  border-radius: tokens.$border-radius-sm;
+  box-shadow: tokens.$box-shadow-sm;
   animation: fade-in 400ms;
 
   span {
-    padding: $spacing-sm $spacing-md;
+    padding: tokens.$spacing-sm tokens.$spacing-md;
   }
 
   .dismissButton {
-    padding: $spacing-md;
+    padding: tokens.$spacing-md;
     background-color: transparent;
     border-style: none;
-    color: $color-white;
-    border-radius: $border-radius-sm;
+    color: tokens.$color-white;
+    border-radius: tokens.$border-radius-sm;
     cursor: pointer;
 
     &:hover {
-      background-color: $color-blue-60;
+      background-color: tokens.$color-blue-60;
     }
   }
 }

--- a/src/app/(proper_react)/(redesign)/(public)/Faq.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/Faq.module.scss
@@ -1,31 +1,31 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .faqWrapper {
   display: flex;
   flex-direction: column;
-  padding: $layout-md $spacing-md;
+  padding: tokens.$layout-md tokens.$spacing-md;
   align-items: center;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
   .faqTitle {
-    font: $text-title-2xs;
+    font: tokens.$text-title-2xs;
     font-weight: 600;
   }
 
   .faqCta {
     font-weight: 600;
-    color: $color-blue-50;
+    color: tokens.$color-blue-50;
   }
 
   dl {
-    padding-top: $spacing-md;
+    padding-top: tokens.$spacing-md;
     display: flex;
     flex-direction: column;
-    gap: $layout-xs;
+    gap: tokens.$layout-xs;
     width: 100%;
 
-    @media screen and (min-width: $screen-lg) {
-      width: $content-lg;
+    @media screen and (min-width: tokens.$screen-lg) {
+      width: tokens.$content-lg;
     }
 
     .faqQuestion {
@@ -38,14 +38,14 @@
       display: flex;
       flex-direction: row;
       justify-content: space-between;
-      gap: $layout-md;
+      gap: tokens.$layout-md;
       align-items: center;
-      font: $text-body-lg;
+      font: tokens.$text-body-lg;
       cursor: pointer;
       text-align: start;
 
       svg {
-        color: $color-blue-60;
+        color: tokens.$color-blue-60;
         width: 12px;
         height: 12px;
         transform: rotate(135deg);
@@ -61,8 +61,8 @@
       display: none;
       height: 0;
 
-      @media screen and (min-width: $screen-lg) {
-        padding-right: $spacing-lg;
+      @media screen and (min-width: tokens.$screen-lg) {
+        padding-right: tokens.$spacing-lg;
       }
 
       &.expanded {

--- a/src/app/(proper_react)/(redesign)/(public)/LandingView.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingView.module.scss
@@ -1,4 +1,4 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .wrapper {
   display: flex;
@@ -6,35 +6,35 @@
   height: 100%;
 }
 .navbar {
-  font: $text-body-xl;
-  padding: $layout-xs;
+  font: tokens.$text-body-xl;
+  padding: tokens.$layout-xs;
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
-  background-color: $color-grey-05;
+  background-color: tokens.$color-grey-05;
   .navbarLinksContainer {
     display: flex;
     flex-direction: column;
     .navbarLinks {
       text-decoration: none;
-      color: $color-grey-50;
+      color: tokens.$color-grey-50;
     }
   }
-  @media screen and (min-width: $screen-sm) {
+  @media screen and (min-width: tokens.$screen-sm) {
     justify-content: flex-end;
     .navbarLinksContainer {
       flex-direction: row;
       justify-content: flex-end;
       .navbarLinks {
-        margin-left: $spacing-lg;
+        margin-left: tokens.$spacing-lg;
       }
     }
   }
-  @media screen and (min-width: $screen-md) {
-    padding: $layout-xs $layout-xl;
+  @media screen and (min-width: tokens.$screen-md) {
+    padding: tokens.$layout-xs tokens.$layout-xl;
     .navbarLinksContainer {
       .navbarLinks {
-        margin-left: $spacing-xl;
+        margin-left: tokens.$spacing-xl;
       }
     }
   }
@@ -45,9 +45,9 @@
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  gap: $spacing-lg;
-  padding-inline: $spacing-md;
-  padding-block-start: $spacing-xl;
+  gap: tokens.$spacing-lg;
+  padding-inline: tokens.$spacing-md;
+  padding-block-start: tokens.$spacing-xl;
   width: 100%;
   background-position: bottom center;
   background-size: cover;
@@ -59,26 +59,26 @@
     rgba(0, 144, 237, 0.08) 100%
   );
 
-  @media screen and (min-width: $screen-lg) {
+  @media screen and (min-width: tokens.$screen-lg) {
     flex-direction: row;
     align-items: center;
     justify-content: space-evenly;
-    gap: $layout-lg;
-    padding-inline: $layout-lg;
+    gap: tokens.$layout-lg;
+    padding-inline: tokens.$layout-lg;
 
     .heroContent {
-      flex: 1 1 $content-sm;
+      flex: 1 1 tokens.$content-sm;
     }
 
     .heroImage {
-      flex: 1 1 $content-sm;
+      flex: 1 1 tokens.$content-sm;
       align-self: flex-end;
     }
   }
 
-  @media screen and (min-width: $screen-xl) {
-    gap: $layout-xl;
-    padding-inline: $layout-xl;
+  @media screen and (min-width: tokens.$screen-xl) {
+    gap: tokens.$layout-xl;
+    padding-inline: tokens.$layout-xl;
   }
 
   .heroContent {
@@ -86,17 +86,17 @@
     display: flex;
     justify-content: center;
     flex-direction: column;
-    gap: $spacing-md;
-    max-width: $screen-xl / 2;
+    gap: tokens.$spacing-md;
+    max-width: tokens.$screen-xl * 0.5;
 
     h1 {
-      font: $text-title-md;
-      color: $color-grey-60;
+      font: tokens.$text-title-md;
+      color: tokens.$color-grey-60;
     }
 
     p {
-      font: $text-body-lg;
-      color: $color-grey-50;
+      font: tokens.$text-body-lg;
+      color: tokens.$color-grey-50;
     }
   }
 
@@ -105,36 +105,36 @@
     display: flex;
     align-items: flex-end;
     justify-content: center;
-    max-width: min($screen-xl / 2, 100%);
-    padding-inline: $spacing-md;
+    max-width: min(tokens.$screen-xl / 2, 100%);
+    padding-inline: tokens.$spacing-md;
 
     .heroImageBadge {
       position: absolute;
       top: 33%;
-      left: -1 * $layout-xs;
-      background-color: $color-green-90;
-      color: $color-white;
-      border-radius: $border-radius-md;
-      box-shadow: $box-shadow-sm;
+      left: -1 * tokens.$layout-xs;
+      background-color: tokens.$color-green-90;
+      color: tokens.$color-white;
+      border-radius: tokens.$border-radius-md;
+      box-shadow: tokens.$box-shadow-sm;
       aspect-ratio: 1 / 1;
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: center;
       text-align: center;
-      padding: $spacing-sm;
+      padding: tokens.$spacing-sm;
 
-      @media screen and (max-width: $screen-xs) {
+      @media screen and (max-width: tokens.$screen-xs) {
         display: none;
       }
 
       .nr {
-        font: $text-title-md;
+        font: tokens.$text-title-md;
       }
 
       .description {
-        font: $text-body-sm;
-        width: $layout-xl;
+        font: tokens.$text-body-sm;
+        width: tokens.$layout-xl;
       }
     }
   }
@@ -144,37 +144,37 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $spacing-lg;
-  background-color: $color-grey-05;
-  padding: $layout-lg 0;
+  gap: tokens.$spacing-lg;
+  background-color: tokens.$color-grey-05;
+  padding: tokens.$layout-lg 0;
 
   .planName,
   .lead,
   table {
-    width: $content-lg;
+    width: tokens.$content-lg;
     max-width: 100%;
   }
 
   .planName,
   .lead {
-    padding-inline: $spacing-lg;
+    padding-inline: tokens.$spacing-lg;
     text-align: center;
   }
 }
 
 .quoteWrapper {
-  padding: $layout-lg $spacing-md;
+  padding: tokens.$layout-lg tokens.$spacing-md;
   display: flex;
   justify-content: center;
 
-  @media screen and (min-width: $content-md) {
-    padding: $layout-lg;
+  @media screen and (min-width: tokens.$content-md) {
+    padding: tokens.$layout-lg;
   }
 
   .quote {
-    max-width: $content-lg;
+    max-width: tokens.$content-lg;
     text-align: center;
-    font: $text-title-3xs;
+    font: tokens.$text-title-3xs;
     line-height: 1.4;
     font-family: var(--font-inter);
     font-weight: normal;
@@ -182,7 +182,7 @@
     h2 {
       .emphasis {
         display: inline;
-        color: $color-violet-50;
+        color: tokens.$color-violet-50;
       }
     }
   }
@@ -194,52 +194,52 @@
     flex-direction: column-reverse;
     align-items: center;
     justify-content: space-between;
-    padding: $spacing-2xl $spacing-md;
-    gap: $spacing-lg;
+    padding: tokens.$spacing-2xl tokens.$spacing-md;
+    gap: tokens.$spacing-lg;
 
     &.grayBg {
-      background: $color-grey-05;
+      background: tokens.$color-grey-05;
     }
 
     .exposureTypeList {
       font-weight: 600;
-      color: $color-purple-70;
+      color: tokens.$color-purple-70;
       display: inline;
     }
 
-    @media screen and (min-width: $screen-md) {
-      padding-inline: $layout-lg;
-      padding-block: $layout-sm;
+    @media screen and (min-width: tokens.$screen-md) {
+      padding-inline: tokens.$layout-lg;
+      padding-block: tokens.$layout-sm;
       flex-direction: row;
-      gap: $spacing-xl;
+      gap: tokens.$spacing-xl;
 
       &.reverseRow {
         flex-direction: row-reverse;
       }
 
-      @media screen and (min-width: $screen-lg) {
-        padding-inline: $layout-lg;
-        gap: $layout-xl;
+      @media screen and (min-width: tokens.$screen-lg) {
+        padding-inline: tokens.$layout-lg;
+        gap: tokens.$layout-xl;
 
-        @media screen and (min-width: $screen-xl) {
-          padding-inline: $layout-xl;
+        @media screen and (min-width: tokens.$screen-xl) {
+          padding-inline: tokens.$layout-xl;
         }
       }
     }
 
     span {
-      gap: $spacing-md;
+      gap: tokens.$spacing-md;
       display: flex;
       flex-direction: column;
 
       h2 {
-        font: $text-title-xs;
+        font: tokens.$text-title-xs;
         font-family: var(--font-inter);
         font-weight: 600;
       }
 
       p {
-        font: $text-body-lg;
+        font: tokens.$text-body-lg;
       }
     }
 
@@ -251,12 +251,12 @@
       img {
         height: auto;
       }
-      @media screen and (min-width: $screen-md) {
+      @media screen and (min-width: tokens.$screen-md) {
         flex: 1;
       }
     }
 
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: tokens.$screen-md) {
       span,
       .illustration {
         flex: 1;
@@ -269,33 +269,33 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: $spacing-2xl $spacing-md;
-  gap: $spacing-sm;
+  padding: tokens.$spacing-2xl tokens.$spacing-md;
+  gap: tokens.$spacing-sm;
   text-align: center;
 
   .pressLogos {
-    padding-top: $layout-md;
+    padding-top: tokens.$layout-md;
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    gap: $spacing-lg;
+    gap: tokens.$spacing-lg;
     align-items: center;
     justify-content: center;
 
-    @media screen and (min-width: $content-md) {
+    @media screen and (min-width: tokens.$content-md) {
       flex-direction: row;
       flex-wrap: nowrap;
     }
 
     .label {
-      @include uppercase-only-english;
+      @include tokens.uppercase-only-english;
       flex-basis: 100%;
-      font: $text-body-sm;
-      color: $color-grey-30;
+      font: tokens.$text-body-sm;
+      color: tokens.$color-grey-30;
       font-weight: 600;
       text-align: center;
 
-      @media screen and (min-width: $content-md) {
+      @media screen and (min-width: tokens.$content-md) {
         flex-basis: auto;
       }
     }
@@ -306,62 +306,62 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: $spacing-2xl $spacing-md;
-  gap: $spacing-sm;
-  background-color: $color-grey-05;
+  padding: tokens.$spacing-2xl tokens.$spacing-md;
+  gap: tokens.$spacing-sm;
+  background-color: tokens.$color-grey-05;
   text-align: center;
 
   ul {
     list-style: none;
     padding: 0;
-    gap: $spacing-md;
-    padding-top: $layout-sm;
+    gap: tokens.$spacing-md;
+    padding-top: tokens.$layout-sm;
     display: grid;
     text-align: start;
 
     li {
       display: flex;
-      gap: $spacing-md;
+      gap: tokens.$spacing-md;
       align-items: center;
 
       svg {
         min-width: 20px; // width of check icon
-        color: $color-blue-50;
+        color: tokens.$color-blue-50;
       }
     }
   }
 
   .heresHowWeHelpCta {
-    margin-top: $layout-sm;
+    margin-top: tokens.$layout-sm;
   }
 }
 
 .scanLimitWrapper {
   display: flex;
   flex-direction: column;
-  gap: $layout-xs;
+  gap: tokens.$layout-xs;
 
   .info {
     display: flex;
     flex-direction: column;
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
 
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: tokens.$screen-md) {
       flex-direction: row;
     }
 
     b {
-      @include uppercase-only-english;
+      @include tokens.uppercase-only-english;
       white-space: nowrap;
       align-self: flex-start;
-      border-radius: $border-radius-sm;
-      font: $text-body-sm;
+      border-radius: tokens.$border-radius-sm;
+      font: tokens.$text-body-sm;
       font-weight: 600;
-      background: $color-purple-70;
-      color: $color-white;
-      padding: $spacing-sm $spacing-md;
+      background: tokens.$color-purple-70;
+      color: tokens.$color-white;
+      padding: tokens.$spacing-sm tokens.$spacing-md;
 
-      @media screen and (min-width: $screen-md) {
+      @media screen and (min-width: tokens.$screen-md) {
         align-self: center;
       }
     }
@@ -371,7 +371,7 @@
 .waitlistCta {
   align-self: flex-start;
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: tokens.$screen-md) {
     min-width: 200px; // width of waitlist button
   }
 }
@@ -381,13 +381,13 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: $layout-sm;
-  background-color: $color-purple-05;
-  padding: $layout-md $spacing-md;
+  gap: tokens.$layout-sm;
+  background-color: tokens.$color-purple-05;
+  padding: tokens.$layout-md tokens.$spacing-md;
   text-align: center;
 
   .title {
-    font: $text-title-2xs;
+    font: tokens.$text-title-2xs;
     font-family: var(--font-inter);
     font-weight: 500;
   }
@@ -401,16 +401,16 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $spacing-lg;
-  padding: $layout-md $spacing-md;
+  gap: tokens.$spacing-lg;
+  padding: tokens.$layout-md tokens.$spacing-md;
 
   .waitlistTitle {
     text-align: center;
-    font: $text-title-2xs;
+    font: tokens.$text-title-2xs;
     font-weight: 600;
     line-height: 1.4;
     font-family: var(--font-inter);
-    color: $color-purple-70;
+    color: tokens.$color-purple-70;
   }
 
   a {

--- a/src/app/(proper_react)/(redesign)/(public)/PlansTable.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/PlansTable.module.scss
@@ -1,13 +1,13 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .plansTable {
-  border-spacing: $spacing-xl 0;
+  border-spacing: tokens.$spacing-xl 0;
   table-layout: fixed;
   width: 100%;
 
   // Set column widths:
   thead th {
-    width: calc(30% - $spacing-xl);
+    width: calc(30% - tokens.$spacing-xl);
   }
 
   // Styles for the column headings
@@ -15,21 +15,21 @@
     th.featureHeadingCell {
       text-align: start;
       vertical-align: bottom;
-      padding-block: $spacing-lg;
+      padding-block: tokens.$spacing-lg;
     }
 
     .freeHeadingCell,
     .plusHeadingCell {
-      padding-block: $spacing-2xl;
+      padding-block: tokens.$spacing-2xl;
       position: relative;
     }
 
     h3 {
-      font: $text-title-xs;
+      font: tokens.$text-title-xs;
       font-weight: 600;
 
       b {
-        color: $color-purple-70;
+        color: tokens.$color-purple-70;
       }
     }
   }
@@ -41,7 +41,7 @@
     // compromise, we only show it on individual cells, rather than on the `tr`:
     tr td,
     tr th {
-      border-top: 1px solid $color-grey-20;
+      border-top: 1px solid tokens.$color-grey-20;
       font-weight: 400;
     }
 
@@ -54,7 +54,7 @@
     /* stylelint-disable no-descending-specificity */
     th,
     td {
-      padding-block: $spacing-md;
+      padding-block: tokens.$spacing-md;
 
       .cellWrapper {
         display: flex;
@@ -63,7 +63,7 @@
 
       svg.checkIcon {
         display: inline-block;
-        color: $color-blue-50;
+        color: tokens.$color-blue-50;
       }
     }
     /* stylelint-enable no-descending-specificity */
@@ -72,23 +72,23 @@
       display: flex;
       flex-direction: column;
       align-items: stretch;
-      gap: $spacing-lg;
+      gap: tokens.$spacing-lg;
       text-align: center;
-      padding-block-end: $spacing-md;
-      padding-inline: $spacing-md;
+      padding-block-end: tokens.$spacing-md;
+      padding-inline: tokens.$spacing-md;
       width: 100%;
 
       .billingPeriod {
         display: flex;
         align-items: center;
         justify-content: center;
-        min-height: $layout-md;
+        min-height: tokens.$layout-md;
         font-weight: 500;
-        color: $color-blue-50;
+        color: tokens.$color-blue-50;
       }
 
       .price {
-        font: $text-title-sm;
+        font: tokens.$text-title-sm;
       }
 
       .total {
@@ -96,17 +96,17 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        min-height: $layout-xl;
-        font: $text-body-lg;
+        min-height: tokens.$layout-xl;
+        font: tokens.$text-body-lg;
 
         .discount {
-          color: $color-purple-70;
+          color: tokens.$color-purple-70;
           font-weight: 700;
           font-style: normal;
         }
 
         .sum {
-          color: $color-grey-40;
+          color: tokens.$color-grey-40;
           font-weight: 500;
         }
       }
@@ -116,7 +116,7 @@
       }
 
       .reassurance {
-        font: $text-body-sm;
+        font: tokens.$text-body-sm;
         font-weight: 400;
       }
     }
@@ -125,9 +125,9 @@
   // Draw purple border around the Plus plan column:
   .freeCell,
   .plusCell {
-    background-color: $color-white;
+    background-color: tokens.$color-white;
     vertical-align: middle;
-    color: $color-grey-50;
+    color: tokens.$color-grey-50;
 
     .cellWrapper {
       justify-content: center;
@@ -136,27 +136,27 @@
 
   .plusCell {
     font-weight: 700;
-    border-inline: 4px solid $color-purple-70;
+    border-inline: 4px solid tokens.$color-purple-70;
   }
 
   .badge {
     position: absolute;
     top: 0;
-    background-color: $color-purple-70;
-    color: $color-white;
+    background-color: tokens.$color-purple-70;
+    color: tokens.$color-white;
     transform: translateX(-50%) translateY(-50%);
-    border-radius: $border-radius-md;
-    font: $text-body-sm;
+    border-radius: tokens.$border-radius-md;
+    font: tokens.$text-body-sm;
     font-weight: 600;
-    padding: $spacing-sm $spacing-md;
+    padding: tokens.$spacing-sm tokens.$spacing-md;
 
-    @include uppercase-only-english;
+    @include tokens.uppercase-only-english;
   }
 
   th.plusHeadingCell {
-    border-top: 4px solid $color-purple-70;
-    border-top-right-radius: $border-radius-md;
-    border-top-left-radius: $border-radius-md;
+    border-top: 4px solid tokens.$color-purple-70;
+    border-top-right-radius: tokens.$border-radius-md;
+    border-top-left-radius: tokens.$border-radius-md;
 
     &::before {
       content: "+";
@@ -164,12 +164,12 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background-color: $color-purple-70;
-      color: $color-white;
-      width: $spacing-2xl;
-      height: $spacing-2xl;
-      border-radius: $border-radius-xl;
-      font: $text-title-sm;
+      background-color: tokens.$color-purple-70;
+      color: tokens.$color-white;
+      width: tokens.$spacing-2xl;
+      height: tokens.$spacing-2xl;
+      border-radius: tokens.$border-radius-xl;
+      font: tokens.$text-title-sm;
       inset-block-start: 0;
       inset-inline-start: 0;
       transform: translateX(-50%) translateY(-50%);
@@ -177,26 +177,26 @@
   }
 
   tbody tr:last-child .plusBodyCell {
-    border-bottom: 4px solid $color-purple-70;
-    border-bottom-right-radius: $border-radius-md;
-    border-bottom-left-radius: $border-radius-md;
+    border-bottom: 4px solid tokens.$color-purple-70;
+    border-bottom-right-radius: tokens.$border-radius-md;
+    border-bottom-left-radius: tokens.$border-radius-md;
   }
 
   // Draw a light-grey line around the Free plan column:
   .freeCell {
-    border-inline: 1px solid $color-grey-20;
+    border-inline: 1px solid tokens.$color-grey-20;
   }
 
   th.freeHeadingCell {
-    border-top: 1px solid $color-grey-20;
-    border-top-right-radius: $border-radius-md;
-    border-top-left-radius: $border-radius-md;
+    border-top: 1px solid tokens.$color-grey-20;
+    border-top-right-radius: tokens.$border-radius-md;
+    border-top-left-radius: tokens.$border-radius-md;
   }
 
   tbody tr:last-child td:nth-child(2) {
-    border-bottom: 1px solid $color-grey-20;
-    border-bottom-right-radius: $border-radius-md;
-    border-bottom-left-radius: $border-radius-md;
+    border-bottom: 1px solid tokens.$color-grey-20;
+    border-bottom-right-radius: tokens.$border-radius-md;
+    border-bottom-left-radius: tokens.$border-radius-md;
   }
 }
 
@@ -204,23 +204,23 @@
   display: flex;
   flex-direction: row-reverse;
   flex-wrap: wrap;
-  gap: $spacing-xl;
-  padding: $spacing-md;
+  gap: tokens.$spacing-xl;
+  padding: tokens.$spacing-md;
 
   [role="group"] {
-    flex: 1 1 $content-sm;
+    flex: 1 1 tokens.$content-sm;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
-    gap: $spacing-lg;
-    background-color: $color-white;
-    border-radius: $border-radius-md;
-    padding: $spacing-2xl $spacing-md;
+    gap: tokens.$spacing-lg;
+    background-color: tokens.$color-white;
+    border-radius: tokens.$border-radius-md;
+    padding: tokens.$spacing-2xl tokens.$spacing-md;
 
     hr {
       border-style: none;
-      border-top: 1px solid $color-grey-20;
+      border-top: 1px solid tokens.$color-grey-20;
       width: 100%;
     }
 
@@ -228,14 +228,14 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: $spacing-sm;
+      gap: tokens.$spacing-sm;
 
       h3 {
-        font: $text-title-xs;
+        font: tokens.$text-title-xs;
         font-weight: 600;
 
         b {
-          color: $color-purple-70;
+          color: tokens.$color-purple-70;
         }
       }
     }
@@ -244,21 +244,21 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: $spacing-lg;
+      gap: tokens.$spacing-lg;
 
       .cost {
         display: flex;
         flex-direction: column;
         align-items: center;
-        gap: $spacing-md;
+        gap: tokens.$spacing-md;
 
         .price {
-          font: $text-title-sm;
+          font: tokens.$text-title-sm;
         }
 
         .total {
           display: block;
-          color: $color-grey-40;
+          color: tokens.$color-grey-40;
 
           em {
             font-weight: 700;
@@ -272,7 +272,7 @@
       }
 
       .reassurance {
-        font: $text-body-sm;
+        font: tokens.$text-body-sm;
         font-weight: 400;
       }
     }
@@ -280,11 +280,11 @@
     .featuresSection {
       display: flex;
       flex-direction: column;
-      gap: $spacing-md;
-      padding-inline: $spacing-sm;
+      gap: tokens.$spacing-md;
+      padding-inline: tokens.$spacing-sm;
 
       h4 {
-        font: $text-title-3xs;
+        font: tokens.$text-title-3xs;
       }
 
       .featureList {
@@ -293,26 +293,26 @@
         flex-direction: column;
         align-items: flex-start;
         justify-content: center;
-        gap: $spacing-lg;
+        gap: tokens.$spacing-lg;
         margin: 0;
         padding: 0;
 
         li {
           display: flex;
           align-items: flex-start;
-          gap: $spacing-xs;
+          gap: tokens.$spacing-xs;
 
           .inclusionIcon {
-            margin: $spacing-xs;
+            margin: tokens.$spacing-xs;
             flex: 1 0 auto;
           }
 
           &.included .inclusionIcon {
-            color: $color-green-90;
+            color: tokens.$color-green-90;
           }
 
           &.notIncluded .inclusionIcon {
-            color: $color-red-60;
+            color: tokens.$color-red-60;
           }
 
           button {
@@ -324,26 +324,26 @@
 
     &.plusCard {
       position: relative;
-      border: 4px solid $color-purple-70;
+      border: 4px solid tokens.$color-purple-70;
     }
 
     &.freeCard {
       position: relative;
-      border: 2px solid $color-grey-20;
+      border: 2px solid tokens.$color-grey-20;
     }
     .badge {
       position: absolute;
       top: 0;
       left: 50%;
       transform: translateY(-50%) translateX(-50%);
-      background-color: $color-purple-70;
-      color: $color-white;
-      border-radius: $border-radius-md;
-      font: $text-body-sm;
+      background-color: tokens.$color-purple-70;
+      color: tokens.$color-white;
+      border-radius: tokens.$border-radius-md;
+      font: tokens.$text-body-sm;
       font-weight: 600;
-      padding: $spacing-sm $spacing-md;
+      padding: tokens.$spacing-sm tokens.$spacing-md;
 
-      @include uppercase-only-english;
+      @include tokens.uppercase-only-english;
     }
   }
 }
@@ -352,12 +352,12 @@
   background-color: transparent;
   border-style: none;
   cursor: pointer;
-  border-radius: $border-radius-md;
+  border-radius: tokens.$border-radius-md;
   padding: 0;
 
   svg {
-    width: $layout-2xs;
-    height: $layout-2xs;
+    width: tokens.$layout-2xs;
+    height: tokens.$layout-2xs;
   }
 }
 
@@ -367,20 +367,20 @@
 }
 
 .popover {
-  box-shadow: $box-shadow-sm;
-  background-color: $color-white;
-  border: 1px solid $color-grey-20;
-  border-radius: $border-radius-md;
-  padding: $spacing-md;
-  max-width: $content-sm;
+  box-shadow: tokens.$box-shadow-sm;
+  background-color: tokens.$color-white;
+  border: 1px solid tokens.$color-grey-20;
+  border-radius: tokens.$border-radius-md;
+  padding: tokens.$spacing-md;
+  max-width: tokens.$content-sm;
 }
 
 .popoverArrow {
   position: absolute;
   width: 12px;
   height: 12px;
-  fill: $color-white;
-  stroke: $color-grey-20;
+  fill: tokens.$color-white;
+  stroke: tokens.$color-grey-20;
   stroke-width: 1px;
 
   &[data-placement="top"] {
@@ -394,12 +394,12 @@
   }
 }
 
-@media (max-width: $screen-lg) {
+@media (max-width: tokens.$screen-lg) {
   .plansTable {
     display: none;
   }
 }
-@media (min-width: calc($screen-lg + 1px)) {
+@media (min-width: calc(tokens.$screen-lg + 1px)) {
   .plansCards {
     display: none;
   }

--- a/src/app/(proper_react)/(redesign)/(public)/PublicShell.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/PublicShell.module.scss
@@ -1,4 +1,4 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .wrapper {
   display: flex;
@@ -6,17 +6,17 @@
   height: 100%;
 
   // See https://fkhadra.github.io/react-toastify/how-to-style#override-css-variabless
-  --toastify-color-light: #{$color-white};
-  --toastify-color-dark: #{$color-grey-50};
-  --toastify-color-info: #{$color-blue-50};
-  --toastify-color-success: #{$color-green-50};
-  --toastify-color-warning: #{$color-yellow-50};
-  --toastify-color-error: #{$color-red-60};
+  --toastify-color-light: #{tokens.$color-white};
+  --toastify-color-dark: #{tokens.$color-grey-50};
+  --toastify-color-info: #{tokens.$color-blue-50};
+  --toastify-color-success: #{tokens.$color-green-50};
+  --toastify-color-warning: #{tokens.$color-yellow-50};
+  --toastify-color-error: #{tokens.$color-red-60};
 
-  --toastify-text-color-info: #{$color-white};
-  --toastify-text-color-success: #{$color-grey-50};
-  --toastify-text-color-warning: #{$color-grey-50};
-  --toastify-text-color-error: #{$color-white};
+  --toastify-text-color-info: #{tokens.$color-white};
+  --toastify-text-color-success: #{tokens.$color-grey-50};
+  --toastify-text-color-warning: #{tokens.$color-grey-50};
+  --toastify-text-color-error: #{tokens.$color-white};
 
   --toastify-toast-min-height: $layout-md;
   --toastify-toast-max-height: $layout-md;
@@ -26,12 +26,12 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: $spacing-md;
-  background-color: $color-white;
-  gap: $spacing-lg;
+  padding: tokens.$spacing-md;
+  background-color: tokens.$color-white;
+  gap: tokens.$spacing-lg;
 
   h1 {
-    font: $text-title-3xs;
+    font: tokens.$text-title-3xs;
   }
 
   .logo {
@@ -44,8 +44,8 @@
     flex-shrink: 0;
   }
 
-  @media screen and (min-width: $screen-md) {
-    padding: $spacing-lg $layout-xl;
+  @media screen and (min-width: tokens.$screen-md) {
+    padding: tokens.$spacing-lg tokens.$layout-xl;
   }
 }
 

--- a/src/app/(proper_react)/(redesign)/(public)/SignUpForm.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/SignUpForm.module.scss
@@ -1,26 +1,26 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .form {
   display: flex;
   flex-wrap: wrap;
-  gap: $spacing-lg;
+  gap: tokens.$spacing-lg;
 
   input {
     flex: 1 0 auto;
-    border-radius: $border-radius-md;
-    border: 1px solid $color-grey-20;
-    padding: $spacing-md;
-    font: $text-body-md;
+    border-radius: tokens.$border-radius-md;
+    border: 1px solid tokens.$color-grey-20;
+    padding: tokens.$spacing-md;
+    font: tokens.$text-body-md;
   }
 
   button {
     flex: 1 0 auto;
-    font: $text-body-md;
+    font: tokens.$text-body-md;
     font-weight: 600;
   }
 
   label {
-    font: $text-body-sm;
+    font: tokens.$text-body-sm;
     font-weight: 500;
   }
 }

--- a/src/app/(proper_react)/(redesign)/(public)/breach-details/[breachName]/BreachDetailView.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/breach-details/[breachName]/BreachDetailView.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../../tokens";
+@use "../../../../../tokens";
 
 .wrapper {
   display: flex;
@@ -6,79 +6,79 @@
   align-items: center;
 
   header {
-    padding: $layout-xl $spacing-xl;
-    max-width: $content-lg;
+    padding: tokens.$layout-xl tokens.$spacing-xl;
+    max-width: tokens.$content-lg;
     text-align: center;
     display: flex;
     flex-direction: column;
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
 
     h1 {
-      font: $text-title-sm;
+      font: tokens.$text-title-sm;
       display: flex;
       align-items: center;
-      gap: $spacing-sm;
+      gap: tokens.$spacing-sm;
     }
 
     a {
-      color: $color-blue-50;
+      color: tokens.$color-blue-50;
       font-weight: 700;
     }
   }
 
   .overview {
     width: 100%;
-    background-color: rgba($color-purple-05, 0.2);
+    background-color: rgba(tokens.$color-purple-05, 0.2);
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: $spacing-lg;
-    padding: $spacing-2xl;
+    gap: tokens.$spacing-lg;
+    padding: tokens.$spacing-2xl;
 
     h2.overviewTitle,
     .content {
-      width: $content-md;
+      width: tokens.$content-md;
       max-width: 100%;
     }
 
     h2.overviewTitle {
-      font: $text-title-sm;
+      font: tokens.$text-title-sm;
     }
 
     .content {
       display: flex;
       flex-direction: column;
-      gap: $spacing-lg;
+      gap: tokens.$spacing-lg;
 
       a[href="#delayed-reporting"] {
-        color: $color-black;
+        color: tokens.$color-black;
       }
 
       h3 {
-        font: $text-title-2xs;
+        font: tokens.$text-title-2xs;
       }
 
       .compromisedDataList ul {
         list-style-type: none;
         display: flex;
         flex-direction: column;
-        gap: $spacing-md;
+        gap: tokens.$spacing-md;
         margin: 0;
-        padding: $spacing-md;
+        padding: tokens.$spacing-md;
 
         li {
           display: flex;
-          gap: $spacing-md;
+          gap: tokens.$spacing-md;
         }
       }
 
       small {
-        color: $color-grey-50;
-        font: $text-body-sm;
+        color: tokens.$color-grey-50;
+        font: tokens.$text-body-sm;
 
         a {
           font-weight: 700;
-          color: $color-grey-50;
+          color: tokens.$color-grey-50;
 
           &:hover {
             text-decoration: none;
@@ -89,23 +89,23 @@
   }
 
   .signUp {
-    background-color: rgba($color-purple-05, 0.5);
+    background-color: rgba(tokens.$color-purple-05, 0.5);
     width: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
     flex-wrap: wrap;
-    gap: $spacing-lg;
-    padding: $spacing-2xl;
+    gap: tokens.$spacing-lg;
+    padding: tokens.$spacing-2xl;
 
     .content {
-      max-width: $content-sm;
+      max-width: tokens.$content-sm;
       display: flex;
       flex-direction: column;
-      gap: $spacing-md;
+      gap: tokens.$spacing-md;
 
       h2.signUpTitle {
-        font: $text-title-3xs;
+        font: tokens.$text-title-3xs;
       }
     }
   }
@@ -116,33 +116,33 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $spacing-2xl;
-  padding: $spacing-2xl;
+  gap: tokens.$spacing-2xl;
+  padding: tokens.$spacing-2xl;
 
   h2.recommendationTitle,
   .lead,
   dl {
-    width: $content-md;
+    width: tokens.$content-md;
     max-width: 100%;
   }
 
   h2.recommendationTitle {
-    font: $text-title-xs;
+    font: tokens.$text-title-xs;
   }
 
   dl {
     display: flex;
     flex-direction: column;
-    gap: $spacing-2xl;
+    gap: tokens.$spacing-2xl;
 
     div {
       $iconWidth: 48px;
 
-      padding-inline-start: calc($iconWidth + $spacing-xl);
+      padding-inline-start: calc($iconWidth + tokens.$spacing-xl);
       position: relative;
       display: flex;
       flex-direction: column;
-      gap: $spacing-md;
+      gap: tokens.$spacing-md;
 
       img {
         position: absolute;
@@ -154,21 +154,21 @@
       }
 
       dt {
-        font: $text-title-3xs;
+        font: tokens.$text-title-3xs;
       }
 
       dd {
         display: flex;
         flex-direction: column;
-        gap: $spacing-md;
-        color: $color-grey-50;
+        gap: tokens.$spacing-md;
+        color: tokens.$color-grey-50;
 
         .cta {
           font-weight: 700;
-          color: $color-blue-50;
+          color: tokens.$color-blue-50;
 
           &:hover {
-            color: $color-blue-80;
+            color: tokens.$color-blue-80;
           }
         }
       }
@@ -177,23 +177,23 @@
 }
 
 .explainers {
-  background-color: rgba($color-purple-05, 0.2);
+  background-color: rgba(tokens.$color-purple-05, 0.2);
   width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $spacing-2xl;
-  padding: $spacing-2xl;
+  gap: tokens.$spacing-2xl;
+  padding: tokens.$spacing-2xl;
 
   .explainer {
-    width: $content-md;
+    width: tokens.$content-md;
     max-width: 100%;
     display: flex;
     flex-direction: column;
-    gap: $spacing-sm;
+    gap: tokens.$spacing-sm;
   }
 
   h2.explainerTitle {
-    font: $text-title-xs;
+    font: tokens.$text-title-xs;
   }
 }

--- a/src/app/(proper_react)/(redesign)/(public)/breaches/BreachIndexView.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/breaches/BreachIndexView.module.scss
@@ -1,26 +1,26 @@
-@import "../../../../tokens";
+@use "../../../../tokens";
 
 .wrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $spacing-lg;
-  padding: $spacing-xs;
+  gap: tokens.$spacing-lg;
+  padding: tokens.$spacing-xs;
 
-  @media (min-width: $screen-md) {
-    padding: $spacing-lg;
+  @media (min-width: tokens.$screen-md) {
+    padding: tokens.$spacing-lg;
   }
 
   header {
-    padding: $spacing-2xl $spacing-xl;
-    max-width: $content-lg;
+    padding: tokens.$spacing-2xl tokens.$spacing-xl;
+    max-width: tokens.$content-lg;
     text-align: center;
     display: flex;
     flex-direction: column;
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
 
     h1 {
-      font: $text-title-sm;
+      font: tokens.$text-title-sm;
     }
   }
 }
@@ -29,8 +29,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $spacing-sm;
-  padding: $spacing-md;
+  gap: tokens.$spacing-sm;
+  padding: tokens.$spacing-md;
   transition: opacity ease-in 500ms;
 
   &[aria-hidden="true"] {
@@ -40,27 +40,27 @@
   }
 
   label {
-    font: $text-body-sm;
-    @include visually-hidden;
+    font: tokens.$text-body-sm;
+    @include tokens.visually-hidden;
   }
   input {
-    font: $text-body-lg;
-    padding: $spacing-sm;
+    font: tokens.$text-body-lg;
+    padding: tokens.$spacing-sm;
   }
 }
 
 .breachList {
-  width: $content-xl;
-  max-width: calc(100% - 2 * $spacing-2xl);
+  width: tokens.$content-xl;
+  max-width: calc(100% - 2 * tokens.$spacing-2xl);
   display: grid;
   align-items: start;
-  grid-gap: $spacing-2xl;
+  grid-gap: tokens.$spacing-2xl;
   list-style-type: none;
   margin: 0;
   padding: 0;
 
-  @media (min-width: $screen-md) {
-    grid-template-columns: repeat(auto-fit, minmax($content-xs, 1fr));
+  @media (min-width: tokens.$screen-md) {
+    grid-template-columns: repeat(auto-fit, minmax(tokens.$content-xs, 1fr));
   }
 
   li {
@@ -70,41 +70,43 @@
   .breachCard {
     display: flex;
     flex-direction: column;
-    box-shadow: $box-shadow-sm;
-    border-radius: $border-radius-md;
+    box-shadow: tokens.$box-shadow-sm;
+    border-radius: tokens.$border-radius-md;
     height: 100%;
     text-decoration: none;
     color: inherit;
 
     &:hover {
-      box-shadow: $box-shadow-md;
+      box-shadow: tokens.$box-shadow-md;
     }
 
     h2 {
-      background-color: $color-grey-05;
+      background-color: tokens.$color-grey-05;
       display: flex;
       align-items: center;
-      gap: $spacing-md;
-      padding: $spacing-md $spacing-lg;
-      font: $text-title-3xs;
+      gap: tokens.$spacing-md;
+      padding: tokens.$spacing-md tokens.$spacing-lg;
+      font: tokens.$text-title-3xs;
     }
 
     dl {
       flex-grow: 1;
       display: flex;
       flex-direction: column;
-      gap: $spacing-md;
-      padding: $spacing-lg $spacing-md;
+      gap: tokens.$spacing-md;
+      padding: tokens.$spacing-lg tokens.$spacing-md;
 
-      @media (min-width: $screen-sm) {
+      @media (min-width: tokens.$screen-sm) {
         // `.breachCard h2` padding + breach logo width + `.breachCard h2` gap,
         // to align the content to the title in the header:
-        padding-inline-start: calc($spacing-md + 32px + $spacing-md);
+        padding-inline-start: calc(
+          tokens.$spacing-md + 32px + tokens.$spacing-md
+        );
       }
 
       dt {
-        font: $text-body-sm;
-        color: $color-grey-50;
+        font: tokens.$text-body-sm;
+        color: tokens.$color-grey-50;
       }
 
       dd {
@@ -113,14 +115,16 @@
     }
 
     .linkDescription {
-      padding: $spacing-md;
-      color: $color-blue-50;
+      padding: tokens.$spacing-md;
+      color: tokens.$color-blue-50;
       font-weight: 700;
 
-      @media (min-width: $screen-sm) {
+      @media (min-width: tokens.$screen-sm) {
         // `.breachCard h2` padding + breach logo width + `.breachCard h2` gap,
         // to align the content to the title in the header:
-        padding-inline-start: calc($spacing-md + 32px + $spacing-md);
+        padding-inline-start: calc(
+          tokens.$spacing-md + 32px + tokens.$spacing-md
+        );
       }
 
       &:hover {

--- a/src/app/(proper_react)/(redesign)/(public)/how-it-works/HowItWorksView.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/how-it-works/HowItWorksView.module.scss
@@ -1,33 +1,33 @@
-@import "../../../../tokens";
+@use "../../../../tokens";
 
 .brokersEmphasis {
   display: inline;
-  color: $color-violet-50;
+  color: tokens.$color-violet-50;
 }
 .breachesEmphasis {
   display: inline;
-  color: $color-purple-70;
+  color: tokens.$color-purple-70;
 }
 
 .header {
-  padding: $layout-lg $spacing-md;
+  padding: tokens.$layout-lg tokens.$spacing-md;
   display: flex;
   justify-content: center;
   span {
     width: 100%;
-    max-width: $content-xl;
+    max-width: tokens.$content-xl;
   }
-  @media screen and (min-width: $content-md) {
-    padding: $layout-lg;
+  @media screen and (min-width: tokens.$content-md) {
+    padding: tokens.$layout-lg;
   }
   .title {
-    font: $text-title-lg;
+    font: tokens.$text-title-lg;
     font-family: "Inter", sans-serif;
-    color: $color-grey-60;
+    color: tokens.$color-grey-60;
   }
   p {
-    color: $color-grey-40;
-    font: $text-body-xl;
+    color: tokens.$color-grey-40;
+    font: tokens.$text-body-xl;
   }
 }
 .sectionWrapper {
@@ -36,7 +36,7 @@
   align-items: center;
   justify-content: space-between;
   &.grayBG {
-    background: $color-grey-05;
+    background: tokens.$color-grey-05;
   }
   ul {
     list-style-type: none;
@@ -47,28 +47,28 @@
     flex-direction: column;
     align-items: center;
     justify-content: space-between;
-    max-width: $content-xl;
-    @media screen and (min-width: $content-md) {
-      padding: $spacing-2xl 0;
-      gap: $spacing-lg;
+    max-width: tokens.$content-xl;
+    @media screen and (min-width: tokens.$content-md) {
+      padding: tokens.$spacing-2xl 0;
+      gap: tokens.$spacing-lg;
     }
     .introContent {
-      gap: $spacing-md;
+      gap: tokens.$spacing-md;
       display: flex;
       flex-direction: column;
-      padding: 0 $spacing-md;
+      padding: 0 tokens.$spacing-md;
       h2 {
-        color: $color-grey-60;
-        font: $text-title-md;
+        color: tokens.$color-grey-60;
+        font: tokens.$text-title-md;
         font-family: "Inter", sans-serif;
       }
       p {
-        color: $color-grey-40;
-        font: $text-body-xl;
+        color: tokens.$color-grey-40;
+        font: tokens.$text-body-xl;
       }
       .horizontalRule {
-        border: 1px solid $color-grey-20;
-        margin: $spacing-md 0;
+        border: 1px solid tokens.$color-grey-20;
+        margin: tokens.$spacing-md 0;
       }
     }
     .introCTA {
@@ -76,18 +76,18 @@
       flex-wrap: wrap;
       align-items: center;
       justify-content: center;
-      gap: $spacing-lg;
-      padding-inline: $spacing-md;
-      padding-block-start: $spacing-xl;
+      gap: tokens.$spacing-lg;
+      padding-inline: tokens.$spacing-md;
+      padding-block-start: tokens.$spacing-xl;
       width: 100%;
       h3 {
-        color: $color-grey-50;
-        font: $text-title-xs;
+        color: tokens.$color-grey-50;
+        font: tokens.$text-title-xs;
         font-family: "Inter", sans-serif;
         flex: auto;
-        max-width: $content-xl;
-        @media screen and (min-width: $screen-md) {
-          width: $content-sm;
+        max-width: tokens.$content-xl;
+        @media screen and (min-width: tokens.$screen-md) {
+          width: tokens.$content-sm;
         }
       }
     }
@@ -98,106 +98,106 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    max-width: $content-xl;
+    max-width: tokens.$content-xl;
     &.reversedStep {
       flex-direction: column-reverse;
     }
     .stepTextContainer {
-      max-width: $content-sm;
-      padding: $spacing-sm;
+      max-width: tokens.$content-sm;
+      padding: tokens.$spacing-sm;
       .stepTitle {
-        font: $text-title-2xs;
+        font: tokens.$text-title-2xs;
         font-family: "Inter", sans-serif;
-        padding-block-start: $spacing-xl;
-        @include uppercase-only-english;
+        padding-block-start: tokens.$spacing-xl;
+        @include tokens.uppercase-only-english;
       }
       .stepSubtitle {
-        color: $color-grey-50;
-        font: $text-title-xs;
+        color: tokens.$color-grey-50;
+        font: tokens.$text-title-xs;
         font-family: "Inter", sans-serif;
-        padding-block-start: $spacing-md;
+        padding-block-start: tokens.$spacing-md;
       }
       .stepBody {
-        color: $color-grey-50;
-        padding-block-start: $spacing-md;
+        color: tokens.$color-grey-50;
+        padding-block-start: tokens.$spacing-md;
       }
       .stepGroupTitleAfter1st {
-        padding-block-start: $spacing-2xl;
+        padding-block-start: tokens.$spacing-2xl;
       }
       .privateInfoRow {
         display: flex;
         flex-direction: row;
         align-items: flex-start;
         justify-content: flex-start;
-        gap: $spacing-xs;
-        padding-block-start: $spacing-sm;
+        gap: tokens.$spacing-xs;
+        padding-block-start: tokens.$spacing-sm;
         width: 100%;
         .privateInfoText {
-          color: $color-grey-50;
+          color: tokens.$color-grey-50;
         }
         img {
           width: 30px;
-          margin-top: $spacing-sm;
-          margin-right: $spacing-sm;
+          margin-top: tokens.$spacing-sm;
+          margin-right: tokens.$spacing-sm;
         }
         .boldedText {
           font-weight: 700;
         }
       }
     }
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: tokens.$screen-md) {
       display: flex;
       flex-wrap: wrap;
       flex-direction: row;
       align-items: center;
       justify-content: space-between;
-      padding: $spacing-md;
-      gap: $spacing-lg;
+      padding: tokens.$spacing-md;
+      gap: tokens.$spacing-lg;
       &.reversedStep {
         flex-direction: row;
       }
       .stepTextContainer {
-        max-width: $content-xs;
+        max-width: tokens.$content-xs;
       }
       img {
-        max-width: $content-xs;
+        max-width: tokens.$content-xs;
       }
     }
-    @media screen and (min-width: $screen-lg) {
-      padding: $spacing-xs;
+    @media screen and (min-width: tokens.$screen-lg) {
+      padding: tokens.$spacing-xs;
       .stepTextContainer {
-        max-width: $content-sm;
+        max-width: tokens.$content-sm;
       }
       img {
-        max-width: $content-sm;
+        max-width: tokens.$content-sm;
       }
     }
-    @media screen and (min-width: $screen-xl) {
-      padding: $spacing-xs;
+    @media screen and (min-width: tokens.$screen-xl) {
+      padding: tokens.$spacing-xs;
       .stepTextContainer {
-        max-width: $content-md;
+        max-width: tokens.$content-md;
       }
       img {
-        max-width: $content-sm;
+        max-width: tokens.$content-sm;
       }
     }
   }
   .sectionCTAButton {
     display: grid;
-    max-width: $content-sm;
+    max-width: tokens.$content-sm;
     width: 100%;
-    margin: $spacing-md 0;
+    margin: tokens.$spacing-md 0;
     button {
-      padding: $spacing-md $spacing-xl;
+      padding: tokens.$spacing-md tokens.$spacing-xl;
     }
     a {
-      margin-inline: $spacing-lg;
+      margin-inline: tokens.$spacing-lg;
     }
     &.breachesCTAButton {
-      padding-inline: $spacing-md;
-      margin-bottom: $spacing-xl;
+      padding-inline: tokens.$spacing-md;
+      margin-bottom: tokens.$spacing-xl;
     }
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: tokens.$screen-md) {
       width: unset;
       max-width: unset;
       a {
@@ -205,21 +205,21 @@
       }
     }
   }
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: tokens.$screen-md) {
     display: flex;
     justify-content: center;
     align-items: center;
     margin: unset;
-    margin-bottom: $layout-lg;
+    margin-bottom: tokens.$layout-lg;
     a {
-      margin: $layout-md;
+      margin: tokens.$layout-md;
     }
     button {
-      margin: $layout-md;
+      margin: tokens.$layout-md;
     }
   }
-  @media screen and (min-width: $screen-lg) {
-    padding-inline: $layout-lg;
+  @media screen and (min-width: tokens.$screen-lg) {
+    padding-inline: tokens.$layout-lg;
   }
 }
 .footerSection {
@@ -227,40 +227,41 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: $color-purple-05;
-  padding: $spacing-2xl $spacing-md;
+  background: tokens.$color-purple-05;
+  padding: tokens.$spacing-2xl tokens.$spacing-md;
   .footerSectionCTA {
-    font: $text-title-2xs;
+    font: tokens.$text-title-2xs;
     font-family: var(--font-inter);
     font-weight: 500;
-    margin-bottom: $spacing-xl;
+    margin-bottom: tokens.$spacing-xl;
   }
   .footerSectionCTAInput {
     display: flex;
     flex-wrap: wrap;
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
     input {
       flex: 1 0 auto;
-      border-radius: $border-radius-md;
-      border: 1px solid $color-grey-20;
-      padding: $spacing-sm;
-      font: $text-body-md;
+      border-radius: tokens.$border-radius-md;
+      border: 1px solid tokens.$color-grey-20;
+      padding: tokens.$spacing-sm;
+      font: tokens.$text-body-md;
     }
     button {
       flex: 1 0 auto;
-      font: $text-body-md;
+      font: tokens.$text-body-md;
       font-weight: 600;
     }
   }
   .note {
-    color: $color-grey-40;
-    font: $text-body-sm;
-    margin-top: $spacing-sm;
+    color: tokens.$color-grey-40;
+    font: tokens.$text-body-sm;
+    margin-top: tokens.$spacing-sm;
   }
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: tokens.$screen-md) {
     .footerSectionCTAInput {
       input {
-        padding: $spacing-md $spacing-xl $spacing-md $spacing-md;
+        padding: tokens.$spacing-md tokens.$spacing-xl tokens.$spacing-md
+          tokens.$spacing-md;
       }
     }
   }

--- a/src/app/(proper_react)/(redesign)/(public)/limitations-apply/LimitationsApply.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/limitations-apply/LimitationsApply.module.scss
@@ -1,35 +1,35 @@
-@import "../../../../tokens";
+@use "../../../../tokens";
 
 .limitationsApplyContainer {
   display: flex;
-  padding: $layout-md $spacing-sm;
+  padding: tokens.$layout-md tokens.$spacing-sm;
 
   .limitationsApplyWrapper {
     display: flex;
     flex-direction: column;
-    gap: $layout-md;
+    gap: tokens.$layout-md;
     align-items: center;
     margin: 0 auto;
 
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: tokens.$screen-md) {
       flex-direction: row;
     }
 
     .limitationsApplyDescription {
       display: flex;
       flex-direction: column;
-      gap: $spacing-md;
+      gap: tokens.$spacing-md;
 
       h1 {
-        font: $text-title-sm;
+        font: tokens.$text-title-sm;
         font-family: var(--font-inter);
       }
 
       aside {
         width: fit-content;
-        background-color: $color-purple-10;
-        border-radius: $border-radius-lg;
-        padding: $spacing-sm $spacing-md;
+        background-color: tokens.$color-purple-10;
+        border-radius: tokens.$border-radius-lg;
+        padding: tokens.$spacing-sm tokens.$spacing-md;
       }
     }
   }

--- a/src/app/(proper_react)/(redesign)/(public)/unsubscribe-email/monthly-report-free/UnsubscribeMonthlyReport.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/unsubscribe-email/monthly-report-free/UnsubscribeMonthlyReport.module.scss
@@ -1,4 +1,4 @@
-@import "../../../../../tokens";
+@use "../../../../../tokens";
 
 .unSubscribeMonthlyReportContainer {
   margin: 0 auto;
@@ -6,25 +6,25 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: $spacing-lg $spacing-sm;
-  gap: $spacing-lg;
+  padding: tokens.$spacing-lg tokens.$spacing-sm;
+  gap: tokens.$spacing-lg;
   text-align: center;
 
-  @media screen and (min-width: $screen-md) {
-    max-width: $content-lg;
+  @media screen and (min-width: tokens.$screen-md) {
+    max-width: tokens.$content-lg;
   }
 
   h1 {
-    font: $text-title-md;
+    font: tokens.$text-title-md;
   }
 
   .cta {
-    max-width: $content-xs;
+    max-width: tokens.$content-xs;
   }
 }
 
 .tryAgain {
-  color: $color-white;
+  color: tokens.$color-white;
   font-weight: 600;
   text-decoration: underline;
   background: none;

--- a/src/app/(proper_react)/(redesign)/MobileShell.module.scss
+++ b/src/app/(proper_react)/(redesign)/MobileShell.module.scss
@@ -1,4 +1,4 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .wrapper {
   display: flex;
@@ -9,15 +9,15 @@
 .header {
   display: none;
 
-  @media screen and (max-width: $screen-xl) {
+  @media screen and (max-width: tokens.$screen-xl) {
     position: sticky;
-    background-color: $color-white;
-    box-shadow: $box-shadow-sm;
+    background-color: tokens.$color-white;
+    box-shadow: tokens.$box-shadow-sm;
     width: 100%;
     display: flex;
     align-items: center;
-    gap: $spacing-sm;
-    padding: $spacing-xs $spacing-sm;
+    gap: tokens.$spacing-sm;
+    padding: tokens.$spacing-xs tokens.$spacing-sm;
     // Overlay `.nonHeader` so that the box-shadow of this element
     // is not covered.
     z-index: 1;
@@ -34,7 +34,7 @@
         justify-content: center;
         background-color: transparent;
         border-style: none;
-        padding: $spacing-md;
+        padding: tokens.$spacing-md;
         cursor: pointer;
 
         svg {
@@ -43,7 +43,7 @@
         }
 
         &:hover svg {
-          color: $color-blue-50;
+          color: tokens.$color-blue-50;
         }
       }
     }
@@ -85,7 +85,7 @@
     display: none;
   }
 
-  @media screen and (max-width: $screen-xl) {
+  @media screen and (max-width: tokens.$screen-xl) {
     .hasOpenMenu & .mainMenuLayer {
       display: block;
       position: sticky;
@@ -97,8 +97,8 @@
       .mainMenu {
         align-items: center;
         display: flex;
-        background-color: $color-white;
-        box-shadow: $box-shadow-sm;
+        background-color: tokens.$color-white;
+        box-shadow: tokens.$box-shadow-sm;
         flex-direction: column;
 
         ul {
@@ -110,33 +110,33 @@
         a,
         a:visited {
           display: block;
-          padding: $spacing-sm $spacing-lg;
-          color: $color-grey-40;
+          padding: tokens.$spacing-sm tokens.$spacing-lg;
+          color: tokens.$color-grey-40;
           font-weight: 500;
-          border-top: 1px solid $color-grey-10;
+          border-top: 1px solid tokens.$color-grey-10;
           text-decoration: none;
 
           &.isActive {
-            color: $color-purple-70;
+            color: tokens.$color-purple-70;
           }
 
           &:hover {
-            background-color: $color-purple-50;
-            color: $color-white;
+            background-color: tokens.$color-purple-50;
+            color: tokens.$color-white;
             text-decoration: underline;
           }
 
           // The `a` and `a:visited` violate this rule, but are safe:
           // stylelint-disable-next-line no-descending-specificity
           &:focus {
-            background-color: $color-blue-50;
-            color: $color-white;
+            background-color: tokens.$color-blue-50;
+            color: tokens.$color-white;
             outline: none;
           }
         }
 
         .subMenu {
-          padding-left: $layout-xs;
+          padding-left: tokens.$layout-xs;
 
           // The `a` and `a:visited` violate this rule, but are safe:
           // stylelint-disable-next-line no-descending-specificity
@@ -145,16 +145,16 @@
             border-top: none;
 
             &.isActive {
-              color: $color-purple-40;
+              color: tokens.$color-purple-40;
               text-decoration: underline;
 
               &:hover {
-                color: $color-purple-70;
+                color: tokens.$color-purple-70;
               }
             }
 
             &:hover {
-              color: $color-grey-40;
+              color: tokens.$color-grey-40;
               background: none;
               text-decoration: underline;
             }
@@ -163,8 +163,8 @@
       }
 
       .premiumCta {
-        margin: $spacing-md;
-        min-width: $screen-xs;
+        margin: tokens.$spacing-md;
+        min-width: tokens.$screen-xs;
 
         & > button {
           width: 100%;

--- a/src/app/(proper_react)/(redesign)/Shell.module.scss
+++ b/src/app/(proper_react)/(redesign)/Shell.module.scss
@@ -1,4 +1,4 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .wrapper {
   height: 100%;
@@ -8,29 +8,29 @@
 .mainMenu {
   display: none;
 
-  @media screen and (min-width: $screen-xl) {
+  @media screen and (min-width: tokens.$screen-xl) {
     flex: 0 0 auto;
     display: flex;
     flex-direction: column;
 
     .homeLink {
-      height: $tab-bar-height;
+      height: tokens.$tab-bar-height;
       display: flex;
       align-items: center;
-      padding: $spacing-xl $spacing-2xl;
-      border-bottom: 1px solid $color-grey-10;
+      padding: tokens.$spacing-xl tokens.$spacing-2xl;
+      border-bottom: 1px solid tokens.$color-grey-10;
 
       &:hover {
-        box-shadow: $box-shadow-sm;
+        box-shadow: tokens.$box-shadow-sm;
       }
 
       &:focus {
-        border-bottom-color: $color-blue-50;
+        border-bottom-color: tokens.$color-blue-50;
       }
 
       img {
         width: auto;
-        height: $layout-sm;
+        height: tokens.$layout-sm;
       }
     }
 
@@ -42,19 +42,19 @@
 
       a {
         display: block;
-        padding: $spacing-md $spacing-lg;
-        color: $color-grey-40;
+        padding: tokens.$spacing-md tokens.$spacing-lg;
+        color: tokens.$color-grey-40;
         font-weight: 500;
-        border-bottom: 1px solid $color-grey-10;
+        border-bottom: 1px solid tokens.$color-grey-10;
         text-decoration: none;
 
         &.isActive {
-          color: $color-purple-70;
+          color: tokens.$color-purple-70;
         }
 
         &:hover {
-          background-color: $color-purple-50;
-          color: $color-white;
+          background-color: tokens.$color-purple-50;
+          color: tokens.$color-white;
           text-decoration: underline;
         }
       }
@@ -74,18 +74,18 @@
 }
 
 .footer {
-  background-color: $color-black;
+  background-color: tokens.$color-black;
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: $spacing-xl;
-  padding-block: $spacing-xl;
+  gap: tokens.$spacing-xl;
+  padding-block: tokens.$spacing-xl;
 
   .mozillaLink {
-    padding: 0 $spacing-md;
+    padding: 0 tokens.$spacing-md;
 
     &:hover img {
-      background-color: $color-purple-50;
+      background-color: tokens.$color-purple-50;
     }
   }
 
@@ -98,18 +98,18 @@
 
     a {
       display: block;
-      color: $color-grey-05;
+      color: tokens.$color-grey-05;
       font-weight: 500;
       text-decoration: none;
-      padding: $spacing-sm $spacing-md;
+      padding: tokens.$spacing-sm tokens.$spacing-md;
 
       &:hover {
-        color: $color-purple-50;
+        color: tokens.$color-purple-50;
       }
     }
   }
 
-  @media screen and (min-width: $screen-lg) {
+  @media screen and (min-width: tokens.$screen-lg) {
     flex-direction: row;
     align-items: center;
     padding-block: 0;
@@ -117,11 +117,11 @@
     .externalLinks {
       flex-direction: row;
       justify-content: flex-end;
-      padding: 0 $spacing-2xl;
+      padding: 0 tokens.$spacing-2xl;
     }
 
     .mozillaLink {
-      padding: $spacing-md $spacing-2xl;
+      padding: tokens.$spacing-md tokens.$spacing-2xl;
     }
   }
 }

--- a/src/app/components/client/BillingPeriod.module.scss
+++ b/src/app/components/client/BillingPeriod.module.scss
@@ -1,32 +1,32 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .toggleContainer {
-  background-color: $color-grey-10;
-  border-radius: $border-radius-xl;
-  border: 1px solid $color-grey-30;
-  padding: $spacing-sm;
+  background-color: tokens.$color-grey-10;
+  border-radius: tokens.$border-radius-xl;
+  border: 1px solid tokens.$color-grey-30;
+  padding: tokens.$spacing-sm;
   display: flex;
   align-items: center;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
 
   .option {
-    border-radius: $border-radius-xl;
-    padding: $spacing-xs $spacing-md;
+    border-radius: tokens.$border-radius-xl;
+    padding: tokens.$spacing-xs tokens.$spacing-md;
     font-weight: 500;
-    color: $color-grey-50;
+    color: tokens.$color-grey-50;
     cursor: pointer;
 
     &.isFocused {
-      outline: 4px solid $color-purple-70;
-      background-color: $color-purple-10;
+      outline: 4px solid tokens.$color-purple-70;
+      background-color: tokens.$color-purple-10;
     }
     &:hover {
-      background-color: $color-purple-20;
+      background-color: tokens.$color-purple-20;
     }
 
     &.isSelected {
-      background-color: $color-white;
-      color: $color-blue-50;
+      background-color: tokens.$color-white;
+      color: tokens.$color-blue-50;
     }
   }
 }

--- a/src/app/components/client/Button.module.scss
+++ b/src/app/components/client/Button.module.scss
@@ -1,11 +1,11 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .button {
-  font: $text-body-md;
+  font: tokens.$text-body-md;
   font-weight: 500;
   border: 0;
-  padding: $spacing-md $spacing-lg;
-  border-radius: $border-radius-md;
+  padding: tokens.$spacing-md tokens.$spacing-lg;
+  border-radius: tokens.$border-radius-md;
   cursor: pointer;
   display: inline-block;
   line-height: 1;
@@ -28,13 +28,13 @@
     animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
 
     &.primary {
-      border: 4px solid $color-white;
-      border-color: $color-white transparent transparent transparent;
+      border: 4px solid tokens.$color-white;
+      border-color: tokens.$color-white transparent transparent transparent;
     }
 
     &.secondary {
-      border: 4px solid $color-purple-70;
-      border-color: $color-purple-70 transparent transparent transparent;
+      border: 4px solid tokens.$color-purple-70;
+      border-color: tokens.$color-purple-70 transparent transparent transparent;
     }
   }
   .ldsRing div:nth-child(1) {
@@ -56,84 +56,84 @@
   }
 
   &.primary {
-    color: $color-white;
-    background-color: $color-purple-70;
+    color: tokens.$color-white;
+    background-color: tokens.$color-purple-70;
 
     &:hover {
-      background-color: $color-purple-80;
+      background-color: tokens.$color-purple-80;
     }
 
     &:focus {
-      outline: $border-focus-width solid $color-purple-30;
+      outline: tokens.$border-focus-width solid tokens.$color-purple-30;
     }
 
     &.destructive {
-      color: $color-white;
-      background-color: $color-red-60;
+      color: tokens.$color-white;
+      background-color: tokens.$color-red-60;
 
       &:hover {
-        background-color: $color-red-70;
+        background-color: tokens.$color-red-70;
       }
 
       &:focus {
-        outline: $border-focus-width solid $color-red-30;
+        outline: tokens.$border-focus-width solid tokens.$color-red-30;
       }
     }
 
     &.disabled {
-      background: $color-grey-20;
+      background: tokens.$color-grey-20;
       pointer-events: none;
     }
   }
 
   &.secondary {
     font-weight: 400;
-    color: $color-purple-70;
-    box-shadow: inset 0 0 0 2px $color-purple-70;
+    color: tokens.$color-purple-70;
+    box-shadow: inset 0 0 0 2px tokens.$color-purple-70;
     background-color: transparent;
 
     &:hover {
-      background-color: $color-purple-70;
-      color: $color-white;
+      background-color: tokens.$color-purple-70;
+      color: tokens.$color-white;
 
       .ldsRing div {
         &.secondary {
-          border: 4px solid $color-white;
-          border-color: $color-white transparent transparent transparent;
+          border: 4px solid tokens.$color-white;
+          border-color: tokens.$color-white transparent transparent transparent;
         }
       }
     }
 
     &.destructive {
-      color: $color-red-70;
-      box-shadow: inset 0 0 0 2px $color-red-70;
+      color: tokens.$color-red-70;
+      box-shadow: inset 0 0 0 2px tokens.$color-red-70;
 
       &:hover {
-        background-color: $color-red-70;
-        color: $color-white;
+        background-color: tokens.$color-red-70;
+        color: tokens.$color-white;
       }
     }
 
     &.disabled {
-      color: $color-grey-20;
+      color: tokens.$color-grey-20;
       background: transparent;
-      box-shadow: inset 0 0 0 2px $color-grey-20;
+      box-shadow: inset 0 0 0 2px tokens.$color-grey-20;
       pointer-events: none;
     }
   }
 
   &.tertiary {
     background: none;
-    color: $color-purple-70;
+    color: tokens.$color-purple-70;
 
     &:hover {
-      background-color: rgba($color-purple-70, 0.2);
+      background-color: rgba(tokens.$color-purple-70, 0.2);
     }
   }
 
   &.link {
     background: none;
-    color: $color-purple-50;
+    color: tokens.$color-purple-50;
     font: inherit;
     padding: 0;
     text-decoration: underline;
@@ -141,11 +141,11 @@
 
   &.icon {
     background: none;
-    color: $color-grey-50;
-    padding: $spacing-md;
+    color: tokens.$color-grey-50;
+    padding: tokens.$spacing-md;
 
     &:hover {
-      background-color: $color-grey-05;
+      background-color: tokens.$color-grey-05;
     }
   }
 
@@ -156,14 +156,14 @@
 
   &.small {
     line-height: 1.5;
-    padding: $spacing-sm $spacing-md;
+    padding: tokens.$spacing-sm tokens.$spacing-md;
 
     &.icon {
-      padding: $spacing-sm;
+      padding: tokens.$spacing-sm;
     }
   }
 
   &.wide {
-    padding: $spacing-md $spacing-2xl;
+    padding: tokens.$spacing-md tokens.$spacing-2xl;
   }
 }

--- a/src/app/components/client/Chart.module.scss
+++ b/src/app/components/client/Chart.module.scss
@@ -1,12 +1,12 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .chartContainer {
   text-align: center;
   display: flex;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
   flex-direction: column;
 
-  @media screen and (min-width: $screen-lg) {
+  @media screen and (min-width: tokens.$screen-lg) {
     align-items: flex-end;
   }
 
@@ -14,12 +14,12 @@
     text-align: center;
     display: flex;
     align-items: center;
-    gap: $spacing-xs;
-    font: $text-body-xs;
+    gap: tokens.$spacing-xs;
+    font: tokens.$text-body-xs;
     font-style: italic;
 
     button {
-      @include question-mark-circle-btn;
+      @include tokens.question-mark-circle-btn;
     }
   }
 }
@@ -27,29 +27,29 @@
 .modalBodyContent {
   display: flex;
   flex-direction: column;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
 
   .confirmButtonWrapper {
     align-self: center;
     display: flex;
     flex-direction: column;
-    min-width: $content-xs;
-    padding-block-start: $spacing-md;
+    min-width: tokens.$content-xs;
+    padding-block-start: tokens.$spacing-md;
   }
 }
 
 .gutter {
-  stroke: $color-white;
+  stroke: tokens.$color-white;
 }
 
 .chartAndLegendWrapper {
   display: flex;
   flex-direction: column;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
-  @media screen and (min-width: $screen-lg) {
+  @media screen and (min-width: tokens.$screen-lg) {
     flex-direction: row;
-    gap: $spacing-xl;
+    gap: tokens.$spacing-xl;
   }
 
   .chart {
@@ -77,16 +77,16 @@
     align-self: center;
     flex-direction: column;
     display: flex;
-    gap: $spacing-sm;
+    gap: tokens.$spacing-sm;
 
     .prompt {
-      font: $text-body-xs;
+      font: tokens.$text-body-xs;
       display: flex;
       text-align: start;
       flex-direction: column;
-      gap: $spacing-xs;
-      border: 1px solid $color-purple-70;
-      padding: $spacing-sm;
+      gap: tokens.$spacing-xs;
+      border: 1px solid tokens.$color-purple-70;
+      padding: tokens.$spacing-sm;
       align-items: flex-start;
     }
 
@@ -107,12 +107,12 @@
 
     tbody tr {
       text-align: start;
-      color: $color-grey-40;
-      font: $text-body-xs;
+      color: tokens.$color-grey-40;
+      font: tokens.$text-body-xs;
 
       td {
-        padding-block: $spacing-xs;
-        padding-inline: $spacing-xs;
+        padding-block: tokens.$spacing-xs;
+        padding-inline: tokens.$spacing-xs;
       }
 
       svg {
@@ -126,123 +126,123 @@
 /* stylelint-disable no-descending-specificity */
 // We start at 2, because element 1 is .gutter
 .slice:nth-child(2) {
-  stroke: $color-purple-90;
+  stroke: tokens.$color-purple-90;
 }
 .legend tbody tr:nth-child(1) {
   .chartAndLegendWrapper:has(.slice:nth-child(2):hover) & {
-    color: $color-purple-90;
+    color: tokens.$color-purple-90;
   }
 
   rect {
-    fill: $color-purple-90;
+    fill: tokens.$color-purple-90;
   }
 }
 .slice:nth-child(3) {
-  stroke: $color-purple-70;
+  stroke: tokens.$color-purple-70;
 }
 .legend tbody tr:nth-child(2) {
   .chartAndLegendWrapper:has(.slice:nth-child(3):hover) & {
-    color: $color-purple-70;
+    color: tokens.$color-purple-70;
   }
 
   rect {
-    fill: $color-purple-70;
+    fill: tokens.$color-purple-70;
   }
 }
 .slice:nth-child(4) {
-  stroke: $color-purple-50;
+  stroke: tokens.$color-purple-50;
 }
 .legend tbody tr:nth-child(3) {
   .chartAndLegendWrapper:has(.slice:nth-child(4):hover) & {
-    color: $color-purple-50;
+    color: tokens.$color-purple-50;
   }
 
   rect {
-    fill: $color-purple-50;
+    fill: tokens.$color-purple-50;
   }
 }
 .slice:nth-child(5) {
-  stroke: $color-purple-30;
+  stroke: tokens.$color-purple-30;
 }
 .legend tbody tr:nth-child(4) {
   .chartAndLegendWrapper:has(.slice:nth-child(5):hover) & {
-    color: $color-purple-30;
+    color: tokens.$color-purple-30;
   }
 
   rect {
-    fill: $color-purple-30;
+    fill: tokens.$color-purple-30;
   }
 }
 .slice:nth-child(6) {
-  stroke: $color-purple-10;
+  stroke: tokens.$color-purple-10;
 }
 .legend tbody tr:nth-child(5) {
   .chartAndLegendWrapper:has(.slice:nth-child(6):hover) & {
-    color: $color-purple-10;
+    color: tokens.$color-purple-10;
   }
 
   rect {
-    fill: $color-purple-10;
+    fill: tokens.$color-purple-10;
   }
 }
 .slice:nth-child(7) {
-  stroke: $color-purple-80;
+  stroke: tokens.$color-purple-80;
 }
 .legend tbody tr:nth-child(6) {
   .chartAndLegendWrapper:has(.slice:nth-child(7):hover) & {
-    color: $color-purple-80;
+    color: tokens.$color-purple-80;
   }
 
   rect {
-    fill: $color-purple-80;
+    fill: tokens.$color-purple-80;
   }
 }
 .slice:nth-child(8) {
-  stroke: $color-purple-60;
+  stroke: tokens.$color-purple-60;
 }
 .legend tbody tr:nth-child(7) {
   .chartAndLegendWrapper:has(.slice:nth-child(8):hover) & {
-    color: $color-purple-60;
+    color: tokens.$color-purple-60;
   }
 
   rect {
-    fill: $color-purple-60;
+    fill: tokens.$color-purple-60;
   }
 }
 .slice:nth-child(9) {
-  stroke: $color-purple-40;
+  stroke: tokens.$color-purple-40;
 }
 .legend tbody tr:nth-child(8) {
   .chartAndLegendWrapper:has(.slice:nth-child(9):hover) & {
-    color: $color-purple-40;
+    color: tokens.$color-purple-40;
   }
 
   rect {
-    fill: $color-purple-40;
+    fill: tokens.$color-purple-40;
   }
 }
 .slice:nth-child(10) {
-  stroke: $color-purple-20;
+  stroke: tokens.$color-purple-20;
 }
 .legend tbody tr:nth-child(9) {
   .chartAndLegendWrapper:has(.slice:nth-child(10):hover) & {
-    color: $color-purple-20;
+    color: tokens.$color-purple-20;
   }
 
   rect {
-    fill: $color-purple-20;
+    fill: tokens.$color-purple-20;
   }
 }
 .slice:nth-child(11) {
-  stroke: $color-violet-90;
+  stroke: tokens.$color-violet-90;
 }
 .legend tbody tr:nth-child(10) {
   .chartAndLegendWrapper:has(.slice:nth-child(11):hover) & {
-    color: $color-violet-90;
+    color: tokens.$color-violet-90;
   }
 
   rect {
-    fill: $color-violet-90;
+    fill: tokens.$color-violet-90;
   }
 }
 /* stylelint-enable no-descending-specificity */

--- a/src/app/components/client/ComboBox.module.scss
+++ b/src/app/components/client/ComboBox.module.scss
@@ -1,6 +1,6 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .popoverList {
-  border-radius: $border-radius-sm;
-  box-shadow: $box-shadow-sm;
+  border-radius: tokens.$border-radius-sm;
+  box-shadow: tokens.$box-shadow-sm;
 }

--- a/src/app/components/client/DataBrokerProfiles.module.scss
+++ b/src/app/components/client/DataBrokerProfiles.module.scss
@@ -1,4 +1,4 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .dataBrokerProfileCardsWapper {
   text-align: center;
@@ -6,10 +6,10 @@
 
 // This view shows the first X many data broker profile cards based on the break point. It uses nth-child to set/unset visibility.
 .dataBrokerProfileCards {
-  padding: $spacing-md 0;
+  padding: tokens.$spacing-md 0;
   display: grid;
   grid-template-columns: 1fr;
-  gap: $spacing-lg;
+  gap: tokens.$spacing-lg;
   list-style: none;
   width: 100%;
 
@@ -27,12 +27,12 @@
   &.showAll {
     li {
       display: unset;
-      @media screen and (min-width: $screen-md) {
+      @media screen and (min-width: tokens.$screen-md) {
         &:nth-child(n + 5) {
           display: unset;
         }
       }
-      @media screen and (min-width: $screen-xl) {
+      @media screen and (min-width: tokens.$screen-xl) {
         &:nth-child(n + 7),
         &:nth-child(n + 9) {
           display: unset;
@@ -41,11 +41,11 @@
     }
   }
 
-  @media screen and (min-width: $screen-sm) {
+  @media screen and (min-width: tokens.$screen-sm) {
     grid-template-columns: 1fr 1fr;
   }
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: tokens.$screen-md) {
     grid-template-columns: 1fr 1fr 1fr;
 
     li:nth-child(n + 5) {
@@ -60,12 +60,12 @@
 }
 
 .dataBrokerProfileCard {
-  background-color: $color-white;
-  box-shadow: $box-shadow-sm;
-  border-radius: $border-radius-sm;
+  background-color: tokens.$color-white;
+  box-shadow: tokens.$box-shadow-sm;
+  border-radius: tokens.$border-radius-sm;
   text-align: center;
-  padding: $spacing-md $spacing-sm $spacing-md;
-  font: $text-body-sm;
+  padding: tokens.$spacing-md tokens.$spacing-sm tokens.$spacing-md;
+  font: tokens.$text-body-sm;
   height: 100%;
   display: flex;
   flex-direction: column;
@@ -84,11 +84,11 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: $spacing-sm;
+    gap: tokens.$spacing-sm;
   }
 
   .openInNewTab {
-    color: $color-blue-50;
+    color: tokens.$color-blue-50;
     display: inline-block;
   }
 }
@@ -100,7 +100,7 @@
   display: inline-flex;
   justify-items: center;
   align-items: center;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
   transition: transform 0.2s ease;
   cursor: pointer;
 

--- a/src/app/components/client/ExposuresFilter.module.scss
+++ b/src/app/components/client/ExposuresFilter.module.scss
@@ -1,13 +1,13 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .filterHeaderWrapper {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  gap: $layout-xs;
-  padding: $spacing-sm $spacing-md;
-  border-bottom: 1px solid $color-grey-20;
+  gap: tokens.$layout-xs;
+  padding: tokens.$spacing-sm tokens.$spacing-md;
+  border-bottom: 1px solid tokens.$color-grey-20;
 
   .rightSpace {
     // Spacing to accomodate the gap where the chevron of the same dimension falls within the alignment
@@ -16,24 +16,24 @@
   }
 
   button {
-    @include question-mark-circle-btn;
+    @include tokens.question-mark-circle-btn;
   }
 
   ul.filterHeaderList {
-    font: $text-body-sm;
+    font: tokens.$text-body-sm;
     font-weight: 600;
     list-style-type: none;
     display: flex;
     align-items: center;
     padding-left: 0;
-    gap: $layout-sm;
+    gap: tokens.$layout-sm;
     width: 100%;
     justify-content: space-between;
 
     li {
       display: flex;
       align-items: center;
-      gap: $spacing-xs;
+      gap: tokens.$spacing-xs;
 
       button svg {
         min-width: 15px;
@@ -43,15 +43,15 @@
         display: none;
       }
 
-      @media screen and (min-width: $screen-lg) {
+      @media screen and (min-width: tokens.$screen-lg) {
         flex: 1 1 0%;
 
         &.exposureImageWrapper {
-          flex: 0.2 0 $width-first-column-filter-bar;
+          flex: 0.2 0 tokens.$width-first-column-filter-bar;
         }
       }
 
-      @media screen and (min-width: $screen-xl) {
+      @media screen and (min-width: tokens.$screen-xl) {
         &.hideOnMobile {
           display: flex;
         }
@@ -65,43 +65,43 @@
     .filterBtn {
       display: flex;
       flex-direction: row;
-      gap: $spacing-xs;
+      gap: tokens.$spacing-xs;
       align-items: center;
     }
   }
 }
 
 .filterDialog {
-  background: $color-white;
-  border-radius: $border-radius-sm;
-  box-shadow: $box-shadow-md;
-  width: $content-xs;
+  background: tokens.$color-white;
+  border-radius: tokens.$border-radius-sm;
+  box-shadow: tokens.$box-shadow-md;
+  width: tokens.$content-xs;
   overflow-y: scroll;
 
-  @media screen and (min-width: $screen-sm) {
+  @media screen and (min-width: tokens.$screen-sm) {
     width: auto;
     overflow-y: hidden;
   }
 
   .exposuresFilterWrapper {
-    padding: $spacing-md;
+    padding: tokens.$spacing-md;
 
-    @media screen and (min-width: $screen-sm) {
-      padding: $spacing-xl;
+    @media screen and (min-width: tokens.$screen-sm) {
+      padding: tokens.$spacing-xl;
     }
 
     .dismissButton {
       position: absolute;
       top: 0;
       right: 0;
-      padding: $spacing-md;
-      color: $color-grey-40;
+      padding: tokens.$spacing-md;
+      color: tokens.$color-grey-40;
       background: none;
       border: none;
       cursor: pointer;
 
       &:hover {
-        color: $color-grey-30;
+        color: tokens.$color-grey-30;
       }
     }
 
@@ -109,43 +109,43 @@
       display: flex;
       justify-content: flex-end;
       flex-direction: row;
-      gap: $spacing-sm;
-      padding-top: $spacing-md;
+      gap: tokens.$spacing-sm;
+      padding-top: tokens.$spacing-md;
       width: 100%;
     }
 
     .exposuresFilterRadioButtons {
       display: flex;
       flex-direction: column;
-      gap: $spacing-md;
+      gap: tokens.$spacing-md;
 
-      @media screen and (min-width: $screen-sm) {
+      @media screen and (min-width: tokens.$screen-sm) {
         flex-direction: row;
-        gap: $spacing-2xl;
+        gap: tokens.$spacing-2xl;
       }
 
       .exposuresFilterCategory {
         .radioButtonsWrapper {
-          padding-top: $spacing-sm;
+          padding-top: tokens.$spacing-sm;
           display: flex;
           flex-direction: column;
-          gap: $spacing-xs;
+          gap: tokens.$spacing-xs;
 
           .radioItem {
-            font: $text-body-sm;
+            font: tokens.$text-body-sm;
             font-weight: 500;
             display: flex;
-            gap: $spacing-xs;
+            gap: tokens.$spacing-xs;
           }
         }
 
         .exposuresFilterLabel {
           font-weight: 600;
-          border-bottom: 1px solid $color-black;
-          padding-bottom: $spacing-xs;
+          border-bottom: 1px solid tokens.$color-black;
+          padding-bottom: tokens.$spacing-xs;
           display: flex;
           flex-direction: row;
-          gap: $spacing-xs;
+          gap: tokens.$spacing-xs;
           align-items: center;
         }
       }
@@ -157,20 +157,20 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
   .statusList {
-    padding: $spacing-md 0;
+    padding: tokens.$spacing-md 0;
 
     .statusListItem {
       align-items: flex-start;
-      gap: $spacing-sm;
+      gap: tokens.$spacing-sm;
       display: flex;
       flex-direction: column;
 
-      @media screen and (min-width: $screen-sm) {
+      @media screen and (min-width: tokens.$screen-sm) {
         align-items: center;
-        gap: $spacing-md;
+        gap: tokens.$spacing-md;
         flex-direction: row;
       }
     }
@@ -178,9 +178,9 @@
 }
 
 .visuallyHidden {
-  @include visually-hidden;
+  @include tokens.visually-hidden;
 }
 
 .companyNameArea {
-  @include company-name-area;
+  @include tokens.company-name-area;
 }

--- a/src/app/components/client/FixNavigation.module.scss
+++ b/src/app/components/client/FixNavigation.module.scss
@@ -1,33 +1,35 @@
-@import "../../tokens";
+@use "sass:math";
+
+@use "../../tokens";
 
 .stepsWrapper {
-  @include no-focus-outline;
-  margin-block-end: $layout-lg;
+  @include tokens.no-focus-outline;
+  margin-block-end: tokens.$layout-lg;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding-inline: $spacing-lg;
+  padding-inline: tokens.$spacing-lg;
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: tokens.$screen-md) {
     height: 33%;
   }
 
-  @media screen and (min-width: $screen-md) {
-    padding-inline: $spacing-2xl;
+  @media screen and (min-width: tokens.$screen-md) {
+    padding-inline: tokens.$spacing-2xl;
   }
 
-  @media screen and (min-width: $screen-lg) {
-    padding-inline: $layout-xl;
+  @media screen and (min-width: tokens.$screen-lg) {
+    padding-inline: tokens.$layout-xl;
   }
 
   .steps {
-    @include no-focus-outline;
+    @include tokens.no-focus-outline;
   }
 }
 
-@media screen and (min-width: $screen-md) {
+@media screen and (min-width: tokens.$screen-md) {
   .steps {
-    $stepGap: $layout-xl;
+    $stepGap: tokens.$layout-xl;
     $iconDiameter: 40px;
     $checkIconDiameter: 15px;
     $iconBorderWidth: 4px;
@@ -38,7 +40,7 @@
     display: flex;
     gap: $stepGap;
     position: relative;
-    max-width: $content-md;
+    max-width: tokens.$content-md;
     align-items: center;
 
     .progressBarLineContainer {
@@ -51,11 +53,11 @@
       .progressBarLineWrapper {
         width: 100%;
         height: 3px;
-        background-color: $color-grey-30;
+        background-color: tokens.$color-grey-30;
         position: relative;
 
         .activeProgressBarLine {
-          background-color: $color-purple-10;
+          background-color: tokens.$color-purple-10;
           height: 3px;
           position: absolute;
 
@@ -65,13 +67,13 @@
               width: calc(100% / 6 + $iconDiameter);
             }
             &.beginHighRiskDataBreaches {
-              width: 100% / 6 * 2;
+              width: math.div(100%, 6) * 2;
             }
             &.duringHighRiskDataBreaches {
-              width: 100% / 6 * 3;
+              width: math.div(100%, 6) * 3;
             }
             &.beginLeakedPasswords {
-              width: 100% / 6 * 4;
+              width: math.div(100%, 6) * 4;
             }
             &.duringLeakedPasswords {
               width: calc(100% / 6 * 5 - $iconDiameter);
@@ -89,7 +91,7 @@
               width: 50%;
             }
             &.duringLeakedPasswords {
-              width: 100% / 3 * 2;
+              width: math.div(100%, 3) * 2;
             }
             &.beginSecurityRecommendations {
               width: 100%;
@@ -103,11 +105,11 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: $spacing-xs;
+      gap: tokens.$spacing-xs;
       text-align: center;
-      font: $text-body-xs;
+      font: tokens.$text-body-xs;
       font-weight: 400;
-      color: $color-grey-30;
+      color: tokens.$color-grey-30;
 
       &.navigationItem {
         // Overlap the horizontal line
@@ -126,48 +128,48 @@
           width: 100%;
           height: 100%;
           border-radius: 100%;
-          padding: $spacing-sm;
-          background-color: $color-grey-30;
+          padding: tokens.$spacing-sm;
+          background-color: tokens.$color-grey-30;
 
           &.checkIcon {
-            color: $color-white;
+            color: tokens.$color-white;
             padding: 12px; // Specific padding for check mark icon
           }
         }
       }
 
       &[aria-current="step"] .stepIcon > * {
-        outline: $iconBorderWidth solid $color-purple-10;
+        outline: $iconBorderWidth solid tokens.$color-purple-10;
       }
 
       .stepLabel {
-        padding-top: $layout-md;
+        padding-top: tokens.$layout-md;
         position: absolute;
         width: 100px;
       }
 
       &[aria-current="step"] .stepLabel {
-        padding-top: calc($layout-md + $spacing-sm);
+        padding-top: calc(tokens.$layout-md + tokens.$spacing-sm);
       }
 
       &.isCompleted,
       &[aria-current="step"] {
-        color: $color-purple-70;
+        color: tokens.$color-purple-70;
 
         .stepIcon > * {
-          background-color: $color-purple-70;
+          background-color: tokens.$color-purple-70;
         }
       }
     }
   }
 }
-@media screen and (max-width: calc($screen-md - 1px)) {
+@media screen and (max-width: calc(tokens.$screen-md - 1px)) {
   .steps {
     padding-inline-start: 0;
     list-style-type: none;
     display: flex;
     justify-content: space-evenly;
-    gap: $spacing-sm;
+    gap: tokens.$spacing-sm;
 
     li {
       .stepIcon {
@@ -176,9 +178,9 @@
         // a 0 height and a border. The images are <1kB in size, so that
         // shouldn't matter too much.
         height: 0;
-        border: 3px solid $color-grey-30;
+        border: 3px solid tokens.$color-grey-30;
         border-radius: 3px;
-        min-width: $layout-sm;
+        min-width: tokens.$layout-sm;
         width: 100%;
         pointer-events: none;
         user-select: none;
@@ -189,24 +191,24 @@
       }
 
       &[aria-current="step"] .stepIcon {
-        border-color: $color-purple-10;
+        border-color: tokens.$color-purple-10;
       }
 
       &.isCompleted .stepIcon {
-        border-color: $color-purple-70;
+        border-color: tokens.$color-purple-70;
       }
 
       .stepLabel {
-        padding-block: $spacing-sm;
-        padding-inline: $spacing-md;
-        color: $color-purple-70;
-        font: $text-body-xs;
+        padding-block: tokens.$spacing-sm;
+        padding-inline: tokens.$spacing-md;
+        color: tokens.$color-purple-70;
+        font: tokens.$text-body-xs;
         font-weight: 600;
-        top: $spacing-lg;
+        top: tokens.$spacing-lg;
       }
 
       &:not([aria-current="step"]) .stepLabel {
-        @include visually-hidden;
+        @include tokens.visually-hidden;
       }
     }
   }

--- a/src/app/components/client/InputField.module.scss
+++ b/src/app/components/client/InputField.module.scss
@@ -1,8 +1,8 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .input,
 .comboBox {
-  background: $color-white;
+  background: tokens.$color-white;
   display: flex;
   flex-direction: column;
   position: relative;
@@ -12,14 +12,14 @@
   }
 
   .floatingLabel {
-    background: $color-white;
-    border-radius: $border-radius-sm;
-    color: $color-black;
+    background: tokens.$color-white;
+    border-radius: tokens.$border-radius-sm;
+    color: tokens.$color-black;
     display: inline-block;
     // Add a bit more space: The next spacing step is too much.
-    left: calc($spacing-sm * 1.5);
+    left: calc(tokens.$spacing-sm * 1.5);
     line-height: 1em;
-    padding: 0 calc($spacing-xs * 0.5);
+    padding: 0 calc(tokens.$spacing-xs * 0.5);
     pointer-events: none;
     position: absolute;
     top: 50%;
@@ -30,51 +30,53 @@
   }
 
   .inputField {
-    border: 1px solid $color-grey-30;
-    border-radius: $border-radius-sm;
-    color: $color-black;
+    border: 1px solid tokens.$color-grey-30;
+    border-radius: tokens.$border-radius-sm;
+    color: tokens.$color-black;
     // Add a bit more space: The next spacing step is too much.
-    padding: calc($spacing-sm * 1.5);
+    padding: calc(tokens.$spacing-sm * 1.5);
     width: 100%;
 
     &.noValue {
-      color: $color-grey-40;
+      color: tokens.$color-grey-40;
     }
 
     &.hasError {
-      border-color: $color-error;
+      border-color: tokens.$color-error;
 
       &:focus {
-        border: 1px solid $color-error;
-        outline: $border-focus-width solid $color-error-focus;
+        border: 1px solid tokens.$color-error;
+        outline: tokens.$border-focus-width solid tokens.$color-error-focus;
       }
     }
 
     &:focus {
-      border: 1px solid $color-informational-active;
-      outline: $border-focus-width solid $color-informational-focus;
+      border: 1px solid tokens.$color-informational-active;
+      outline: tokens.$border-focus-width solid
+        tokens.$color-informational-focus;
     }
 
     &:disabled {
       background: none;
-      border: 1px solid $color-grey-10;
+      border: 1px solid tokens.$color-grey-10;
     }
   }
 
   &:has(.floatingLabel) {
     ::placeholder {
-      @include visually-hidden;
+      @include tokens.visually-hidden;
     }
     .inputField {
       // Move the value string off-center.
-      padding: calc($spacing-md * 1.25) calc($spacing-sm * 1.5) $spacing-xs;
+      padding: calc(tokens.$spacing-md * 1.25) calc(tokens.$spacing-sm * 1.5)
+        tokens.$spacing-xs;
     }
   }
 
   &:focus-within,
   &:not(:has(:placeholder-shown)) {
     .floatingLabel {
-      color: $color-grey-40;
+      color: tokens.$color-grey-40;
       // Make the floating label visually align with the input value.
       transform: translate(-0.05em, -115%) scale(0.75);
     }
@@ -82,32 +84,32 @@
 
   .inputLabel {
     font-weight: 600;
-    margin-bottom: $spacing-sm;
+    margin-bottom: tokens.$spacing-sm;
   }
 
   .buttonIcon {
     position: absolute;
-    right: $spacing-xs;
+    right: tokens.$spacing-xs;
     top: 50%;
     transform: translateY(-50%);
 
     &:hover button {
-      color: $color-error;
+      color: tokens.$color-error;
     }
   }
 
   .inputMessage {
     display: flex;
     align-items: center;
-    color: $color-grey-40;
-    gap: $spacing-xs;
+    color: tokens.$color-grey-40;
+    gap: tokens.$spacing-xs;
     background: inherit;
-    border-radius: $border-radius-sm;
+    border-radius: tokens.$border-radius-sm;
     bottom: 0;
-    font: $text-body-xs;
+    font: tokens.$text-body-xs;
     left: 0;
-    margin: 0 $spacing-sm;
-    padding: 0 $spacing-sm;
+    margin: 0 tokens.$spacing-sm;
+    padding: 0 tokens.$spacing-sm;
     position: absolute;
     // the negative y-offset is 50% of the line-height plus a bit extra for
     // visual balance in relation to the input border endings left and right
@@ -115,6 +117,6 @@
   }
 
   &:has([aria-invalid="true"]) .inputMessage {
-    color: $color-error;
+    color: tokens.$color-error;
   }
 }

--- a/src/app/components/client/ListBox.module.scss
+++ b/src/app/components/client/ListBox.module.scss
@@ -1,24 +1,24 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .listBox {
   list-style: none;
   margin: 0;
-  padding: $spacing-sm 0;
+  padding: tokens.$spacing-sm 0;
 }
 
 .item {
-  background: $color-white;
+  background: tokens.$color-white;
   color: color;
   cursor: pointer;
   outline: none;
 
   &.isSelected {
-    background: $color-purple-10;
+    background: tokens.$color-purple-10;
   }
   &.isFocused {
-    background: $color-grey-10;
+    background: tokens.$color-grey-10;
   }
   &.isDisabled {
-    color: $color-grey-30;
+    color: tokens.$color-grey-30;
   }
 }

--- a/src/app/components/client/LocationAutocomplete.module.scss
+++ b/src/app/components/client/LocationAutocomplete.module.scss
@@ -1,9 +1,9 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .locationItem {
-  font: $text-body-sm;
+  font: tokens.$text-body-sm;
   // Add a bit more vertical space: The next spacing step is too much.
-  padding: $spacing-sm calc($spacing-sm * 1.5);
+  padding: tokens.$spacing-sm calc(tokens.$spacing-sm * 1.5);
 
   strong {
     // Space small bold letters a bit wider for legibility.
@@ -11,13 +11,13 @@
   }
 
   span {
-    color: $color-grey-40;
-    font: $text-body-xs;
+    color: tokens.$color-grey-40;
+    font: tokens.$text-body-xs;
     margin-left: 0.5em;
   }
 }
 
 .infoText {
-  font: $text-body-xs;
-  padding: $spacing-sm 0;
+  font: tokens.$text-body-xs;
+  padding: tokens.$spacing-sm 0;
 }

--- a/src/app/components/client/PercentageChart.module.scss
+++ b/src/app/components/client/PercentageChart.module.scss
@@ -1,9 +1,9 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .chartContainer {
   text-align: center;
   display: flex;
-  gap: $spacing-lg;
+  gap: tokens.$spacing-lg;
   flex-direction: column;
   align-items: center;
 
@@ -11,12 +11,12 @@
     text-align: center;
     display: flex;
     align-items: center;
-    gap: $spacing-xs;
-    font: $text-body-xs;
+    gap: tokens.$spacing-xs;
+    font: tokens.$text-body-xs;
     font-style: italic;
 
     button {
-      @include question-mark-circle-btn;
+      @include tokens.question-mark-circle-btn;
     }
   }
 }
@@ -24,29 +24,29 @@
 .modalBodyContent {
   display: flex;
   flex-direction: column;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
 
   .confirmButtonWrapper {
     align-self: center;
     display: flex;
     flex-direction: column;
-    min-width: $content-xs;
-    padding-block-start: $spacing-md;
+    min-width: tokens.$content-xs;
+    padding-block-start: tokens.$spacing-md;
   }
 }
 
 .gutter {
-  stroke: $color-white;
+  stroke: tokens.$color-white;
 }
 
 .chartWrapper {
   display: flex;
   flex-direction: column;
-  gap: $spacing-md;
+  gap: tokens.$spacing-md;
 
-  @media screen and (min-width: $screen-sm) {
+  @media screen and (min-width: tokens.$screen-sm) {
     flex-direction: row;
-    gap: $spacing-xl;
+    gap: tokens.$spacing-xl;
   }
 
   .chart {
@@ -83,34 +83,34 @@
 /* stylelint-disable no-descending-specificity */
 // We start at 2, because element 1 is .gutter
 .slice:nth-child(2) {
-  stroke: $color-purple-90;
+  stroke: tokens.$color-purple-90;
 }
 
 .slice:nth-child(3) {
-  stroke: $color-purple-70;
+  stroke: tokens.$color-purple-70;
 }
 .slice:nth-child(4) {
-  stroke: $color-purple-50;
+  stroke: tokens.$color-purple-50;
 }
 .slice:nth-child(5) {
-  stroke: $color-purple-30;
+  stroke: tokens.$color-purple-30;
 }
 .slice:nth-child(6) {
-  stroke: $color-purple-10;
+  stroke: tokens.$color-purple-10;
 }
 .slice:nth-child(7) {
-  stroke: $color-purple-80;
+  stroke: tokens.$color-purple-80;
 }
 .slice:nth-child(8) {
-  stroke: $color-purple-60;
+  stroke: tokens.$color-purple-60;
 }
 .slice:nth-child(9) {
-  stroke: $color-purple-40;
+  stroke: tokens.$color-purple-40;
 }
 .slice:nth-child(10) {
-  stroke: $color-purple-20;
+  stroke: tokens.$color-purple-20;
 }
 .slice:nth-child(11) {
-  stroke: $color-violet-90;
+  stroke: tokens.$color-violet-90;
 }
 /* stylelint-enable no-descending-specificity */

--- a/src/app/components/client/PetitionBanner.module.scss
+++ b/src/app/components/client/PetitionBanner.module.scss
@@ -1,68 +1,72 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .banner {
-  background: linear-gradient(90deg, $color-purple-90 50%, $color-purple-60);
+  background: linear-gradient(
+    90deg,
+    tokens.$color-purple-90 50%,
+    tokens.$color-purple-60
+  );
   display: flex;
   justify-content: center;
-  padding: $layout-xs $layout-sm;
+  padding: tokens.$layout-xs tokens.$layout-sm;
   position: relative;
 }
 
 .content {
   h2 {
-    font: $text-title-xs;
+    font: tokens.$text-title-xs;
     font-weight: 500;
   }
 
   display: flex;
   flex-direction: column;
-  gap: $spacing-xs;
-  color: $color-white;
-  max-width: $content-lg;
+  gap: tokens.$spacing-xs;
+  color: tokens.$color-white;
+  max-width: tokens.$content-lg;
 }
 
 .buttons {
   display: flex;
-  gap: $spacing-xs;
-  margin-top: $spacing-md;
+  gap: tokens.$spacing-xs;
+  margin-top: tokens.$spacing-md;
 
   .signButton {
-    background-color: $color-purple-60;
+    background-color: tokens.$color-purple-60;
     &:hover {
-      background-color: $color-purple-50;
+      background-color: tokens.$color-purple-50;
     }
   }
 
   .signLink {
-    background-color: $color-purple-60;
-    border-radius: $border-radius-md;
-    color: $color-white;
-    font: $text-body-md;
+    background-color: tokens.$color-purple-60;
+    border-radius: tokens.$border-radius-md;
+    color: tokens.$color-white;
+    font: tokens.$text-body-md;
     font-weight: 500;
     line-height: 1;
-    padding: $spacing-md $spacing-lg;
+    padding: tokens.$spacing-md tokens.$spacing-lg;
     text-align: center;
     text-decoration: none;
     &:hover {
-      background-color: $color-purple-50;
+      background-color: tokens.$color-purple-50;
     }
   }
 
   .dismissButton {
-    color: $color-white;
+    color: tokens.$color-white;
     &:hover {
-      background-color: rgba($color-purple-50, 0.2);
+      background-color: rgba(tokens.$color-purple-50, 0.2);
     }
   }
 }
 
 .closeButton {
   background-color: transparent;
-  border-radius: $border-radius-sm;
+  border-radius: tokens.$border-radius-sm;
   border-style: none;
-  color: $color-white;
+  color: tokens.$color-white;
   cursor: pointer;
-  padding: $spacing-md;
+  padding: tokens.$spacing-md;
   position: absolute;
   right: 0;
   top: 0;

--- a/src/app/components/client/Popover.module.scss
+++ b/src/app/components/client/Popover.module.scss
@@ -1,4 +1,4 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .underlay {
   position: fixed;
@@ -6,11 +6,11 @@
 }
 
 .popover {
-  background: $color-white;
+  background: tokens.$color-white;
   box-shadow: none;
-  border-radius: $border-radius-sm;
+  border-radius: tokens.$border-radius-sm;
 
   &.isOpen {
-    box-shadow: $box-shadow-sm;
+    box-shadow: tokens.$box-shadow-sm;
   }
 }

--- a/src/app/components/client/ProgressBar.module.scss
+++ b/src/app/components/client/ProgressBar.module.scss
@@ -1,15 +1,15 @@
-@import "../../tokens";
+@use "../../tokens";
 
 $progressBarHeight: 56px;
 .progressContainer {
   .labelContainer {
-    font: $text-title-2xs;
-    padding: 0 $spacing-sm;
-    margin-bottom: $spacing-sm;
+    font: tokens.$text-title-2xs;
+    padding: 0 tokens.$spacing-sm;
+    margin-bottom: tokens.$spacing-sm;
   }
 
   .progressBar {
-    background: $color-grey-05;
+    background: tokens.$color-grey-05;
     border-radius: calc($progressBarHeight / 2);
     height: $progressBarHeight;
     overflow: hidden;
@@ -17,10 +17,10 @@ $progressBarHeight: 56px;
     width: 100%;
 
     &Percentage {
-      color: $color-white;
+      color: tokens.$color-white;
       position: absolute;
-      font: $text-title-xs;
-      left: $spacing-lg;
+      font: tokens.$text-title-xs;
+      left: tokens.$spacing-lg;
       // Center vertically plus some extra for visual balance of the label
       // within the progress bar.
       top: 52%;
@@ -29,7 +29,7 @@ $progressBarHeight: 56px;
     }
 
     &Inner {
-      background: $gradient-linear-purple;
+      background: tokens.$gradient-linear-purple;
       border-radius: calc($progressBarHeight / 2);
       height: 100%;
       left: 0;

--- a/src/app/components/client/ProgressCard.module.scss
+++ b/src/app/components/client/ProgressCard.module.scss
@@ -1,34 +1,34 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .progressCard {
-  background: $color-white;
-  border-radius: $border-radius-md;
-  border: 2px solid rgba($color-purple-70, 0.4);
+  background: tokens.$color-white;
+  border-radius: tokens.$border-radius-md;
+  border: 2px solid rgba(tokens.$color-purple-70, 0.4);
   display: flex;
   flex-direction: column;
   height: 100%;
   justify-content: center;
-  padding: $spacing-lg;
+  padding: tokens.$spacing-lg;
 
-  @media screen and (min-width: $screen-lg) {
-    min-width: $content-sm;
+  @media screen and (min-width: tokens.$screen-lg) {
+    min-width: tokens.$content-sm;
   }
 
   .header {
     display: flex;
     align-items: center;
-    gap: $spacing-sm;
+    gap: tokens.$spacing-sm;
     justify-content: center;
-    font: $text-title-3xs;
+    font: tokens.$text-title-3xs;
     font-weight: 600;
 
     button {
-      @include question-mark-circle-btn;
+      @include tokens.question-mark-circle-btn;
     }
   }
 
   .progressBarContainer {
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
     align-items: center;
     display: flex;
 
@@ -38,30 +38,30 @@
     }
 
     .fullProgressBar {
-      border-radius: $border-radius-lg;
+      border-radius: tokens.$border-radius-lg;
       height: 15px;
       background: repeating-linear-gradient(
         -45deg,
-        $color-grey-20,
-        $color-grey-20 5px,
-        $color-grey-10 5px,
-        $color-grey-10 10px
+        tokens.$color-grey-20,
+        tokens.$color-grey-20 5px,
+        tokens.$color-grey-10 5px,
+        tokens.$color-grey-10 10px
       );
       position: relative;
       width: 100%;
 
       .activeProgressBar {
         height: inherit;
-        border-radius: $border-radius-lg;
+        border-radius: tokens.$border-radius-lg;
         position: absolute;
-        background: $gradient-blue;
+        background: tokens.$gradient-blue;
       }
 
       .percentageBreakdown {
-        font: $text-body-sm;
-        color: $color-grey-60;
+        font: tokens.$text-body-sm;
+        color: tokens.$color-grey-60;
         margin-top: 15px; // offset height of progress bar
-        padding-top: $spacing-xs;
+        padding-top: tokens.$spacing-xs;
         display: flex;
         justify-content: space-between;
       }
@@ -69,12 +69,12 @@
   }
 
   .progressStatsWrapper {
-    font: $text-body-sm;
+    font: tokens.$text-body-sm;
     font-weight: 500;
     display: flex;
     flex-direction: row;
-    gap: $layout-md;
-    padding: $spacing-md 0;
+    gap: tokens.$layout-md;
+    padding: tokens.$spacing-md 0;
     justify-content: center;
 
     .progressItem {
@@ -86,14 +86,14 @@
 
       &:not(:first-child)::before {
         // Lines in between the different items in the progress cardå
-        @media screen and (min-width: $screen-sm) {
+        @media screen and (min-width: tokens.$screen-sm) {
           content: "";
           position: absolute;
-          left: -($layout-xs);
+          left: -(tokens.$layout-xs);
           top: 0;
           bottom: 0;
           width: 1px;
-          background-color: $color-grey-20;
+          background-color: tokens.$color-grey-20;
         }
       }
 
@@ -101,12 +101,12 @@
         align-items: center;
         justify-content: center;
         display: flex;
-        gap: $spacing-sm;
+        gap: tokens.$spacing-sm;
 
         img {
           display: none;
 
-          @media screen and (min-width: $screen-sm) {
+          @media screen and (min-width: tokens.$screen-sm) {
             display: block;
             width: 50px;
             height: auto;
@@ -115,15 +115,15 @@
       }
 
       span {
-        font: $text-title-sm;
-        color: $color-purple-70;
+        font: tokens.$text-title-sm;
+        color: tokens.$color-purple-70;
 
-        @media screen and (min-width: $screen-sm) {
-          font: $text-title-md;
+        @media screen and (min-width: tokens.$screen-sm) {
+          font: tokens.$text-title-md;
         }
 
-        @media screen and (min-width: $screen-xl) {
-          font: $text-title-lg;
+        @media screen and (min-width: tokens.$screen-xl) {
+          font: tokens.$text-title-lg;
           font-weight: 600;
         }
       }
@@ -134,13 +134,13 @@
         }
 
         span {
-          color: $color-grey-40;
+          color: tokens.$color-grey-40;
         }
         p {
-          color: $color-grey-40;
+          color: tokens.$color-grey-40;
           display: flex;
           align-items: center;
-          gap: $spacing-xs;
+          gap: tokens.$spacing-xs;
         }
       }
     }
@@ -150,13 +150,13 @@
 .modalBodyContent {
   display: flex;
   flex-direction: column;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
 
   .confirmButtonWrapper {
     align-self: center;
     display: flex;
     flex-direction: column;
-    min-width: $content-xs;
-    padding-block-start: $spacing-md;
+    min-width: tokens.$content-xs;
+    padding-block-start: tokens.$spacing-md;
   }
 }

--- a/src/app/components/client/RadioInput.module.scss
+++ b/src/app/components/client/RadioInput.module.scss
@@ -1,18 +1,18 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .radioButton {
-  stroke: $color-purple-50;
+  stroke: tokens.$color-purple-50;
 
   svg {
-    fill: $color-purple-50;
+    fill: tokens.$color-purple-50;
     stroke: none;
   }
 
   &.isSelected {
-    stroke: $color-grey-20;
+    stroke: tokens.$color-grey-20;
   }
 
   .focusRing {
-    stroke: $color-blue-50;
+    stroke: tokens.$color-blue-50;
   }
 }

--- a/src/app/components/client/SubscriberWaitlistDialog.module.scss
+++ b/src/app/components/client/SubscriberWaitlistDialog.module.scss
@@ -1,17 +1,17 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .dialogContent {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
-  color: $color-grey-50;
+  gap: tokens.$spacing-lg;
+  color: tokens.$color-grey-50;
 
   .buttonWrapper {
     align-self: center;
     display: flex;
     flex-direction: column;
-    gap: $spacing-sm;
-    min-width: $content-xs;
-    padding-block-start: $spacing-md;
+    gap: tokens.$spacing-sm;
+    min-width: tokens.$content-xs;
+    padding-block-start: tokens.$spacing-md;
   }
 }

--- a/src/app/components/client/SwitchInput.module.scss
+++ b/src/app/components/client/SwitchInput.module.scss
@@ -1,20 +1,20 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .switchInput {
   svg {
-    fill: $color-grey-40;
+    fill: tokens.$color-grey-40;
     stroke: none;
 
     circle {
-      fill: $color-white;
+      fill: tokens.$color-white;
     }
   }
 
   &.isSelected svg {
-    fill: $color-green-50;
+    fill: tokens.$color-green-50;
   }
 
   .focusRing {
-    stroke: $color-blue-50;
+    stroke: tokens.$color-blue-50;
   }
 }

--- a/src/app/components/client/TabList.module.scss
+++ b/src/app/components/client/TabList.module.scss
@@ -1,4 +1,4 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .container {
   display: flex;
@@ -6,7 +6,7 @@
 
 .tabs {
   display: flex;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
 
   &[aria-orientation="vertical"] {
     flex-direction: column;
@@ -15,16 +15,16 @@
 
 .tab {
   cursor: pointer;
-  border-radius: $border-radius-sm;
+  border-radius: tokens.$border-radius-sm;
   display: flex;
-  gap: $spacing-xs;
-  padding: $spacing-sm;
+  gap: tokens.$spacing-xs;
+  padding: tokens.$spacing-sm;
   position: relative;
 
   &::after {
     bottom: 0;
     content: "";
-    height: $border-focus-width;
+    height: tokens.$border-focus-width;
     position: absolute;
     right: 0;
     width: 100%;
@@ -32,20 +32,20 @@
 
   &:hover,
   &:focus {
-    outline: 2px solid $color-blue-50;
+    outline: 2px solid tokens.$color-blue-50;
     &::after {
       background: none;
     }
   }
 
   &[aria-selected="true"] {
-    color: $color-purple-70;
+    color: tokens.$color-purple-70;
 
     // Only show the tab underline when the item
     // is selected and not hovered or focussed.
     &:not(:hover, :focus) {
       &::after {
-        background: $color-purple-70;
+        background: tokens.$color-purple-70;
       }
     }
   }
@@ -54,21 +54,21 @@
 .secondary {
   .tabs {
     align-items: flex-start;
-    gap: $spacing-sm;
+    gap: tokens.$spacing-sm;
   }
 
   .tab {
-    color: $color-grey-40;
-    padding: $spacing-xs $spacing-xs $spacing-xs 0;
+    color: tokens.$color-grey-40;
+    padding: tokens.$spacing-xs tokens.$spacing-xs tokens.$spacing-xs 0;
 
     &[aria-selected="true"] {
-      color: $color-purple-50;
+      color: tokens.$color-purple-50;
 
       // Only show the tab underline when the item
       // is selected and not hovered or focussed.
       &:not(:hover, :focus) {
         &::after {
-          background: $color-purple-50;
+          background: tokens.$color-purple-50;
           height: 2px;
         }
       }

--- a/src/app/components/client/TelemetryLink.module.scss
+++ b/src/app/components/client/TelemetryLink.module.scss
@@ -1,8 +1,8 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .link {
   align-items: center;
-  color: $color-blue-50;
+  color: tokens.$color-blue-50;
   display: inline-flex;
   gap: 0.25em;
 }

--- a/src/app/components/client/csat_survey/CsatSurveyBanner.module.scss
+++ b/src/app/components/client/csat_survey/CsatSurveyBanner.module.scss
@@ -1,22 +1,26 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .wrapper {
   align-items: center;
-  background: linear-gradient(90deg, $color-purple-90 50%, $color-purple-60);
-  color: $color-white;
+  background: linear-gradient(
+    90deg,
+    tokens.$color-purple-90 50%,
+    tokens.$color-purple-60
+  );
+  color: tokens.$color-white;
   display: flex;
-  padding: $layout-xs $layout-sm;
+  padding: tokens.$layout-xs tokens.$layout-sm;
   position: relative;
   flex-direction: column;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
 }
 
 .prompt,
 .prompt a {
   align-items: center;
-  color: $color-white;
+  color: tokens.$color-white;
   display: flex;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
 }
 
 .answers {
@@ -24,24 +28,24 @@
   display: flex;
   flex-flow: row wrap;
   justify-content: center;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
 
   .answer {
-    background-color: $color-purple-40;
+    background-color: tokens.$color-purple-40;
 
     &:hover {
-      background-color: $color-purple-50;
+      background-color: tokens.$color-purple-50;
     }
   }
 }
 
 .closeButton {
   background-color: transparent;
-  border-radius: $border-radius-sm;
+  border-radius: tokens.$border-radius-sm;
   border-style: none;
-  color: $color-white;
+  color: tokens.$color-white;
   cursor: pointer;
-  padding: $spacing-md;
+  padding: tokens.$spacing-md;
   position: absolute;
   right: 0;
   top: 0;

--- a/src/app/components/client/dialog/Dialog.module.scss
+++ b/src/app/components/client/dialog/Dialog.module.scss
@@ -1,16 +1,16 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .dialog {
-  background-color: $color-white;
-  border-radius: $border-radius-md;
+  background-color: tokens.$color-white;
+  border-radius: tokens.$border-radius-md;
   display: flex;
   flex-direction: column;
-  max-height: calc(100% - (2 * $spacing-md));
-  max-width: $content-lg;
+  max-height: calc(100% - (2 * tokens.$spacing-md));
+  max-width: tokens.$content-lg;
   outline: none;
   overflow-y: auto;
   position: relative;
-  width: calc(100% - (2 * $spacing-md));
+  width: calc(100% - (2 * tokens.$spacing-md));
 
   .header,
   .content {
@@ -18,51 +18,53 @@
   }
 
   .header {
-    @include no-focus-outline;
+    @include tokens.no-focus-outline;
     display: flex;
     flex-direction: column;
-    gap: $spacing-md;
-    padding: $layout-sm $layout-sm $spacing-sm;
+    gap: tokens.$spacing-md;
+    padding: tokens.$layout-sm tokens.$layout-sm tokens.$spacing-sm;
 
-    @media screen and (min-width: $screen-lg) {
-      padding: $layout-md $layout-xl $spacing-sm;
+    @media screen and (min-width: tokens.$screen-lg) {
+      padding: tokens.$layout-md tokens.$layout-xl tokens.$spacing-sm;
     }
   }
 
   .content {
-    padding: $spacing-sm $layout-sm $layout-sm;
+    padding: tokens.$spacing-sm tokens.$layout-sm tokens.$layout-sm;
 
-    @media screen and (min-width: $screen-lg) {
-      padding: $spacing-sm $layout-xl $layout-md;
+    @media screen and (min-width: tokens.$screen-lg) {
+      padding: tokens.$spacing-sm tokens.$layout-xl tokens.$layout-md;
     }
   }
 
   .title {
-    color: $color-grey-50;
-    font: $text-title-2xs;
+    color: tokens.$color-grey-50;
+    font: tokens.$text-title-2xs;
     text-align: center;
   }
 
   &.horizontal {
-    @media screen and (min-width: $screen-lg) {
+    @media screen and (min-width: tokens.$screen-lg) {
       flex-direction: row;
     }
 
     .header {
-      background-color: $color-grey-05;
+      background-color: tokens.$color-grey-05;
       flex-direction: column-reverse;
-      gap: $spacing-xl;
+      gap: tokens.$spacing-xl;
       justify-content: center;
       text-align: left;
 
-      @media screen and (min-width: $screen-lg) {
-        padding: $layout-md $layout-sm $layout-md $layout-xl;
+      @media screen and (min-width: tokens.$screen-lg) {
+        padding: tokens.$layout-md tokens.$layout-sm tokens.$layout-md
+          tokens.$layout-xl;
       }
     }
 
     .content {
-      @media screen and (min-width: $screen-lg) {
-        padding: $layout-md $layout-xl $layout-md $layout-sm;
+      @media screen and (min-width: tokens.$screen-lg) {
+        padding: tokens.$layout-md tokens.$layout-xl tokens.$layout-md
+          tokens.$layout-sm;
       }
     }
 
@@ -74,15 +76,15 @@
   .dismissButton {
     background: none;
     border: none;
-    color: $color-grey-40;
+    color: tokens.$color-grey-40;
     cursor: pointer;
-    padding: $spacing-md;
+    padding: tokens.$spacing-md;
     position: absolute;
     right: 0;
     top: 0;
 
     &:hover {
-      color: $color-grey-30;
+      color: tokens.$color-grey-30;
     }
   }
 
@@ -97,6 +99,6 @@
   ol {
     display: flex;
     flex-direction: column;
-    gap: $spacing-sm;
+    gap: tokens.$spacing-sm;
   }
 }

--- a/src/app/components/client/dialog/ModalOverlay.module.scss
+++ b/src/app/components/client/dialog/ModalOverlay.module.scss
@@ -1,9 +1,9 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .underlay {
   position: fixed;
   inset: 0;
-  background-color: rgba($color-black, 0.5);
+  background-color: rgba(tokens.$color-black, 0.5);
   // Overlap all regular content on the site with a z-index,
   // the highest of which (at the time of writing) are the <Steps> in the
   // onboarding flow, whose images have a z-index of 1:

--- a/src/app/components/client/exposure_card/ExposureCard.module.scss
+++ b/src/app/components/client/exposure_card/ExposureCard.module.scss
@@ -1,18 +1,18 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .exposureCard {
-  font: $text-body-sm;
-  background-color: $color-white;
-  border: 2px solid rgba($color-purple-70, 0.2);
-  border-radius: $border-radius-md;
+  font: tokens.$text-body-sm;
+  background-color: tokens.$color-white;
+  border: 2px solid rgba(tokens.$color-purple-70, 0.2);
+  border-radius: tokens.$border-radius-md;
 
   .exposureHeader {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    padding: calc($spacing-md * 1.25) $spacing-md;
-    gap: $layout-xs;
+    padding: calc(tokens.$spacing-md * 1.25) tokens.$spacing-md;
+    gap: tokens.$layout-xs;
 
     .chevron {
       flex-shrink: 0;
@@ -20,11 +20,11 @@
       border-style: none;
       padding: 0;
       cursor: pointer;
-      color: rgba($color-purple-70, 0.7);
+      color: rgba(tokens.$color-purple-70, 0.7);
       width: 15px; // size of the chevron on mobile
       height: 20px; // height of down chevron
 
-      @media screen and (min-width: $screen-md) {
+      @media screen and (min-width: tokens.$screen-md) {
         width: 20px; // size of the chevron on larger devices
       }
 
@@ -47,13 +47,13 @@
     .hideOnMobile {
       display: none;
 
-      @media screen and (min-width: $screen-lg) {
+      @media screen and (min-width: tokens.$screen-lg) {
         display: block;
       }
     }
 
-    @media screen and (min-width: $screen-lg) {
-      gap: $layout-sm;
+    @media screen and (min-width: tokens.$screen-lg) {
+      gap: tokens.$layout-sm;
     }
 
     .dataBrokerLogo {
@@ -68,7 +68,7 @@
       height: 35px;
       border-radius: 50px;
       color: black;
-      font: $text-title-3xs;
+      font: tokens.$text-title-3xs;
     }
 
     dd {
@@ -76,14 +76,14 @@
       align-items: center;
 
       .exposureCompanyTitle {
-        font: $text-body-sm;
+        font: tokens.$text-body-sm;
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
 
-        @media screen and (max-width: $screen-sm) {
+        @media screen and (max-width: tokens.$screen-sm) {
           &.makeFontSmaller {
-            font: $text-body-2xs;
+            font: tokens.$text-body-2xs;
           }
         }
       }
@@ -94,13 +94,13 @@
         }
       }
 
-      @media screen and (min-width: $screen-lg) {
+      @media screen and (min-width: tokens.$screen-lg) {
         &.exposureImageWrapper {
-          flex: 0.2 0 $width-first-column-filter-bar;
+          flex: 0.2 0 tokens.$width-first-column-filter-bar;
         }
       }
 
-      @media screen and (min-width: $screen-xl) {
+      @media screen and (min-width: tokens.$screen-xl) {
         flex: 1 1 0%;
 
         &.hideOnMobile {
@@ -112,7 +112,7 @@
 
   .exposureBreachLink {
     align-items: center;
-    color: $color-blue-50;
+    color: tokens.$color-blue-50;
     display: inline-flex;
     gap: 0.25em;
   }
@@ -120,7 +120,7 @@
   .exposureDetailsSection {
     margin: 0;
     overflow: hidden;
-    padding: 0 $layout-md;
+    padding: 0 tokens.$layout-md;
     height: 0;
     display: none;
 
@@ -128,15 +128,15 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: $layout-xs;
+      gap: tokens.$layout-xs;
 
-      @media screen and (min-width: $screen-sm) {
+      @media screen and (min-width: tokens.$screen-sm) {
         flex-direction: row;
         justify-content: space-between;
       }
 
-      @media screen and (min-width: $screen-md) {
-        gap: $layout-xl;
+      @media screen and (min-width: tokens.$screen-md) {
+        gap: tokens.$layout-xl;
       }
 
       span {
@@ -145,54 +145,54 @@
     }
 
     .exposureDetailsContent {
-      margin-top: $layout-xs;
-      background: $color-grey-05;
-      padding: $spacing-md $spacing-lg;
-      border-radius: $border-radius-md;
+      margin-top: tokens.$layout-xs;
+      background: tokens.$color-grey-05;
+      padding: tokens.$spacing-md tokens.$spacing-lg;
+      border-radius: tokens.$border-radius-md;
 
       .exposedDataTypes {
-        margin-top: $spacing-md;
+        margin-top: tokens.$spacing-md;
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
-        gap: $spacing-lg;
+        gap: tokens.$spacing-lg;
       }
     }
 
     .openInNewTab {
-      color: $color-blue-50;
+      color: tokens.$color-blue-50;
 
       svg {
         display: inline;
-        margin: 0 $spacing-xs;
+        margin: 0 tokens.$spacing-xs;
       }
     }
 
     &.isOpen {
-      border-top: 2px solid rgba($color-purple-70, 0.2);
+      border-top: 2px solid rgba(tokens.$color-purple-70, 0.2);
       overflow: auto;
       height: auto;
       display: block;
-      padding: $spacing-lg;
+      padding: tokens.$spacing-lg;
 
-      @media screen and (min-width: $screen-lg) {
-        padding: $spacing-xl $layout-xl;
+      @media screen and (min-width: tokens.$screen-lg) {
+        padding: tokens.$spacing-xl tokens.$layout-xl;
       }
     }
   }
 }
 
 .visuallyHidden {
-  @include visually-hidden;
+  @include tokens.visually-hidden;
 }
 
 .companyNameArea {
-  @include company-name-area;
+  @include tokens.company-name-area;
 }
 
 .resolveExposuresCtaDesktop {
   display: none;
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: tokens.$screen-md) {
     display: block;
   }
 }
@@ -200,14 +200,14 @@
 .resolveExposuresCtaMobile {
   display: flex;
   justify-content: center;
-  margin-top: $spacing-lg;
+  margin-top: tokens.$spacing-lg;
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: tokens.$screen-md) {
     display: none;
   }
 }
 
 .manualResolutionPraise {
   display: flex;
-  gap: $spacing-xs;
+  gap: tokens.$spacing-xs;
 }

--- a/src/app/components/client/exposure_card/ExposureCardDataClass.module.scss
+++ b/src/app/components/client/exposure_card/ExposureCardDataClass.module.scss
@@ -1,10 +1,10 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .detailsFoundItem {
   .label {
     display: flex;
     align-items: center;
-    gap: $spacing-xs;
+    gap: tokens.$spacing-xs;
     font-weight: 700;
   }
 
@@ -14,8 +14,8 @@
     .dataClassListDetails {
       list-style: none;
       margin: 0;
-      padding: $spacing-sm 0 0 0;
-      gap: $spacing-xs;
+      padding: tokens.$spacing-sm 0 0 0;
+      gap: tokens.$spacing-xs;
       display: flex;
       flex-direction: column;
 

--- a/src/app/components/client/toolbar/AppPicker.module.scss
+++ b/src/app/components/client/toolbar/AppPicker.module.scss
@@ -1,4 +1,4 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .wrapper {
   align-items: center;
@@ -14,23 +14,23 @@
   width: 24px;
   height: 24px;
   padding: 0;
-  border-radius: $border-radius-sm;
+  border-radius: tokens.$border-radius-sm;
 
   svg {
-    color: $color-violet-70;
+    color: tokens.$color-violet-70;
 
     &:hover {
-      color: $color-violet-90;
+      color: tokens.$color-violet-90;
     }
   }
 }
 
 .popup {
-  width: $content-xs;
+  width: tokens.$content-xs;
   list-style-type: none;
-  box-shadow: $box-shadow-sm;
-  border-radius: $border-radius-sm;
-  background-color: $color-white;
+  box-shadow: tokens.$box-shadow-sm;
+  border-radius: tokens.$border-radius-sm;
+  background-color: tokens.$color-white;
   position: relative;
 
   &::before {
@@ -46,38 +46,38 @@
   }
 
   .appPickerHeading {
-    color: $color-black;
-    padding: $spacing-lg;
+    color: tokens.$color-black;
+    padding: tokens.$spacing-lg;
     text-align: center;
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: $spacing-sm;
+    gap: tokens.$spacing-sm;
     // The first gradient is all white, except for the bottom 3 pixels which
     // are transparent. That way, they leave a gap for the coloured background
     // that flows to the right, rendering it as a coloured bottom border.
     background-image: linear-gradient(
         to bottom,
-        $color-white calc(100% - 3px),
+        tokens.$color-white calc(100% - 3px),
         rgba(0, 0, 0, 0)
       ),
       linear-gradient(to right, #f73940 1.25%, #a83db5 96.87%);
-    border-radius: $border-radius-sm $border-radius-sm 0 0;
+    border-radius: tokens.$border-radius-sm tokens.$border-radius-sm 0 0;
 
     img {
-      height: $layout-sm;
+      height: tokens.$layout-sm;
     }
 
     h2 {
-      font: $text-body-md;
+      font: tokens.$text-body-md;
     }
   }
 
   ul {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: $spacing-md;
-    padding: $spacing-lg;
+    gap: tokens.$spacing-md;
+    padding: tokens.$spacing-lg;
     list-style-type: none;
   }
 
@@ -89,27 +89,27 @@
     .menuLink {
       display: flex;
       flex-direction: column;
-      color: $color-black;
+      color: tokens.$color-black;
       align-items: center;
       text-align: center;
       text-decoration: none;
 
-      font: $text-body-sm;
+      font: tokens.$text-body-sm;
 
       img {
-        height: $layout-sm;
-        padding: $spacing-lg;
+        height: tokens.$layout-sm;
+        padding: tokens.$spacing-lg;
         width: -moz-fit-content;
         width: fit-content;
         box-sizing: content-box;
-        border-radius: $border-radius-md;
+        border-radius: tokens.$border-radius-md;
       }
 
       &.mozillaLink {
-        color: $color-blue-50;
+        color: tokens.$color-blue-50;
         justify-content: center;
         width: 100%;
-        margin-top: $spacing-lg;
+        margin-top: tokens.$spacing-lg;
       }
     }
 
@@ -118,10 +118,10 @@
       cursor: pointer;
 
       .menuLink {
-        color: $color-violet-90;
+        color: tokens.$color-violet-90;
 
         img {
-          background-color: $color-violet-10;
+          background-color: tokens.$color-violet-10;
         }
       }
     }

--- a/src/app/components/client/toolbar/Toolbar.module.scss
+++ b/src/app/components/client/toolbar/Toolbar.module.scss
@@ -1,8 +1,8 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .toolbar {
-  height: $tab-bar-height;
-  border-bottom: 1px solid $color-grey-20;
+  height: tokens.$tab-bar-height;
+  border-bottom: 1px solid tokens.$color-grey-20;
   display: flex;
   align-items: center;
 
@@ -10,17 +10,17 @@
     flex: 1 0 auto;
     display: flex;
     align-items: center;
-    padding-inline: $spacing-xl;
+    padding-inline: tokens.$spacing-xl;
   }
 
   .end {
-    padding-inline: $spacing-xl;
+    padding-inline: tokens.$spacing-xl;
     display: flex;
     align-items: center;
-    gap: $spacing-md;
+    gap: tokens.$spacing-md;
   }
 
-  @media screen and (max-width: $screen-md) {
+  @media screen and (max-width: tokens.$screen-md) {
     .start {
       justify-content: center;
     }

--- a/src/app/components/client/toolbar/UpsellBadge.module.scss
+++ b/src/app/components/client/toolbar/UpsellBadge.module.scss
@@ -1,31 +1,31 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .upsellBadge {
   align-items: center;
   background: none;
-  border-radius: $border-radius-xl;
-  border: 1px solid $color-grey-40;
-  color: $color-black;
+  border-radius: tokens.$border-radius-xl;
+  border: 1px solid tokens.$color-grey-40;
+  color: tokens.$color-black;
   cursor: pointer;
   display: flex;
-  font: $text-body-md;
+  font: tokens.$text-body-md;
   font-weight: 600;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
   justify-content: center;
-  padding: $spacing-sm $spacing-md;
+  padding: tokens.$spacing-sm tokens.$spacing-md;
   user-select: none;
 
   .toggleIndicator {
-    background: $color-grey-40;
-    border-radius: $border-radius-md;
+    background: tokens.$color-grey-40;
+    border-radius: tokens.$border-radius-md;
     display: block;
     position: relative;
-    outline: $border-focus-width solid $color-grey-40;
+    outline: tokens.$border-focus-width solid tokens.$color-grey-40;
     height: 16px;
     width: 32px;
 
     &::after {
-      background-color: $color-white;
+      background-color: tokens.$color-white;
       border-radius: 50%;
       content: "";
       display: block;
@@ -49,7 +49,7 @@
       width: 16px;
 
       &::after {
-        background-color: $color-green-50;
+        background-color: tokens.$color-green-50;
       }
     }
   }
@@ -58,7 +58,7 @@
 .lastScanIndicator {
   display: flex;
   align-items: center;
-  font: $text-body-xs;
-  padding-inline: $spacing-md;
+  font: tokens.$text-body-xs;
+  padding-inline: tokens.$spacing-md;
   position: absolute;
 }

--- a/src/app/components/client/toolbar/UpsellDialog.module.scss
+++ b/src/app/components/client/toolbar/UpsellDialog.module.scss
@@ -1,19 +1,19 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 .modalContent {
   display: flex;
   flex-direction: column;
-  gap: $spacing-lg;
-  padding: $spacing-sm;
+  gap: tokens.$spacing-lg;
+  padding: tokens.$spacing-sm;
 
   dl {
     display: flex;
     flex-direction: column;
-    gap: $spacing-sm;
+    gap: tokens.$spacing-sm;
     padding: 0;
 
     dt {
-      margin-bottom: $spacing-sm;
+      margin-bottom: tokens.$spacing-sm;
     }
 
     dd {
@@ -21,7 +21,7 @@
         no-repeat left top;
       list-style: none;
       margin: 0;
-      padding-left: $spacing-lg;
+      padding-left: tokens.$spacing-lg;
     }
   }
 
@@ -29,7 +29,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: $spacing-sm;
+    gap: tokens.$spacing-sm;
 
     .pricingInfoWrapper {
       display: flex;
@@ -43,13 +43,13 @@
   }
 
   .pricingPill {
-    margin-top: $spacing-lg;
+    margin-top: tokens.$spacing-lg;
     align-items: center;
-    border-radius: $border-radius-xl;
-    border: 2px solid $color-purple-70;
+    border-radius: tokens.$border-radius-xl;
+    border: 2px solid tokens.$color-purple-70;
     display: flex;
-    gap: $spacing-md;
-    padding: $spacing-sm $spacing-lg;
+    gap: tokens.$spacing-md;
+    padding: tokens.$spacing-sm tokens.$spacing-lg;
 
     .pricingLabel {
       display: flex;

--- a/src/app/components/client/toolbar/UserMenu.module.scss
+++ b/src/app/components/client/toolbar/UserMenu.module.scss
@@ -1,4 +1,4 @@
-@import "../../../tokens";
+@use "../../../tokens";
 
 $button-size: 42px;
 
@@ -12,24 +12,24 @@ $button-size: 42px;
   width: $button-size;
   overflow: hidden;
 
-  @media screen and (max-width: $screen-md) {
-    margin-right: $spacing-sm;
+  @media screen and (max-width: tokens.$screen-md) {
+    margin-right: tokens.$spacing-sm;
   }
 
   &:focus,
   &:hover {
-    outline: 2px solid $color-purple-70;
+    outline: 2px solid tokens.$color-purple-70;
   }
 }
 
 .menuList {
-  border-radius: $border-radius-md;
-  box-shadow: $box-shadow-md;
-  font: $text-body-md;
+  border-radius: tokens.$border-radius-md;
+  box-shadow: tokens.$box-shadow-md;
+  font: tokens.$text-body-md;
   list-style-type: none;
-  min-width: $content-xs;
+  min-width: tokens.$content-xs;
   outline: 0;
-  padding: $spacing-sm 0;
+  padding: tokens.$spacing-sm 0;
   position: relative;
   right: 0;
 
@@ -39,12 +39,12 @@ $button-size: 42px;
     content: "";
     height: $tooltip-size;
     position: absolute;
-    right: calc($spacing-md + $button-size * 0.5);
+    right: calc(tokens.$spacing-md + $button-size * 0.5);
     top: 0;
     transform: translateY(-50%) rotate(45deg);
     width: $tooltip-size;
 
-    @media screen and (max-width: $screen-md) {
+    @media screen and (max-width: tokens.$screen-md) {
       right: calc($button-size * 0.5);
     }
   }
@@ -52,27 +52,27 @@ $button-size: 42px;
 
 .menuItemWrapper {
   cursor: pointer;
-  padding: $spacing-sm $spacing-lg;
+  padding: tokens.$spacing-sm tokens.$spacing-lg;
   position: relative;
 
   &:focus {
     outline: none;
-    background: $color-grey-10;
+    background: tokens.$color-grey-10;
   }
 
   &:first-of-type {
     // Margin to create visual space between the pseudo element and
     // the first item after it.
-    margin-bottom: $spacing-sm;
-    padding: calc($spacing-sm * 1.5) calc($spacing-md * 1.5);
+    margin-bottom: tokens.$spacing-sm;
+    padding: calc(tokens.$spacing-sm * 1.5) calc(tokens.$spacing-md * 1.5);
 
     b {
-      color: $color-purple-90;
-      margin-bottom: $spacing-xs;
+      color: tokens.$color-purple-90;
+      margin-bottom: tokens.$spacing-xs;
     }
 
     &::after {
-      background: $monitor-gradient;
+      background: tokens.$monitor-gradient;
       content: "";
       height: 2px;
       left: 0;
@@ -87,10 +87,10 @@ $button-size: 42px;
   align-items: center;
   background: none;
   border: 0;
-  color: $color-black;
+  color: tokens.$color-black;
   cursor: pointer;
   display: flex;
-  gap: $spacing-sm;
+  gap: tokens.$spacing-sm;
   margin: 0;
   padding: 0;
   text-decoration: none;

--- a/src/app/components/server/BreachLogo.module.scss
+++ b/src/app/components/server/BreachLogo.module.scss
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@import "../../tokens";
+@use "../../tokens";
 
 .breachLogo {
   height: 1.75rem;
@@ -19,94 +19,94 @@ span.breachLogo {
   text-align: center;
 
   &.purple40 {
-    background-color: $color-purple-40;
+    background-color: tokens.$color-purple-40;
   }
 
   &.purple30 {
-    background-color: $color-purple-30;
+    background-color: tokens.$color-purple-30;
   }
 
   &.purple10 {
-    background-color: $color-purple-10;
+    background-color: tokens.$color-purple-10;
   }
 
   &.purple05 {
-    background-color: $color-purple-05;
+    background-color: tokens.$color-purple-05;
   }
 
   &.green50 {
-    background-color: $color-green-50;
+    background-color: tokens.$color-green-50;
   }
 
   &.green40 {
-    background-color: $color-green-40;
+    background-color: tokens.$color-green-40;
   }
 
   &.green30 {
-    background-color: $color-green-30;
+    background-color: tokens.$color-green-30;
   }
 
   &.green20 {
-    background-color: $color-green-20;
+    background-color: tokens.$color-green-20;
   }
 
   &.green10 {
-    background-color: $color-green-10;
+    background-color: tokens.$color-green-10;
   }
 
   &.violet30 {
-    background-color: $color-violet-30;
+    background-color: tokens.$color-violet-30;
   }
 
   &.violet20 {
-    background-color: $color-violet-20;
+    background-color: tokens.$color-violet-20;
   }
 
   &.violet10 {
-    background-color: $color-violet-10;
+    background-color: tokens.$color-violet-10;
   }
 
   &.blue30 {
-    background-color: $color-blue-30;
+    background-color: tokens.$color-blue-30;
   }
 
   &.blue20 {
-    background-color: $color-blue-20;
+    background-color: tokens.$color-blue-20;
   }
 
   &.blue10 {
-    background-color: $color-blue-10;
+    background-color: tokens.$color-blue-10;
   }
 
   &.red30 {
-    background-color: $color-red-30;
+    background-color: tokens.$color-red-30;
   }
 
   &.red20 {
-    background-color: $color-red-20;
+    background-color: tokens.$color-red-20;
   }
 
   &.red10 {
-    background-color: $color-red-10;
+    background-color: tokens.$color-red-10;
   }
 
   &.orange30 {
-    background-color: $color-orange-30;
+    background-color: tokens.$color-orange-30;
   }
 
   &.orange20 {
-    background-color: $color-orange-20;
+    background-color: tokens.$color-orange-20;
   }
 
   &.orange10 {
-    background-color: $color-orange-10;
+    background-color: tokens.$color-orange-10;
   }
 
   &.pink20 {
-    background-color: $color-pink-20;
+    background-color: tokens.$color-pink-20;
   }
 
   &.pink10 {
-    background-color: $color-pink-10;
+    background-color: tokens.$color-pink-10;
   }
 }

--- a/src/app/components/server/StatusPill.module.scss
+++ b/src/app/components/server/StatusPill.module.scss
@@ -1,40 +1,40 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .pillWrapper {
-  font: $text-body-2xs;
+  font: tokens.$text-body-2xs;
   display: inline-block;
   line-height: 1;
   text-align: center;
 
-  @media screen and (min-width: $screen-sm) {
-    font: $text-body-xs;
+  @media screen and (min-width: tokens.$screen-sm) {
+    font: tokens.$text-body-xs;
     min-width: 145px; // keep the width fixed
   }
 
   .pill {
-    padding: $spacing-xs $spacing-sm;
-    border-radius: $border-radius-sm;
+    padding: tokens.$spacing-xs tokens.$spacing-sm;
+    border-radius: tokens.$border-radius-sm;
     font-weight: 600;
 
-    @media screen and (min-width: $screen-sm) {
-      padding: $spacing-xs 0;
+    @media screen and (min-width: tokens.$screen-sm) {
+      padding: tokens.$spacing-xs 0;
     }
 
     &.actionNeeded {
-      background: $color-red-10;
+      background: tokens.$color-red-10;
     }
 
     &.requestedRemoval {
-      background: $color-violet-10;
+      background: tokens.$color-violet-10;
     }
 
     &.inProgress {
-      background: $color-blue-05;
+      background: tokens.$color-blue-05;
     }
 
     &.removed,
     &.fixed {
-      background: $color-green-20;
+      background: tokens.$color-green-20;
     }
   }
 }

--- a/src/app/components/server/VisuallyHidden.module.scss
+++ b/src/app/components/server/VisuallyHidden.module.scss
@@ -1,5 +1,5 @@
-@import "../../tokens";
+@use "../../tokens";
 
 .visuallyHidden {
-  @include visually-hidden;
+  @include tokens.visually-hidden;
 }

--- a/src/app/not-found.module.scss
+++ b/src/app/not-found.module.scss
@@ -1,4 +1,4 @@
-@import "./tokens";
+@use "tokens";
 
 .wrapper {
   background-image: url("./(proper_react)/images/error-bg.svg");
@@ -25,6 +25,6 @@
   font: var(--h3-font);
   font-weight: bold;
   font-size: 10rem;
-  color: $color-purple-60;
-  text-shadow: 0.75rem 0 0 $color-purple-20;
+  color: tokens.$color-purple-60;
+  text-shadow: 0.75rem 0 0 tokens.$color-purple-20;
 }

--- a/src/app/tokens.scss
+++ b/src/app/tokens.scss
@@ -1,3 +1,6 @@
+@use "sass:list";
+@use "sass:math";
+
 // Nebula Colours //
 // Purple:
 $color-purple-90: #321c64;
@@ -228,40 +231,41 @@ $layout-2xl: 192px;
 // In most cases they'll snap to one of the clamped values though, so it
 // doesn't matter too much.
 $text-title-lg:
-  700 clamp(48px, 4.4svw, 56px) / clamp(48px, 4.4svw, 56px)
+  700 list.slash(clamp(48px, 4.4svw, 56px), clamp(48px, 4.4svw, 56px))
     var(--font-metropolis),
   sans-serif;
 $text-title-md:
-  700 clamp(38px, 3.8svw, 48px) / clamp(40px, 3.8svw, 48px)
+  700 list.slash(clamp(38px, 3.8svw, 48px), clamp(40px, 3.8svw, 48px))
     var(--font-metropolis),
   sans-serif;
 $text-title-sm:
-  700 clamp(28px, 3svw, 38px) / clamp(30px, 3.16svw, 40px)
+  700 list.slash(clamp(28px, 3svw, 38px), clamp(30px, 3.16svw, 40px))
     var(--font-metropolis),
   sans-serif;
 $text-title-xs:
-  700 clamp(24px, 2.2svw, 28px) / clamp(26px, 2.4svw, 30px)
+  700 list.slash(clamp(24px, 2.2svw, 28px), clamp(26px, 2.4svw, 30px))
     var(--font-metropolis),
   sans-serif;
 $text-title-2xs:
-  700 clamp(20px, 1.6svw, 24px) / clamp(20px, 2svw, 26px) var(--font-metropolis),
+  700 list.slash(clamp(20px, 1.6svw, 24px), clamp(20px, 2svw, 26px))
+    var(--font-metropolis),
   sans-serif;
 $text-title-3xs:
-  700 clamp(16px, 1.4svw, 18px) / 20px var(--font-metropolis),
+  700 list.slash(clamp(16px, 1.4svw, 18px), 20px) var(--font-metropolis),
   sans-serif;
 
 // Body copy
 $text-body-xl:
-  400 clamp(18px, 1.7svw, 21px) / 1.5 var(--font-inter),
+  400 list.slash(clamp(18px, 1.7svw, 21px), 1.5) var(--font-inter),
   sans-serif;
 $text-body-lg:
-  400 clamp(16px, 1.5svw, 18px) / 1.5 var(--font-inter),
+  400 list.slash(clamp(16px, 1.5svw, 18px), 1.5) var(--font-inter),
   sans-serif;
 $text-body-md:
-  400 clamp(14px, 1.3svw, 16px) / 1.5 var(--font-inter),
+  400 list.slash(clamp(14px, 1.3svw, 16px), 1.5) var(--font-inter),
   sans-serif;
 $text-body-sm:
-  400 clamp(12px, 1.14svw, 14px) / 1.5 var(--font-inter),
+  400 list.slash(clamp(12px, 1.14svw, 14px), 1.5) var(--font-inter),
   sans-serif;
 $text-body-xs:
   400 12px / 1.5 var(--font-inter),


### PR DESCRIPTION
This fixes Sass deprecation warnings by running

    npx sass-migrator division **/*.scss

and

    npx sass-migrator module **/*.scss

These warnings start to show up after upgrading to Next.js 15, so this is in preparation for that.

The only manual change after that was replacing `math.div` with `list.slash` in the `$text-title-*` and `$text-body-*` variables in tokens.scss, as the `/` there wasn't part of a division.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3861