### PR TITLE
Fix sidebar notifications link

### DIFF
--- a/src/app/(proper_react)/(redesign)/Shell/ShellRedesign.tsx
+++ b/src/app/(proper_react)/(redesign)/Shell/ShellRedesign.tsx
@@ -88,7 +88,7 @@ export const NavbarList = (props: {
       )}
       <li key="settings-notifications">
         <PageLink
-          href="/user/settings/announcements"
+          href="/user/settings/notifications"
           activeClassName={styles.isActive}
           hasTelemetry={{
             link_id: "navigation_settings_notifications",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

PR #5701

<!-- When adding a new feature: -->

# Description

In PR #5701, the “Set notifications” sidebar link was mistakenly updated.