### PR TITLE
MNTOR-3971: Use last optout date instead of last update

### DIFF
--- a/src/apiMocks/mockData.ts
+++ b/src/apiMocks/mockData.ts
@@ -87,6 +87,10 @@ export function createRandomScanResult(
     created_at: options.createdDate ?? faker.date.recent({ days: 2 }),
     updated_at: faker.date.recent({ days: 1 }),
     optout_attempts,
+    last_optout_at:
+      typeof optout_attempts === "number" && optout_attempts > 0
+        ? faker.date.recent({ days: 3 })
+        : undefined,
     broker_status: options.broker_status ?? "active",
     scan_result_status: faker.helpers.arrayElement(
       Object.values(RemovalStatusMap),

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/qa-customs/onerepConfig.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/qa-customs/onerepConfig.tsx
@@ -23,6 +23,7 @@ interface QaBrokerDataCounts {
   status: string;
   manually_resolved: string;
   optout_attempts?: number;
+  last_optout_at?: string;
 }
 
 const endpointBase = "/api/v1/admin/qa-customs/onerep";
@@ -391,6 +392,18 @@ const OnerepConfigPage = (props: Props) => {
                   name="optout_attempts"
                   placeholder="0"
                   value={newBroker.optout_attempts ?? ""}
+                  onChange={handleChange}
+                />
+              </label>
+
+              <label className={styles.label}>
+                Last opt-out attempt:
+                <input
+                  className={styles.input}
+                  type="date"
+                  name="last_optout_at"
+                  placeholder={new Date().toISOString().split("T")[0]}
+                  value={newBroker.last_optout_at ?? ""}
                   onChange={handleChange}
                 />
               </label>

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardPlusUsers.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardPlusUsers.stories.tsx
@@ -248,6 +248,12 @@ const meta: Meta<typeof DashboardWrapper> = {
         type: "number",
       },
     },
+    enabledFeatureFlags: {
+      name: "Enabled feature flags",
+      control: {
+        type: "object",
+      },
+    },
   },
 };
 

--- a/src/app/api/mock/onerep/config/config.ts
+++ b/src/app/api/mock/onerep/config/config.ts
@@ -25,6 +25,7 @@ export interface Broker {
   data_broker: string;
   data_broker_id: number;
   optout_attempts: number;
+  last_optout_at: string;
   created_at: string;
   updated_at: string;
 }
@@ -46,6 +47,7 @@ export interface BrokerOptionals {
   data_broker?: string;
   data_broker_id?: number;
   optout_attempts?: number;
+  last_optout_at?: string;
   created_at?: string;
   updated_at?: string;
 }
@@ -191,6 +193,7 @@ export async function mockOnerepBrokers(
         data_broker: elem["data_broker"] || `mockexample${index}.com`,
         data_broker_id: elem["data_broker_id"] || idStartDataBroker - index,
         optout_attempts: elem["optout_attempts"] || 0,
+        last_optout_at: elem["last_optout_at"] || mockOnerepTime(),
         created_at: elem["created_at"] || mockOnerepTime(),
         updated_at: elem["updated_at"] || mockOnerepTime(),
       }) as Broker,

--- a/src/app/api/v1/admin/qa-customs/onerep/route.ts
+++ b/src/app/api/v1/admin/qa-customs/onerep/route.ts
@@ -91,6 +91,7 @@ export async function POST(req: NextRequest) {
   const status = body.status || "new";
   const manually_resolved = body.manually_resolved || false;
   const optout_attempts = body.optout_attempts || null;
+  const last_optout_at = body.last_optout_at || null;
 
   const brokerData: QaBrokerData = {
     onerep_profile_id,
@@ -107,6 +108,7 @@ export async function POST(req: NextRequest) {
     status,
     manually_resolved,
     optout_attempts,
+    last_optout_at,
   };
   try {
     await addQaCustomBroker(brokerData);

--- a/src/app/components/client/exposure_card/ExposureCard.test.tsx
+++ b/src/app/components/client/exposure_card/ExposureCard.test.tsx
@@ -189,6 +189,33 @@ describe("ScanResultCard", () => {
       elementsWithClass[0].previousElementSibling;
     expect(prevElementToInfoForSale).toHaveClass("hideOnMobile");
   });
+
+  it("shows the date of the last attempted opt-out, if known", () => {
+    const ComposedProgressCard = composeStory(DataBrokerInProgress, Meta);
+    render(
+      <ComposedProgressCard
+        enabledFeatureFlags={[
+          "AdditionalRemovalStatuses",
+          "DataBrokerRemovalAttempts",
+        ]}
+        exposureData={createRandomScanResult({
+          // `createRandomScanResult` explicitly sets the last opt-out date
+          // for scan results that are waiting for verification:
+          status: "waiting_for_verification",
+          manually_resolved: false,
+        })}
+      />,
+    );
+    const attemptListing = screen.getByText(/Attempt ⁨\d+⁩:/);
+    expect(attemptListing).toBeInTheDocument();
+    const textContent = attemptListing.textContent
+      // Remove the special characters that Fluent places around variables:
+      ?.replaceAll("⁨", "")
+      .replaceAll("⁩", "")
+      .split(/\s/);
+    const datePart = textContent?.[textContent.length - 1];
+    expect(Date.parse(datePart ?? "invalid date")).not.toBeNaN();
+  });
 });
 
 describe("DataBreachCard", () => {

--- a/src/app/components/client/exposure_card/ScanResultCard.tsx
+++ b/src/app/components/client/exposure_card/ScanResultCard.tsx
@@ -220,11 +220,12 @@ export const ScanResultCard = (props: ScanResultCardProps) => {
     props.enabledFeatureFlags?.includes("DataBrokerRemovalAttempts") &&
     !scanResult.manually_resolved &&
     scanResult.status === "waiting_for_verification" &&
-    attemptCount >= 1
+    attemptCount >= 1 &&
+    typeof scanResult.last_optout_at !== "undefined"
       ? l10n.getString("status-pill-requested-removal-info", {
           attempt_count: attemptCount,
           last_attempt_date: new Intl.DateTimeFormat(locale).format(
-            scanResult.updated_at,
+            scanResult.last_optout_at,
           ),
         })
       : "";

--- a/src/app/functions/server/onerep.ts
+++ b/src/app/functions/server/onerep.ts
@@ -93,6 +93,7 @@ export type ScanResult = {
   data_broker: string;
   status: RemovalStatus;
   optout_attempts?: number;
+  last_optout_at?: ISO8601DateString;
   data_broker_id: number;
   created_at: ISO8601DateString;
   updated_at: ISO8601DateString;

--- a/src/db/tables/onerep_scans.ts
+++ b/src/db/tables/onerep_scans.ts
@@ -263,6 +263,10 @@ async function addOnerepScanResults(
     last_name: scanResult.last_name,
     status: scanResult.status,
     optout_attempts: scanResult.optout_attempts,
+    last_optout_at:
+      typeof scanResult.last_optout_at === "string"
+        ? scanResult.last_optout_at
+        : undefined,
   }));
 
   // Only log metadata. This is used for reporting purposes.

--- a/src/db/tables/qa_customs.ts
+++ b/src/db/tables/qa_customs.ts
@@ -25,6 +25,7 @@ interface QaBrokerData {
   status: string;
   manually_resolved: boolean;
   optout_attempts: number;
+  last_optout_at: string;
 }
 
 interface QaBreachData {

--- a/src/knex-tables.d.ts
+++ b/src/knex-tables.d.ts
@@ -294,13 +294,14 @@ declare module "knex/types/tables" {
     last_name: string;
     status: RemovalStatus;
     optout_attempts?: number;
+    last_optout_at?: Date;
     manually_resolved: boolean;
     created_at: Date;
     updated_at: Date;
   }
   type OnerepScanResultOptionalColumns = Extract<
     keyof OnerepScanResultRow,
-    "manually_resolved" | "middle_name" | "optout_attempts"
+    "manually_resolved" | "middle_name" | "optout_attempts" | "last_optout_at"
   >;
   type OnerepScanResultSerializedColumns = Extract<
     keyof OnerepScanResultRow,


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3971
Figma: N/A

<!-- When adding a new feature: -->

# Description

This newly-added API response property accurately reflects the last scan date (which we had incorrectly hoped the last update date to do).

Note that I'm not familiar with the QA customs tool, so I mostly followed existing patterns and added `last_optout_at` wherever I could find `optout_attempts`. I think that covers it, but it uses quite a few custom types and otherwise lives fairly separate from the rest of the codebase, so I'm not particularly confident.

# Screenshot (if applicable)

Not applicable.

# How to test

Make sure the `DataBrokerRemovalAttempts` and `AdditionalRemovalStatuses` flags are on, which in Storybook you can do by [setting it to](https://deploy-preview-5591--fx-monitor-storybook.netlify.app/?path=/story/pages-logged-in-dashboard-us-user-plus--dashboard-us-premium-unresolved-scan-unresolved-breaches&args=enabledFeatureFlags[0]:DataBrokerRemovalAttempts;enabledFeatureFlags[1]:AdditionalRemovalStatuses):

```json
["DataBrokerRemovalAttempts", "AdditionalRemovalStatuses"]
```

(You might have to refresh, because the initial value Storybook sets is `{}`, which is not an array and thus causes an error.)

A Plus user (e.g. in [the above story](https://deploy-preview-5591--fx-monitor-storybook.netlify.app/?path=/story/pages-logged-in-dashboard-us-user-plus--dashboard-us-premium-unresolved-scan-unresolved-breaches&args=enabledFeatureFlags[0]:DataBrokerRemovalAttempts;enabledFeatureFlags[1]:AdditionalRemovalStatuses)) should then see the removal attempt in the Fixed tab for any "Requested removal" scan results. If you want to be sure that it's showing the last optout date as returned from the API, you can set it to some recognisable value in `/src/apiMocks/mockData.ts`.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
