### PR TITLE
fix(cronjobs): Replace return with continue in for..of loop

### DIFF
--- a/src/scripts/cronjobs/syncBreaches.ts
+++ b/src/scripts/cronjobs/syncBreaches.ts
@@ -48,7 +48,7 @@ export async function getBreachIcons(breaches: HibpGetBreachesResponse) {
     if (!breachDomain || breachDomain.length === 0) {
       console.log("empty domain: ", breachName);
       await updateBreachFaviconUrl(breachName, null);
-      return;
+      continue;
     }
     const logoFilename = breachDomain.toLowerCase() + ".ico";
     if (existingLogos.includes(logoFilename)) {
@@ -57,7 +57,7 @@ export async function getBreachIcons(breaches: HibpGetBreachesResponse) {
         breachName,
         `https://s3.amazonaws.com/${process.env.S3_BUCKET}/${logoFilename}`,
       );
-      return;
+      continue;
     }
     console.log(`fetching: ${logoFilename}`);
     const res = await fetch(
@@ -67,7 +67,7 @@ export async function getBreachIcons(breaches: HibpGetBreachesResponse) {
       // update logo path with null
       console.log(`Logo does not exist for: ${breachName} ${breachDomain}`);
       await updateBreachFaviconUrl(breachName, null);
-      return;
+      continue;
     }
 
     try {
@@ -78,7 +78,7 @@ export async function getBreachIcons(breaches: HibpGetBreachesResponse) {
       );
     } catch (e) {
       console.error(e);
-      return;
+      continue;
     }
   }
 }


### PR DESCRIPTION
Follow-up from #5942 - I forgot to convert the return statements to continue statements, so the script is exiting early on every run when it hits `17app.co`

```
> cron:db-pull-breaches
> node dist/scripts/cronjobs/syncBreaches.js
Breaches found:  887
Unique breaches based on Name + BreachDate 887
upsertBreaches {
  Name: '000webhost',
  Title: '000webhost',
  Domain: '000webhost.com',
  BreachDate: '2015-03-01',
  AddedDate: '2015-10-26T23:35:45Z',
  ModifiedDate: '2017-12-10T21:44:27Z',
  PwnCount: 14936670,
  Description: 'In approximately March 2015, the free web hosting provider <a href="http://www.troyhunt.com/2015/10/breaches-traders-plain-text-passwords.html" target="_blank" rel="noopener">000webhost suffered a major data breach</a> that exposed almost 15 million customer records. The data was sold and traded before 000webhost was alerted in October. The breach included names, email addresses and plain text passwords.',
  LogoPath: 'https://haveibeenpwned.com/Content/Images/PwnedLogos/000webhost.png',
  DataClasses: [ 'Email addresses', 'IP addresses', 'Names', 'Passwords' ],
  IsVerified: true,
  IsFabricated: false,
  IsSensitive: false,
  IsRetired: false,
  IsSpamList: false,
  IsMalware: false,
  IsSubscriptionFree: false,
  IsStealerLog: false
}
Number of breaches in the database after upsert: 888
Logo folder: /tmp
fetching: 000webhost.com.ico
Attempt to upload to s3:  000webhost.com.ico
Successfully uploaded data to firefoxmonitor-stage-monitor-cdn-stage-static-website/000webhost.com.ico
fetching: 123rf.com.ico
Attempt to upload to s3:  123rf.com.ico
Successfully uploaded data to firefoxmonitor-stage-monitor-cdn-stage-static-website/123rf.com.ico
fetching: 126.com.ico
Attempt to upload to s3:  126.com.ico
Successfully uploaded data to firefoxmonitor-stage-monitor-cdn-stage-static-website/126.com.ico
fetching: 17app.co.ico
Logo does not exist for: 17Media 17app.co
```