### PR TITLE
Make lack of plaintext emails explicit

### DIFF
--- a/src/emails/StorybookEmailRenderer.tsx
+++ b/src/emails/StorybookEmailRenderer.tsx
@@ -9,6 +9,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 export type Props = {
   children: ReactNode;
+  plainTextVersion: string | null;
   emulateDarkMode?: boolean;
 };
 
@@ -18,7 +19,7 @@ export const StorybookEmailRenderer = (props: Props) => {
   const rawMjml = renderToStaticMarkup(props.children);
   const renderResult = mjml2html(rawMjml);
   return (
-    <>
+    <div className="wrapper">
       <style>{`
       @media (prefers-color-scheme: dark) {
         * {
@@ -31,22 +32,65 @@ export const StorybookEmailRenderer = (props: Props) => {
         background-color: #1e293b !important;
         color: white !important;
       }
+
+      .wrapper {
+        display: flex;
+        gap: 10px;
+      }
+
+      .badge {
+        align-self: flex-start;
+        display: inline-block;
+        font-family: monospace;
+        background-color: #eee;
+        border-radius: 3px;
+        text-transform: uppercase;
+        padding: 3px 5px;
+        color: #444;
+      }
+
+      .wrapper .styled {
+        flex: 3 1 0;
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 20px;
+      }
+      .wrapper .plaintext {
+        flex: 1 1 0;
+        font-family: monospace;
+        border-inline-start: 1px solid #eee;
+        padding: 20px;
+        padding-inline-start: calc(10px + 20px);
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 20px;
+      }
   `}</style>
-      <div
-        dangerouslySetInnerHTML={{
-          __html:
-            renderResult.errors.length > 0
-              ? `
-                <h1>MJML rendering errors:</h1>
-                <ul style="font-family: monospace;">${renderResult.errors.map((error) => `<li>${error.message}</li>`).join("\n")}</ul>
-                <hr/>
-                ${renderResult.html}
-                `
-              : renderResult.html,
-        }}
-        className={props.emulateDarkMode ? "dark-mode-enforced" : ""}
-      />
-    </>
+      <section className="styled">
+        <div className="badge">HTML</div>
+        <div
+          dangerouslySetInnerHTML={{
+            __html:
+              renderResult.errors.length > 0
+                ? `
+                  <h1>MJML rendering errors:</h1>
+                  <ul style="font-family: monospace;">${renderResult.errors.map((error) => `<li>${error.message}</li>`).join("\n")}</ul>
+                  <hr/>
+                  ${renderResult.html}
+                  `
+                : renderResult.html,
+          }}
+          className={props.emulateDarkMode ? "dark-mode-enforced" : ""}
+        />
+      </section>
+      <section className="plaintext">
+        <div className="badge">Plaintext</div>
+        <pre>{props.plainTextVersion ?? "Not set"}</pre>
+      </section>
+    </div>
   );
 };
 /* c8 ignore stop */

--- a/src/emails/StorybookEmailRenderer.tsx
+++ b/src/emails/StorybookEmailRenderer.tsx
@@ -50,7 +50,8 @@ export const StorybookEmailRenderer = (props: Props) => {
       }
 
       .wrapper .styled {
-        flex: 3 1 0;
+        flex: 2 0 auto;
+        width: 66%;
         padding: 20px;
         display: flex;
         flex-direction: column;
@@ -58,7 +59,8 @@ export const StorybookEmailRenderer = (props: Props) => {
         gap: 20px;
       }
       .wrapper .plaintext {
-        flex: 1 1 0;
+        flex: 1 0 auto;
+        width: 33%;
         font-family: monospace;
         border-inline-start: 1px solid #eee;
         padding: 20px;
@@ -67,6 +69,10 @@ export const StorybookEmailRenderer = (props: Props) => {
         flex-direction: column;
         align-items: flex-start;
         gap: 20px;
+      }
+
+      .plaintext pre {
+        white-space: pre-wrap;
       }
   `}</style>
       <section className="styled">

--- a/src/emails/templates/boilerplate/BoilerplateEmail.stories.tsx
+++ b/src/emails/templates/boilerplate/BoilerplateEmail.stories.tsx
@@ -12,7 +12,7 @@ import { getL10n } from "../../../app/functions/l10n/storybookAndJest";
 const meta: Meta<FC<Props>> = {
   title: "Emails/Email boilerplate",
   component: (props: Props) => (
-    <StorybookEmailRenderer>
+    <StorybookEmailRenderer plainTextVersion={null}>
       <BoilerplateEmail {...props} />
     </StorybookEmailRenderer>
   ),

--- a/src/emails/templates/breachAlert/BreachAlertEmail.stories.tsx
+++ b/src/emails/templates/breachAlert/BreachAlertEmail.stories.tsx
@@ -21,7 +21,7 @@ import { getDashboardSummary } from "../../../app/functions/server/dashboard";
 const meta: Meta<FC<RedesignedBreachAlertEmailProps>> = {
   title: "Emails/Breach alert",
   component: (props: RedesignedBreachAlertEmailProps) => (
-    <StorybookEmailRenderer>
+    <StorybookEmailRenderer plainTextVersion={null}>
       <RedesignedBreachAlertEmail {...props} />
     </StorybookEmailRenderer>
   ),

--- a/src/emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed.stories.tsx
+++ b/src/emails/templates/firstDataBrokerRemovalFixed/FirstDataBrokerRemovalFixed.stories.tsx
@@ -14,7 +14,7 @@ import { getL10n } from "../../../app/functions/l10n/storybookAndJest";
 const meta: Meta<FC<Props>> = {
   title: "Emails/First data broker removal fixed",
   component: (props: Props) => (
-    <StorybookEmailRenderer>
+    <StorybookEmailRenderer plainTextVersion={null}>
       <FirstDataBrokerRemovalFixed {...props} />
     </StorybookEmailRenderer>
   ),

--- a/src/emails/templates/monthlyActivityFree/MonthlyActivityFreeEmail.stories.tsx
+++ b/src/emails/templates/monthlyActivityFree/MonthlyActivityFreeEmail.stories.tsx
@@ -16,7 +16,7 @@ import { dataClassKeyMap } from "../../../app/functions/server/dashboard";
 const meta: Meta<FC<MonthlyActivityFreeEmailProps>> = {
   title: "Emails/Monthly activity (free user)",
   component: (props: MonthlyActivityFreeEmailProps) => (
-    <StorybookEmailRenderer>
+    <StorybookEmailRenderer plainTextVersion={null}>
       <MonthlyActivityFreeEmail {...props} />
     </StorybookEmailRenderer>
   ),

--- a/src/emails/templates/monthlyActivityPlus/MonthlyActivityPlusEmail.stories.tsx
+++ b/src/emails/templates/monthlyActivityPlus/MonthlyActivityPlusEmail.stories.tsx
@@ -14,7 +14,10 @@ type StoryProps = Props & { emulateDarkMode?: boolean };
 const meta: Meta<FC<Props>> = {
   title: "Emails/Monthly activity (Plus user)",
   component: (props: StoryProps) => (
-    <StorybookEmailRenderer emulateDarkMode={props.emulateDarkMode}>
+    <StorybookEmailRenderer
+      plainTextVersion={null}
+      emulateDarkMode={props.emulateDarkMode}
+    >
       <MonthlyActivityPlusEmail {...props} />
     </StorybookEmailRenderer>
   ),

--- a/src/emails/templates/signupReport/SignupReportEmail.stories.tsx
+++ b/src/emails/templates/signupReport/SignupReportEmail.stories.tsx
@@ -12,7 +12,7 @@ import { createRandomHibpListing } from "../../../apiMocks/mockData";
 const meta: Meta<FC<Props>> = {
   title: "Emails/Signup Report",
   component: (props: Props) => (
-    <StorybookEmailRenderer>
+    <StorybookEmailRenderer plainTextVersion={null}>
       <SignupReportEmail {...props} />
     </StorybookEmailRenderer>
   ),

--- a/src/emails/templates/verifyEmailAddress/VerifyEmailAddressEmail.stories.tsx
+++ b/src/emails/templates/verifyEmailAddress/VerifyEmailAddressEmail.stories.tsx
@@ -12,7 +12,7 @@ import { getL10n } from "../../../app/functions/l10n/storybookAndJest";
 const meta: Meta<FC<Props>> = {
   title: "Emails/Verify email address",
   component: (props: Props) => (
-    <StorybookEmailRenderer>
+    <StorybookEmailRenderer plainTextVersion={null}>
       <VerifyEmailAddressEmail {...props} />
     </StorybookEmailRenderer>
   ),


### PR DESCRIPTION
SubPlat apparently sends plaintext emails:
https://storage.googleapis.com/mozilla-storybooks-fxa/commits/d06a74b249ebfe979642fdc94f4086a3ed031312/fxa-auth-server/index.html?path=/story/subplat-emails-layout--layout-with-was-deleted

We currently don't, although technically, we easily could: we'd just have to add a `text` property [to the options object passed to `gTransporter.sendMail`](https://github.com/mozilla/blurts-server/blob/a99b0506c72bcb02570839d9426513f040b01cb2/src/utils/email.ts#L65). Since there's currently discussion about whether to send them ourselves, I figured I'd at least adopt SubPlat's style for Storybook, to make it top-of-mind that we could send them, and to make it apparent where we're not and, in case we do start sending them, to make it ease to compare and see where we include information in the HTML email that we don't in the plaintext version.
