### PR TITLE
Add feature flag to conditionally show data broker removal attempts

### DIFF
--- a/src/app/components/client/exposure_card/ExposureCard.stories.tsx
+++ b/src/app/components/client/exposure_card/ExposureCard.stories.tsx
@@ -87,7 +87,10 @@ export const DataBrokerRequestedRemoval: Story = {
   args: {
     exposureImg: FamilyTreeImage,
     exposureData: ScanMockItemRequestedRemoval,
-    enabledFeatureFlags: ["AdditionalRemovalStatuses"],
+    enabledFeatureFlags: [
+      "AdditionalRemovalStatuses",
+      "DataBrokerRemovalAttempts",
+    ],
   },
 };
 

--- a/src/app/components/client/exposure_card/ExposureCard.test.tsx
+++ b/src/app/components/client/exposure_card/ExposureCard.test.tsx
@@ -150,7 +150,7 @@ describe("ScanResultCard", () => {
     expect(innerDescription).toBeInTheDocument();
   });
 
-  it("shows an additional note for “requested removal” status label", () => {
+  it("shows an additional note for “requested removal” status label if the feature flag `DataBrokerRemovalAttempts` is enabled", () => {
     const ComposedProgressCard = composeStory(DataBrokerRequestedRemoval, Meta);
     render(<ComposedProgressCard />);
     const statusLabel = screen.getByText("Requested removal");
@@ -160,6 +160,22 @@ describe("ScanResultCard", () => {
     });
 
     expect(labelNote).toBeInTheDocument();
+  });
+
+  it("does not show an additional note for “requested removal” status label if the feature flag `DataBrokerRemovalAttempts` is not enabled", () => {
+    const ComposedProgressCard = composeStory(DataBrokerRequestedRemoval, Meta);
+    render(
+      <ComposedProgressCard
+        enabledFeatureFlags={["AdditionalRemovalStatuses"]}
+      />,
+    );
+    const statusLabel = screen.getByText("Requested removal");
+    const statusLabelParent = statusLabel.parentElement as HTMLElement;
+    const labelNote = within(statusLabelParent).queryByText("Attempt", {
+      exact: false,
+    });
+
+    expect(labelNote).not.toBeInTheDocument();
   });
 
   it("hides the dt element if its dd counterpart has hideonmobile", () => {

--- a/src/app/components/client/exposure_card/ScanResultCard.tsx
+++ b/src/app/components/client/exposure_card/ScanResultCard.tsx
@@ -217,6 +217,7 @@ export const ScanResultCard = (props: ScanResultCardProps) => {
   const attemptCount = scanResult.optout_attempts ?? 0;
   const statusPillNote =
     props.enabledFeatureFlags?.includes("AdditionalRemovalStatuses") &&
+    props.enabledFeatureFlags?.includes("DataBrokerRemovalAttempts") &&
     !scanResult.manually_resolved &&
     scanResult.status === "waiting_for_verification" &&
     attemptCount >= 1

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -57,6 +57,7 @@ export const featureFlagNames = [
   "LandingPageRedesign",
   "EnableRemovalUnderMaintenanceStep",
   "CirrusV2",
+  "DataBrokerRemovalAttempts",
 ] as const;
 export type FeatureFlagName = (typeof featureFlagNames)[number];
 


### PR DESCRIPTION
…w data broker removal attempts

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-3925](https://mozilla-hub.atlassian.net/browse/MNTOR-3925)

<!-- When adding a new feature: -->

# Description

Adds the feature flag `DataBrokerRemovalAttempts` to conditionally show data broker removal attempts.

# Screenshot

| Enabled | Disabled |
| --- | --- |
| <img width="168" alt="image" src="https://github.com/user-attachments/assets/c4f7a732-f789-4290-9c0e-88056cb5c6fa" /> | <img width="169" alt="image" src="https://github.com/user-attachments/assets/04a27cea-e534-4606-9efb-7222edb1fb61" /> |

# How to test

Enable/disable the feature flag `DataBrokerRemovalAttempts`.