### PR TITLE
MNTOR-4060 Remove duplicate sign-in button on mobile, and prevent logo from shrinking

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.stories.tsx
@@ -204,6 +204,14 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
           nonce=""
           countryCode={props.countryCode}
           enabledFeatureFlags={props.enabledFeatureFlags ?? []}
+          experimentData={
+            props.experimentData ?? {
+              ...defaultExperimentData["Features"],
+              "last-scan-date": {
+                enabled: true,
+              },
+            }
+          }
         >
           <DashboardEl
             user={user}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardNonUSUsers.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardNonUSUsers.stories.tsx
@@ -171,6 +171,14 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
           nonce=""
           countryCode={props.countryCode}
           enabledFeatureFlags={props.enabledFeatureFlags ?? []}
+          experimentData={
+            props.experimentData ?? {
+              ...defaultExperimentData["Features"],
+              "last-scan-date": {
+                enabled: true,
+              },
+            }
+          }
         >
           <DashboardEl
             user={user}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardPlusUsers.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardPlusUsers.stories.tsx
@@ -170,6 +170,14 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
           nonce=""
           countryCode={props.countryCode}
           enabledFeatureFlags={props.enabledFeatureFlags ?? []}
+          experimentData={
+            props.experimentData ?? {
+              ...defaultExperimentData["Features"],
+              "last-scan-date": {
+                enabled: true,
+              },
+            }
+          }
         >
           <DashboardEl
             user={user}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardUSUsers.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardUSUsers.stories.tsx
@@ -171,6 +171,14 @@ const DashboardWrapper = (props: DashboardWrapperProps) => {
           nonce=""
           countryCode={props.countryCode}
           enabledFeatureFlags={props.enabledFeatureFlags ?? []}
+          experimentData={
+            props.experimentData ?? {
+              ...defaultExperimentData["Features"],
+              "last-scan-date": {
+                enabled: true,
+              },
+            }
+          }
         >
           <DashboardEl
             user={user}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/automatic-remove/AutomaticRemove.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/automatic-remove/AutomaticRemove.stories.tsx
@@ -13,6 +13,7 @@ import {
 import { Shell } from "../../../../../../../Shell";
 import { getL10n } from "../../../../../../../../../functions/l10n/storybookAndJest";
 import { LatestOnerepScanData } from "../../../../../../../../../../db/tables/onerep_scans";
+import { defaultExperimentData } from "../../../../../../../../../../telemetry/generated/nimbus/experiments";
 
 const mockedScan: OnerepScanRow = {
   created_at: new Date(1998, 2, 31),
@@ -56,6 +57,7 @@ export const AutomaticRemoveViewStory: Story = {
         nonce=""
         countryCode="us"
         enabledFeatureFlags={[]}
+        experimentData={defaultExperimentData["Features"]}
       >
         <AutomaticRemoveView
           data={{

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/manual-remove/ManualRemove.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/manual-remove/ManualRemove.stories.tsx
@@ -14,6 +14,7 @@ import { Shell } from "../../../../../../../Shell";
 import { getL10n } from "../../../../../../../../../functions/l10n/storybookAndJest";
 import { LatestOnerepScanData } from "../../../../../../../../../../db/tables/onerep_scans";
 import { hasPremium } from "../../../../../../../../../functions/universal/user";
+import { defaultExperimentData } from "../../../../../../../../../../telemetry/generated/nimbus/experiments";
 
 const mockedScan: OnerepScanRow = {
   created_at: new Date(1998, 2, 31),
@@ -57,6 +58,7 @@ export const ManualRemoveViewStory: Story = {
         nonce=""
         countryCode="us"
         enabledFeatureFlags={[]}
+        experimentData={defaultExperimentData["Features"]}
       >
         <ManualRemoveView
           scanData={mockedScanData}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/removal-under-maintenance/RemovalUnderMaintenanceView.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/removal-under-maintenance/RemovalUnderMaintenanceView.stories.tsx
@@ -13,6 +13,7 @@ import { Shell } from "../../../../../../../Shell";
 import { getL10n } from "../../../../../../../../../functions/l10n/storybookAndJest";
 import { LatestOnerepScanData } from "../../../../../../../../../../db/tables/onerep_scans";
 import { RemovalUnderMaintenanceView } from "./RemovalUnderMaintenanceView";
+import { defaultExperimentData } from "../../../../../../../../../../telemetry/generated/nimbus/experiments";
 
 const meta: Meta<typeof RemovalUnderMaintenanceView> = {
   title: "Pages/Logged in/Guided resolution/1d. Removal Under Maintenance",
@@ -54,6 +55,7 @@ export const RemovalUnderMaintenanceViewStory: Story = {
         nonce=""
         countryCode="us"
         enabledFeatureFlags={[]}
+        experimentData={defaultExperimentData["Features"]}
       >
         <RemovalUnderMaintenanceView
           data={mockedScanData}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/start-free-scan/StartFreeScan.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/start-free-scan/StartFreeScan.stories.tsx
@@ -13,6 +13,7 @@ import {
 import { Shell } from "../../../../../../../Shell";
 import { getL10n } from "../../../../../../../../../functions/l10n/storybookAndJest";
 import { LatestOnerepScanData } from "../../../../../../../../../../db/tables/onerep_scans";
+import { defaultExperimentData } from "../../../../../../../../../../telemetry/generated/nimbus/experiments";
 
 const mockedScan: OnerepScanRow = {
   created_at: new Date(1998, 2, 31),
@@ -56,6 +57,7 @@ export const StartFreeScanViewStory: Story = {
         nonce=""
         countryCode="us"
         enabledFeatureFlags={[]}
+        experimentData={defaultExperimentData["Features"]}
       >
         <StartFreeScanView
           data={{

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/ViewDataBrokers.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/ViewDataBrokers.stories.tsx
@@ -15,6 +15,7 @@ import {
 import { Shell } from "../../../../../../../Shell";
 import { getL10n } from "../../../../../../../../../functions/l10n/storybookAndJest";
 import { LatestOnerepScanData } from "../../../../../../../../../../db/tables/onerep_scans";
+import { defaultExperimentData } from "../../../../../../../../../../telemetry/generated/nimbus/experiments";
 
 const brokerOptions = {
   "no-scan": "No scan started",
@@ -103,6 +104,7 @@ const ViewWrapper = (props: ViewWrapperProps) => {
       nonce=""
       countryCode="us"
       enabledFeatureFlags={[]}
+      experimentData={defaultExperimentData["Features"]}
     >
       <ViewDataBrokersView
         data={{

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/WelcomeToPlus.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/WelcomeToPlus.stories.tsx
@@ -13,6 +13,7 @@ import {
 import { Shell } from "../../../../../../../Shell";
 import { getL10n } from "../../../../../../../../../functions/l10n/storybookAndJest";
 import { LatestOnerepScanData } from "../../../../../../../../../../db/tables/onerep_scans";
+import { defaultExperimentData } from "../../../../../../../../../../telemetry/generated/nimbus/experiments";
 
 const mockedScan: OnerepScanRow = {
   created_at: new Date(1998, 2, 31),
@@ -64,6 +65,7 @@ const WelcomeToPlusViewWrapper = (props: { brokerScanCount: number }) => {
       nonce=""
       countryCode="us"
       enabledFeatureFlags={[]}
+      experimentData={defaultExperimentData["Features"]}
     >
       <WelcomeToPlusView
         data={{

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/[type]/HighRiskDataBreach.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/[type]/HighRiskDataBreach.stories.tsx
@@ -17,6 +17,7 @@ import {
 import { BreachDataTypes } from "../../../../../../../../../functions/universal/breach";
 import { StepDeterminationData } from "../../../../../../../../../functions/server/getRelevantGuidedSteps";
 import { OnerepScanRow } from "knex/types/tables";
+import { defaultExperimentData } from "../../../../../../../../../../telemetry/generated/nimbus/experiments";
 
 const user = createUserWithPremiumSubscription();
 
@@ -108,6 +109,7 @@ const HighRiskBreachWrapper = (props: {
       nonce=""
       countryCode={data.countryCode}
       enabledFeatureFlags={[]}
+      experimentData={defaultExperimentData["Features"]}
     >
       <HighRiskBreachLayout
         subscriberEmails={[]}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/[type]/LeakedPasswords.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/[type]/LeakedPasswords.stories.tsx
@@ -15,6 +15,7 @@ import {
   leakedPasswordTypes,
 } from "../leakedPasswordsData";
 import { BreachDataTypes } from "../../../../../../../../../functions/universal/breach";
+import { defaultExperimentData } from "../../../../../../../../../../telemetry/generated/nimbus/experiments";
 
 const user = createUserWithPremiumSubscription();
 
@@ -70,6 +71,7 @@ const LeakedPasswordsWrapper = (props: {
       nonce=""
       countryCode="nl"
       enabledFeatureFlags={[]}
+      experimentData={defaultExperimentData["Features"]}
     >
       <LeakedPasswordsLayout
         subscriberEmails={[]}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/[type]/SecurityRecommendations.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/[type]/SecurityRecommendations.stories.tsx
@@ -15,6 +15,7 @@ import {
   securityRecommendationTypes,
 } from "../securityRecommendationsData";
 import { BreachDataTypes } from "../../../../../../../../../functions/universal/breach";
+import { defaultExperimentData } from "../../../../../../../../../../telemetry/generated/nimbus/experiments";
 
 const mockedBreaches = [...Array(5)].map(() => createRandomBreach());
 // Ensure all security recommendation data breaches are present in at least one breach:
@@ -48,6 +49,7 @@ const SecurityRecommendationsWrapper = (props: {
       nonce=""
       countryCode="nl"
       enabledFeatureFlags={[]}
+      experimentData={defaultExperimentData["Features"]}
     >
       <SecurityRecommendationsLayout
         subscriberEmails={[]}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/layout.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/layout.tsx
@@ -14,6 +14,9 @@ import { headers } from "next/headers";
 import { AutoSignIn } from "../../../../../components/client/AutoSignIn";
 import { getCountryCode } from "../../../../../functions/server/getCountryCode";
 import { getEnabledFeatureFlags } from "../../../../../../db/tables/featureFlags";
+import { getExperimentationId } from "../../../../../functions/server/getExperimentationId";
+import { getExperiments } from "../../../../../functions/server/getExperiments";
+import { getLocale } from "../../../../../functions/universal/getLocale";
 
 export default async function Layout({ children }: { children: ReactNode }) {
   const l10nBundles = getL10nBundles(
@@ -32,6 +35,13 @@ export default async function Layout({ children }: { children: ReactNode }) {
   const enabledFeatureFlags = await getEnabledFeatureFlags({
     email: session.user.email,
   });
+  const currentLocale = getLocale(l10n);
+  const experimentationId = await getExperimentationId(session?.user ?? null);
+  const experimentData = await getExperiments({
+    experimentationId,
+    countryCode,
+    locale: currentLocale,
+  });
 
   return (
     <Shell
@@ -40,6 +50,7 @@ export default async function Layout({ children }: { children: ReactNode }) {
       nonce={nonce}
       countryCode={countryCode}
       enabledFeatureFlags={enabledFeatureFlags}
+      experimentData={experimentData["Features"]}
     >
       {children}
     </Shell>

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPage.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPage.test.tsx
@@ -262,6 +262,7 @@ const SettingsWrapper = (props: {
       nonce=""
       countryCode="en"
       enabledFeatureFlags={props.enabledFeatureFlags ?? []}
+      experimentData={defaultExperimentData["Features"]}
     >
       {props.children}
     </Shell>

--- a/src/app/(proper_react)/(redesign)/(public)/LandingViewRedesign/components/TopNavBar.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingViewRedesign/components/TopNavBar.module.scss
@@ -1,4 +1,4 @@
-@use "../../../tokens";
+@use "../../../../../tokens";
 
 .wrapper {
   align-items: center;
@@ -7,12 +7,12 @@
   gap: tokens.$spacing-md;
   padding-bottom: tokens.$spacing-md;
   width: 100%;
-}
 
-.signInButton {
-  display: block;
+  .signInButton {
+    display: block;
 
-  @media screen and (min-width: tokens.$screen-sm) {
-    display: none;
+    @media screen and (min-width: tokens.$screen-sm) {
+      display: none;
+    }
   }
 }

--- a/src/app/(proper_react)/(redesign)/(public)/LandingViewRedesign/components/TopNavBar.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingViewRedesign/components/TopNavBar.tsx
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use client";
+
+import { SignInButton } from "../../../../../components/client/SignInButton";
+import { TelemetryLink } from "../../../../../components/client/TelemetryLink";
+import { useL10n } from "../../../../../hooks/l10n";
+import styles from "./TopNavBar.module.scss";
+
+export const TopNavBar = () => {
+  const l10n = useL10n();
+  return (
+    <div className={styles.wrapper}>
+      <ul className="noList">
+        <li>
+          <TelemetryLink
+            href="/how-it-works"
+            eventData={{
+              link_id: "navbar_how_it_works",
+            }}
+          >
+            {l10n.getString("landing-premium-hero-navbar-link-how-it-works")}
+          </TelemetryLink>
+        </li>
+        <li>
+          <TelemetryLink
+            href="/#pricing"
+            eventData={{
+              link_id: "navbar_pricing",
+            }}
+          >
+            {l10n.getString("landing-premium-hero-navbar-link-pricing")}
+          </TelemetryLink>
+        </li>
+        <li>
+          <TelemetryLink
+            data-testid="navbar_faqs"
+            href="/#faq"
+            eventData={{
+              link_id: "navbar_faqs",
+            }}
+          >
+            {l10n.getString("landing-premium-hero-navbar-link-faqs")}
+          </TelemetryLink>
+        </li>
+        <li>
+          <TelemetryLink
+            href="/breaches"
+            eventData={{
+              link_id: "navbar_recent_breaches",
+            }}
+          >
+            {l10n.getString("landing-premium-hero-navbar-link-recent-breaches")}
+          </TelemetryLink>
+        </li>
+      </ul>
+      <SignInButton className={styles.signInButton} variant="secondary" small />
+    </div>
+  );
+};

--- a/src/app/(proper_react)/(redesign)/(public)/PublicShell.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/PublicShell.module.scss
@@ -26,7 +26,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: tokens.$spacing-lg tokens.$layout-xl;
+  padding: tokens.$spacing-lg tokens.$spacing-md;
   background-color: tokens.$color-white;
   gap: tokens.$spacing-lg;
 

--- a/src/app/(proper_react)/(redesign)/(public)/PublicShell.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/PublicShell.tsx
@@ -18,7 +18,7 @@ import {
   getSubscriptionBillingAmount,
 } from "../../../functions/server/getPremiumSubscriptionInfo";
 import { FeatureFlagName } from "../../../../db/tables/featureFlags";
-import { TopNavBar } from "./TopNavBar";
+import { TopNavBar } from "./LandingViewRedesign/components/TopNavBar";
 import { ExperimentData } from "../../../../telemetry/generated/nimbus/experiments";
 
 export type Props = {
@@ -39,6 +39,7 @@ const PublicMobileShell = (
       <MobileShell
         countryCode={props.countryCode}
         enabledFeatureFlags={props.enabledFeatureFlags}
+        experimentData={props.experimentData}
         fxaSettingsUrl={process.env.FXA_SETTINGS_URL!}
         monthlySubscriptionUrl={getPremiumSubscriptionUrl({ type: "monthly" })}
         session={null}

--- a/src/app/(proper_react)/(redesign)/(public)/TopNavBar.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/TopNavBar.tsx
@@ -4,59 +4,54 @@
 
 "use client";
 
-import { SignInButton } from "../../../components/client/SignInButton";
 import { TelemetryLink } from "../../../components/client/TelemetryLink";
 import { useL10n } from "../../../hooks/l10n";
-import styles from "./TopNavBar.module.scss";
 
 export const TopNavBar = () => {
   const l10n = useL10n();
   return (
-    <div className={styles.wrapper}>
-      <ul className="noList">
-        <li>
-          <TelemetryLink
-            href="/how-it-works"
-            eventData={{
-              link_id: "navbar_how_it_works",
-            }}
-          >
-            {l10n.getString("landing-premium-hero-navbar-link-how-it-works")}
-          </TelemetryLink>
-        </li>
-        <li>
-          <TelemetryLink
-            href="/#pricing"
-            eventData={{
-              link_id: "navbar_pricing",
-            }}
-          >
-            {l10n.getString("landing-premium-hero-navbar-link-pricing")}
-          </TelemetryLink>
-        </li>
-        <li>
-          <TelemetryLink
-            data-testid="navbar_faqs"
-            href="/#faq"
-            eventData={{
-              link_id: "navbar_faqs",
-            }}
-          >
-            {l10n.getString("landing-premium-hero-navbar-link-faqs")}
-          </TelemetryLink>
-        </li>
-        <li>
-          <TelemetryLink
-            href="/breaches"
-            eventData={{
-              link_id: "navbar_recent_breaches",
-            }}
-          >
-            {l10n.getString("landing-premium-hero-navbar-link-recent-breaches")}
-          </TelemetryLink>
-        </li>
-      </ul>
-      <SignInButton className={styles.signInButton} variant="secondary" small />
-    </div>
+    <ul className="noList">
+      <li>
+        <TelemetryLink
+          href="/how-it-works"
+          eventData={{
+            link_id: "navbar_how_it_works",
+          }}
+        >
+          {l10n.getString("landing-premium-hero-navbar-link-how-it-works")}
+        </TelemetryLink>
+      </li>
+      <li>
+        <TelemetryLink
+          href="/#pricing"
+          eventData={{
+            link_id: "navbar_pricing",
+          }}
+        >
+          {l10n.getString("landing-premium-hero-navbar-link-pricing")}
+        </TelemetryLink>
+      </li>
+      <li>
+        <TelemetryLink
+          data-testid="navbar_faqs"
+          href="/#faq"
+          eventData={{
+            link_id: "navbar_faqs",
+          }}
+        >
+          {l10n.getString("landing-premium-hero-navbar-link-faqs")}
+        </TelemetryLink>
+      </li>
+      <li>
+        <TelemetryLink
+          href="/breaches"
+          eventData={{
+            link_id: "navbar_recent_breaches",
+          }}
+        >
+          {l10n.getString("landing-premium-hero-navbar-link-recent-breaches")}
+        </TelemetryLink>
+      </li>
+    </ul>
   );
 };

--- a/src/app/(proper_react)/(redesign)/MobileShell.stories.ts
+++ b/src/app/(proper_react)/(redesign)/MobileShell.stories.ts
@@ -7,6 +7,7 @@ import { SerializedSubscriber } from "../../../next-auth";
 
 import type { Meta, StoryObj } from "@storybook/react";
 import { MobileShell } from "./MobileShell";
+import { defaultExperimentData } from "../../../telemetry/generated/nimbus/experiments";
 
 function createUser(): Session["user"] {
   return {
@@ -33,6 +34,16 @@ const mockedSession = {
 const meta: Meta<typeof MobileShell> = {
   title: "Layout/Mobile Shell",
   component: MobileShell,
+  args: {
+    enabledFeatureFlags: ["LandingPageRedesign"],
+    experimentData: {
+      ...defaultExperimentData["Features"],
+      "landing-page-redesign-plus-eligible-experiment": {
+        enabled: true,
+        variant: "redesign",
+      },
+    },
+  },
 };
 export default meta;
 type Story = StoryObj<typeof MobileShell>;
@@ -48,6 +59,5 @@ export const MobileShellAuthenticated: Story = {
   args: {
     countryCode: "us",
     session: mockedSession,
-    enabledFeatureFlags: [],
   },
 };

--- a/src/app/(proper_react)/(redesign)/MobileShell.tsx
+++ b/src/app/(proper_react)/(redesign)/MobileShell.tsx
@@ -21,6 +21,8 @@ import { CONST_SETTINGS_TAB_SLUGS } from "../../../constants";
 import { FeatureFlagName } from "../../../db/tables/featureFlags";
 import { SignInButton } from "../../components/client/SignInButton";
 import { TopNavBar } from "./(public)/TopNavBar";
+import { TopNavBar as RedesignedTopNavBar } from "./(public)/LandingViewRedesign/components/TopNavBar";
+import { ExperimentData } from "../../../telemetry/generated/nimbus/experiments";
 
 export type Props = {
   countryCode: string;
@@ -34,6 +36,7 @@ export type Props = {
   fxaSettingsUrl: string;
   children: ReactNode;
   enabledFeatureFlags: FeatureFlagName[];
+  experimentData: ExperimentData["Features"];
 };
 
 export const MobileShell = (props: Props) => {
@@ -196,6 +199,19 @@ export const MobileShell = (props: Props) => {
                   />
                 </div>
               </>
+            ) : props.enabledFeatureFlags.includes("LandingPageRedesign") &&
+              props.experimentData[
+                "landing-page-redesign-plus-eligible-experiment"
+              ].enabled &&
+              props.experimentData[
+                "landing-page-redesign-plus-eligible-experiment"
+              ].variant === "redesign" ? (
+              // The old <TopNavBar /> component is no longer hit by unit tests
+              // that have already enabled the experiment, so ignore that for now:
+              // (But c8 is weird so just pretend that this ignore comment is
+              // two lines lower.)
+              /* c8 ignore next 4 */
+              <RedesignedTopNavBar />
             ) : (
               <TopNavBar />
             )}

--- a/src/app/(proper_react)/(redesign)/Shell.tsx
+++ b/src/app/(proper_react)/(redesign)/Shell.tsx
@@ -18,6 +18,7 @@ import {
 import { SubscriptionCheck } from "../../components/client/SubscriptionCheck";
 import { Footer } from "./Footer";
 import { FeatureFlagName } from "../../../db/tables/featureFlags";
+import { ExperimentData } from "../../../telemetry/generated/nimbus/experiments";
 
 export type Props = {
   l10n: ExtendedReactLocalization;
@@ -26,6 +27,7 @@ export type Props = {
   nonce: string;
   countryCode: string;
   enabledFeatureFlags: FeatureFlagName[];
+  experimentData: ExperimentData["Features"];
 };
 
 export const Shell = (props: Props) => {
@@ -47,6 +49,7 @@ export const Shell = (props: Props) => {
         fxaSettingsUrl={process.env.FXA_SETTINGS_URL!}
         subscriptionBillingAmount={getSubscriptionBillingAmount()}
         enabledFeatureFlags={props.enabledFeatureFlags}
+        experimentData={props.experimentData}
       >
         <div className={styles.wrapper}>
           <nav


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-4060
Figma:

<!-- When adding a new feature: -->

# Description

For the redesigned landing page, we added a sign-in button to the `<TopNavBar>` component. This was used in three places:

1. in the redesigned landing page, on desktop (from within `<PublicShell>`),
2. in the regular landing page, on desktop (from `<LandingView>`), and
3. in the shell that we use for loginwalled pages and the redesigned landing page, on mobile (from within `<MobileShell>`).

I split the `<TopNavBar>` into a redesigned version and the old version, reverting the recent changes in the latter - thus, only the former has the sign-in button. I then updated 1. to use the redesigned version, and 3. to use the version depending on the experiment and flag status.

I also updated the padding in the old top nav to remove some superfluous and inconsistent spacing.

# Screenshot (if applicable)

New:

![image](https://github.com/user-attachments/assets/6af914a1-f388-45ff-b68c-33efcc2df10f)

Old:

![image](https://github.com/user-attachments/assets/80f66253-7de1-4fb0-a9e9-e199885e13b9)

# How to test

Visit the landing page, both the old one and the new one, and inside and outside the US. Verify that only one sign-in button is visible.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
