### PR TITLE
Use correct From: address for local dev

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -44,7 +44,8 @@ NEXTAUTH_URL=http://localhost:6060
 # A random string, see
 # https://next-auth.js.org/configuration/options#secret
 NEXTAUTH_SECRET=r7nKAKDWV0Bl53GHgQ/kA/EJCM2zvuH+8G3wZtwbXEA=
-EMAIL_FROM="Firefox Monitor (local) breach-alerts@mozilla.com"
+# This needs to match the "From:" address for the AWS account linked to $SMTP_URL
+EMAIL_FROM="Mozilla Monitor Stage <breach-alerts@stage.mozaws.net>"
 # Whether GA4 sends data or not. NOTE: must be set in build environment.
 NEXT_PUBLIC_GA4_DEBUG_MODE=true
 SUBSCRIPTION_BILLING_AMOUNT_YEARLY_US=13.37


### PR DESCRIPTION
See https://mozilla.slack.com/archives/C04BLQVN151/p1739285607564839?thread_ts=1739282569.423019&cid=C04BLQVN151 - this updates the example `.env` file that new contributors start with to use the correct From: email address for local development, so that sending emails actually works (assuming the stage `$STMP_URL`).