### PR TITLE
Use correct HIBP URL in example .env

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -52,7 +52,7 @@ SUBSCRIPTION_BILLING_AMOUNT_YEARLY_US=13.37
 SUBSCRIPTION_BILLING_AMOUNT_MONTHLY_US=42.42
 
 # HIBP setup
-HIBP_KANON_API_ROOT=https://api.haveibeenpwned.com
+HIBP_KANON_API_ROOT=https://enterprise.stage-api.haveibeenpwned.com
 
 # Sentry setup
 SENTRY_DSN=https://573f784b5cc7481ebf8c0c385d2ad776@o1069899.ingest.sentry.io/4504612374052864


### PR DESCRIPTION
We switched to a different URL a while ago.
