### PR TITLE
Add setting views to Storybook and mock Server Actions

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -37,6 +37,17 @@ const config: StorybookConfig = {
       type: "asset/source",
     });
 
+    // Defining `paths` in tsconfig.json breaks Storybook’s path resolution.
+    // Removing `TsconfigPathsPlugin` ensures that Storybook uses the default
+    // module resolution behavior.
+    config.resolve = {
+      ...config.resolve,
+      plugins:
+        config.resolve?.plugins?.filter(
+          (plugin) => plugin?.constructor.name !== "TsconfigPathsPlugin",
+        ) ?? [],
+    };
+
     return config;
   },
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -120,6 +120,7 @@ const customJestConfig = {
     "react-dom/server": "react-dom/server.edge",
     // Force module uuid to resolve with the CJS entry point, because Jest does not support package.json.exports. See https://github.com/uuidjs/uuid/issues/451
     uuid: require.resolve("uuid"),
+    // With `paths` defined in tsconfig.json, Jest requires explicit mapping.
     "^\\.storybook/preview$": "<rootDir>/.storybook/preview.tsx",
   },
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -120,6 +120,7 @@ const customJestConfig = {
     "react-dom/server": "react-dom/server.edge",
     // Force module uuid to resolve with the CJS entry point, because Jest does not support package.json.exports. See https://github.com/uuidjs/uuid/issues/451
     uuid: require.resolve("uuid"),
+    "^\\.storybook/preview$": "<rootDir>/.storybook/preview.tsx",
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/package.json
+++ b/package.json
@@ -177,5 +177,12 @@
   "overrides": {
     "@types/react": "19.0.3",
     "@types/react-dom": "19.0.2"
+  },
+  "imports": {
+    "#settings/actions": {
+      "storybook": "./src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/actions.mock.ts",
+      "default": "./src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/actions.ts"
+    },
+    "#*": ["./*", "./*.ts", "./*.tsx"]
   }
 }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/CancelFlow.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/CancelFlow.tsx
@@ -18,9 +18,12 @@ import { Button } from "../../../../../../components/client/Button";
 import { useL10n } from "../../../../../../hooks/l10n";
 import { TelemetryButton } from "../../../../../../components/client/TelemetryButton";
 import { ExperimentData } from "../../../../../../../telemetry/generated/nimbus/experiments";
-import { onApplyCouponCode, onCheckUserHasCurrentCouponSet } from "./actions";
 import { TelemetryLink } from "../../../../../../components/client/TelemetryLink";
 import { OpenInNew } from "../../../../../../components/server/Icons";
+import {
+  onApplyCouponCode,
+  onCheckUserHasCurrentCouponSet,
+} from "#settings/actions";
 
 export type Props = {
   fxaSubscriptionsUrl: string;

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/DeleteAccountButton.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/DeleteAccountButton.tsx
@@ -7,8 +7,8 @@
 import { useState } from "react";
 import { signOut } from "next-auth/react";
 import { Button } from "../../../../../../components/client/Button";
-import { onDeleteAccount } from "./actions";
 import { useTelemetry } from "../../../../../../hooks/useTelemetry";
+import { onDeleteAccount } from "#settings/actions";
 
 /**
  * Since <Button> is a client component, the `onDeleteAccount` handler can only

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/EmailAddressAdder.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/EmailAddressAdder.tsx
@@ -20,9 +20,9 @@ import { Button } from "../../../../../../components/client/Button";
 import { useL10n } from "../../../../../../hooks/l10n";
 import { ModalOverlay } from "../../../../../../components/client/dialog/ModalOverlay";
 import { Dialog } from "../../../../../../components/client/dialog/Dialog";
-import { onAddEmail } from "./actions";
 import { CONST_MAX_NUM_ADDRESSES } from "../../../../../../../constants";
 import { useTelemetry } from "../../../../../../hooks/useTelemetry";
+import { onAddEmail } from "#settings/actions";
 
 export const EmailAddressAdder = () => {
   const l10n = useL10n();

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPage.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPage.test.tsx
@@ -16,7 +16,7 @@ import {
   onApplyCouponCode,
   onCheckUserHasCurrentCouponSet,
   onRemoveEmail,
-} from "./actions";
+} from "#settings/actions";
 
 const mockedSessionUpdate = jest.fn();
 const mockedRecordTelemetry = jest.fn();

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/actions.mock.ts
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/actions.mock.ts
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { fn } from "@storybook/test";
+
+export type { AddEmailFormState } from "./actions";
+export const onAddEmail = fn().mockName("onAddEmail");
+export const onRemoveEmail = fn().mockName("onRemoveEmail");
+export const onDeleteAccount = fn().mockName("onDeleteAccount");
+export const onApplyCouponCode = fn().mockName("onApplyCouponCode");
+export const onCheckUserHasCurrentCouponSet = fn().mockName(
+  "onCheckUserHasCurrentCouponSet",
+);
+export const onHandleUpdateProfileData = fn().mockName(
+  "onHandleUpdateProfileData",
+);

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelEditInfo.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelEditInfo.tsx
@@ -18,7 +18,7 @@ import {
 import { useTelemetry } from "../../../../../../../hooks/useTelemetry";
 import { Button } from "../../../../../../../components/client/Button";
 import styles from "./SettingsPanelEditInfo.module.scss";
-import { onRemoveEmail } from "../actions";
+import { onRemoveEmail } from "#settings/actions";
 
 export type SettingsPanelEditInfoProps = {
   breachCountByEmailAddress: Record<string, number>;

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/stories/Settings.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/stories/Settings.stories.tsx
@@ -8,7 +8,7 @@ import { SettingsWrapper } from "./SettingsStoryWrapper";
 import { CONST_SETTINGS_TAB_SLUGS } from "../../../../../../../../constants";
 
 const meta: Meta<typeof SettingsWrapper> = {
-  title: "Pages/Logged in/Settings/Default",
+  title: "Pages/Logged in/Settings",
   component: SettingsWrapper,
   argTypes: {
     activeTab: {
@@ -25,7 +25,6 @@ export const SettingsEditYourInfo: Story = {
   args: {
     countryCode: "us",
     activeTab: "edit-info",
-    enabledFeatureFlags: [],
   },
 };
 
@@ -34,7 +33,6 @@ export const SettingsEditManageAccount: Story = {
   args: {
     countryCode: "us",
     activeTab: "manage-account",
-    enabledFeatureFlags: [],
   },
 };
 
@@ -43,6 +41,5 @@ export const SettingsEditNotifications: Story = {
   args: {
     countryCode: "us",
     activeTab: "notifications",
-    enabledFeatureFlags: [],
   },
 };

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/stories/Settings.stories.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/stories/Settings.stories.tsx
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { SettingsWrapper } from "./SettingsStoryWrapper";
+import { CONST_SETTINGS_TAB_SLUGS } from "../../../../../../../../constants";
+
+const meta: Meta<typeof SettingsWrapper> = {
+  title: "Pages/Logged in/Settings/Default",
+  component: SettingsWrapper,
+  argTypes: {
+    activeTab: {
+      options: CONST_SETTINGS_TAB_SLUGS,
+      control: { type: "select" },
+    },
+  },
+};
+export default meta;
+type Story = StoryObj<typeof SettingsWrapper>;
+
+export const SettingsEditYourInfo: Story = {
+  name: "Edit your info",
+  args: {
+    countryCode: "us",
+    activeTab: "edit-info",
+    enabledFeatureFlags: [],
+  },
+};
+
+export const SettingsEditManageAccount: Story = {
+  name: "Manage account",
+  args: {
+    countryCode: "us",
+    activeTab: "manage-account",
+    enabledFeatureFlags: [],
+  },
+};
+
+export const SettingsEditNotifications: Story = {
+  name: "Notifications",
+  args: {
+    countryCode: "us",
+    activeTab: "notifications",
+    enabledFeatureFlags: [],
+  },
+};

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/stories/SettingsStoryWrapper.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/stories/SettingsStoryWrapper.tsx
@@ -18,11 +18,8 @@ import { FeatureFlagName } from "../../../../../../../../db/tables/featureFlags"
 import { SubscriberEmailPreferencesOutput } from "../../../../../../../../db/tables/subscriber_email_preferences";
 import {
   mockedSubscriber,
-  mockedVerifiedEmailSecond,
-  mockedVerifiedEmailThird,
-  mockedVerifiedEmailFourth,
-  mockedVerifiedEmailFifth,
-} from "./sharedSettingsMockData";
+  breachCountByEmailAddress,
+} from "./settingsMockData";
 
 export type SettingsWrapperProps = {
   activeTab: TabType;
@@ -32,6 +29,7 @@ export type SettingsWrapperProps = {
   isMonthlySubscriber: boolean;
   isEligibleForPremium: boolean;
   subscriber: SubscriberRow;
+  breachCountByEmailAddress: Record<string, number>;
   emailAddresses?: EmailAddressRow[];
   profileData?: OnerepProfileRow;
   data?: SubscriberEmailPreferencesOutput;
@@ -61,13 +59,9 @@ export const SettingsWrapper = (props: SettingsWrapperProps) => {
             subscriber={props.subscriber ?? mockedSubscriber}
             data={props.data}
             emailAddresses={props.emailAddresses ?? []}
-            breachCountByEmailAddress={{
-              [mockedSubscriber.primary_email]: 12,
-              [mockedVerifiedEmailSecond.email]: 23,
-              [mockedVerifiedEmailThird.email]: 45,
-              [mockedVerifiedEmailFourth.email]: 56,
-              [mockedVerifiedEmailFifth.email]: 78,
-            }}
+            breachCountByEmailAddress={
+              props.breachCountByEmailAddress ?? breachCountByEmailAddress
+            }
             fxaSettingsUrl=""
             fxaSubscriptionsUrl=""
             monthlySubscriptionUrl=""

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/stories/SettingsStoryWrapper.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/stories/SettingsStoryWrapper.tsx
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  EmailAddressRow,
+  OnerepProfileRow,
+  SubscriberRow,
+} from "knex/types/tables";
+import { SettingsView, TabType } from "../View";
+import { Shell } from "../../../../../Shell/Shell";
+import { getL10n } from "../../../../../../../functions/l10n/storybookAndJest";
+import { createUserWithPremiumSubscription } from "../../../../../../../../apiMocks/mockData";
+import { defaultExperimentData } from "../../../../../../../../telemetry/generated/nimbus/experiments";
+import { CountryCodeProvider } from "../../../../../../../../contextProviders/country-code";
+import { SessionProvider } from "../../../../../../../../contextProviders/session";
+import { FeatureFlagName } from "../../../../../../../../db/tables/featureFlags";
+import { SubscriberEmailPreferencesOutput } from "../../../../../../../../db/tables/subscriber_email_preferences";
+import {
+  mockedSubscriber,
+  mockedVerifiedEmailSecond,
+  mockedVerifiedEmailThird,
+  mockedVerifiedEmailFourth,
+  mockedVerifiedEmailFifth,
+} from "./sharedSettingsMockData";
+
+export type SettingsWrapperProps = {
+  activeTab: TabType;
+  breaches: unknown;
+  countryCode: string;
+  enabledFeatureFlags?: FeatureFlagName[];
+  isMonthlySubscriber: boolean;
+  isEligibleForPremium: boolean;
+  subscriber: SubscriberRow;
+  emailAddresses?: EmailAddressRow[];
+  profileData?: OnerepProfileRow;
+  data?: SubscriberEmailPreferencesOutput;
+};
+
+export const SettingsWrapper = (props: SettingsWrapperProps) => {
+  const user = createUserWithPremiumSubscription();
+  const mockedSession = {
+    expires: new Date().toISOString(),
+    user,
+  };
+
+  return (
+    <SessionProvider session={mockedSession}>
+      <CountryCodeProvider countryCode={props.countryCode}>
+        <Shell
+          l10n={getL10n()}
+          session={mockedSession}
+          nonce=""
+          countryCode={props.countryCode}
+          enabledFeatureFlags={props.enabledFeatureFlags ?? []}
+          experimentData={defaultExperimentData["Features"]}
+        >
+          <SettingsView
+            l10n={getL10n()}
+            user={user}
+            subscriber={props.subscriber ?? mockedSubscriber}
+            data={props.data}
+            emailAddresses={props.emailAddresses ?? []}
+            breachCountByEmailAddress={{
+              [mockedSubscriber.primary_email]: 12,
+              [mockedVerifiedEmailSecond.email]: 23,
+              [mockedVerifiedEmailThird.email]: 45,
+              [mockedVerifiedEmailFourth.email]: 56,
+              [mockedVerifiedEmailFifth.email]: 78,
+            }}
+            fxaSettingsUrl=""
+            fxaSubscriptionsUrl=""
+            monthlySubscriptionUrl=""
+            yearlySubscriptionUrl=""
+            subscriptionBillingAmount={{
+              yearly: 13.37,
+              monthly: 42.42,
+            }}
+            enabledFeatureFlags={props.enabledFeatureFlags ?? []}
+            experimentData={defaultExperimentData["Features"]}
+            lastScanDate={new Date(Date.UTC(2024, 6, 31))}
+            isMonthlySubscriber={props.isMonthlySubscriber}
+            activeTab={props.activeTab ?? "action-needed"}
+          />
+        </Shell>
+      </CountryCodeProvider>
+    </SessionProvider>
+  );
+};

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/stories/settingsMockData.ts
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/stories/settingsMockData.ts
@@ -2,53 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { EmailAddressRow, SubscriberRow } from "knex/types/tables";
+import { SubscriberRow } from "knex/types/tables";
 
 const subscriberId = 7;
-
-export const mockedVerifiedEmailSecond: EmailAddressRow = {
-  id: 2,
-  email: "email2@example.com",
-  sha1: "arbitrary string",
-  subscriber_id: subscriberId,
-  verified: true,
-  created_at: new Date("1337-04-02T04:02:42.000Z"),
-  updated_at: new Date("1337-04-02T04:02:42.000Z"),
-  verification_token: "arbitrary_token",
-};
-
-export const mockedVerifiedEmailThird: EmailAddressRow = {
-  id: 3,
-  email: "email3@example.com",
-  sha1: "arbitrary string",
-  subscriber_id: subscriberId,
-  verified: true,
-  created_at: new Date("1337-04-02T04:02:42.000Z"),
-  updated_at: new Date("1337-04-02T04:02:42.000Z"),
-  verification_token: "arbitrary_token",
-};
-
-export const mockedVerifiedEmailFourth: EmailAddressRow = {
-  id: 4,
-  email: "email4@example.com",
-  sha1: "arbitrary string",
-  subscriber_id: subscriberId,
-  verified: false,
-  created_at: new Date("1337-04-02T04:02:42.000Z"),
-  updated_at: new Date("1337-04-02T04:02:42.000Z"),
-  verification_token: "arbitrary_token",
-};
-
-export const mockedVerifiedEmailFifth: EmailAddressRow = {
-  id: 5,
-  email: "email5@example.com",
-  sha1: "arbitrary string",
-  subscriber_id: subscriberId,
-  verified: false,
-  created_at: new Date("1337-04-02T04:02:42.000Z"),
-  updated_at: new Date("1337-04-02T04:02:42.000Z"),
-  verification_token: "arbitrary_token",
-};
 
 export const mockedSubscriber: SubscriberRow = {
   updated_at: new Date(),
@@ -59,7 +15,7 @@ export const mockedSubscriber: SubscriberRow = {
   id: subscriberId,
   created_at: new Date("2022-06-07 14:29:00.000-05"),
   primary_sha1: "abcabc",
-  primary_email: "primary@email.com",
+  primary_email: "example@example.com",
   primary_verification_token: "c165711a-69d1-42f1-9850-ce74754f36de",
   primary_verified: true,
   fxa_access_token:
@@ -92,4 +48,8 @@ export const mockedSubscriber: SubscriberRow = {
   sign_in_count: null,
   first_broker_removal_email_sent: false,
   churn_prevention_email_sent_at: null,
+};
+
+export const breachCountByEmailAddress = {
+  [mockedSubscriber.primary_email]: 12,
 };

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/stories/sharedSettingsMockData.ts
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/stories/sharedSettingsMockData.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { EmailAddressRow, SubscriberRow } from "knex/types/tables";
+
+const subscriberId = 7;
+
+export const mockedVerifiedEmailSecond: EmailAddressRow = {
+  id: 2,
+  email: "email2@example.com",
+  sha1: "arbitrary string",
+  subscriber_id: subscriberId,
+  verified: true,
+  created_at: new Date("1337-04-02T04:02:42.000Z"),
+  updated_at: new Date("1337-04-02T04:02:42.000Z"),
+  verification_token: "arbitrary_token",
+};
+
+export const mockedVerifiedEmailThird: EmailAddressRow = {
+  id: 3,
+  email: "email3@example.com",
+  sha1: "arbitrary string",
+  subscriber_id: subscriberId,
+  verified: true,
+  created_at: new Date("1337-04-02T04:02:42.000Z"),
+  updated_at: new Date("1337-04-02T04:02:42.000Z"),
+  verification_token: "arbitrary_token",
+};
+
+export const mockedVerifiedEmailFourth: EmailAddressRow = {
+  id: 4,
+  email: "email4@example.com",
+  sha1: "arbitrary string",
+  subscriber_id: subscriberId,
+  verified: false,
+  created_at: new Date("1337-04-02T04:02:42.000Z"),
+  updated_at: new Date("1337-04-02T04:02:42.000Z"),
+  verification_token: "arbitrary_token",
+};
+
+export const mockedVerifiedEmailFifth: EmailAddressRow = {
+  id: 5,
+  email: "email5@example.com",
+  sha1: "arbitrary string",
+  subscriber_id: subscriberId,
+  verified: false,
+  created_at: new Date("1337-04-02T04:02:42.000Z"),
+  updated_at: new Date("1337-04-02T04:02:42.000Z"),
+  verification_token: "arbitrary_token",
+};
+
+export const mockedSubscriber: SubscriberRow = {
+  updated_at: new Date(),
+  fx_newsletter: true,
+  all_emails_to_primary: true,
+  waitlists_joined: true,
+  email_addresses: [],
+  id: subscriberId,
+  created_at: new Date("2022-06-07 14:29:00.000-05"),
+  primary_sha1: "abcabc",
+  primary_email: "primary@email.com",
+  primary_verification_token: "c165711a-69d1-42f1-9850-ce74754f36de",
+  primary_verified: true,
+  fxa_access_token:
+    "5a4792b89434153f1a6262fbd6a4510c00834ff842585fc4f4d972da158f0fc0",
+  fxa_refresh_token:
+    "5a4792b89434153f1a6262fbd6a4510c00834ff842585fc4f4d972da158f0fc1",
+  fxa_session_expiry: new Date(0),
+  fxa_uid: "12346",
+  fxa_profile_json: {
+    uid: "123",
+    email: "test@test.com",
+    avatar: "https://profile.stage.mozaws.net/v1/avatar/abc",
+    locale: "en-US,en;q=0.5",
+    amrValues: ["pwd", "email"],
+    avatarDefault: false,
+    metricsEnabled: true,
+    twoFactorAuthentication: false,
+    subscriptions: ["monitor"],
+  },
+  breaches_last_shown: new Date("2022-07-08 14:19:00.000-05"),
+  breaches_resolved: null,
+  breach_stats: null,
+  breach_resolution: null,
+  monthly_email_at: "2022-08-07 14:22:00.000-05",
+  monthly_email_optout: false,
+  signup_language: "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7,*;q=0.5",
+  onerep_profile_id: null,
+  monthly_monitor_report_at: null,
+  monthly_monitor_report: false,
+  sign_in_count: null,
+  first_broker_removal_email_sent: false,
+  churn_prevention_email_sent_at: null,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,6 @@
     ],
     "paths": {
       "#settings/*": [
-        "./src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/*.mock.ts",
         "./src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/*.ts",
       ],
     },                                                   /* Specify a set of entries that re-map imports to additional lookup locations. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,7 @@
     "module": "ESNext"                                   /* Specify what module code is generated. */,
     "moduleResolution": "node"                           /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "rootDir": "./src/"                               /* Specify the root folder within your source files. */,
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    "baseUrl": "./",                                     /* Specify the base directory to resolve non-relative module names. */
     "plugins": [
       {
         "name": "next"
@@ -41,7 +41,7 @@
     ],
     "paths": {
       "#settings/*": [
-        "./src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/*.ts",
+        "./src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/*",
       ],
     },                                                   /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
+    ".storybook/*.ts",
+    ".storybook/*.tsx",
     // JS files that are not yet migrated to TS.
     "src/app/global-error.js",
     "src/db/migrations/*.js",
@@ -27,16 +29,22 @@
     // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    "moduleDetection": "force" /* Control what method is used to detect module-format JS files. */ /* Modules */,
-    "module": "esnext" /* Specify what module code is generated. */,
-    // "rootDir": "./src/" /* Specify the root folder within your source files. */,
-    "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */, // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    "moduleDetection": "force"                           /* Control what method is used to detect module-format JS files. */ /* Modules */,
+    "module": "ESNext"                                   /* Specify what module code is generated. */,
+    "moduleResolution": "node"                           /* Specify how TypeScript looks up a file from a given module specifier. */,
+    // "rootDir": "./src/"                               /* Specify the root folder within your source files. */,
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     "plugins": [
       {
         "name": "next"
       }
     ],
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    "paths": {
+      "#settings/*": [
+        "./src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/*.mock.ts",
+        "./src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/*.ts",
+      ],
+    },                                                   /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */


### PR DESCRIPTION
<!-- When adding a new feature: -->

# Description

For the [settings redesign](https://www.figma.com/design/2iCgADpFXKOFZTEgCPkQsR/Settings?node-id=597-10052&t=c2UkGyKPdbvneuz5-4), we are about to introduce more permutations that would be useful for reviewing and testing in Storybook. This PR is only adding the default views to focus on resolving an issue with adding components and views that rely on Server Actions:

With the Server Actions we use for the setting views, Storybook currently breaks when importing Actions that have node dependencies, and we need a way to mock those. To mock modules [Storybook suggests](https://storybook.js.org/docs/writing-stories/mocking-data-and-modules/mocking-modules) to use Node.js native [subpath imports](https://nodejs.org/api/packages.html#subpath-imports).