### PR TITLE
SVCSE-2596: Log how many emails we've sent at a timeout

### DIFF
--- a/src/scripts/cronjobs/monthlyActivityFree.tsx
+++ b/src/scripts/cronjobs/monthlyActivityFree.tsx
@@ -21,8 +21,13 @@ import { getMonthlyActivityFreeUnsubscribeLink } from "../../app/functions/cronj
 import { hasPremium } from "../../app/functions/universal/user";
 import { getFeatureFlagData } from "../../db/tables/featureFlags";
 
+let sentEmails = 0;
 process.on("SIGINT", () => {
-  logger.info("SIGINT received, exiting...");
+  logger.info(`SIGINT received, exiting ([${sentEmails}] emails sent)...`);
+  tearDown();
+});
+process.on("SIGTERM", () => {
+  logger.info(`SIGTERM received, exiting ([${sentEmails}] emails sent)...`);
   tearDown();
 });
 
@@ -139,6 +144,7 @@ async function sendMonthlyActivityEmail(
         />,
       ),
     );
+    sentEmails += 1;
   } catch (e) {
     logger.error("send_monthly_activity_email_free", {
       exception: e,


### PR DESCRIPTION
We don't know for sure how many emails we manage to send before our cronjobs get terminated; this adds logs so that we have a better picture.

# How to test

Run `kill -SIGTERM <process ID>`. I added a timeout myself so that I had enough time to run that.