### PR TITLE
MNTOR-3919: getting setter for churn email state (Part 2)

### DIFF
--- a/src/db/tables/subscribers.ts
+++ b/src/db/tables/subscribers.ts
@@ -559,7 +559,9 @@ async function markChurnPreventionEmailAsJustSent(
 ) {
   const affectedSubscribers = await knex("subscribers")
     .update({
-      churn_prevention_email_sent: true,
+      // @ts-ignore knex.fn.now() results in it being set to a date,
+      // even if it's not typed as a JS date object:
+      churn_prevention_email_sent_at: knex.fn.now(),
       // @ts-ignore knex.fn.now() results in it being set to a date,
       // even if it's not typed as a JS date object:
       updated_at: knex.fn.now(),
@@ -696,11 +698,13 @@ async function isSubscriberPlus(subscriberId: SubscriberRow["id"]) {
 
 // Not covered by tests; mostly side-effects. See test-coverage.md#mock-heavy
 /* c8 ignore start */
-async function getChurnPreventionEmailSent(subscriberId: SubscriberRow["id"]) {
+async function getChurnPreventionEmailSentAt(
+  subscriberId: SubscriberRow["id"],
+) {
   const res = await knex("subscribers")
-    .select("churn_prevention_email_sent")
+    .select("churn_prevention_email_sent_at")
     .where("id", subscriberId);
-  return res?.[0]?.["churn_prevention_email_sent"] ?? null;
+  return res?.[0]?.["churn_prevention_email_sent_at"] ?? null;
 }
 /* c8 ignore stop */
 
@@ -729,7 +733,7 @@ export {
   deleteOnerepProfileId,
   incrementSignInCountForEligibleFreeUser,
   getSignInCount,
-  getChurnPreventionEmailSent,
+  getChurnPreventionEmailSentAt,
   unresolveAllBreaches,
   isSubscriberPlus,
   knex as knexSubscribers,

--- a/src/db/tables/subscribers.ts
+++ b/src/db/tables/subscribers.ts
@@ -551,6 +551,31 @@ async function markFirstDataBrokerRemovalFixedEmailAsJustSent(
 }
 
 /* c8 ignore stop */
+
+// Not covered by tests; mostly side-effects. See test-coverage.md#mock-heavy
+/* c8 ignore start */
+async function markChurnPreventionEmailAsJustSent(
+  subscriberId: SubscriberRow["id"],
+) {
+  const affectedSubscribers = await knex("subscribers")
+    .update({
+      churn_prevention_email_sent: true,
+      // @ts-ignore knex.fn.now() results in it being set to a date,
+      // even if it's not typed as a JS date object:
+      updated_at: knex.fn.now(),
+    })
+    .where("id", subscriberId)
+    .returning("*");
+
+  if (affectedSubscribers.length !== 1) {
+    throw new Error(
+      `Attempted to mark 1 user as having just been sent the churn prevention email, but instead found [${affectedSubscribers.length}] matching its ID.`,
+    );
+  }
+}
+
+/* c8 ignore stop */
+
 // Not covered by tests; mostly side-effects. See test-coverage.md#mock-heavy
 /* c8 ignore start */
 async function markMonthlyActivityPlusEmailAsJustSent(
@@ -669,6 +694,16 @@ async function isSubscriberPlus(subscriberId: SubscriberRow["id"]) {
 }
 /* c8 ignore stop */
 
+// Not covered by tests; mostly side-effects. See test-coverage.md#mock-heavy
+/* c8 ignore start */
+async function getChurnPreventionEmailSent(subscriberId: SubscriberRow["id"]) {
+  const res = await knex("subscribers")
+    .select("churn_prevention_email_sent")
+    .where("id", subscriberId);
+  return res?.[0]?.["churn_prevention_email_sent"] ?? null;
+}
+/* c8 ignore stop */
+
 export {
   getOnerepProfileId,
   getSubscribersByHashes,
@@ -685,6 +720,7 @@ export {
   getPotentialSubscribersWaitingForFirstDataBrokerRemovalFixedEmail,
   getFreeSubscribersWaitingForMonthlyEmail,
   getPlusSubscribersWaitingForMonthlyEmail,
+  markChurnPreventionEmailAsJustSent,
   markFirstDataBrokerRemovalFixedEmailAsJustSent,
   markMonthlyActivityPlusEmailAsJustSent,
   deleteUnverifiedSubscribers,
@@ -693,6 +729,7 @@ export {
   deleteOnerepProfileId,
   incrementSignInCountForEligibleFreeUser,
   getSignInCount,
+  getChurnPreventionEmailSent,
   unresolveAllBreaches,
   isSubscriberPlus,
   knex as knexSubscribers,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3919
Figma:

<!-- When adding a new feature: -->

# Description
These functions will be used by the cronjob to get/set churn email state for a user. 

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
