### PR TITLE
MNTOR-3917: Add feature flag, admin email UI and tests for the expiration email

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/EmailTrigger.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/emails/EmailTrigger.tsx
@@ -12,6 +12,7 @@ import {
   triggerFirstDataBrokerRemovalFixed,
   triggerMonthlyActivityFree,
   triggerMonthlyActivityPlus,
+  triggerPlusExpirationEmail,
   triggerSignupReportEmail,
   triggerVerificationEmail,
 } from "./actions";
@@ -37,6 +38,10 @@ export const EmailTrigger = (props: Props) => {
   const [
     isSendingMonthlyActivityPlusOverview,
     setIsSendingMonthlyActivityPlusOverview,
+  ] = useState(false);
+  const [
+    isSendingPlusExpirationNotification,
+    setIsSendingPlusExpirationNotification,
   ] = useState(false);
   const [firstDataBrokerRemovalFixed, setFirstDataBrokerRemovalFixed] =
     useState(false);
@@ -154,6 +159,18 @@ export const EmailTrigger = (props: Props) => {
           }}
         >
           First data broker removal fixed
+        </Button>
+        <Button
+          variant="primary"
+          isLoading={isSendingPlusExpirationNotification}
+          onPress={() => {
+            setIsSendingPlusExpirationNotification(true);
+            void triggerPlusExpirationEmail(selectedEmailAddress).then(() => {
+              setIsSendingPlusExpirationNotification(false);
+            });
+          }}
+        >
+          Plus expiration notification
         </Button>
       </div>
     </main>

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/plus-expiration/PlusExpiration.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/plus-expiration/PlusExpiration.test.tsx
@@ -1,0 +1,176 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { it, expect } from "@jest/globals";
+import { render, screen } from "@testing-library/react";
+import { composeStory } from "@storybook/react";
+import { axe } from "jest-axe";
+import userEvent from "@testing-library/user-event";
+import Meta, {
+  CouponAlreadyApplied,
+  FreeUser,
+  HappyPath,
+  NotExpiring,
+} from "./PlusExpiration.stories";
+
+it("passes the axe accessibility test suite", async () => {
+  const PlusExpirationView = composeStory(HappyPath, Meta);
+  const { container } = render(<PlusExpirationView />);
+  expect(await axe(container)).toHaveNoViolations();
+});
+
+it("includes a link to the terms on the renewal page", () => {
+  const PlusExpirationView = composeStory(HappyPath, Meta);
+  render(<PlusExpirationView />);
+
+  const termsLink = screen.getByRole("link", {
+    name: "Limited terms and restrictions apply Open link in a new tab",
+  });
+  expect(termsLink).toBeInTheDocument();
+});
+
+it("confirms the renewal after it's applied", async () => {
+  const user = userEvent.setup();
+  const PlusExpirationView = composeStory(HappyPath, Meta);
+  render(
+    <PlusExpirationView
+      applyCouponAction={jest.fn().mockResolvedValue({ success: true })}
+    />,
+  );
+
+  expect(
+    screen.queryByRole("heading", {
+      name: "Thanks for renewing your subscription",
+    }),
+  ).not.toBeInTheDocument();
+
+  const renewalButton = screen.getByRole("button", {
+    name: "Renew subscription",
+  });
+  await user.click(renewalButton);
+
+  expect(
+    screen.getByRole("heading", {
+      name: "Thanks for renewing your subscription",
+    }),
+  ).toBeInTheDocument();
+});
+
+it("shows an error if applying the coupon failed", async () => {
+  const user = userEvent.setup();
+  const PlusExpirationView = composeStory(HappyPath, Meta);
+  render(
+    <PlusExpirationView
+      applyCouponAction={jest.fn().mockResolvedValue({
+        success: false,
+        error: "apply_renewal_coupon_error",
+      })}
+    />,
+  );
+
+  expect(
+    screen.queryByText(/Couldn’t renew subscription./),
+  ).not.toBeInTheDocument();
+
+  const renewalButton = screen.getByRole("button", {
+    name: "Renew subscription",
+  });
+  await user.click(renewalButton);
+
+  expect(screen.getByText(/Couldn’t renew subscription./)).toBeInTheDocument();
+});
+
+it("hides the error after dismissing it", async () => {
+  const user = userEvent.setup();
+  const PlusExpirationView = composeStory(HappyPath, Meta);
+  render(
+    <PlusExpirationView
+      applyCouponAction={jest.fn().mockResolvedValue({
+        success: false,
+        error: "apply_renewal_coupon_error",
+      })}
+    />,
+  );
+
+  const renewalButton = screen.getByRole("button", {
+    name: "Renew subscription",
+  });
+  await user.click(renewalButton);
+
+  expect(screen.getByText(/Couldn’t renew subscription./)).toBeInTheDocument();
+
+  const dismissButton = screen.getByRole("button", { name: "Dismiss" });
+  await user.click(dismissButton);
+  expect(
+    screen.queryByText(/Couldn’t renew subscription./),
+  ).not.toBeInTheDocument();
+});
+
+it("allows retrying after an error", async () => {
+  const user = userEvent.setup();
+  const PlusExpirationView = composeStory(HappyPath, Meta);
+  render(
+    <PlusExpirationView
+      applyCouponAction={jest
+        .fn()
+        .mockResolvedValueOnce({
+          success: false,
+          error: "apply_renewal_coupon_error",
+        })
+        .mockResolvedValueOnce({ success: true })}
+    />,
+  );
+
+  const renewalButton = screen.getByRole("button", {
+    name: "Renew subscription",
+  });
+  await user.click(renewalButton);
+
+  expect(screen.getByText(/Couldn’t renew subscription./)).toBeInTheDocument();
+
+  const retryButton = screen.getByRole("button", { name: "Try again" });
+  await user.click(retryButton);
+  expect(
+    screen.queryByText(/Couldn’t renew subscription./),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.getByRole("heading", {
+      name: "Thanks for renewing your subscription",
+    }),
+  ).toBeInTheDocument();
+});
+
+it("tells free users that this is only available to existing Plus users", () => {
+  const PlusExpirationView = composeStory(FreeUser, Meta);
+  render(<PlusExpirationView />);
+
+  const heading = screen.getByRole("heading", {
+    name: "Discount valid for current ⁨Monitor Plus⁩ customers",
+  });
+  const cta = screen.getByRole("link", {
+    name: "Subscribe to ⁨Monitor Plus⁩",
+  });
+  expect(heading).toBeInTheDocument();
+  expect(cta).toBeInTheDocument();
+});
+
+it("doesn't allow people to apply the coupon twice", () => {
+  const PlusExpirationView = composeStory(CouponAlreadyApplied, Meta);
+  render(<PlusExpirationView />);
+
+  const heading = screen.getByRole("heading", {
+    name: "Discount code already applied",
+  });
+  expect(heading).toBeInTheDocument();
+});
+
+it("only applies to people whose subscriptions are expiring", () => {
+  const PlusExpirationView = composeStory(NotExpiring, Meta);
+  render(<PlusExpirationView />);
+
+  const heading = screen.getByRole("heading", {
+    name: "Your ⁨Monitor Plus⁩ subscription is still active",
+  });
+  expect(heading).toBeInTheDocument();
+});

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/plus-expiration/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/plus-expiration/page.tsx
@@ -10,6 +10,7 @@ import { View } from "./View";
 import { logger } from "../../../../../functions/server/logging";
 import { checkChurnCouponCode } from "../../../../../functions/server/applyCoupon";
 import { applyRenewalCoupon } from "./actions";
+import { getEnabledFeatureFlags } from "../../../../../../db/tables/featureFlags";
 
 export default async function PlusExpirationPage() {
   const session = await getServerSession();
@@ -27,6 +28,14 @@ export default async function PlusExpirationPage() {
   );
   if (!subscriber) {
     logger.warn("plus_expiration_no_subscriber_found_for_session");
+    return notFound();
+  }
+
+  const enabledFeatureFlags = await getEnabledFeatureFlags({
+    email: subscriber.primary_email,
+  });
+  if (!enabledFeatureFlags.includes("ExpirationNotification")) {
+    logger.warn("plus_expiration_accessing_offer_with_flag_off");
     return notFound();
   }
 

--- a/src/app/(proper_react)/(redesign)/terms/expiration-offer/page.tsx
+++ b/src/app/(proper_react)/(redesign)/terms/expiration-offer/page.tsx
@@ -2,13 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { notFound } from "next/navigation";
 import { View } from "./View";
 import {
   getAcceptLangHeaderInServerComponents,
   getL10n,
 } from "../../../../functions/l10n/serverComponents";
+import { getEnabledFeatureFlags } from "../../../../../db/tables/featureFlags";
+import { logger } from "../../../../functions/server/logging";
 
 export default async function ExpirationOfferTermsPage() {
+  const enabledFeatureFlags = await getEnabledFeatureFlags({
+    isSignedOut: true,
+  });
+  if (!enabledFeatureFlags.includes("ExpirationNotification")) {
+    logger.warn("plus_expiration_viewing_terms_with_flag_off");
+    return notFound();
+  }
+
   const l10n = getL10n(await getAcceptLangHeaderInServerComponents());
 
   return <View l10n={l10n} />;

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -57,6 +57,7 @@ export const featureFlagNames = [
   "EnableRemovalUnderMaintenanceStep",
   "CirrusV2",
   "DataBrokerRemovalAttempts",
+  "ExpirationNotification",
 ] as const;
 export type FeatureFlagName = (typeof featureFlagNames)[number];
 

--- a/src/emails/templates/upcomingExpiration/UpcomingExpirationEmail.test.tsx
+++ b/src/emails/templates/upcomingExpiration/UpcomingExpirationEmail.test.tsx
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { it, expect } from "@jest/globals";
+import { composeStory } from "@storybook/react";
+import { render, screen } from "@testing-library/react";
+import Meta, {
+  UpcomingExpirationEmailStory,
+} from "./UpcomingExpirationEmail.stories";
+
+it("offers people to renew their subscription", () => {
+  const ComposedEmail = composeStory(UpcomingExpirationEmailStory, Meta);
+  render(<ComposedEmail />);
+
+  const renewalLnk = screen.getByRole("link", { name: /Renew/ });
+  expect(renewalLnk).toBeInTheDocument();
+});


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3917
Figma:

<!-- When adding a new feature: -->

# Description

Followup to https://github.com/mozilla/blurts-server/pull/5559: adds a feature flag, the admin email UI, and tests.

# How to test

Use the feature flag UI and admin email UI.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
