### PR TITLE
MNTOR-3989: fix version endpoint

### DIFF
--- a/.github/workflows/docker_build_deploy.yml
+++ b/.github/workflows/docker_build_deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create version.json
         run: |
-          echo "{\"commit\":\"$GITHUB_SHA\",\"version\":\"$GITHUB_REF\",\"source\":\"https://github.com/$GITHUB_REPOSITORY\",\"build\":\"$GITHUB_RUN_ID\"}" > version.json
+          echo "{\"commit\":\"$GITHUB_SHA\",\"version\":\"$GITHUB_REF_NAME\",\"source\":\"https://github.com/$GITHUB_REPOSITORY\",\"build\":\"$GITHUB_RUN_ID\"}" > version.json
 
       - name: Check Docker Version
         run: docker --version


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-3989

<!-- When adding a new feature: -->

# Description
We should be able to pick up the version.json created by docker build and use that as a part of the version endpoint

# How to test
* Create a docker image
* Run the docker image
* Go to the version endpoint
* Or wait till stage deploy and check there

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
