### PR TITLE
Add a profile scans section to /admin/dev

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/actions.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/actions.tsx
@@ -15,6 +15,8 @@ import {
   UpdateableProfileDetails,
 } from "../../../../../functions/server/onerep";
 import updateDataBrokerScanProfile from "../../../../../functions/server/updateDataBrokerScanProfile";
+import { getAllScansForProfile } from "../../../../../../db/tables/onerep_scans";
+import { refreshStoredScanResults } from "../../../../../functions/server/refreshStoredScanResults";
 
 export async function lookupFxaUid(emailHash: string) {
   const session = await getServerSession();
@@ -72,9 +74,28 @@ export async function updateOnerepProfile(
   }
 }
 
+export async function getAllProfileScans(onerepProfileId: number) {
+  const session = await getServerSession();
+  if (
+    !session?.user?.email ||
+    !isAdmin(session.user.email) ||
+    // only allow admins to trigger a scan for their own profile in production
+    (process.env.APP_ENV === "production" &&
+      session.user.subscriber?.onerep_profile_id !== onerepProfileId)
+  ) {
+    return notFound();
+  }
+
+  try {
+    return await getAllScansForProfile(onerepProfileId);
+  } catch (error) {
+    console.error("Getting all profile scans failed:", error);
+  }
+}
+
 // This function is only meant for testing purposes if we need to run a scan
 // before the next montly scan.
-export async function triggerManualPaidScanForTestingPurposes(
+export async function triggerManualPaidProfileScanForTestingPurposes(
   onerepProfileId: number,
 ) {
   const session = await getServerSession();
@@ -90,7 +111,9 @@ export async function triggerManualPaidScanForTestingPurposes(
   console.info("Manual scan initiated by admin for:", onerepProfileId);
 
   try {
-    return await createScan(onerepProfileId);
+    const scanResult = await createScan(onerepProfileId);
+    await refreshStoredScanResults(onerepProfileId);
+    return scanResult;
   } catch (error) {
     console.error("Manual scan triggered by admin failed:", error);
   }

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/actions.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/actions.tsx
@@ -93,11 +93,7 @@ export async function getAllProfileScans(onerepProfileId: number) {
   }
 }
 
-// This function is only meant for testing purposes if we need to run a scan
-// before the next montly scan.
-export async function triggerManualPaidProfileScanForTestingPurposes(
-  onerepProfileId: number,
-) {
+export async function triggerManualProfileScan(onerepProfileId: number) {
   const session = await getServerSession();
   if (
     !session?.user?.email ||

--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/page.tsx
@@ -5,16 +5,15 @@
 import { getServerSession } from "../../../../../functions/server/getServerSession";
 import { notFound } from "next/navigation";
 import { isAdmin } from "../../../../../api/utils/auth";
-import { UserAdmin } from "./UserAdmin";
 import { getEnabledFeatureFlags } from "../../../../../../db/tables/featureFlags";
+import { UserAdmin } from "./UserAdmin";
 
 export default async function DevPage() {
   const session = await getServerSession();
-
   if (
     !session?.user?.email ||
     !isAdmin(session.user.email) ||
-    process.env.APP_ENV !== "local"
+    process.env.APP_ENV === "production"
   ) {
     return notFound();
   }
@@ -22,6 +21,10 @@ export default async function DevPage() {
   const enabledFeatureFlags = await getEnabledFeatureFlags({
     email: session.user.email,
   });
-
-  return <UserAdmin enabledFeatureFlags={enabledFeatureFlags} />;
+  return (
+    <UserAdmin
+      isLocal={process.env.APP_ENV === "local"}
+      enabledFeatureFlags={enabledFeatureFlags}
+    />
+  );
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-4297](https://mozilla-hub.atlassian.net/browse/MNTOR-4297)

<!-- When adding a new feature: -->

# Description

This PR adds a section to the admin panel that lists existing profile scans for a subscriber as well as the ability to trigger a manual scan on demand. We need this in place for QA to confirm that https://github.com/mozilla/blurts-server/pull/5793 is working as expected without having to wait for a monthly scan to be run so some functionality on `/admin/dev` will be available on `stage` as well.

# How to test

1. Enable the feature flag `EditScanProfileDetails`
2. Visit `/admin/dev` with an authenticated admin user
3. Make profile info updates to a subscriber that has a OneRep scan profile
4. Trigger a manual scan

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.


[MNTOR-4297]: https://mozilla-hub.atlassian.net/browse/MNTOR-4297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ