### PR TITLE
Make feature flags auditable

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/components/FlagEditor.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/components/FlagEditor.module.scss
@@ -72,10 +72,15 @@
 .addressAdder {
   display: flex;
   align-items: center;
-  gap: tokens.$spacing-sm;
+  flex-wrap: wrap;
+
+  label {
+    width: 100%;
+  }
 
   input[type="email"] {
     flex-grow: 1;
+    min-width: 0;
   }
 
   // This rule is more specific than the button:hover in `.addressListing`,
@@ -86,6 +91,7 @@
     justify-content: center;
     align-items: center;
     height: 100%;
+    aspect-ratio: 1;
     background-color: transparent;
     color: tokens.$color-blue-50;
     border: none;
@@ -99,4 +105,22 @@
     }
   }
   /* stylelint-enable no-descending-specificity */
+}
+
+.editLog {
+  color: tokens.$color-grey-50;
+  font: tokens.$text-body-sm;
+  padding-top: tokens.$spacing-md;
+  /* Bottom-align the edit log */
+  margin-block-start: auto;
+
+  div {
+    display: flex;
+    gap: tokens.$spacing-xs;
+    justify-content: center;
+  }
+
+  dd {
+    font-weight: bold;
+  }
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/components/FlagEditor.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/components/FlagEditor.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 "use client";
-import { FeatureFlagViewRow } from "knex/types/tables";
+import { FeatureFlagViewRow, SubscriberRow } from "knex/types/tables";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import styles from "./FlagEditor.module.scss";
@@ -50,7 +50,9 @@ export const NewFlagEditor = (props: {
 };
 
 export const ExistingFlagEditor = (props: {
-  flag: FeatureFlagViewRow;
+  flag: FeatureFlagViewRow & {
+    last_updated_by_subscriber_email: SubscriberRow["primary_email"];
+  };
   adminOnly: boolean;
 }) => {
   return (
@@ -81,6 +83,8 @@ export const ExistingFlagEditor = (props: {
           console.error(e);
         }
       }}
+      lastUpdated={props.flag.updated_at}
+      lastUpdatedBy={props.flag.last_updated_by_subscriber_email}
     />
   );
 };
@@ -92,6 +96,8 @@ type Props = {
   allowList: string[];
   adminOnly: boolean;
   onUpdateAllowlist: (allowList: string[]) => Promise<void>;
+  lastUpdated?: Date;
+  lastUpdatedBy?: string;
 };
 const FlagEditor = (props: Props) => {
   const router = useRouter();
@@ -130,6 +136,22 @@ const FlagEditor = (props: Props) => {
         )}
       </div>
       {!props.isEnabled && <AllowlistEditor {...props} />}
+      {typeof props.lastUpdated !== "undefined" &&
+        typeof props.lastUpdatedBy !== "undefined" && (
+          <dl className={styles.editLog}>
+            <div>
+              <dt>Last update:</dt>
+              <dd>
+                {props.lastUpdated.toLocaleDateString()}{" "}
+                {props.lastUpdated.toLocaleTimeString()}
+              </dd>
+            </div>
+            <div>
+              <dt>by</dt>
+              <dd>{props.lastUpdatedBy}</dd>
+            </div>
+          </dl>
+        )}
     </div>
   );
 };

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/components/FlagEditor.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/components/FlagEditor.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 "use client";
-import { FeatureFlagRow } from "knex/types/tables";
+import { FeatureFlagViewRow } from "knex/types/tables";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import styles from "./FlagEditor.module.scss";
@@ -50,7 +50,7 @@ export const NewFlagEditor = (props: {
 };
 
 export const ExistingFlagEditor = (props: {
-  flag: FeatureFlagRow;
+  flag: FeatureFlagViewRow;
   adminOnly: boolean;
 }) => {
   return (

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/page.module.scss
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/page.module.scss
@@ -55,5 +55,5 @@
   grid-template-columns: repeat(auto-fit, minmax(tokens.$content-xs, 1fr));
   justify-content: flex-start;
   gap: tokens.$spacing-lg;
-  padding: tokens.$spacing-2xl;
+  padding: tokens.$spacing-xl;
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/page.tsx
@@ -37,7 +37,7 @@ export default async function FeatureFlagPage() {
 
   const featureFlags =
     (await getAllFeatureFlags()).toSorted(
-      (flagA, flagB) => flagB.created_at.getTime() - flagA.created_at.getTime(),
+      (flagA, flagB) => flagB.updated_at.getTime() - flagA.updated_at.getTime(),
     ) ?? [];
 
   /**

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/feature-flags/page.tsx
@@ -20,6 +20,10 @@ import {
 import { defaultExperimentData } from "../../../../../../telemetry/generated/nimbus/experiments";
 import { ExistingFlagEditor, NewFlagEditor } from "./components/FlagEditor";
 
+export const metadata = {
+  title: "Monitor Feature Flags",
+};
+
 export default async function FeatureFlagPage() {
   const session = await getServerSession();
 

--- a/src/app/api/v1/admin/feature-flags/[flagId]/route.ts
+++ b/src/app/api/v1/admin/feature-flags/[flagId]/route.ts
@@ -9,9 +9,6 @@ import {
   enableFeatureFlagByName,
   getFeatureFlagByName,
   updateAllowList,
-  updateDependencies,
-  updateOwner,
-  updateWaitList,
 } from "../../../../../../db/tables/featureFlags";
 import { isAdmin } from "../../../../utils/auth";
 
@@ -42,25 +39,16 @@ export type UpdateFeatureFlagRequestBody =
       isEnabled: boolean;
     }
   | {
-      id: "dependencies";
-      value: string;
-    }
-  | {
       id: "allowList";
-      value: string;
-    }
-  | {
-      id: "waitList";
-      value: string;
-    }
-  | {
-      id: "owner";
       value: string;
     };
 
 export async function PUT(req: NextRequest) {
   const session = await getServerSession();
-  if (isAdmin(session?.user?.email || "")) {
+  if (
+    isAdmin(session?.user?.email || "") &&
+    typeof session?.user?.subscriber?.id === "number"
+  ) {
     // Signed in
     try {
       const flagName = req.nextUrl.pathname.split("/").at(-1);
@@ -70,19 +58,14 @@ export async function PUT(req: NextRequest) {
       const result: UpdateFeatureFlagRequestBody = await req.json();
 
       if (result.id === "isEnabled") {
-        await enableFeatureFlagByName(flagName, result.isEnabled);
-      } else if (result.id === "dependencies") {
-        const dependencies = result.value.split(",");
-        await updateDependencies(flagName, dependencies);
+        await enableFeatureFlagByName(
+          flagName,
+          result.isEnabled,
+          session.user.subscriber.id,
+        );
       } else if (result.id === "allowList") {
         const allowList = result.value.split(",");
-        await updateAllowList(flagName, allowList);
-      } else if (result.id === "waitList") {
-        const waitList = result.value.split(",");
-        await updateWaitList(flagName, waitList);
-      } else if (result.id === "owner") {
-        const owner = result.value;
-        await updateOwner(flagName, owner);
+        await updateAllowList(flagName, allowList, session.user.subscriber.id);
       }
 
       return NextResponse.json({ success: true }, { status: 200 });

--- a/src/app/api/v1/admin/feature-flags/route.ts
+++ b/src/app/api/v1/admin/feature-flags/route.ts
@@ -10,9 +10,6 @@ import {
   addFeatureFlag,
   enableFeatureFlagByName,
   disableFeatureFlagByName,
-  updateAllowList,
-  updateWaitList,
-  deleteFeatureFlagByName,
 } from "../../../../../db/tables/featureFlags";
 
 import { isAdmin } from "../../../utils/auth";
@@ -46,7 +43,10 @@ export type CreateFeatureFlagRequestBody = {
 
 export async function POST(req: NextRequest) {
   const session = await getServerSession();
-  if (isAdmin(session?.user?.email || "")) {
+  if (
+    isAdmin(session?.user?.email || "") &&
+    typeof session?.user?.subscriber?.id === "number"
+  ) {
     // Signed in
     try {
       const newFlag = (await req.json()) as CreateFeatureFlagRequestBody;
@@ -56,12 +56,8 @@ export async function POST(req: NextRequest) {
       const resp = await addFeatureFlag({
         name: newFlag.name,
         is_enabled: newFlag.isEnabled,
-        description: newFlag.description,
-        dependencies: newFlag.dependencies,
         allow_list: newFlag.allowList,
-        wait_list: newFlag.waitList,
-        expired_at: newFlag.expiredAt,
-        owner: newFlag.owner,
+        last_updated_by_subscriber_id: session.user.subscriber.id,
       });
       return NextResponse.json(resp);
     } catch (e) {
@@ -82,46 +78,26 @@ export type FeatureFlagPutRequest = {
 
 export async function PUT(req: NextRequest) {
   const session = await getServerSession();
-  if (isAdmin(session?.user?.email || "")) {
+  if (
+    isAdmin(session?.user?.email || "") &&
+    typeof session?.user?.subscriber?.id === "number"
+  ) {
     // Signed in
     try {
       const reqBody = (await req.json()) as FeatureFlagPutRequest;
       // if toggle request
       if (reqBody.isEnabled !== undefined && reqBody.isEnabled) {
-        await enableFeatureFlagByName(reqBody.name, reqBody.isEnabled);
+        await enableFeatureFlagByName(
+          reqBody.name,
+          reqBody.isEnabled,
+          session.user.subscriber.id,
+        );
       } else if (reqBody.isEnabled !== undefined && !reqBody.isEnabled) {
-        await disableFeatureFlagByName(reqBody.name);
+        await disableFeatureFlagByName(
+          reqBody.name,
+          session.user.subscriber.id,
+        );
       }
-
-      if (reqBody.allowList) {
-        await updateAllowList(reqBody.name, reqBody.allowList);
-      }
-
-      if (reqBody.waitList) {
-        await updateWaitList(reqBody.name, reqBody.waitList);
-      }
-
-      return NextResponse.json({ success: true, name: reqBody.name });
-    } catch {
-      return NextResponse.json({ success: false }, { status: 500 });
-    }
-  } else {
-    return NextResponse.json({ success: false }, { status: 401 });
-  }
-}
-
-export type FeatureFlagDeleteRequest = {
-  name: string;
-};
-
-export async function DELETE(req: NextRequest) {
-  const session = await getServerSession();
-  if (isAdmin(session?.user?.email || "")) {
-    // Signed in
-    try {
-      const reqBody = (await req.json()) as FeatureFlagDeleteRequest;
-      await deleteFeatureFlagByName(reqBody.name);
-
       return NextResponse.json({ success: true, name: reqBody.name });
     } catch {
       return NextResponse.json({ success: false }, { status: 500 });

--- a/src/db/migrations/20250225111207_add_feature_flag_events.js
+++ b/src/db/migrations/20250225111207_add_feature_flag_events.js
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.createTable("feature_flag_events", (table) => {
+    table.string("name").notNullable();
+    table.boolean("is_enabled").notNullable().defaultTo(false);
+    table.specificType("allow_list", "character varying(255)[]").nullable();
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+    table.integer("created_by_subscriber_id").notNullable();
+    table.index(["name", "created_at"]);
+
+    table
+      .foreign("created_by_subscriber_id")
+      .references("id")
+      .inTable("subscribers");
+  });
+
+  await knex.schema.createView("feature_flag_view", (view) => {
+    view.columns([
+      "name",
+      "is_enabled",
+      "allow_list",
+      "updated_at",
+      "last_updated_by_subscriber_id",
+    ]);
+    view.as(
+      knex("feature_flag_events")
+        .select(
+          "name",
+          "is_enabled",
+          "allow_list",
+          "created_at as updated_at",
+          "created_by_subscriber_id as last_updated_by_subscriber_id",
+        )
+        .distinctOn("name")
+        .orderBy([
+          { column: "name", order: "asc" },
+          { column: "created_at", order: "desc" },
+        ]),
+    );
+  });
+
+  const existingFeatureFlags = await knex("feature_flags").select(
+    "name",
+    "is_enabled",
+    "allow_list",
+    "modified_at as created_at",
+  );
+
+  if (existingFeatureFlags.length > 0) {
+    const fakeFirstuser = await knex("subscribers")
+      .select("id")
+      .whereLike("primary_email", "%@mozilla.com")
+      .first();
+    if (!fakeFirstuser) {
+      throw new Error(
+        "Couldn't find a subscriber with an @mozilla.com email address to attribute pre-existing feature flags to.",
+      );
+    }
+    await knex("feature_flag_events").insert(
+      existingFeatureFlags.map((flag) => ({
+        ...flag,
+        created_by_subscriber_id: fakeFirstuser.id,
+      })),
+    );
+  }
+}
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  const existingFeatureFlags = await knex("feature_flag_view").select("*");
+  await knex("feature_flags")
+    .insert(
+      existingFeatureFlags.map((flag) => ({
+        name: flag.name,
+        is_enabled: flag.is_enabled,
+        allow_list: flag.allow_list,
+        modified_at: flag.updated_at,
+      })),
+    )
+    .onConflict("name")
+    .merge();
+  await knex.schema.dropViewIfExists("feature_flag_view");
+  await knex.schema.dropTableIfExists("feature_flag_events");
+}

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -4,7 +4,7 @@
 
 import createDbConnection from "../connect";
 import { logger } from "../../app/functions/server/logging";
-import { FeatureFlagRow } from "knex/types/tables";
+import { FeatureFlagViewRow, SubscriberRow } from "knex/types/tables";
 
 const knex = createDbConnection();
 
@@ -23,18 +23,12 @@ export type FeatureFlag = {
 
 /** @deprecated The method should not be used, use Nimbus experiment or roll-out: /src/app/functions/server/getExperiments */
 export async function getAllFeatureFlags() {
-  return await knex("feature_flags")
-    .whereNull("deleted_at")
-    .orderBy("name")
-    .returning("*");
+  return await knex("feature_flag_view").select("*").orderBy("name");
 }
 
 /** @deprecated The method should not be used, use Nimbus experiment or roll-out: /src/app/functions/server/getExperiments */
 export async function getDeletedFeatureFlags() {
-  return await knex("feature_flags")
-    .whereNotNull("deleted_at")
-    .orderBy("name")
-    .returning("*");
+  return await knex("feature_flag_view").select("*").orderBy("name");
 }
 
 export const featureFlagNames = [
@@ -66,10 +60,8 @@ export type FeatureFlagName = (typeof featureFlagNames)[number];
 export async function getEnabledFeatureFlags(
   options: { isSignedOut?: false; email: string } | { isSignedOut: true },
 ): Promise<FeatureFlagName[]> {
-  const query = knex("feature_flags")
+  const query = knex("feature_flag_view")
     .select("name")
-    .where("deleted_at", null)
-    .and.where("expired_at", null)
     .and.where((subQuery) => {
       subQuery = subQuery.where("is_enabled", true);
       if (!options.isSignedOut) {
@@ -115,20 +107,16 @@ export async function getEnabledFeatureFlags(
  */
 export async function getFeatureFlagData(
   featureFlagName: FeatureFlagName,
-): Promise<FeatureFlagRow | null> {
+): Promise<FeatureFlagViewRow | null> {
   return (
-    (await knex("feature_flags")
-      .first()
-      .where("name", featureFlagName)
-      // The `.andWhereNull` alias doesn't seem to exist:
-      // https://github.com/knex/knex/issues/1881#issuecomment-275433906
-      .whereNull("deleted_at")) ?? null
+    (await knex("feature_flag_view").first().where("name", featureFlagName)) ??
+    null
   );
 }
 
 export async function getFeatureFlagByName(name: string) {
   logger.info("getFeatureFlagByName", name);
-  const res = await knex("feature_flags").where("name", name);
+  const res = await knex("feature_flag_view").where("name", name);
 
   return res[0] || null;
 }
@@ -138,87 +126,22 @@ export async function getFeatureFlagByName(name: string) {
  * @deprecated The method should not be used, use Nimbus experiment or roll-out: /src/app/functions/server/getExperiments
  */
 export async function addFeatureFlag(
-  flag: Omit<FeatureFlagRow, "created_at" | "modified_at">,
+  flag: Omit<FeatureFlagViewRow, "updated_at">,
 ) {
   logger.info("addFeatureFlag", flag);
-  const featureFlagDb: Omit<FeatureFlagRow, "created_at" | "modified_at"> = {
+  await knex("feature_flag_events").insert({
     name: flag.name,
     is_enabled: flag.is_enabled,
-    description: flag.description,
-    dependencies: flag.dependencies,
-    allow_list: flag.allow_list
-      ?.map((email: string) => email.trim())
-      .filter((email: string) => email.length > 0),
-    wait_list: flag.wait_list
-      ?.map((email: string) => email.trim())
-      .filter((email: string) => email.length > 0),
-    expired_at: flag.expired_at,
-    owner: flag.owner,
-  };
-  const res = await knex("feature_flags")
-    .insert(featureFlagDb)
-    .onConflict("name")
-    .merge(["deleted_at"])
-    .returning("*");
+    allow_list: flag.allow_list,
+    created_by_subscriber_id: flag.last_updated_by_subscriber_id,
+  });
 
-  return res[0];
-}
+  const flagFromDb = await knex("feature_flag_view")
+    .select("*")
+    .where("name", flag.name)
+    .first();
 
-/**
- * @param name
- * @deprecated The method should not be used, use Nimbus experiment or roll-out: /src/app/functions/server/getExperiments
- */
-export async function deleteFeatureFlagByName(name: string) {
-  logger.info("deleteFeatureFlagByName", name);
-  const res = await knex("feature_flags")
-    .where("name", name)
-    .update({
-      // @ts-ignore knex.fn.now() results in it being set to a date,
-      // even if it's not typed as a JS date object:
-      deleted_at: knex.fn.now(),
-    })
-    .returning("*");
-  return res[0];
-}
-
-/**
- * @param name
- * @param dependencies
- * @deprecated The method should not be used, use Nimbus experiment or roll-out: /src/app/functions/server/getExperiments
- */
-export async function updateDependencies(name: string, dependencies: string[]) {
-  logger.info("updateDependencies", { name, dependencies });
-  const res = await knex("feature_flags")
-    .where("name", name)
-    .update({
-      dependencies,
-      // @ts-ignore knex.fn.now() results in it being set to a date,
-      // even if it's not typed as a JS date object:
-      modified_at: knex.fn.now(),
-    })
-    .returning("*");
-
-  return res[0];
-}
-
-/**
- * @param name
- * @param owner
- * @deprecated The method should not be used, use Nimbus experiment or roll-out: /src/app/functions/server/getExperiments
- */
-export async function updateOwner(name: string, owner: string) {
-  logger.info("updateOwner", { name, owner });
-  const res = await knex("feature_flags")
-    .where("name", name)
-    .update({
-      owner: owner,
-      // @ts-ignore knex.fn.now() results in it being set to a date,
-      // even if it's not typed as a JS date object:
-      modified_at: knex.fn.now(),
-    })
-    .returning("*");
-
-  return res[0];
+  return flagFromDb!;
 }
 
 /**
@@ -226,49 +149,30 @@ export async function updateOwner(name: string, owner: string) {
  * @param allowList
  * @deprecated The method should not be used, use Nimbus experiment or roll-out: /src/app/functions/server/getExperiments
  */
-export async function updateAllowList(name: string, allowList: string[]) {
+export async function updateAllowList(
+  name: string,
+  allowList: string[],
+  updaterId: SubscriberRow["id"],
+) {
   allowList = allowList.reduce((acc: string[], e: string) => {
     e = e.trim();
     if (e) acc.push(e);
     return acc;
   }, []);
   logger.info("updateAllowList", { name, allowList });
-  const res = await knex("feature_flags")
+  const existingFlag = await knex("feature_flag_view")
+    .select("*")
     .where("name", name)
-    .update({
-      allow_list: allowList,
-      // @ts-ignore knex.fn.now() results in it being set to a date,
-      // even if it's not typed as a JS date object:
-      modified_at: knex.fn.now(),
-    })
-    .returning("*");
-
-  return res[0];
-}
-
-/**
- * @param name
- * @param waitList
- * @deprecated The method should not be used, use Nimbus experiment or roll-out: /src/app/functions/server/getExperiments
- */
-export async function updateWaitList(name: string, waitList: string[]) {
-  waitList = waitList.reduce((acc: string[], e: string) => {
-    e = e.trim();
-    if (e) acc.push(e);
-    return acc;
-  }, []);
-  logger.info("updateWaitList", { name, waitList });
-  const res = await knex("feature_flags")
-    .where("name", name)
-    .update({
-      wait_list: waitList,
-      // @ts-ignore knex.fn.now() results in it being set to a date,
-      // even if it's not typed as a JS date object:
-      modified_at: knex.fn.now(),
-    })
-    .returning("*");
-
-  return res[0];
+    .first();
+  if (!existingFlag) {
+    throw new Error(`No flag found with name [${name}]`);
+  }
+  await knex("feature_flag_events").insert({
+    name: existingFlag.name,
+    is_enabled: existingFlag.is_enabled,
+    created_by_subscriber_id: updaterId,
+    allow_list: allowList,
+  });
 }
 
 /**
@@ -279,38 +183,46 @@ export async function updateWaitList(name: string, waitList: string[]) {
 export async function enableFeatureFlagByName(
   name: string,
   isEnabled: boolean,
+  updaterId: SubscriberRow["id"],
 ) {
   logger.info("enableFeatureFlagByName", name);
-  const res = await knex("feature_flags")
+  const existingFlag = await knex("feature_flag_view")
+    .select("*")
     .where("name", name)
-    .update({
-      is_enabled: isEnabled,
-      // @ts-ignore knex.fn.now() results in it being set to a date,
-      // even if it's not typed as a JS date object:
-      modified_at: knex.fn.now(),
-    })
-    .returning("*");
-
-  return res[0];
+    .first();
+  if (!existingFlag) {
+    throw new Error(`No flag found with name [${name}]`);
+  }
+  await knex("feature_flag_events").insert({
+    name: existingFlag.name,
+    is_enabled: isEnabled,
+    created_by_subscriber_id: updaterId,
+    allow_list: existingFlag.allow_list,
+  });
 }
 
 /**
  * @param name
  * @deprecated The method should not be used, use Nimbus experiment or roll-out: /src/app/functions/server/getExperiments
  */
-export async function disableFeatureFlagByName(name: string) {
+export async function disableFeatureFlagByName(
+  name: string,
+  updaterId: SubscriberRow["id"],
+) {
   logger.info("disableFeatureFlagByName", name);
-  const res = await knex("feature_flags")
+  const existingFlag = await knex("feature_flag_view")
+    .select("*")
     .where("name", name)
-    .update({
-      is_enabled: false,
-      // @ts-ignore knex.fn.now() results in it being set to a date,
-      // even if it's not typed as a JS date object:
-      modified_at: knex.fn.now(),
-    })
-    .returning("*");
-
-  return res[0];
+    .first();
+  if (!existingFlag) {
+    throw new Error(`No flag found with name [${name}]`);
+  }
+  await knex("feature_flag_events").insert({
+    name: existingFlag.name,
+    is_enabled: false,
+    created_by_subscriber_id: updaterId,
+    allow_list: existingFlag.allow_list,
+  });
 }
 
 export function isFeatureFlagAdminOnly(flagName: string): boolean {

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -22,8 +22,24 @@ export type FeatureFlag = {
 };
 
 /** @deprecated The method should not be used, use Nimbus experiment or roll-out: /src/app/functions/server/getExperiments */
-export async function getAllFeatureFlags() {
-  return await knex("feature_flag_view").select("*").orderBy("name");
+export async function getAllFeatureFlags(): Promise<
+  Array<
+    FeatureFlagViewRow & {
+      last_updated_by_subscriber_email: SubscriberRow["primary_email"];
+    }
+  >
+> {
+  return await knex("feature_flag_view")
+    .join(
+      "subscribers",
+      "subscribers.id",
+      "feature_flag_view.last_updated_by_subscriber_id",
+    )
+    .select(
+      "feature_flag_view.*",
+      "subscribers.primary_email as last_updated_by_subscriber_email",
+    )
+    .orderBy("feature_flag_view.name");
 }
 
 /** @deprecated The method should not be used, use Nimbus experiment or roll-out: /src/app/functions/server/getExperiments */

--- a/src/knex-tables.d.ts
+++ b/src/knex-tables.d.ts
@@ -70,6 +70,7 @@ declare module "knex/types/tables" {
     "id" | "subscriber_id" | "created_at" | "updated_at"
   >;
 
+  /** @deprecated MNTOR-4191 */
   interface FeatureFlagRow {
     name: string;
     is_enabled: boolean;
@@ -96,6 +97,40 @@ declare module "knex/types/tables" {
   type FeatureFlagAutoInsertedColumns = Extract<
     keyof FeatureFlagRow,
     "name" | "created_at" | "modified_at"
+  >;
+
+  interface FeatureFlagViewRow {
+    name: string;
+    is_enabled: boolean;
+    allow_list?: string[];
+    updated_at: Date;
+    last_updated_by_subscriber_id: SubscriberRow["id"];
+  }
+
+  type FeatureFlagViewOptionalColumns = Extract<
+    keyof FeatureFlagViewRow,
+    "allow_list"
+  >;
+  type FeatureFlagViewAutoInsertedColumns = Extract<
+    keyof FeatureFlagViewRow,
+    "created_at"
+  >;
+
+  interface FeatureFlagEventRow {
+    name: string;
+    is_enabled: boolean;
+    allow_list?: string[];
+    created_at: Date;
+    created_by_subscriber_id: SubscriberRow["id"];
+  }
+
+  type FeatureFlagEventOptionalColumns = Extract<
+    keyof FeatureFlagEventRow,
+    "allow_list"
+  >;
+  type FeatureFlagEventAutoInsertedColumns = Extract<
+    keyof FeatureFlagEventRow,
+    "created_at"
   >;
 
   interface SubscriberEmail {
@@ -437,6 +472,7 @@ declare module "knex/types/tables" {
       >
     >;
 
+    /** @deprecated MNTOR-4191 */
     feature_flags: Knex.CompositeTableType<
       FeatureFlagRow,
       // On inserts, auto-generated columns cannot be set, and nullable columns are optional:
@@ -449,6 +485,36 @@ declare module "knex/types/tables" {
       >,
       // On updates, don't allow updating the ID and created date; all other fields are optional:
       WritableDateColumns<Partial<Omit<FeatureFlagRow, "name" | "created_at">>>
+    >;
+
+    feature_flag_view: Knex.CompositeTableType<
+      FeatureFlagViewRow,
+      // On inserts, auto-generated columns cannot be set, and nullable columns are optional:
+      WritableDateColumns<
+        Omit<
+          FeatureFlagViewRow,
+          FeatureFlagViewAutoInsertedColumns | FeatureFlagViewOptionalColumns
+        > &
+          Partial<Pick<FeatureFlagViewRow, FeatureFlagViewOptionalColumns>>
+      >,
+      // Don't allow updates; updating a flag requires adding a new event.
+      // This allows us to make sure all updates are auditable.
+      Record<string, never>
+    >;
+
+    feature_flag_events: Knex.CompositeTableType<
+      FeatureFlagEventRow,
+      // On inserts, auto-generated columns cannot be set, and nullable columns are optional:
+      WritableDateColumns<
+        Omit<
+          FeatureFlagEventRow,
+          FeatureFlagEventAutoInsertedColumns | FeatureFlagEventOptionalColumns
+        > &
+          Partial<Pick<FeatureFlagEventRow, FeatureFlagEventOptionalColumns>>
+      >,
+      // Don't allow updates; updating a flag requires adding a new event.
+      // This allows us to make sure all updates are auditable.
+      Record<string, never>
     >;
 
     subscribers: Knex.CompositeTableType<


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-4062
Figma:

<!-- When adding a new feature: -->

# Description

The main change here is deprecating the `feature_flags` table (I wasn't brave enough to drop it yet), and replacing it by a `feature_flag_events` table that is append-only. This will allow us to have a full audit trail of when feature flags get modified.

To keep a similar experience as the `feature_flags` table, I added a `feature_flag_view` view.  Note that I did not preserve the wait list, description, dependencies, expiration, deletion, and owner, since we haven't used those.

The feature flag UI exposes the last date a flag was modified, and who modified it - but the full history is available in the DB if we ever need it.

I also updated the feature flag API to list all enabled flags when the user is not logged in. This will allow us to compare stage's and prod's enabled feature flags before deploying in the future, and warn the BLE to flip back a flag in stage if they don't match.

I can create a PR with just c76fc434a616438aecdc57e5e83c3484a6be9fb4 if the overall approach looks OK.

# How to test

Use feature flags!

Also, the migration is more complex than usual, also moving over data, so doing the migration, verifying that there is no data loss, modifying some flags, and rolling back and again verifying that there is no data loss, is probably a good idea.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - No, side-effect heavy (just DB)
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met. - N/A
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process. - N/A
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage. - N/A
