### PR TITLE
Try to skip Node versions 24.x until 24.10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,4 +77,4 @@ updates:
         # to indicate any matching version until the next major one..
         # See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versions-ignore
         # and https://guides.rubygems.org/patterns/#pessimistic-version-constraint
-        versions: ["~> 23", "~> 25", "~> 27", "~> 29"]
+        versions: ["~> 23", "<= 24.10", "~> 25", "~> 27", "~> 29"]


### PR DESCRIPTION
It's not certain that 24.10 will be the first LTS release, but it probably won't be a non-LTS one anymore.