### PR TITLE
MNTOR-3945: Add a search icon to the breach filter field

### DIFF
--- a/src/app/(proper_react)/(redesign)/(public)/breaches/BreachIndexView.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/breaches/BreachIndexView.module.scss
@@ -39,13 +39,28 @@
     opacity: 0;
   }
 
-  label {
-    font: tokens.$text-body-sm;
-    @include tokens.visually-hidden;
-  }
-  input {
-    font: tokens.$text-body-lg;
-    padding: tokens.$spacing-sm;
+  .control {
+    position: relative;
+    $searchIconWidth: 24px;
+
+    label {
+      position: absolute;
+      inset-block-start: 50%;
+      transform: translateY(-50%);
+      inset-inline-start: tokens.$spacing-md;
+      width: $searchIconWidth;
+
+      svg {
+        width: $searchIconWidth;
+      }
+    }
+    input {
+      font: tokens.$text-body-lg;
+      padding: tokens.$spacing-sm;
+      /* Left label padding + label width + left input padding */
+      $inputPadding: tokens.$spacing-md + $searchIconWidth + tokens.$spacing-sm;
+      padding-inline-start: $inputPadding;
+    }
   }
 }
 

--- a/src/app/(proper_react)/(redesign)/(public)/breaches/BreachIndexView.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/breaches/BreachIndexView.tsx
@@ -13,6 +13,7 @@ import { BreachLogo } from "../../../../components/server/BreachLogo";
 import { getLocale } from "../../../../functions/universal/getLocale";
 import { useHasRenderedClientSide } from "../../../../hooks/useHasRenderedClientSide";
 import { memo, useMemo, useState, useTransition } from "react";
+import { SearchIcon } from "../../../../components/server/Icons";
 
 export type Props = {
   allBreaches: HibpLikeDbBreach[];
@@ -58,17 +59,21 @@ const FilterForm = (props: { onChange: (newValue: string) => void }) => {
 
   return (
     <form className={styles.filterForm} aria-hidden={!hasRenderedClientSide}>
-      <label htmlFor="filterTerm">{l10n.getString("search-breaches")}</label>
-      <input
-        onChange={(e) => {
-          setFilterTerm(e.target.value);
-          props.onChange(e.target.value);
-        }}
-        value={filterTerm}
-        type="search"
-        name="filterTerm"
-        id="filterTerm"
-      />
+      <div className={styles.control}>
+        <label htmlFor="filterTerm">
+          <SearchIcon alt={l10n.getString("search-breaches")} />
+        </label>
+        <input
+          onChange={(e) => {
+            setFilterTerm(e.target.value);
+            props.onChange(e.target.value);
+          }}
+          value={filterTerm}
+          type="search"
+          name="filterTerm"
+          id="filterTerm"
+        />
+      </div>
     </form>
   );
 };

--- a/src/app/components/server/Icons.tsx
+++ b/src/app/components/server/Icons.tsx
@@ -755,3 +755,25 @@ export const BackArrow = (props: SVGProps<SVGSVGElement> & { alt: string }) => {
     </svg>
   );
 };
+
+// Keywords: search, magnifying glass, find
+export const SearchIcon = (
+  props: SVGProps<SVGSVGElement> & { alt: string },
+) => {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      role="img"
+      aria-label={props.alt}
+      aria-hidden={props.alt === ""}
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+      className={`${props.className ?? ""} ${styles.colorifyFill}`}
+    >
+      <title>{props.alt}</title>
+      <path d="m19.745 18.33-4.822-4.821a6.018 6.018 0 1 0-1.414 1.414l4.822 4.822a1 1 0 0 0 1.414-1.414m-9.707-4.292a4 4 0 1 1 0-7.999 4 4 0 0 1 0 7.999"></path>
+    </svg>
+  );
+};


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3945
Figma:

<!-- When adding a new feature: -->

# Description

Adds a search icon to the breach filter field. I wrapped the label and input in a `.control`, replaced the label contents with the icon, positioned it absolutely on the left of the control, and added padding to the input field to not have its contents behind the icon.

# Screenshot (if applicable)

![image](https://github.com/user-attachments/assets/a7400c09-0868-4b68-a967-b40152fee5fe)

# How to test

[Visit `/breaches`.](https://deploy-preview-5682--fx-monitor-storybook.netlify.app/?path=/story/pages-public-breach-index--breach-index-view-story)

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, visual
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
