### PR TITLE
MNTOR-4499: drop fk for feature flag events table (option 2)

### DIFF
--- a/src/db/migrations/20250516164728_drop_feature_flag_events_subscriber_id_fk.js
+++ b/src/db/migrations/20250516164728_drop_feature_flag_events_subscriber_id_fk.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex) {
+  await knex.schema.alterTable("feature_flag_events", (table) => {
+    table.dropForeign(
+      ["created_by_subscriber_id"],
+      "feature_flag_events_created_by_subscriber_id_foreign",
+    );
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex) {
+  await knex.schema.alterTable("feature_flag_events", (table) => {
+    table
+      .foreign(
+        "created_by_subscriber_id",
+        "feature_flag_events_created_by_subscriber_id_foreign",
+      )
+      .references("id")
+      .inTable("subscribers");
+  });
+}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-4499

<!-- When adding a new feature: -->

# Description
Option B: if we want to completely abolish the foreign key in `feature flag events` table. See slack thread for clarification

# Screenshot (if applicable)

Not applicable.

# How to test

# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
