### PR TITLE
Fix landing page sections layout and update string

### DIFF
--- a/locales-pending/landing-redesign-experiment.ftl
+++ b/locales-pending/landing-redesign-experiment.ftl
@@ -63,7 +63,7 @@ landing-redesign-bundle-banner-button-label = Get year-round protection
 # Variables:
 #   $yearlyPrice (string) - annual plan's price in total, including currency, e.g. "$13.37"
 landing-redesign-bundle-banner-pricing-plan-billing-info = { $yearlyPrice }/year, billed annually.
-landing-redesign-bundle-banner-pricing-plan-billing-terms = 30-day, money-back guarantee.
+landing-redesign-bundle-banner-pricing-plan-billing-terms = 30-day money-back guarantee.
 
 # Pricing plans
 

--- a/src/app/(proper_react)/(redesign)/(public)/LandingViewRedesign/index.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingViewRedesign/index.tsx
@@ -43,7 +43,7 @@ export const View = (props: LandingPageProps) => {
         <section className={styles.section}>
           <CtaBanner {...props} />
         </section>
-        <section className={styles.hasBackground}>
+        <section className={`${styles.section} ${styles.hasBackground}`}>
           <InfoBlock {...props} />
         </section>
         {props.enabledFeatureFlags.includes("PrivacyProductsBundle") && (
@@ -62,7 +62,7 @@ export const View = (props: LandingPageProps) => {
             <PricingPlans {...props} />
           )}
         </section>
-        <section className={styles.hasBackground}>
+        <section className={`${styles.section} ${styles.hasBackground}`}>
           <LogoBlock l10n={props.l10n} />
         </section>
         <section className={styles.section}>


### PR DESCRIPTION
# Description

Fixes the layout for the landing page sections and updates a bundle banner string as per [this comment](https://www.figma.com/design/KytF3NIQfR8OoWu0osldg7?node-id=10141-33178&m=dev#1264076686).