### PR TITLE
Disable preview deployments

### DIFF
--- a/.github/workflows/preview_deploy_gcp.yml
+++ b/.github/workflows/preview_deploy_gcp.yml
@@ -2,8 +2,13 @@ name: Deploy Preview
 
 permissions: {}
 
-on:
-  pull_request:
+# Disabled since we can't log in to the preview sites yet,
+# so they're not very useful, but take a long time to deploy.
+# We can re-enable once we migrate to Auth.js, which supports
+# redirect proxies for this use case:
+# https://authjs.dev/getting-started/deployment#securing-a-preview-deployment
+# on:
+  # pull_request:
 
 env:
   PROJECT_ID: ${{ secrets.GCP_PROJECT }}

--- a/.github/workflows/preview_deploy_gcp_cleanup.yml
+++ b/.github/workflows/preview_deploy_gcp_cleanup.yml
@@ -2,10 +2,15 @@ name: Deploy Preview Cleanup
 
 permissions: {}
 
-on:
-  # when pull request is merged or closed
-  pull_request:
-    types: [closed]
+# Disabled since we can't log in to the preview sites yet,
+# so they're not very useful, but take a long time to deploy.
+# We can re-enable once we migrate to Auth.js, which supports
+# redirect proxies for this use case:
+# https://authjs.dev/getting-started/deployment#securing-a-preview-deployment
+# on:
+#   # when pull request is merged or closed
+#   pull_request:
+#     types: [closed]
 
 env:
   PROJECT_ID: ${{ secrets.GCP_PROJECT }}


### PR DESCRIPTION
Since we can't log in to the preview sites yet, they're not very useful, but take a long time to deploy. We can re-enable once we migrate to Auth.js