### PR TITLE
Increase timeout for running axe

### DIFF
--- a/src/app/(bundle)/bundle/onboarding/BundleOnboardingView.test.tsx
+++ b/src/app/(bundle)/bundle/onboarding/BundleOnboardingView.test.tsx
@@ -22,7 +22,7 @@ it("passes the axe accessibility test suite", async () => {
   const ComposedBundlePage = composeStory(BundleOnboarding, Meta);
   const { container } = render(<ComposedBundlePage />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("tracks the click on the ctas", async () => {
   const mockedRecord = useTelemetry();

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
@@ -94,7 +94,7 @@ it("passes the axe accessibility test suite", async () => {
   );
   const { container } = render(<ComposedDashboard />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("shows the 'Start a free scan' CTA to free US-based users who haven't performed a scan yet", () => {
   const ComposedDashboard = composeStory(

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/automatic-remove/AutomaticRemove.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/automatic-remove/AutomaticRemove.test.tsx
@@ -17,7 +17,7 @@ it("passes the axe accessibility test suite", async () => {
   const AutomaticRemoveView = composeStory(AutomaticRemoveViewStory, Meta);
   const { container } = render(<AutomaticRemoveView />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("toggles between the monthly and yearly plan view", async () => {
   const user = userEvent.setup();

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/manual-remove/ManualRemove.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/manual-remove/ManualRemove.test.tsx
@@ -40,7 +40,7 @@ it("passes the axe accessibility test suite", async () => {
   const ComposedManualRemoveView = composeStory(ManualRemoveViewStory, Meta);
   const { container } = render(<ComposedManualRemoveView />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("removes the manual resolution button once a profile has been resolved", async () => {
   const user = userEvent.setup();

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/removal-under-maintenance/RemovalUnderMaintenanceView.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/removal-under-maintenance/RemovalUnderMaintenanceView.test.tsx
@@ -37,7 +37,7 @@ describe("Removal under  maintenance", () => {
     );
     const { container } = render(<RemovalUnderMaintenanceView />);
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 10_000);
 
   it("shows removal instructions", async () => {
     const user = userEvent.setup();

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/WelcomeToPlus.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/welcome-to-plus/WelcomeToPlus.test.tsx
@@ -21,7 +21,7 @@ it("passes the axe accessibility test suite", async () => {
   );
   const { container } = render(<ComposedWelcomeToPlusView />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("shows the progress indicator on the “Welcome to Plus” view", () => {
   const ComposedWelcomeToPlusView = composeStory(

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/[type]/HighRiskBreachLayout.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/high-risk-data-breaches/[type]/HighRiskBreachLayout.test.tsx
@@ -32,31 +32,31 @@ it("passes the axe accessibility test suite for credit card breaches", async () 
   const ComposedComponent = composeStory(CreditCardStory, Meta);
   const { container } = render(<ComposedComponent />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("passes the axe accessibility test suite for bank account breaches", async () => {
   const ComposedComponent = composeStory(BankAccountStory, Meta);
   const { container } = render(<ComposedComponent />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("passes the axe accessibility test suite for SSN breaches", async () => {
   const ComposedComponent = composeStory(SsnStory, Meta);
   const { container } = render(<ComposedComponent />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("passes the axe accessibility test suite for PIN breaches", async () => {
   const ComposedComponent = composeStory(PinStory, Meta);
   const { container } = render(<ComposedComponent />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("passes the axe accessibility test suite for the high-risk celebration view", async () => {
   const ComposedComponent = composeStory(HighRiskBreachDoneStory, Meta);
   const { container } = render(<ComposedComponent />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("marks the Broker step as complete if a scan has been done without results", () => {
   const ComposedComponent = composeStory(CreditCardStory, Meta);

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/[type]/LeakedPasswordsLayout.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/leaked-passwords/[type]/LeakedPasswordsLayout.test.tsx
@@ -31,19 +31,19 @@ it("leaked passwords component passes the axe accessibility test suite", async (
   const ComposedComponent = composeStory(PasswordsStory, Meta);
   const { container } = render(<ComposedComponent />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("security questions component passes the axe accessibility test suite", async () => {
   const ComposedComponent = composeStory(SecurityQuestionsStory, Meta);
   const { container } = render(<ComposedComponent />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("passes the axe accessibility test suite for the leaked passwords celebration view", async () => {
   const ComposedComponent = composeStory(LeakedPasswordsDoneStory, Meta);
   const { container } = render(<ComposedComponent />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("shows the leaked passwords celebration view, next step is security questions", () => {
   const ComposedComponent = composeStory(LeakedPasswordsDoneStory, Meta);

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/[type]/SecurityRecommendations.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/security-recommendations/[type]/SecurityRecommendations.test.tsx
@@ -30,25 +30,25 @@ it("passes the axe accessibility test suite for phone security recommendations",
   const ComposedComponent = composeStory(PhoneStory, Meta);
   const { container } = render(<ComposedComponent />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("passes the axe accessibility test suite for email security recommendations", async () => {
   const ComposedComponent = composeStory(EmailStory, Meta);
   const { container } = render(<ComposedComponent />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("passes the axe accessibility test suite for IP security recommendations", async () => {
   const ComposedComponent = composeStory(IpStory, Meta);
   const { container } = render(<ComposedComponent />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("passes the axe accessibility test suite for the security recommendations celebration view", async () => {
   const ComposedComponent = composeStory(DoneStory, Meta);
   const { container } = render(<ComposedComponent />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("marks the security recommendations step as the current one", () => {
   const ComposedComponent = composeStory(PhoneStory, Meta);

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPage.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPage.test.tsx
@@ -388,7 +388,7 @@ describe("Settings page", () => {
         </SettingsWrapper>,
       );
       expect(await axe(container)).toHaveNoViolations();
-    });
+    }, 10_000);
 
     it("changes the active tab", async () => {
       const user = userEvent.setup();

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPageRedesign.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/SettingsPageRedesign.test.tsx
@@ -57,7 +57,7 @@ describe("Settings page redesign", () => {
       );
       const { container } = render(<ComposedStory />);
       expect(await axe(container)).toHaveNoViolations();
-    });
+    }, 10_000);
 
     it("shows the max number of emails that can be added to the list of addresses to monitor for breaches", () => {
       const ComposedStory = composeStory(
@@ -254,7 +254,7 @@ describe("Settings page redesign", () => {
       );
       const { container } = render(<ComposedDashboard />);
       expect(await axe(container)).toHaveNoViolations();
-    });
+    }, 10_000);
 
     it("shows the max number of emails that can be added to the list of addresses to monitor for breaches for subscribers without Plus", () => {
       const ComposedStory = composeStory(
@@ -470,7 +470,7 @@ describe("Settings page redesign", () => {
       );
       const { container } = render(<ComposedStory />);
       expect(await axe(container)).toHaveNoViolations();
-    });
+    }, 10_000);
 
     it("does not show for users without Plus subscription", async () => {
       const ComposedStory = composeStory(
@@ -1062,7 +1062,7 @@ describe("Settings page redesign", () => {
       );
       const { container } = render(<ComposedStory />);
       expect(await axe(container)).toHaveNoViolations();
-    });
+    }, 10_000);
   });
 
   describe("Set notifications", () => {
@@ -1073,6 +1073,6 @@ describe("Settings page redesign", () => {
       );
       const { container } = render(<ComposedStory />);
       expect(await axe(container)).toHaveNoViolations();
-    });
+    }, 10_000);
   });
 });

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/plus-expiration/PlusExpiration.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/plus-expiration/PlusExpiration.test.tsx
@@ -18,7 +18,7 @@ it("passes the axe accessibility test suite", async () => {
   const PlusExpirationView = composeStory(HappyPath, Meta);
   const { container } = render(<PlusExpirationView />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("includes a link to the terms on the renewal page", () => {
   const PlusExpirationView = composeStory(HappyPath, Meta);

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/Onboarding.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/welcome/Onboarding.test.tsx
@@ -28,7 +28,7 @@ it("passes the axe accessibility test suite on step 1", async () => {
   const ComposedOnboarding = composeStory(Onboarding, Meta);
   const { container } = render(<ComposedOnboarding />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("shows the explainer dialog on step 1", async () => {
   const user = userEvent.setup();
@@ -51,7 +51,7 @@ it("passes the axe accessibility test suite on step 2", async () => {
   });
   expect(proceedButton).toBeInTheDocument();
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("can open the explainer dialog shows on step 1", async () => {
   const user = userEvent.setup();
@@ -327,7 +327,7 @@ it("passes the axe accessibility test suite on step 3", async () => {
   const ComposedOnboarding = composeStory(Onboarding, Meta);
   const { container } = render(<ComposedOnboarding stepId="findExposures" />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("shows a condensed version of the onboarding skipping step “Get started”", () => {
   const ComposedOnboarding = composeStory(Onboarding, Meta);

--- a/src/app/(proper_react)/(redesign)/(public)/LandingView.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingView.test.tsx
@@ -64,7 +64,7 @@ describe("When Premium is not available", () => {
     const ComposedDashboard = composeStory(LandingNonUs, Meta);
     const { container } = render(<ComposedDashboard />);
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 10_000);
 
   it("passes the user's email address to the identity provider", async () => {
     const user = userEvent.setup();
@@ -215,7 +215,7 @@ describe("When Premium is available", () => {
     const ComposedDashboard = composeStory(LandingUs, Meta);
     const { container } = render(<ComposedDashboard />);
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 10_000);
 
   it("can open and close the tooltip with the keyboard", async () => {
     const user = userEvent.setup();

--- a/src/app/(proper_react)/(redesign)/(public)/LandingViewRedesign/LandingViewRedesign.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/LandingViewRedesign/LandingViewRedesign.test.tsx
@@ -62,7 +62,7 @@ describe("Navigation and authentication", () => {
     const ComposedLanding = composeStory(LandingRedesignUs, Meta);
     const { container } = render(<ComposedLanding />);
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 10_000);
 
   it("does not show a 'Sign In' button in the header if the user is signed in", () => {
     const mockedUseSession = useSession as jest.Mock<
@@ -789,7 +789,7 @@ describe("Pricing plan with bundle", () => {
     );
     const { container } = render(<ComposedLanding />);
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 10_000);
 
   it("can switch from the yearly to the monthly plan with the keyboard", async () => {
     const user = userEvent.setup();
@@ -1366,7 +1366,7 @@ describe("Scan limit reached", () => {
     const ComposedLanding = composeStory(LandingRedesignUsScanLimit, Meta);
     const { container } = render(<ComposedLanding />);
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 10_000);
 
   it("shows the scan limit and waitlist cta when it hits the threshold", () => {
     const ComposedDashboard = composeStory(LandingRedesignUsScanLimit, Meta);

--- a/src/app/(proper_react)/(redesign)/(public)/how-it-works/HowItWorksView.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/how-it-works/HowItWorksView.test.tsx
@@ -40,7 +40,7 @@ describe("How it works page", () => {
     const ComposedPage = composeStory(HowItWorks, Meta);
     const { container } = render(<ComposedPage />);
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 10_000);
 
   it("Data Removal buttons enter user into premium subscription flow", () => {
     const yearlySubscriptionUrl = getPremiumSubscriptionUrl({

--- a/src/app/(proper_react)/(redesign)/MobileShell.test.tsx
+++ b/src/app/(proper_react)/(redesign)/MobileShell.test.tsx
@@ -17,7 +17,7 @@ describe("MobileShell public", () => {
     const ComposedMobileShell = composeStory(MobileShellPublic, Meta);
     const { container } = render(<ComposedMobileShell />);
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 10_000);
 
   it("shows the sign-in buttons", () => {
     const ComposedMobileShell = composeStory(MobileShellPublic, Meta);
@@ -58,7 +58,7 @@ describe("MobileShell authenticated", () => {
     const ComposedMobileShell = composeStory(MobileShellAuthenticated, Meta);
     const { container } = render(<ComposedMobileShell />);
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 10_000);
 
   it("does not show the sign-in button", () => {
     const ComposedMobileShell = composeStory(MobileShellAuthenticated, Meta);

--- a/src/app/(proper_react)/(redesign)/Shell/Shell.test.tsx
+++ b/src/app/(proper_react)/(redesign)/Shell/Shell.test.tsx
@@ -16,7 +16,7 @@ describe("ShellAuthenticated", () => {
     const ShellComponent = composeStory(ShellAuthenticated, Meta);
     const { container } = render(<ShellComponent />);
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 10_000);
 });
 
 describe("ShellAuthenticatedRedesign", () => {
@@ -24,7 +24,7 @@ describe("ShellAuthenticatedRedesign", () => {
     const ShellComponent = composeStory(ShellAuthenticatedRedesign, Meta);
     const { container } = render(<ShellComponent />);
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 10_000);
 
   it("shows the “Update scan info” navbar item when the flag `EditScanProfileDetails` is enabled", async () => {
     const ShellComponent = composeStory(ShellAuthenticatedRedesign, Meta);

--- a/src/app/components/client/ComboBox.test.tsx
+++ b/src/app/components/client/ComboBox.test.tsx
@@ -16,13 +16,13 @@ it("passes the axe accessibility test suite if empty", async () => {
   const ComposedTextComboBox = composeStory(TextComboBoxEmpty, Meta);
   const { container } = render(<ComposedTextComboBox />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("passes the axe accessibility test suite if required", async () => {
   const ComposedTextComboBox = composeStory(TextComboBoxRequired, Meta);
   const { container } = render(<ComposedTextComboBox />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("shows suggestions when typing", async () => {
   const user = userEvent.setup();

--- a/src/app/components/client/ExposuresFilter.test.tsx
+++ b/src/app/components/client/ExposuresFilter.test.tsx
@@ -23,7 +23,7 @@ it("passes the axe accessibility test suite", async () => {
   const ExposuresFilter = composeStory(ExposuresFilterDefault, Meta);
   const { container } = render(<ExposuresFilter enabledFeatureFlags={[]} />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("shows and hides the exposure type explainer", async () => {
   const user = userEvent.setup();

--- a/src/app/components/client/InputField.test.tsx
+++ b/src/app/components/client/InputField.test.tsx
@@ -19,9 +19,13 @@ describe("InputField", () => {
     TextInputFieldFilled,
     TextInputFieldEmptyFloatingLabel,
     TextInputFieldFilledFloatingLabel,
-  ])("passes the axe accessibility test suite for %s", async (component) => {
-    const ComposedInput = composeStory(component, Meta);
-    const { container } = render(<ComposedInput hasFloatingLabel />);
-    expect(await axe(container)).toHaveNoViolations();
-  });
+  ])(
+    "passes the axe accessibility test suite for %s",
+    async (component) => {
+      const ComposedInput = composeStory(component, Meta);
+      const { container } = render(<ComposedInput hasFloatingLabel />);
+      expect(await axe(container)).toHaveNoViolations();
+    },
+    10_000,
+  );
 });

--- a/src/app/components/client/ProgressCard.test.tsx
+++ b/src/app/components/client/ProgressCard.test.tsx
@@ -29,7 +29,7 @@ it("passes the axe accessibility test suite", async () => {
   const ComposedProgressCard = composeStory(ProgressCardItemUsPremium, Meta);
   const { container } = render(<ComposedProgressCard />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("shows and hides the explainer dialog", async () => {
   const user = userEvent.setup();

--- a/src/app/components/client/csat_survey/CsatSurvey.test.tsx
+++ b/src/app/components/client/csat_survey/CsatSurvey.test.tsx
@@ -27,7 +27,7 @@ describe("CSAT survey banner: Automatic Removal", () => {
     const ComposedCsatSurvey = composeStory(CsatSurveyAutomaticRemoval, Meta);
     const { container } = render(<ComposedCsatSurvey />);
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 10_000);
 
   it("displays the survey to users with automatic data removal enabled for less than 90 days", () => {
     const ComposedCsatSurvey = composeStory(CsatSurveyAutomaticRemoval, Meta);
@@ -217,7 +217,7 @@ describe("CSAT survey banner: Latest scan date", () => {
     const ComposedCsatSurvey = composeStory(CsatSurveyLatestScanDate, Meta);
     const { container } = render(<ComposedCsatSurvey />);
     expect(await axe(container)).toHaveNoViolations();
-  });
+  }, 10_000);
 
   it("displays the survey to free users on the “action needed” tab", () => {
     const ComposedCsatSurvey = composeStory(CsatSurveyLatestScanDate, Meta);

--- a/src/app/components/client/exposure_card/ExposureCard.test.tsx
+++ b/src/app/components/client/exposure_card/ExposureCard.test.tsx
@@ -39,7 +39,7 @@ it("passes the axe accessibility test suite", async () => {
   const ComposedProgressCard = composeStory(DataBrokerActionNeeded, Meta);
   const { container } = render(<ComposedProgressCard />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 describe("ScanResultCard", () => {
   // Data broker action needed

--- a/src/app/components/client/toolbar/AnnouncementDialog.test.tsx
+++ b/src/app/components/client/toolbar/AnnouncementDialog.test.tsx
@@ -22,7 +22,7 @@ it("passes the axe accessibility test suite", async () => {
   );
   const { container } = render(<ComposedAnnouncementDialog />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("closes and opens the announcement button", async () => {
   // jsdom will complain about not being able to find the right fluent-id which we can ignore

--- a/src/app/components/client/toolbar/AppPicker.test.tsx
+++ b/src/app/components/client/toolbar/AppPicker.test.tsx
@@ -14,7 +14,7 @@ it("passes the axe accessibility test suite", async () => {
   const ComposedAppPicker = composeStory(AppPickerDefault, Meta);
   const { container } = render(<ComposedAppPicker />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("opens and closes the app picker", async () => {
   const user = userEvent.setup();

--- a/src/app/components/client/toolbar/UserMenu.test.tsx
+++ b/src/app/components/client/toolbar/UserMenu.test.tsx
@@ -24,7 +24,7 @@ it("passes the axe accessibility test suite", async () => {
   const ComposedDashboard = composeStory(UserMenuDefault, Meta);
   const { container } = render(<ComposedDashboard />);
   expect(await axe(container)).toHaveNoViolations();
-});
+}, 10_000);
 
 it("opens and closes the user menu", async () => {
   const user = userEvent.setup();


### PR DESCRIPTION
The axe accessibility testing suite regularly times out in CI, making the results flaky. Since it's essentially running a whole bunch of tests, allowing it to run for a bit longer than usual is fine.
