### PR TITLE
Update silent auth flow

### DIFF
--- a/src/app/components/client/PromptNoneAuth.tsx
+++ b/src/app/components/client/PromptNoneAuth.tsx
@@ -8,21 +8,21 @@ import { ReactNode, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { containsExpectedSearchParams } from "../../functions/universal/attributions";
-import { CONST_MOZILLA_ACCOUNTS_SETTINGS_PROMO_SEARCH_PARAMS } from "../../../constants";
 
 export const PromptNoneAuth = (): ReactNode => {
   const searchParams = useSearchParams();
 
   useEffect(() => {
+    const authParams = { prompt: "none" };
     const isPromptNoneAuthAttempt = containsExpectedSearchParams(
-      CONST_MOZILLA_ACCOUNTS_SETTINGS_PROMO_SEARCH_PARAMS,
+      authParams,
       searchParams,
     );
     if (isPromptNoneAuthAttempt) {
       void signIn(
         "fxa",
         { callbackUrl: "/user/dashboard/action-needed?dialog=subscriptions" },
-        { prompt: "none" },
+        authParams,
       );
     }
     // This effect should only run once

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,11 +42,6 @@ export const CONST_URL_MONITOR_GITHUB =
 export const CONST_DAY_MILLISECONDS = 24 * 60 * 60 * 1000;
 export const CONST_URL_MONITOR_LANDING_PAGE_ID =
   "monitor.mozilla.org-monitor-product-page";
-export const CONST_MOZILLA_ACCOUNTS_SETTINGS_PROMO_SEARCH_PARAMS = {
-  utm_source: "moz-account",
-  utm_campaign: "settings-promo",
-  utm_content: "monitor-free",
-} as const;
 export const CONST_SETTINGS_TAB_SLUGS = [
   "edit-info",
   "notifications",


### PR DESCRIPTION
Initiate the silent authentication flow with the UTM parameter `prompt=none`.

# How to test

- Enable the feature flag `PromptNoneAuthFlow`
- `http://localhost:6060/?prompt=none` with and without the user authenticated with FxA