### PR TITLE
Replace static SubPlat links in emails

### DIFF
--- a/src/emails/templates/breachAlert/BreachAlertEmail.tsx
+++ b/src/emails/templates/breachAlert/BreachAlertEmail.tsx
@@ -11,7 +11,6 @@ import { getLocale } from "../../../app/functions/universal/getLocale";
 import { isEligibleForPremium } from "../../../app/functions/universal/premium";
 import { hasPremium } from "../../../app/functions/universal/user";
 import { getSignupLocaleCountry } from "../../functions/getSignupLocaleCountry";
-import { getPremiumSubscriptionUrl } from "../../../app/functions/server/getPremiumSubscriptionInfo";
 import { DashboardSummary } from "../../../app/functions/server/dashboard";
 import { ResolutionRelevantBreachDataTypes } from "../../../app/functions/universal/breach";
 import { EmailBanner } from "../../components/EmailBanner";
@@ -65,10 +64,7 @@ export const BreachAlertEmail = (props: BreachAlertEmailProps) => {
   }
 
   const premiumSubscriptionUrlObject = new URL(
-    getPremiumSubscriptionUrl({
-      type: "yearly",
-      enabledFeatureFlags: props.enabledFeatureFlags,
-    }),
+    `${process.env.SERVER_URL}/link/subscribe/yearly`,
   );
   premiumSubscriptionUrlObject.searchParams.set("utm_medium", "product-email");
   premiumSubscriptionUrlObject.searchParams.set(

--- a/src/emails/templates/monthlyActivityFree/MonthlyActivityFreeEmail.tsx
+++ b/src/emails/templates/monthlyActivityFree/MonthlyActivityFreeEmail.tsx
@@ -8,7 +8,6 @@ import { EmailHero } from "../../components/EmailHero";
 import { DataPointCount } from "../../components/EmailDataPointCount";
 import { DashboardSummary } from "../../../app/functions/server/dashboard";
 import { EmailBanner } from "../../components/EmailBanner";
-import { getPremiumSubscriptionUrl } from "../../../app/functions/server/getPremiumSubscriptionInfo";
 import { isEligibleForPremium } from "../../../app/functions/universal/premium";
 import { getSignupLocaleCountry } from "../../functions/getSignupLocaleCountry";
 import { HeaderStyles, MetaTags } from "../../components/HeaderStyles";
@@ -79,10 +78,7 @@ export const MonthlyActivityFreeEmail = (
   };
 
   const unlockWithMonitorPlusCta = modifyAttributionsForUrl(
-    getPremiumSubscriptionUrl({
-      type: "yearly",
-      enabledFeatureFlags: props.enabledFeatureFlags,
-    }),
+    `${process.env.SERVER_URL}/link/subscribe/yearly`,
     {
       ...replaceValues,
       utm_content: `unlock-with-monitor-plus${utmContentSuffix}`,

--- a/src/scripts/cronjobs/emailBreachAlerts.test.ts
+++ b/src/scripts/cronjobs/emailBreachAlerts.test.ts
@@ -372,9 +372,7 @@ test("that the rendered MJML-based template includes the correct subscription li
   expect(subClient.acknowledge).toHaveBeenCalledTimes(1);
   expect(sendEmail).toHaveBeenCalledTimes(1);
   const emailBody = sendEmail.mock.calls[0][2];
-  expect(emailBody).toMatch(
-    /\/subscriptions\/products\/prod_\w+\?plan=price_\w+/,
-  );
+  expect(emailBody).toMatch(/\/link\/subscribe\/yearly/);
   expect(consoleLog).toHaveBeenCalledWith(
     'Received message: {"breachName":"test1","hashPrefix":"test-prefix1","hashSuffixes":["test-suffix1"]}',
   );
@@ -425,7 +423,7 @@ test("that the rendered MJML-based template includes the correct subscription li
   expect(subClient.acknowledge).toHaveBeenCalledTimes(1);
   expect(sendEmail).toHaveBeenCalledTimes(1);
   const emailBody = sendEmail.mock.calls[0][2];
-  expect(emailBody).toMatch(/\/monitorplusstage\/yearly\/landing/);
+  expect(emailBody).toMatch(/\/link\/subscribe\/yearly/);
   expect(consoleLog).toHaveBeenCalledWith(
     'Received message: {"breachName":"test1","hashPrefix":"test-prefix1","hashSuffixes":["test-suffix1"]}',
   );
@@ -488,7 +486,7 @@ test("that the rendered MJML-based template includes the correct subscription li
   expect(subClient.acknowledge).toHaveBeenCalledTimes(1);
   expect(sendEmail).toHaveBeenCalledTimes(1);
   const emailBody = sendEmail.mock.calls[0][2];
-  expect(emailBody).toMatch(/\/monitorplusstage\/yearly\/landing/);
+  expect(emailBody).toMatch(/\/link\/subscribe\/yearly/);
   expect(consoleLog).toHaveBeenCalledWith(
     'Received message: {"breachName":"test1","hashPrefix":"test-prefix1","hashSuffixes":["test-suffix1"]}',
   );


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-4607](https://mozilla-hub.atlassian.net/browse/MNTOR-4607)
Figma:

<!-- When adding a new feature: -->

# Description

Replace static SubPlat links in emails with the new links introduced in [MNTOR-4263](https://mozilla-hub.atlassian.net/browse/MNTOR-4263). These first route to the Monitor web application and then redirect to the correct SubPlat subscription plan.

# How to test

Make sure that the `BreachAlertEmail` and `MonthlyActivitiyFreeEmail` include the updated subscription links `/link/subscribe/yearly` instead of the static links to SubPlat.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
