### PR TITLE
Enable landing page redesign for testing

### DIFF
--- a/config/nimbus.yaml
+++ b/config/nimbus.yaml
@@ -120,7 +120,7 @@ features:
         }
       - channel: staging
         value: {
-          "enabled": false,
+          "enabled": true,
           "variant": redesign,
         }
       - channel: production


### PR DESCRIPTION
The experiment override with `?nimbus_preview=true` does not work ([MNTOR-3981](https://mozilla-hub.atlassian.net/browse/MNTOR-3981)) as we are working through the updated integration with Nimbus. We need to enable the landing page redesign experiment on `stage` by default for testing purposes.