### PR TITLE
Make explicit that this isn't a package to install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
-  "name": "monitor",
+  "name": "@mozilla/monitor",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "monitor",
-      "version": "1.0.0",
+      "name": "@mozilla/monitor",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "monitor",
-  "version": "1.0.0",
+  "name": "@mozilla/monitor",
+  "private": true,
   "description": "Firefox Monitor",
   "engines": {
     "node": "20.19.x",

--- a/src/utils/dockerflow.ts
+++ b/src/utils/dockerflow.ts
@@ -45,7 +45,7 @@ if (!versionData) {
   console.warn("Falling back to version data derived from package.json");
   versionData = {
     source: packageJson.homepage,
-    version: packageJson.version, // Use version from package.json as fallback
+    version: "unknown",
     commit: "unknown",
     build: "unknown",
   };


### PR DESCRIPTION
Recreated from https://github.com/mozilla/blurts-server/pull/5882 because the preview deploy was failed and couldn't be recreated.