### PR TITLE
Migration for last_optout_at columns

### DIFF
--- a/src/db/migrations/20250204102945_add_last_optout_at.js
+++ b/src/db/migrations/20250204102945_add_last_optout_at.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export async function up(knex) {
+  await knex.schema.table("onerep_scan_results", (table) => {
+    table.timestamp("last_optout_at").after("optout_attempts").nullable();
+  });
+  await knex.schema.table("qa_custom_brokers", (table) => {
+    table.timestamp("last_optout_at").after("optout_attempts").nullable();
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.table("onerep_scan_results", (table) => {
+    table.dropColumn("last_optout_at");
+  });
+  await knex.schema.table("qa_custom_brokers", (table) => {
+    table.dropColumn("last_optout_at");
+  });
+}


### PR DESCRIPTION
This is the same as https://github.com/mozilla/blurts-server/pull/5591, with the same commit 9670eb8, but without 8748975. That one's already been approved.