### PR TITLE
MNTOR-3946: State that we don't endorse breached sites

### DIFF
--- a/src/app/(proper_react)/(redesign)/(public)/breach-details/[breachName]/BreachDetailView.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/breach-details/[breachName]/BreachDetailView.tsx
@@ -117,7 +117,7 @@ export const BreachDetailsView = (props: Props) => {
               href={`https://${breach.Domain}`}
               eventData={{ link_id: breach.Domain }}
               target="_blank"
-              rel="noopener noreferrer"
+              rel="nofollow noopener noreferrer"
             >
               {breach.Domain}
             </TelemetryLink>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3946
Figma:

<!-- When adding a new feature: -->

# Description

We link to breached sites, but we don't endorse or advertise them, and search engines and other agents shouldn't interpret our links to them as such. That is what [`nofollow`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#nofollow) does.

# How to test

Visit a public breach page, verify that its link has a `nofollow` attribute.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
