### PR TITLE
MNTOR-4028: Allow renewing after receiving an expiration email

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/plus-expiration/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/plus-expiration/page.tsx
@@ -11,7 +11,7 @@ import { logger } from "../../../../../functions/server/logging";
 import { checkChurnCouponCode } from "../../../../../functions/server/applyCoupon";
 import { applyRenewalCoupon } from "./actions";
 import { getEnabledFeatureFlags } from "../../../../../../db/tables/featureFlags";
-import { getChurnsToEmail } from "../../../../../../db/tables/subscriber_churns";
+import { getUpcomingChurns } from "../../../../../../db/tables/subscriber_churns";
 
 export default async function PlusExpirationPage() {
   const session = await getServerSession();
@@ -41,7 +41,7 @@ export default async function PlusExpirationPage() {
   }
 
   const couponCheckResult = await checkChurnCouponCode(subscriber);
-  const subscribersToEmail = await getChurnsToEmail();
+  const expiringSubscriptions = await getUpcomingChurns();
 
   return (
     <View
@@ -50,9 +50,9 @@ export default async function PlusExpirationPage() {
       applyCouponAction={applyRenewalCoupon}
       manageSubscriptionsUrl={process.env.FXA_SUBSCRIPTIONS_URL!}
       isOnExpirationList={
-        typeof subscribersToEmail.find(
-          (subscriberToEmail) =>
-            subscriberToEmail.userid === subscriber.fxa_uid,
+        typeof expiringSubscriptions.find(
+          (expiringSubscription) =>
+            expiringSubscription.userid === subscriber.fxa_uid,
         ) !== "undefined"
       }
     />

--- a/src/db/tables/subscriber_churns.ts
+++ b/src/db/tables/subscriber_churns.ts
@@ -59,6 +59,29 @@ async function getAllSubscriberChurns(): Promise<SubscriberChurnRow[]> {
   }
 }
 
+async function getUpcomingChurns(): Promise<Array<SubscriberChurnRow>> {
+  try {
+    const res = await knex("subscriber_churns")
+      .select("*")
+      .where("intervl", "year")
+      .whereNotNull("current_period_end")
+      .where(knex.raw("current_period_end::timestamptz"), ">=", knex.fn.now())
+      .where(
+        knex.raw("current_period_end::timestamptz"),
+        "<=",
+        knex.raw("CURRENT_TIMESTAMP + interval '7 days'"),
+      );
+
+    logger.info("get_upcoming_churns_success", { count: res.length });
+    return res;
+  } catch (e) {
+    logger.error("get_upcoming_churns_error", {
+      error: JSON.stringify(e),
+    });
+    throw e;
+  }
+}
+
 async function getChurnsToEmail(): Promise<
   Array<SubscriberChurnRow & SubscriberRow>
 > {
@@ -92,5 +115,6 @@ export {
   upsertSubscriberChurns,
   getAllSubscriberChurns,
   deleteSubscriberChurns,
+  getUpcomingChurns,
   getChurnsToEmail,
 };


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-4028
Figma:

<!-- When adding a new feature: -->

# Description

We email people that their subscription is about to expire, then mark them as having received the email. We check whether we have marked someone as having received the email when collecting the list of subscribers to email, which means that we shouldn't use that list when determining whether someone can renew.

I've updated it to use a similar check, but to skip the check for `churn_prevention_email_sent_at`.

# How to test

Create a `.csv` file with the following contents:

```csv
userid,customer,created,nickname,intervl,intervl_count,plan_id,product_id,current_period_end
18b8ea3c9b12427893ded71fda0cb8aa,cus_custom,2/6/2024 10:57:57,Yearly Production Pricing ($8.99 per month: $107.88),year,1,price_1Nv4ODJNcmPzuWtRoYpoFHXd,prod_OiV9RSaatywSRy,2/2/2025 13:37:00
```

Replace `18b8ea3c9b12427893ded71fda0cb8aa` with the `fxa_uid` of the subscriber you want to email. (This subscriber should have Plus; you can give them Plus via `/admin/dev`.) Then upload that file via `/admin/churn-subscribers/`. It should say that there's one customer to email in the next cron run.

Then, run that cron job through `npm run dev:cron:churn-discount`. The customer should receive an email.

If you click the CTA in that email with `main` checked out, you should see "Your ⁨Monitor Plus⁩ subscription is still active", whereas on this branch, you should be able to renew successfully.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - No, because it involves a DB query, which we don't have a good way to test for.
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
