### PR TITLE
Use router.push() for redirecting to /subscription-plans

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
@@ -60,15 +60,17 @@ import {
   DashboardUsPremiumScanInProgressResolvedBreaches,
   DashboardUsPremiumScanInProgressUnresolvedBreaches,
 } from "./DashboardPlusUsers.stories";
-import { redirect } from "next/navigation";
+
+const routerPushMock = jest.fn();
 
 jest.mock("next/navigation", () => ({
-  useRouter: jest.fn(),
+  useRouter: () => ({
+    push: routerPushMock,
+  }),
   usePathname: jest.fn(),
   useSearchParams: () => ({
     get: jest.fn(),
   }),
-  redirect: jest.fn(),
 }));
 jest.mock("../../../../../../hooks/useTelemetry");
 // We need to override the types of `useTelemetry` here, because otherwise
@@ -3944,7 +3946,7 @@ describe("Upsell badge", () => {
     ).toBeInTheDocument();
   });
 
-  it("redirects to the subscription plans page on render when `autoOpenUpsellDialog={true}` and the feature flag SubscriptionPlansPage is enabled)", () => {
+  it("navigates to the subscription plans page on render when `autoOpenUpsellDialog={true}` and the feature flag SubscriptionPlansPage is enabled)", () => {
     const ComposedDashboard = composeStory(
       DashboardUsNoPremiumNoScanNoBreaches,
       Meta,
@@ -3956,10 +3958,10 @@ describe("Upsell badge", () => {
       />,
     );
 
-    expect(redirect).toHaveBeenCalledWith("/subscription-plans");
+    expect(routerPushMock).toHaveBeenCalledWith("/subscription-plans");
   });
 
-  it("redirects to the subscription plans page when the feature flag SubscriptionPlansPage is enabled when clicking the the upsell badge)", async () => {
+  it("navigates to the subscription plans page when the feature flag SubscriptionPlansPage is enabled when clicking the the upsell badge)", async () => {
     const user = userEvent.setup();
     const ComposedDashboard = composeStory(
       DashboardUsNoPremiumNoScanNoBreaches,
@@ -3976,7 +3978,7 @@ describe("Upsell badge", () => {
     expect(premiumCtas.length).toBe(2);
 
     await user.click(premiumCtas[0]);
-    expect(redirect).toHaveBeenCalledWith("/subscription-plans");
+    expect(routerPushMock).toHaveBeenCalledWith("/subscription-plans");
   });
 
   it("closes the premium upsell dialog of the Premium upsell badge after it opened by default)", async () => {

--- a/src/app/components/client/toolbar/UpsellBadge.tsx
+++ b/src/app/components/client/toolbar/UpsellBadge.tsx
@@ -5,7 +5,7 @@
 "use client";
 
 import { useContext, useEffect, useRef } from "react";
-import { redirect, usePathname, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams, useRouter } from "next/navigation";
 import Image from "next/image";
 import { useOverlayTrigger, useToggleButton } from "react-aria";
 import { useOverlayTriggerState, useToggleState } from "react-stately";
@@ -98,13 +98,15 @@ function UpsellToggleButton(props: UpsellToggleButtonProps) {
   });
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const router = useRouter();
 
   useEffect(() => {
     if (
       props.enabledFeatureFlags.includes("SubscriptionPlansPage") &&
       props.autoOpenUpsellDialog
     ) {
-      return redirect("/subscription-plans");
+      router.push("/subscription-plans");
+      return;
     }
     // This effect should only run once
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -119,7 +121,8 @@ function UpsellToggleButton(props: UpsellToggleButtonProps) {
         props.enabledFeatureFlags.includes("SubscriptionPlansPage") &&
         isOpen
       ) {
-        return redirect("/subscription-plans");
+        router.push("/subscription-plans");
+        return;
       }
 
       // Remove `dialog` from URLSearchParams on closing the upsell dialog


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-4707](https://mozilla-hub.atlassian.net/browse/MNTOR-4707)

<!-- When adding a new feature: -->

# Description

Use `router.push()` instead of `redirect()` to ensure the browser history stack is preserved.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added a unit test to test for potential regressions of this bug.


[MNTOR-4707]: https://mozilla-hub.atlassian.net/browse/MNTOR-4707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ