### PR TITLE
MNTOR-4267: Remove trailing slash from expected SubPlat URL

### DIFF
--- a/src/e2e/pages/landingPage.ts
+++ b/src/e2e/pages/landingPage.ts
@@ -267,7 +267,7 @@ export class LandingPage {
     await this.page.waitForTimeout(500); // sign in button may not be loaded at this point.
     await this.signInButton.click({ force: true });
     // FxA can take a while to load on stage:
-    await this.page.waitForURL("**/oauth/**", { timeout: 60_000 });
+    await this.page.waitForURL("**/oauth**", { timeout: 60_000 });
   }
 
   async enterFreeScanEmail(email: string) {

--- a/src/e2e/specs/landing/landing-content.spec.ts
+++ b/src/e2e/specs/landing/landing-content.spec.ts
@@ -23,7 +23,7 @@ test.describe(`${process.env.E2E_TEST_ENV} - Verify the Landing Page content`, (
 
     await expect(landingPage.monitorLandingHeader).toBeVisible();
     await landingPage.signInButton.click();
-    await page.waitForURL("**/oauth/**");
+    await page.waitForURL("**/oauth**");
     expect(page.url()).toContain("oauth");
   });
 


### PR DESCRIPTION
Apparently it no longer automatically redirects to the trailing- slash version.