### PR TITLE
Dedupe Sentry logs about missing Cirrus user ID

### DIFF
--- a/src/app/(proper_react)/(redesign)/(public)/layout.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/layout.tsx
@@ -38,9 +38,15 @@ export default async function Layout(props: { children: ReactNode }) {
     experimentData.Enrollments ?? []
   ).find((enrollment) => enrollment.nimbus_user_id !== experimentationId);
   if (typeof enrollmentWithConflictingUserId !== "undefined") {
-    Sentry.captureMessage(
-      `Nimbus user ID from Cirrus: [${enrollmentWithConflictingUserId.nimbus_user_id}] did not match experimentationId: [${experimentationId}]`,
-    );
+    if (enrollmentWithConflictingUserId.nimbus_user_id === "-1") {
+      Sentry.captureMessage(
+        `Cirrus did not provide a Nimbus user ID: [${enrollmentWithConflictingUserId.nimbus_user_id}].`,
+      );
+    } else {
+      Sentry.captureMessage(
+        `Nimbus user ID from Cirrus: [${enrollmentWithConflictingUserId.nimbus_user_id}] did not match experimentationId: [${experimentationId}]`,
+      );
+    }
   }
 
   return (


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-4062
Figma:

<!-- When adding a new feature: -->

# Description

Currently we get a separate warning in Sentry every time we get -1 from Cirrus, because it also logs the guest string, which is irrelevant for this error. Thus, I set an error message that excludes it so that Sentry can group these instances.

# How to test

Not sure, I think we should just see these coming in to Sentry once it's on stage?

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [X] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
