### PR TITLE
Workaround inaccurate Jest coverage reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,7 @@
         "jest-fail-on-console": "^3.3.1",
         "lint-staged": "^15.4.3",
         "mjml-browser": "^4.15.3",
+        "patch-package": "^8.0.0",
         "prettier": "3.5.0",
         "sass": "^1.84.0",
         "storybook": "^8.4.6",
@@ -12355,6 +12356,12 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -12890,6 +12897,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -16654,6 +16670,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -20307,6 +20332,25 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.2.1.tgz",
+      "integrity": "sha512-Lp6HbbBgosLmJbjx0pBLbgvx68FaFU1sdkmBuckmhhJ88kL13OA51CDtR2yJB50eCNMH9wRqtQNNiAqQH4YXnA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -20335,6 +20379,15 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -20493,6 +20546,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -22823,6 +22885,138 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/path-browserify": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "cron:report-lighthouse-results": "node dist/scripts/cronjobs/reportLighthouseResults.js",
     "db:migrate": "node -r dotenv-flow/config node_modules/knex/bin/cli.js migrate:latest --knexfile src/db/knexfile.js",
     "db:rollback": "node -r dotenv-flow/config node_modules/knex/bin/cli.js migrate:rollback --knexfile src/db/knexfile.js",
-    "prepare": "husky",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "npm run build-glean && npm run build-nimbus && storybook build",
     "create-location-data": "node src/scripts/build/uploadAutoCompleteLocations.js",
@@ -59,7 +58,9 @@
     "build-glean-backend-docs": "glean translate src/telemetry/backend-metrics.yaml --format markdown --output docs/telemetry/backend",
     "loadtest:hbibp-webhook": "echo 'Ensure k6 is installed; see:\n\thttps://grafana.com/docs/k6/latest/set-up/install-k6/\n' && k6 run src/scripts/loadtest/hibp.js",
     "validate-nimbus": "sh src/scripts/build/validate-nimbus-file.sh",
-    "lighthouse": "lhci autorun"
+    "lighthouse": "lhci autorun",
+    "prepare": "husky",
+    "postinstall": "patch-package"
   },
   "repository": {
     "type": "git",
@@ -162,6 +163,7 @@
     "jest-fail-on-console": "^3.3.1",
     "lint-staged": "^15.4.3",
     "mjml-browser": "^4.15.3",
+    "patch-package": "^8.0.0",
     "prettier": "3.5.0",
     "sass": "^1.84.0",
     "storybook": "^8.4.6",

--- a/patches/collect-v8-coverage+1.0.2.patch
+++ b/patches/collect-v8-coverage+1.0.2.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/collect-v8-coverage/index.js b/node_modules/collect-v8-coverage/index.js
+index 08b7853..db9ea66 100644
+--- a/node_modules/collect-v8-coverage/index.js
++++ b/node_modules/collect-v8-coverage/index.js
+@@ -13,6 +13,8 @@ class CoverageInstrumenter {
+   async startInstrumenting() {
+     this.session.connect();
+ 
++    await this.postSession('Debugger.enable');
++
+     await this.postSession('Profiler.enable');
+ 
+     await this.postSession('Profiler.startPreciseCoverage', {
+@@ -30,6 +32,8 @@ class CoverageInstrumenter {
+ 
+     await this.postSession('Profiler.disable');
+ 
++    await this.postSession('Debugger.disable');
++
+     // When using networked filesystems on Windows, v8 sometimes returns URLs
+     // of the form file:////<host>/path. These URLs are not well understood
+     // by NodeJS (see https://github.com/nodejs/node/issues/48530).

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/filterExposures.ts
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/filterExposures.ts
@@ -14,9 +14,6 @@ export function filterExposures(
   filters: FilterState,
 ): Exposure[] {
   return exposures.filter((exposure) => {
-    /* c8 ignore start */
-    // Since the Node 20.10 upgrade, it's been marking this  as uncovered, even
-    // though it's covered by tests.
     if (filters.exposureType === "data-breach" && isScanResult(exposure)) {
       return false;
     }
@@ -46,7 +43,6 @@ export function filterExposures(
     ) {
       return false;
     }
-    /* c8 ignore stop */
 
     return true;
   });

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/FixView.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/FixView.tsx
@@ -76,13 +76,7 @@ export const FixView = (props: FixViewProps) => {
       {props.showConfetti && <Confetti />}
       <div
         className={`${styles.fixWrapper} ${
-          isResolutionLayout
-            ? styles.highRiskDataBreachContentBg
-            : /* c8 ignore next 4 */
-              // Since the Node 20.10 upgrade, it's been intermittently marking
-              // this (and this comment) as uncovered, even though I think it's
-              // covered by tests.
-              ""
+          isResolutionLayout ? styles.highRiskDataBreachContentBg : ""
         }`}
       >
         {!props.hideProgressIndicator && (

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/ResolutionContainer.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/ResolutionContainer.tsx
@@ -32,9 +32,6 @@ type ResolutionContainerProps = {
 export const ResolutionContainer = (props: ResolutionContainerProps) => {
   const l10n = useL10n();
   const estimatedTimeString =
-    /* c8 ignore next 8 */
-    // Since the Node 20.10 upgrade, it's been intermittently marking this (and
-    // this comment) as uncovered, even though I think it's covered by tests.
     props.type === "leakedPasswords"
       ? "leaked-passwords-estimated-time"
       : "high-risk-breach-estimated-time";

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/ResolutionContent.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/ResolutionContent.tsx
@@ -28,9 +28,6 @@ export const ResolutionContent = ({
   });
 
   const listOfBreaches =
-    /* c8 ignore next 4 */
-    // Since the Node 20.10 upgrade, it's been intermittently marking this (and
-    // this comment) as uncovered, even though I think it's covered by tests.
     exposedData &&
     exposedData.map(({ id, title, breachDate }) => (
       <li key={id} className={styles.breachItem}>

--- a/src/app/components/client/Button.tsx
+++ b/src/app/components/client/Button.tsx
@@ -80,12 +80,7 @@ export const Button = (props: ButtonProps) => {
       target={target}
       className={classes}
     >
-      {
-        /* c8 ignore next 3 */
-        // Since the Node 20.10 upgrade, it's been intermittently marking this (and
-        // this comment) as uncovered, even though I think it's covered by tests.
-        isLoading ? <Loader /> : children
-      }
+      {isLoading ? <Loader /> : children}
     </Link>
   ) : (
     <button

--- a/src/app/components/client/Button.tsx
+++ b/src/app/components/client/Button.tsx
@@ -69,9 +69,6 @@ export const Button = (props: ButtonProps) => {
   // If `props.isLoading` is not undefined, the contents of the link is going to
   // change into a loading indicator, which needs to be read by a screen reader:
   const ariaLiveValue: AriaAttributes["aria-live"] =
-    /* c8 ignore next 3 */
-    // Since the Node 20.10 upgrade, it's been intermittently marking this (and
-    // this comment) as uncovered, even though I think it's covered by tests.
     typeof isLoading === "boolean" ? "polite" : undefined;
 
   return typeof href === "string" ? (

--- a/src/app/components/client/ComboBox.tsx
+++ b/src/app/components/client/ComboBox.tsx
@@ -38,9 +38,6 @@ function ComboBox(props: ComboBoxProps) {
   const l10n = useL10n();
 
   useEffect(() => {
-    /* c8 ignore next 5 */
-    // This does get hit by unit tests, but for some reason, since the Node
-    // 20.10 upgrade, it (and this comment) no longer gets marked as such:
     if (inputProps.value === "") {
       state.close();
     }
@@ -51,27 +48,13 @@ function ComboBox(props: ComboBoxProps) {
       <div className={inputFieldStyles.comboBox}>
         <label {...labelProps} className={inputFieldStyles.inputLabel}>
           {label}
-          {isRequired ? (
-            <span aria-hidden="true">*</span>
-          ) : (
-            /* c8 ignore next 4 */
-            // This does get hit by unit tests, but for some reason, since the
-            // Node 20.10 upgrade, it (and this comment) no longer gets marked
-            // as such:
-            ""
-          )}
+          {isRequired ? <span aria-hidden="true">*</span> : ""}
         </label>
         <input
           {...inputProps}
           ref={inputRef}
           className={`${inputFieldStyles.inputField} ${
-            !inputProps.value
-              ? /* c8 ignore next 4 */
-                // This does get hit by unit tests, but for some reason, since
-                // the Node 20.10 upgrade, it (and this comment) no longer gets
-                // marked as such:
-                inputFieldStyles.noValue
-              : ""
+            !inputProps.value ? inputFieldStyles.noValue : ""
           } ${isInvalid ? /* c8 ignore next */ inputFieldStyles.hasError : ""}`}
         />
         {isInvalid && typeof errorMessage === "string" && (

--- a/src/app/components/client/ExposuresFilter.tsx
+++ b/src/app/components/client/ExposuresFilter.tsx
@@ -110,9 +110,6 @@ export const ExposuresFilter = ({
   // Status filter explainer dialog
   const exposureStatusExplainerDialogState = useOverlayTriggerState({
     onOpenChange: (isOpen) => {
-      /* c8 ignore next 3 */
-      // Since the Node 20.10 upgrade, it's been intermittently marking this
-      // (and this comment) as uncovered.
       recordTelemetry("popup", isOpen ? "view" : "exit", {
         popup_id: "exposure_status_info",
       });

--- a/src/app/components/client/FixNavigation.tsx
+++ b/src/app/components/client/FixNavigation.tsx
@@ -206,11 +206,7 @@ const StepImage = (props: {
       ? stepDataBrokerProfilesIcon
       : props.section === "HighRisk"
         ? stepHighRiskDataBreachesIcon
-        : /* c8 ignore next 6 */
-          // These lines should be covered by unit tests, but since the Node
-          // 20.10 upgrade, it's been intermittently marking this (and this
-          // comment) as uncovered.
-          props.section === "LeakedPasswords"
+        : props.section === "LeakedPasswords"
           ? stepLeakedPasswordsIcon
           : stepSecurityRecommendationsIcon;
 
@@ -220,10 +216,6 @@ const StepImage = (props: {
 function calculateActiveProgressBarPosition(section: Props["currentSection"]) {
   if (section === "high-risk-data-breach") {
     return styles.beginHighRiskDataBreaches;
-    /* c8 ignore next 10 */
-    // These lines should be covered by unit tests, but since the Node 20.10
-    // upgrade, it's been intermittently marking them (and this comment) as
-    // uncovered.
   } else if (section === "leaked-passwords") {
     return styles.beginLeakedPasswords;
   } else if (section === "security-recommendations") {

--- a/src/app/components/client/FixNavigation.tsx
+++ b/src/app/components/client/FixNavigation.tsx
@@ -98,10 +98,6 @@ export const Steps = (props: {
       {isEligibleForStep(props.data, "Scan") && (
         <li
           aria-current={
-            /* c8 ignore next 7 */
-            // These lines should be covered by unit tests, but since the Node
-            // 20.10 upgrade, it's been intermittently marking this (and this
-            // comment) as uncovered.
             props.currentSection === "data-broker-profiles" ? "step" : undefined
           }
           className={`${styles.navigationItem} ${
@@ -119,10 +115,6 @@ export const Steps = (props: {
       )}
       <li
         aria-current={
-          /* c8 ignore next 11 */
-          // These lines should be covered by unit tests, but since the Node
-          // 20.10 upgrade, it's been intermittently marking this (and this
-          // comment) as uncovered.
           props.currentSection === "high-risk-data-breach" ? "step" : undefined
         }
         className={`${styles.navigationItem} ${
@@ -143,10 +135,6 @@ export const Steps = (props: {
       </li>
       <li
         aria-current={
-          /* c8 ignore next 11 */
-          // These lines should be covered by unit tests, but since the Node
-          // 20.10 upgrade, it's been intermittently marking this (and this
-          // comment) as uncovered.
           props.currentSection === "leaked-passwords" ? "step" : undefined
         }
         className={`${styles.navigationItem} ${
@@ -167,30 +155,18 @@ export const Steps = (props: {
       </li>
       <li
         aria-current={
-          /* c8 ignore next 5 */
-          // This line should be covered by unit tests, but since the Node 20.10
-          // upgrade, it's been intermittently marking this (and this comment)
-          // as uncovered.
           props.currentSection === "security-recommendations"
             ? "step"
             : undefined
         }
         className={`${styles.navigationItem} ${
-          /* c8 ignore next 5 */
-          // This line should be covered by unit tests, but since the Node 20.10
-          // upgrade, it's been intermittently marking this (and this comment)
-          // as uncovered.
           props.currentSection === "security-recommendations"
             ? styles.active
             : ""
         } ${
           hasCompletedStepSection(props.data, "SecurityTips")
             ? styles.isCompleted
-            : /* c8 ignore next 4 */
-              // This line should be covered by unit tests, but since the Node 20.10
-              // upgrade, it's been intermittently marking this (and this comment)
-              // as uncovered.
-              ""
+            : ""
         }`}
       >
         <div className={styles.stepIcon}>

--- a/src/app/components/client/FixNavigation.tsx
+++ b/src/app/components/client/FixNavigation.tsx
@@ -62,9 +62,6 @@ export const Steps = (props: {
     breachesByClassification.highRisk,
   ).reduce((acc, array) => acc + array.length, 0);
   const totalDataBrokerProfiles =
-    /* c8 ignore next 3 */
-    // Since the Node 20.10 upgrade, it's been intermittently marking this (and
-    // this comment) as uncovered, even though I think it's covered by tests.
     props.data.latestScanData?.results.length ?? 0;
   const totalPasswordBreaches = Object.values(
     breachesByClassification.passwordBreaches,
@@ -183,10 +180,6 @@ export const Steps = (props: {
             className={`${
               styles.activeProgressBarLine
             } ${calculateActiveProgressBarPosition(props.currentSection)} ${
-              /* c8 ignore next 5 */
-              // Since the Node 20.10 upgrade, it's been intermittently marking
-              // this (and this comment) as uncovered, even though I think it's
-              // covered by tests.
               isEligibleForStep(props.data, "Scan")
                 ? styles.hasFourSteps
                 : styles.hasThreeSteps
@@ -208,28 +201,29 @@ const StepImage = (props: {
     );
   }
 
-  /* c8 ignore next 10 */
-  // Since the Node 20.10 upgrade, it's been intermittently marking this (and
-  // this comment) as uncovered, even though I think it's covered by tests.
   const src =
     props.section === "Scan"
       ? stepDataBrokerProfilesIcon
       : props.section === "HighRisk"
         ? stepHighRiskDataBreachesIcon
-        : props.section === "LeakedPasswords"
+        : /* c8 ignore next 6 */
+          // These lines should be covered by unit tests, but since the Node
+          // 20.10 upgrade, it's been intermittently marking this (and this
+          // comment) as uncovered.
+          props.section === "LeakedPasswords"
           ? stepLeakedPasswordsIcon
           : stepSecurityRecommendationsIcon;
 
   return <Image src={src} alt="" width={22} height={22} />;
 };
 
-/* c8 ignore next 14 */
-// These lines should be covered by unit tests, but since the Node 20.10
-// upgrade, it's been intermittently marking them (and this comment) as
-// uncovered.
 function calculateActiveProgressBarPosition(section: Props["currentSection"]) {
   if (section === "high-risk-data-breach") {
     return styles.beginHighRiskDataBreaches;
+    /* c8 ignore next 10 */
+    // These lines should be covered by unit tests, but since the Node 20.10
+    // upgrade, it's been intermittently marking them (and this comment) as
+    // uncovered.
   } else if (section === "leaked-passwords") {
     return styles.beginLeakedPasswords;
   } else if (section === "security-recommendations") {

--- a/src/app/components/client/dialog/Dialog.tsx
+++ b/src/app/components/client/dialog/Dialog.tsx
@@ -58,8 +58,7 @@ export const Dialog = ({
           height="14"
         />
       </button>
-    ) : /* c8 ignore next */
-    null;
+    ) : null;
 
   return (
     <div

--- a/src/app/components/client/toolbar/UpsellBadge.tsx
+++ b/src/app/components/client/toolbar/UpsellBadge.tsx
@@ -176,9 +176,6 @@ export function UpsellBadge(props: UpsellBadgeProps) {
   const countryCode = useContext(CountryCodeContext);
   const session = useSession();
 
-  /* c8 ignore next 5 */
-  // Since the Node 20.10 upgrade, it's been intermittently marking this (and
-  // this comment) as uncovered, even though I think it's covered by tests.
   if (!session.data) {
     return <></>;
   }

--- a/src/app/components/client/toolbar/UserMenu.tsx
+++ b/src/app/components/client/toolbar/UserMenu.tsx
@@ -61,9 +61,6 @@ export const UserMenu = (props: UserMenuProps) => {
     signout: "signout",
   };
 
-  /* c8 ignore next 21 */
-  // Since the Node 20.10 upgrade, it's been intermittently marking this (and
-  // this comment) as uncovered, even though I think it's covered by tests.
   const handleOnAction = (menuItemKey: Key) => {
     switch (menuItemKey) {
       case itemKeys.fxa:

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -481,9 +481,6 @@ function sanitizeDataPoints(
 }
 
 export function getDataPointReduction(summary: DashboardSummary): number {
-  // The `if` statement is totally covered by unit tests, but for some reason,
-  // since the upgrade to Node 20.10, it doesn't get marked as covered anymore:
-  /* c8 ignore next */
   if (summary.totalDataPointsNum <= 0) return 100;
   return Math.round(
     (summary.dataBrokerTotalDataPointsNum / summary.totalDataPointsNum) * 100,

--- a/src/app/functions/server/dashboard.ts
+++ b/src/app/functions/server/dashboard.ts
@@ -379,9 +379,6 @@ export function getDashboardSummary(
       }
     }
 
-    /* c8 ignore next 11 */
-    // Since the Node 20.10 upgrade, it's been intermittently marking this (and
-    // this comment) as uncovered, even though I think it's covered by tests.
     if (dataClasses.includes(BreachDataTypes.BankAccount)) {
       summary.totalDataPointsNum += increment;
       summary.dataBreachTotalDataPointsNum += increment;

--- a/src/app/functions/server/getRelevantGuidedSteps.ts
+++ b/src/app/functions/server/getRelevantGuidedSteps.ts
@@ -234,9 +234,6 @@ export function hasCompletedStepSection(
     return hasCompletedStep(data, "Scan");
   }
   if (section === "HighRisk") {
-    /* c8 ignore next 7 */
-    // I believe this *is* covered by unit tests, but for some reason,
-    // since the upgrade to Node 20.10, it doesn't get marked as covered anymore:
     return (
       hasCompletedStep(data, "HighRiskSsn") &&
       hasCompletedStep(data, "HighRiskCreditCard") &&

--- a/src/app/functions/server/getRelevantGuidedSteps.ts
+++ b/src/app/functions/server/getRelevantGuidedSteps.ts
@@ -227,9 +227,6 @@ export function hasCompletedStepSection(
   ) {
     return hasCompletedStep(data, "DataBrokerManualRemoval");
   }
-  /* c8 ignore next 5 */
-  // I believe this *is* covered by unit tests, but for some reason,
-  // since the upgrade to Node 20.10, it doesn't get marked as covered anymore:
   if (section === "Scan") {
     return hasCompletedStep(data, "Scan");
   }

--- a/src/app/functions/universal/guidedExperienceBreaches.ts
+++ b/src/app/functions/universal/guidedExperienceBreaches.ts
@@ -51,23 +51,14 @@ export function getGuidedExperienceBreaches(
       guidedExperienceBreaches.highRisk.ssnBreaches.push(breach);
     }
 
-    // This does get covered by unit tests, but for some reason, since the
-    // upgrade to Node 20.10, it doesn't get marked as covered anymore:
-    /* c8 ignore next 3 */
     if (isUnresolvedDataBreachClass(breach, BreachDataTypes.CreditCard)) {
       guidedExperienceBreaches.highRisk.creditCardBreaches.push(breach);
     }
 
-    // This does get covered by unit tests, but for some reason, since the
-    // upgrade to Node 20.10, it doesn't get marked as covered anymore:
-    /* c8 ignore next 3 */
     if (isUnresolvedDataBreachClass(breach, BreachDataTypes.PIN)) {
       guidedExperienceBreaches.highRisk.pinBreaches.push(breach);
     }
 
-    // This does get covered by unit tests, but for some reason, since the
-    // upgrade to Node 20.10, it doesn't get marked as covered anymore:
-    /* c8 ignore next 3 */
     if (isUnresolvedDataBreachClass(breach, BreachDataTypes.BankAccount)) {
       guidedExperienceBreaches.highRisk.bankBreaches.push(breach);
     }

--- a/src/app/functions/universal/guidedExperienceBreaches.ts
+++ b/src/app/functions/universal/guidedExperienceBreaches.ts
@@ -44,9 +44,6 @@ export function getGuidedExperienceBreaches(
 
   subscriberBreaches.forEach((breach) => {
     // high risks
-    // This does get covered by unit tests, but for some reason, since the
-    // upgrade to Node 20.10, it doesn't get marked as covered anymore:
-    /* c8 ignore next 3 */
     if (isUnresolvedDataBreachClass(breach, BreachDataTypes.SSN)) {
       guidedExperienceBreaches.highRisk.ssnBreaches.push(breach);
     }

--- a/src/app/hooks/useLocalDismissal.ts
+++ b/src/app/hooks/useLocalDismissal.ts
@@ -45,10 +45,6 @@ export function useLocalDismissal(
 
   const dismiss = (dismissOptions?: DismissOptions) => {
     const maxAgeInSeconds =
-      /* c8 ignore next 6 */
-      // Since the Node 20.10 upgrade, it's been intermittently marking this
-      // (and this comment) as uncovered, even though I think it's covered by
-      // tests.
       typeof options.duration === "number"
         ? options.duration
         : COOKIE_DISMISSAL_MAX_AGE_IN_SECONDS;
@@ -68,9 +64,6 @@ export function useLocalDismissal(
 
 function hasDismissedCookie(cookieValue?: string, duration?: number): boolean {
   const dismissalTimeStamp =
-    /* c8 ignore next 4 */
-    // Since the Node 20.10 upgrade, it's been intermittently marking this (and
-    // this comment) as uncovered, even though I think it's covered by tests.
     typeof cookieValue === "string"
       ? Number.parseInt(cookieValue, 10)
       : // Unfortunately react-cookie seems to implicitly parse the cookie value

--- a/src/app/hooks/useLocalDismissal.ts
+++ b/src/app/hooks/useLocalDismissal.ts
@@ -55,9 +55,6 @@ export function useLocalDismissal(
     setCookie(cookieId, Date.now().toString(), {
       maxAge: maxAgeInSeconds,
     });
-    /* c8 ignore next 5 */
-    // Since the Node 20.10 upgrade, it's been intermittently marking this (and
-    // this comment) as uncovered, even though I think it's covered by tests.
     if (dismissOptions?.soft !== true) {
       setIsDismissed(true);
     }


### PR DESCRIPTION
This directly applies the following Pull Request:
https://github.com/SimenB/collect-v8-coverage/pull/235

It's not entirely clear why it's needed, but it seems reasonable
and harmless enough, and there are no signs that Jest is really
maintained anymore, so a longer-term fix does not appear to be
forthcoming. Thus, this'll at least properly unblock Node upgrades
and other annoying coverage surprises.