### PR TITLE
Fix profile location preview

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelEditInfoRedesign.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelEditInfoRedesign.tsx
@@ -135,8 +135,6 @@ function ProfileInfoSection({
     date_of_birth,
     phone_numbers,
     addresses,
-    city_name,
-    state_code,
   } = profileData;
   const dateOfBirthString = new Date(date_of_birth).toLocaleDateString(
     getLocale(l10n),
@@ -144,6 +142,7 @@ function ProfileInfoSection({
   );
   const additionalNamesCount =
     first_names.length + middle_names.length + last_names.length;
+  const { city, state } = addresses[0];
   return (
     <section className={styles.section}>
       <div>
@@ -194,7 +193,7 @@ function ProfileInfoSection({
             {l10n.getString("settings-details-about-you-location-label")}
           </div>
           <div className={styles.detailContent}>
-            {`${city_name}, ${state_code}`}
+            {`${city}, ${state}`}
             {addresses.length > 1 && (
               <span className={styles.detailMore}>
                 {l10n.getString("settings-details-about-you-more-indicator", {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira:
- [MNTOR-4411](https://mozilla-hub.atlassian.net/browse/MNTOR-4411)

<!-- When adding a new feature: -->

# Description

Use the `addresses` array instead of the deprecated `city_name` and `state_code` for the profile location preview.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

[MNTOR-1806]: https://mozilla-hub.atlassian.net/browse/MNTOR-1806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MNTOR-4411]: https://mozilla-hub.atlassian.net/browse/MNTOR-4411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ