### PR TITLE
Add a primary key on feature_flag_events

### DIFF
--- a/src/db/migrations/20250430104448_add_feature_flag_events_primary_key.js
+++ b/src/db/migrations/20250430104448_add_feature_flag_events_primary_key.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable("feature_flag_events", (table) => {
+    table.primary(["name", "created_at"], {
+      constraintName: "feature_flag_events_pkey",
+    });
+  });
+}
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable("feature_flag_events", (table) => {
+    table.dropPrimary("feature_flag_events_pkey");
+  });
+}


### PR DESCRIPTION
This is supposedly necessary to have its data carry over in a backup-restore procedure.