### PR TITLE
Cirrus has enrolments as an array

### DIFF
--- a/src/app/hooks/useGlean.ts
+++ b/src/app/hooks/useGlean.ts
@@ -50,17 +50,17 @@ export const useGlean = () => {
         typeof experimentData["Enrollments"] !== "undefined"
       ) {
         (data as GleanMetricMap["button"]["click"]).nimbus_user_id =
-          experimentData["Enrollments"]["nimbus_user_id"];
+          experimentData["Enrollments"][0]?.nimbus_user_id;
         (data as GleanMetricMap["button"]["click"]).nimbus_app_id =
-          experimentData["Enrollments"]["app_id"];
+          experimentData["Enrollments"][0]?.app_id;
         (data as GleanMetricMap["button"]["click"]).nimbus_experiment =
-          experimentData["Enrollments"]["experiment"];
+          experimentData["Enrollments"][0]?.experiment;
         (data as GleanMetricMap["button"]["click"]).nimbus_branch =
-          experimentData["Enrollments"]["branch"];
+          experimentData["Enrollments"][0]?.branch;
         (data as GleanMetricMap["button"]["click"]).nimbus_experiment_type =
-          experimentData["Enrollments"]["experiment_type"];
+          experimentData["Enrollments"][0]?.experiment_type;
         (data as GleanMetricMap["button"]["click"]).nimbus_is_preview =
-          experimentData["Enrollments"]["is_preview"].toString();
+          experimentData["Enrollments"][0]?.is_preview.toString();
       } else {
         console.warn("No experiment data available for Glean");
       }

--- a/src/app/hooks/useGlean.ts
+++ b/src/app/hooks/useGlean.ts
@@ -49,23 +49,23 @@ export const useGlean = () => {
         experimentData &&
         typeof experimentData["Enrollments"] !== "undefined"
       ) {
-        (data as GleanMetricMap["button"]["click"]).nimbus_user_id =
+        (data as GleanMetricMap["button"]["click"]).nimbus_user_ids =
           experimentData["Enrollments"].map(
             (enrollment) => enrollment.nimbus_user_id,
           );
-        (data as GleanMetricMap["button"]["click"]).nimbus_app_id =
+        (data as GleanMetricMap["button"]["click"]).nimbus_app_ids =
           experimentData["Enrollments"].map((enrollment) => enrollment.app_id);
-        (data as GleanMetricMap["button"]["click"]).nimbus_experiment =
+        (data as GleanMetricMap["button"]["click"]).nimbus_experiments =
           experimentData["Enrollments"].map(
             (enrollment) => enrollment.experiment,
           );
-        (data as GleanMetricMap["button"]["click"]).nimbus_branch =
+        (data as GleanMetricMap["button"]["click"]).nimbus_branches =
           experimentData["Enrollments"].map((enrollment) => enrollment.branch);
-        (data as GleanMetricMap["button"]["click"]).nimbus_experiment_type =
+        (data as GleanMetricMap["button"]["click"]).nimbus_experiment_types =
           experimentData["Enrollments"].map(
             (enrollment) => enrollment.experiment_type,
           );
-        (data as GleanMetricMap["button"]["click"]).nimbus_is_preview =
+        (data as GleanMetricMap["button"]["click"]).nimbus_are_previews =
           experimentData["Enrollments"].map(
             (enrollment) => enrollment.is_preview,
           );

--- a/src/app/hooks/useGlean.ts
+++ b/src/app/hooks/useGlean.ts
@@ -66,8 +66,8 @@ export const useGlean = () => {
             (enrollment) => enrollment.experiment_type,
           );
         (data as GleanMetricMap["button"]["click"]).nimbus_is_preview =
-          experimentData["Enrollments"].map((enrollment) =>
-            enrollment.is_preview.toString(),
+          experimentData["Enrollments"].map(
+            (enrollment) => enrollment.is_preview,
           );
       } else {
         console.warn("No experiment data available for Glean");

--- a/src/app/hooks/useGlean.ts
+++ b/src/app/hooks/useGlean.ts
@@ -13,7 +13,7 @@ import { useExperiments } from "../../contextProviders/experiments";
 
 export const useGlean = () => {
   const session = useSession();
-  const experimentData = useExperiments();
+  const experiments = useExperiments();
   // Telemetry recording is mocked in our unit tests, therefore we
   // do not have test coverage for this method.
   /* c8 ignore start */
@@ -44,39 +44,19 @@ export const useGlean = () => {
       // Record the `nimbus_*` keys on all events.
       // `nimbus_*` is set on every metric, but it's too much work for TypeScript
       // to infer that — hence the type assertion.
-
-      if (
-        experimentData &&
-        typeof experimentData["Enrollments"] !== "undefined"
-      ) {
-        (data as GleanMetricMap["button"]["click"]).nimbus_user_ids =
-          experimentData["Enrollments"].map(
-            (enrollment) => enrollment.nimbus_user_id,
-          );
-        (data as GleanMetricMap["button"]["click"]).nimbus_app_ids =
-          experimentData["Enrollments"].map((enrollment) => enrollment.app_id);
-        (data as GleanMetricMap["button"]["click"]).nimbus_experiments =
-          experimentData["Enrollments"].map(
-            (enrollment) => enrollment.experiment,
-          );
-        (data as GleanMetricMap["button"]["click"]).nimbus_branches =
-          experimentData["Enrollments"].map((enrollment) => enrollment.branch);
-        (data as GleanMetricMap["button"]["click"]).nimbus_experiment_types =
-          experimentData["Enrollments"].map(
-            (enrollment) => enrollment.experiment_type,
-          );
-        (data as GleanMetricMap["button"]["click"]).nimbus_are_previews =
-          experimentData["Enrollments"].map(
-            (enrollment) => enrollment.is_preview,
-          );
+      if (experiments === null) {
+        console.warn(
+          "`useGlean` is used in a component that is not a (grand)child of <ExperimentsProvider>",
+        );
       } else {
-        console.warn("No experiment data available for Glean");
+        (data as GleanMetricMap["button"]["click"]).nimbus_user_id =
+          experiments.experimentationId;
       }
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mod[event].record(data as any);
     },
-    [isPremiumUser, experimentData],
+    [isPremiumUser, experiments],
   );
   /* c8 ignore end */
 

--- a/src/app/hooks/useGlean.ts
+++ b/src/app/hooks/useGlean.ts
@@ -50,17 +50,25 @@ export const useGlean = () => {
         typeof experimentData["Enrollments"] !== "undefined"
       ) {
         (data as GleanMetricMap["button"]["click"]).nimbus_user_id =
-          experimentData["Enrollments"][0]?.nimbus_user_id;
+          experimentData["Enrollments"].map(
+            (enrollment) => enrollment.nimbus_user_id,
+          );
         (data as GleanMetricMap["button"]["click"]).nimbus_app_id =
-          experimentData["Enrollments"][0]?.app_id;
+          experimentData["Enrollments"].map((enrollment) => enrollment.app_id);
         (data as GleanMetricMap["button"]["click"]).nimbus_experiment =
-          experimentData["Enrollments"][0]?.experiment;
+          experimentData["Enrollments"].map(
+            (enrollment) => enrollment.experiment,
+          );
         (data as GleanMetricMap["button"]["click"]).nimbus_branch =
-          experimentData["Enrollments"][0]?.branch;
+          experimentData["Enrollments"].map((enrollment) => enrollment.branch);
         (data as GleanMetricMap["button"]["click"]).nimbus_experiment_type =
-          experimentData["Enrollments"][0]?.experiment_type;
+          experimentData["Enrollments"].map(
+            (enrollment) => enrollment.experiment_type,
+          );
         (data as GleanMetricMap["button"]["click"]).nimbus_is_preview =
-          experimentData["Enrollments"][0]?.is_preview.toString();
+          experimentData["Enrollments"].map((enrollment) =>
+            enrollment.is_preview.toString(),
+          );
       } else {
         console.warn("No experiment data available for Glean");
       }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -78,7 +78,7 @@ export default async function RootLayout({
     previewMode: nimbusPreviewMode === "true",
   });
 
-  const nimbus_user_id = experimentData["Enrollments"]?.nimbus_user_id;
+  const nimbus_user_id = experimentData["Enrollments"]?.[0]?.nimbus_user_id;
   if (
     typeof nimbus_user_id !== "undefined" &&
     nimbus_user_id !== experimentationId

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -78,13 +78,12 @@ export default async function RootLayout({
     previewMode: nimbusPreviewMode === "true",
   });
 
-  const nimbus_user_id = experimentData["Enrollments"]?.[0]?.nimbus_user_id;
-  if (
-    typeof nimbus_user_id !== "undefined" &&
-    nimbus_user_id !== experimentationId
-  ) {
+  const enrollmentWithConflictingUserId = (
+    experimentData.Enrollments ?? []
+  ).find((enrollment) => enrollment.nimbus_user_id !== experimentationId);
+  if (typeof enrollmentWithConflictingUserId !== "undefined") {
     Sentry.captureMessage(
-      `Nimbus user ID from Cirrus: [${nimbus_user_id}] did not match experimentationId: [${experimentationId}]`,
+      `Nimbus user ID from Cirrus: [${enrollmentWithConflictingUserId.nimbus_user_id}] did not match experimentationId: [${experimentationId}]`,
     );
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -97,7 +97,10 @@ export default async function RootLayout({
         data-ga4-measurement-id={CONST_GA4_MEASUREMENT_ID}
         data-node-env={process.env.NODE_ENV}
       >
-        <ExperimentsProvider experimentData={experimentData}>
+        <ExperimentsProvider
+          experimentData={experimentData}
+          experimentationId={experimentationId}
+        >
           <SessionProvider session={session}>{children}</SessionProvider>
         </ExperimentsProvider>
       </body>

--- a/src/contextProviders/experiments.test.tsx
+++ b/src/contextProviders/experiments.test.tsx
@@ -14,7 +14,10 @@ describe("Experiment context provider", () => {
       return <div />;
     };
     const { container } = render(
-      <ExperimentsProvider experimentData={defaultExperimentData}>
+      <ExperimentsProvider
+        experimentData={defaultExperimentData}
+        experimentationId="-1"
+      >
         <TestComponent />
       </ExperimentsProvider>,
     );

--- a/src/contextProviders/experiments.tsx
+++ b/src/contextProviders/experiments.tsx
@@ -10,18 +10,23 @@ import { ExperimentData_V2_Or_V2LikeV1 } from "../app/functions/server/getExperi
 interface ExperimentsProviderProps {
   children: ReactNode;
   experimentData: ExperimentData_V2_Or_V2LikeV1;
+  experimentationId: string;
 }
 
-export const ExperimentsContext =
-  createContext<ExperimentData_V2_Or_V2LikeV1 | null>(null);
+export const ExperimentsContext = createContext<{
+  experimentData: ExperimentData_V2_Or_V2LikeV1;
+  experimentationId: string;
+} | null>(null);
 
-export const ExperimentsProvider = ({
-  children,
-  experimentData,
-}: ExperimentsProviderProps) => {
+export const ExperimentsProvider = (props: ExperimentsProviderProps) => {
   return (
-    <ExperimentsContext.Provider value={experimentData}>
-      {children}
+    <ExperimentsContext.Provider
+      value={{
+        experimentData: props.experimentData,
+        experimentationId: props.experimentationId,
+      }}
+    >
+      {props.children}
     </ExperimentsContext.Provider>
   );
 };

--- a/src/scripts/build/nimbusTypes.js
+++ b/src/scripts/build/nimbusTypes.js
@@ -96,17 +96,19 @@ function getFallbackObject(nimbusConfig) {
   );
 
   const defaultExperimentData = `
-    "Features": {
+    Features: {
       ${featureFallbackDefs.join("\n")}
     },
-    "Enrollments": {
-      "nimbus_user_id": "-1",
-      "app_id": "-1",
-      "experiment": "-1",
-      "branch": "-1",
-      "experiment_type": "-1",
-      "is_preview": false
-    }`;
+    Enrollments: [
+      {
+        nimbus_user_id: "-1",
+        app_id: "-1",
+        experiment: "-1",
+        branch: "-1",
+        experiment_type: "-1",
+        is_preview: false
+      }
+    ]`;
   return `export const defaultExperimentData: ExperimentData = {\n${defaultExperimentData}};\n`;
 }
 
@@ -129,17 +131,19 @@ function getLocalOverrides(nimbusConfig) {
   );
 
   const localExperimentData = `
-  "Features": {
+  Features: {
     ${featureLocalOverridesDefs.join("\n")}
   },
-  "Enrollments": {
-    "nimbus_user_id": "-1",
-    "app_id": "-1",
-    "experiment": "-1",
-    "branch": "-1",
-    "experiment_type": "-1",
-    "is_preview": false
-  }`;
+  Enrollments: [
+    {
+      nimbus_user_id: "-1",
+      app_id: "-1",
+      experiment: "-1",
+      branch: "-1",
+      experiment_type: "-1",
+      is_preview: false
+    }
+  ]`;
 
   return `export const localExperimentData: ExperimentData = {\n${localExperimentData}};\n`;
 }
@@ -160,15 +164,15 @@ function getFeaturesTypeDef(nimbusConfig) {
   });
 
   const experimentDataType = `{
-  "Features": {${featureDefs.join("")}};
-  "Enrollments": {
-    "nimbus_user_id": string,
-    "app_id": string,
-    "experiment": string,
-    "branch": string,
-    "experiment_type": string,
-    "is_preview": boolean
-    };
+  Features: {${featureDefs.join("")}};
+  Enrollments: Array<{
+    nimbus_user_id: string,
+    app_id: string,
+    experiment: string,
+    branch: string,
+    experiment_type: string,
+    is_preview: boolean
+    }>;
   };`;
 
   const experimentDataTypeDef = `/** Status of experiments, as setup in Experimenter */\nexport type ExperimentData = ${experimentDataType}`;

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -58,22 +58,34 @@ page:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
 dashboard:
   view:
@@ -122,22 +134,34 @@ dashboard:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
 popup:
   view:
@@ -173,22 +197,34 @@ popup:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
   exit:
     type: event
@@ -223,22 +259,34 @@ popup:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
 banner:
   view:
@@ -274,22 +322,34 @@ banner:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
 button:
   click:
@@ -325,22 +385,34 @@ button:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
 field:
   focus:
@@ -376,22 +448,34 @@ field:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
 link:
   click:
@@ -427,22 +511,34 @@ link:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
 upgrade_intent:
   click:
@@ -478,22 +574,34 @@ upgrade_intent:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
   success:
     type: event
@@ -526,22 +634,34 @@ upgrade_intent:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
 expand:
   click:
@@ -577,22 +697,34 @@ expand:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
 collapse:
   click:
@@ -628,22 +760,34 @@ collapse:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
 cta_button:
   click:
@@ -679,22 +823,34 @@ cta_button:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
   view:
     type: event
@@ -729,22 +885,34 @@ cta_button:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
 csat_survey:
   view:
@@ -780,22 +948,34 @@ csat_survey:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
   dismiss:
     type: event
@@ -830,22 +1010,34 @@ csat_survey:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string
 
   click:
     type: event
@@ -883,19 +1075,31 @@ csat_survey:
         type: string
       nimbus_user_id:
         description: Nimbus user ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_app_id:
         description: Nimbus application ID
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment:
         description: Nimbus experiment name
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_branch:
         description: Nimbus branch
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_experiment_type:
         description: Nimbus experiment type
-        type: string
+        type: array
+        items:
+          type: string
       nimbus_is_preview:
         description: Nimbus preview mode enabled
-        type: string
+        type: array
+        items:
+          type: string

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -56,36 +56,9 @@ page:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
 dashboard:
   view:
@@ -132,36 +105,9 @@ dashboard:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
 popup:
   view:
@@ -195,36 +141,9 @@ popup:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
   exit:
     type: event
@@ -257,36 +176,9 @@ popup:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
 banner:
   view:
@@ -320,36 +212,9 @@ banner:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
 button:
   click:
@@ -383,36 +248,9 @@ button:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
 field:
   focus:
@@ -446,36 +284,9 @@ field:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
 link:
   click:
@@ -509,36 +320,9 @@ link:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
 upgrade_intent:
   click:
@@ -572,36 +356,9 @@ upgrade_intent:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
   success:
     type: event
@@ -632,36 +389,9 @@ upgrade_intent:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
 expand:
   click:
@@ -695,36 +425,9 @@ expand:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
 collapse:
   click:
@@ -758,36 +461,9 @@ collapse:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
 cta_button:
   click:
@@ -821,36 +497,9 @@ cta_button:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
   view:
     type: event
@@ -883,36 +532,9 @@ cta_button:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
 csat_survey:
   view:
@@ -946,36 +568,9 @@ csat_survey:
       automated_removal_period:
         description: The time period since the first automated removal for the user. [initial, 3-months, 6-months, 12-months]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
   dismiss:
     type: event
@@ -1008,36 +603,9 @@ csat_survey:
       automated_removal_period:
         description: The time period since the first automated removal for the user. [initial, 3-months, 6-months, 12-months]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string
 
   click:
     type: event
@@ -1073,33 +641,6 @@ csat_survey:
       automated_removal_period:
         description: The time period since the first automated removal for the user. [initial, 3-months, 6-months, 12-months]
         type: string
-      nimbus_user_ids:
+      nimbus_user_id:
         description: Nimbus user ID
-        type: array
-        items:
-          type: string
-      nimbus_app_ids:
-        description: Nimbus application ID
-        type: array
-        items:
-          type: string
-      nimbus_experiments:
-        description: Nimbus experiment name
-        type: array
-        items:
-          type: string
-      nimbus_branches:
-        description: Nimbus branch
-        type: array
-        items:
-          type: string
-      nimbus_experiment_types:
-        description: Nimbus experiment type
-        type: array
-        items:
-          type: string
-      nimbus_are_previews:
-        description: Nimbus preview mode enabled
-        type: array
-        items:
-          type: boolean
+        type: string

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -56,32 +56,32 @@ page:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -132,32 +132,32 @@ dashboard:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -195,32 +195,32 @@ popup:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -257,32 +257,32 @@ popup:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -320,32 +320,32 @@ banner:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -383,32 +383,32 @@ button:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -446,32 +446,32 @@ field:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -509,32 +509,32 @@ link:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -572,32 +572,32 @@ upgrade_intent:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -632,32 +632,32 @@ upgrade_intent:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -695,32 +695,32 @@ expand:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -758,32 +758,32 @@ collapse:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -821,32 +821,32 @@ cta_button:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -883,32 +883,32 @@ cta_button:
       plan_tier:
         description: Which tier of plan the user is on [Free, Plus]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -946,32 +946,32 @@ csat_survey:
       automated_removal_period:
         description: The time period since the first automated removal for the user. [initial, 3-months, 6-months, 12-months]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -1008,32 +1008,32 @@ csat_survey:
       automated_removal_period:
         description: The time period since the first automated removal for the user. [initial, 3-months, 6-months, 12-months]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:
@@ -1073,32 +1073,32 @@ csat_survey:
       automated_removal_period:
         description: The time period since the first automated removal for the user. [initial, 3-months, 6-months, 12-months]
         type: string
-      nimbus_user_id:
+      nimbus_user_ids:
         description: Nimbus user ID
         type: array
         items:
           type: string
-      nimbus_app_id:
+      nimbus_app_ids:
         description: Nimbus application ID
         type: array
         items:
           type: string
-      nimbus_experiment:
+      nimbus_experiments:
         description: Nimbus experiment name
         type: array
         items:
           type: string
-      nimbus_branch:
+      nimbus_branches:
         description: Nimbus branch
         type: array
         items:
           type: string
-      nimbus_experiment_type:
+      nimbus_experiment_types:
         description: Nimbus experiment type
         type: array
         items:
           type: string
-      nimbus_is_preview:
+      nimbus_are_previews:
         description: Nimbus preview mode enabled
         type: array
         items:

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -85,7 +85,7 @@ page:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
 dashboard:
   view:
@@ -161,7 +161,7 @@ dashboard:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
 popup:
   view:
@@ -224,7 +224,7 @@ popup:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
   exit:
     type: event
@@ -286,7 +286,7 @@ popup:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
 banner:
   view:
@@ -349,7 +349,7 @@ banner:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
 button:
   click:
@@ -412,7 +412,7 @@ button:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
 field:
   focus:
@@ -475,7 +475,7 @@ field:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
 link:
   click:
@@ -538,7 +538,7 @@ link:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
 upgrade_intent:
   click:
@@ -601,7 +601,7 @@ upgrade_intent:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
   success:
     type: event
@@ -661,7 +661,7 @@ upgrade_intent:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
 expand:
   click:
@@ -724,7 +724,7 @@ expand:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
 collapse:
   click:
@@ -787,7 +787,7 @@ collapse:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
 cta_button:
   click:
@@ -850,7 +850,7 @@ cta_button:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
   view:
     type: event
@@ -912,7 +912,7 @@ cta_button:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
 csat_survey:
   view:
@@ -975,7 +975,7 @@ csat_survey:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
   dismiss:
     type: event
@@ -1037,7 +1037,7 @@ csat_survey:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean
 
   click:
     type: event
@@ -1102,4 +1102,4 @@ csat_survey:
         description: Nimbus preview mode enabled
         type: array
         items:
-          type: string
+          type: boolean


### PR DESCRIPTION
This PR I'm not sure about, and it's probably wrong, but: in MNTOR-3812, @rhelmer showed an example with `Enrollments` being an array, whereas our code says that it's a single object.

I'm not sure if it actually is, and if it is, I'm not sure why and how we're supposed to handle it - in this PR, I'm just always getting the first element, but that's probably not correct. However, I figured I'd submit this PR to at least have this observation in play somewhere.