### PR TITLE
fix: Force UTC timezone for DOB on /user/settings/edit-profile screen

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelEditProfile/EditProfileFormInputs.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelEditProfile/EditProfileFormInputs.tsx
@@ -211,6 +211,7 @@ function EditProfileFormInputs(props: {
         dobData.value &&
         new Date(dobData.value).toLocaleDateString(getLocale(l10n), {
           dateStyle: "short",
+          timeZone: "UTC",
         });
       return (
         <div className={styles.itemDob}>


### PR DESCRIPTION
# Description

Small followup for https://github.com/mozilla/blurts-server/pull/5859 — the date of birth is stored as UTC but it's displayed on the `edit-profile` screen in the local timezone, which can cause it to look off by one day.

The previous PR fixed this for the `edit-info` but not the `edit-profile` screen. It's the same one-line fix to the client JS otherwise.

# How to test

Navigate to "Update scan info" on sidebar, check DoB, then press "Add details" button and check DoB. I'm seeing different values when my system is in PST.

Changing system to UTC and reloading the page causes the problem to go away.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
