### PR TITLE
Update upsell CTAs

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/Dashboard.test.tsx
@@ -1428,7 +1428,7 @@ it("shows the correct dashboard banner CTA and sends telemetry for US users, wit
     "upgradeIntent",
     "click",
     expect.objectContaining({
-      button_id: "nav_upsell",
+      button_id: "us_non_premium_scans_resolved",
     }),
   );
 });
@@ -1523,7 +1523,7 @@ it("shows the correct dashboard banner CTA and sends telemetry for US users, wit
     "upgradeIntent",
     "click",
     expect.objectContaining({
-      button_id: "nav_upsell",
+      button_id: "us_non_premium_scans_resolved",
     }),
   );
 });

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
@@ -300,6 +300,8 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
             </p>
             <div className={styles.cta}>
               <UpsellLinkButton
+                variant="primary"
+                small
                 enabledFeatureFlags={props.enabledFeatureFlags}
                 eventData={{
                   button_id: "us_non_premium_no_exposures",
@@ -419,6 +421,8 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
             </p>
             <div className={styles.cta}>
               <UpsellLinkButton
+                variant="primary"
+                small
                 enabledFeatureFlags={props.enabledFeatureFlags}
                 eventData={{
                   button_id: "us_non_premium_scans_resolved",

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/DashboardTopBanner/DashboardTopBannerContent.tsx
@@ -299,7 +299,12 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
               )}
             </p>
             <div className={styles.cta}>
-              <UpsellLinkButton enabledFeatureFlags={props.enabledFeatureFlags}>
+              <UpsellLinkButton
+                enabledFeatureFlags={props.enabledFeatureFlags}
+                eventData={{
+                  button_id: "us_non_premium_no_exposures",
+                }}
+              >
                 {l10n.getString("dashboard-top-banner-no-exposures-found-cta")}
               </UpsellLinkButton>
             </div>
@@ -413,7 +418,12 @@ export const DashboardTopBannerContent = (props: DashboardTopBannerProps) => {
               )}
             </p>
             <div className={styles.cta}>
-              <UpsellLinkButton enabledFeatureFlags={props.enabledFeatureFlags}>
+              <UpsellLinkButton
+                enabledFeatureFlags={props.enabledFeatureFlags}
+                eventData={{
+                  button_id: "us_non_premium_scans_resolved",
+                }}
+              >
                 {l10n.getString("dashboard-top-banner-no-exposures-found-cta")}
               </UpsellLinkButton>
             </div>

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/manual-remove/ManualRemoveView.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/manual-remove/ManualRemoveView.tsx
@@ -24,9 +24,9 @@ import {
   getNextGuidedStep,
 } from "../../../../../../../../../functions/server/getRelevantGuidedSteps";
 import { FixView } from "../../FixView";
-import { TelemetryLink } from "../../../../../../../../../components/client/TelemetryLink";
 import { TelemetryButton } from "../../../../../../../../../components/client/TelemetryButton";
 import { FeatureFlagName } from "../../../../../../../../../../db/tables/featureFlags";
+import { UpsellLinkButton } from "../../../../../../../../../components/client/toolbar/UpsellBadge";
 
 export type Props = {
   scanData: LatestOnerepScanData;
@@ -130,10 +130,12 @@ export function ManualRemoveView(props: Props) {
                   {
                     elems: {
                       subscribe_link: (
-                        <TelemetryLink
-                          href="/subscription-plans"
+                        <UpsellLinkButton
+                          variant="link"
+                          small
+                          enabledFeatureFlags={props.enabledFeatureFlags}
                           eventData={{
-                            link_id: "manual_removal_instructions_upsell",
+                            button_id: "manual_removal_instructions_upsell",
                           }}
                         />
                       ),
@@ -173,21 +175,18 @@ export function ManualRemoveView(props: Props) {
           </div>
         </div>
         <div className={styles.buttonsWrapper}>
-          <TelemetryButton
+          <UpsellLinkButton
             variant="primary"
-            event={{
-              module: "upgradeIntent",
-              name: "click",
-              data: {
-                button_id: "manual_removal_upsell",
-              },
+            small
+            enabledFeatureFlags={props.enabledFeatureFlags}
+            eventData={{
+              button_id: "manual_removal_upsell",
             }}
-            href="/subscription-plans"
           >
             {l10n.getString(
               "fix-flow-data-broker-profiles-manual-remove-button-remove-for-me",
             )}
-          </TelemetryButton>
+          </UpsellLinkButton>
           <TelemetryButton
             variant="secondary"
             href={stepAfterSkip.href}

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/View.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/fix/data-broker-profiles/view-data-brokers/View.tsx
@@ -13,6 +13,7 @@ import {
 import { ExtendedReactLocalization } from "../../../../../../../../../functions/l10n";
 import { TelemetryButton } from "../../../../../../../../../components/client/TelemetryButton";
 import { FeatureFlagName } from "../../../../../../../../../../db/tables/featureFlags";
+import { UpsellLinkButton } from "../../../../../../../../../components/client/toolbar/UpsellBadge";
 
 export type Props = {
   data: StepDeterminationData;
@@ -63,21 +64,17 @@ export const ViewDataBrokersView = (props: Props) => {
           <DataBrokerProfiles data={props.data.latestScanData?.results ?? []} />
         </div>
         <div className={styles.buttonsWrapper}>
-          <TelemetryButton
+          <UpsellLinkButton
             variant="primary"
-            href="/subscription-plans"
-            event={{
-              module: "upgradeIntent",
-              name: "click",
-              data: {
-                button_id: "guided_experience_upsell",
-              },
+            enabledFeatureFlags={props.enabledFeatureFlags}
+            eventData={{
+              button_id: "guided_experience_upsell",
             }}
           >
             {l10n.getString(
               "fix-flow-data-broker-profiles-view-data-broker-profiles-button-remove-for-me",
             )}
-          </TelemetryButton>
+          </UpsellLinkButton>
           <TelemetryButton
             variant="secondary"
             href="/user/dashboard/fix/data-broker-profiles/manual-remove"

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelEditInfoRedesign.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/panels/SettingsPanelEditInfoRedesign.tsx
@@ -34,6 +34,7 @@ import InfoShield from "../images/InfoShield.svg";
 import { type onAddEmail, type onRemoveEmail } from "../actions";
 import { formatPhone } from "../../../../../../../functions/universal/formatPhone";
 import { FeatureFlagName } from "../../../../../../../../db/tables/featureFlags";
+import { UpsellLinkButton } from "../../../../../../../components/client/toolbar/UpsellBadge";
 
 export type SettingsPanelEditInfoRedesignProps = {
   breachCountByEmailAddress: Record<string, number>;
@@ -302,14 +303,16 @@ function SettingsPanelEditInfoRedesign(
       <MonitoredEmailAddressesSection {...props} />
       {props.isEligibleForPremium && !hasPremium(props.user) && (
         <div className={styles.upsellLinkContainer}>
-          <TelemetryLink
-            href="/subscription-plans"
+          <UpsellLinkButton
+            variant="primary"
+            small
+            enabledFeatureFlags={props.enabledFeatureFlags}
             eventData={{
-              link_id: "settings_edit_info_upsell_cta",
+              button_id: "settings_edit_info_upsell_cta",
             }}
           >
             {l10n.getString("settings-update-scan-info-upsell-button-label")}
-          </TelemetryLink>
+          </UpsellLinkButton>
         </div>
       )}
     </>

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/plus-expiration/View.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/plus-expiration/View.tsx
@@ -17,6 +17,7 @@ import { CloseBtn, OpenInNew } from "../../../../../components/server/Icons";
 import type { applyRenewalCoupon } from "./actions";
 import { useL10n } from "../../../../../hooks/l10n";
 import { FeatureFlagName } from "../../../../../../db/tables/featureFlags";
+import { UpsellLinkButton } from "../../../../../components/client/toolbar/UpsellBadge";
 
 export type Props = {
   subscriber: SubscriberRow;
@@ -45,9 +46,16 @@ export const View = (props: Props) => {
         <div className={styles.wrapper}>
           <h1>{l10n.getString("plus-expiration-error-free-heading")}</h1>
           <p>{l10n.getString("plus-expiration-error-free-content")}</p>
-          <Button variant="primary" href="/subscription-plans">
+          <UpsellLinkButton
+            variant="primary"
+            small
+            enabledFeatureFlags={props.enabledFeatureFlags}
+            eventData={{
+              button_id: "plus_expiration_upsell_cta",
+            }}
+          >
             {l10n.getString("plus-expiration-error-free-cta-label")}
-          </Button>
+          </UpsellLinkButton>
         </div>
       </RenewalShell>
     );

--- a/src/app/components/client/exposure_card/ScanResultCard.tsx
+++ b/src/app/components/client/exposure_card/ScanResultCard.tsx
@@ -18,6 +18,7 @@ import { FeatureFlagName } from "../../../../db/tables/featureFlags";
 import { ExperimentData } from "../../../../telemetry/generated/nimbus/experiments";
 import SparkleImage from "../assets/sparkle.png";
 import { isDataBrokerUnderMaintenance } from "../../../(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/View";
+import { UpsellLinkButton } from "../toolbar/UpsellBadge";
 
 export type ScanResultCardProps = {
   scanResult: OnerepScanResultDataBrokerRow;
@@ -106,16 +107,6 @@ export const ScanResultCard = (props: ScanResultCardProps) => {
     />
   );
 
-  const upsellLink = (
-    <TelemetryLink
-      upsell
-      eventData={{
-        link_id: "clicked_upsell",
-      }}
-      href="/subscription-plans"
-    />
-  );
-
   const dataBrokerDescription = () => {
     // Data broker cards manually resolved do not change their status to "removed";
     // instead, we track them using the "manually_resolved" property.
@@ -184,7 +175,18 @@ export const ScanResultCard = (props: ScanResultCardProps) => {
             {
               elems: {
                 data_broker_profile: dataBrokerProfileLink,
-                upsell_link: upsellLink,
+                upsell_link: (
+                  <UpsellLinkButton
+                    variant="primary"
+                    small
+                    enabledFeatureFlags={props.enabledFeatureFlags}
+                    eventData={{
+                      button_id: "clicked_upsell",
+                    }}
+                  >
+                    {l10n.getString("plus-expiration-error-free-cta-label")}
+                  </UpsellLinkButton>
+                ),
               },
             },
           );

--- a/src/app/components/client/stories/UpsellCta.stories.tsx
+++ b/src/app/components/client/stories/UpsellCta.stories.tsx
@@ -40,6 +40,8 @@ const UpsellCtaWrapper = (props: UpsellCtaWrapperProps) => {
           />
         ) : (
           <UpsellLinkButton
+            variant="primary"
+            small
             enabledFeatureFlags={props.enabledFeatureFlags}
             eventData={{
               button_id: "upsell_cta_story",

--- a/src/app/components/client/stories/UpsellCta.stories.tsx
+++ b/src/app/components/client/stories/UpsellCta.stories.tsx
@@ -39,7 +39,12 @@ const UpsellCtaWrapper = (props: UpsellCtaWrapperProps) => {
             enabledFeatureFlags={props.enabledFeatureFlags}
           />
         ) : (
-          <UpsellLinkButton enabledFeatureFlags={props.enabledFeatureFlags}>
+          <UpsellLinkButton
+            enabledFeatureFlags={props.enabledFeatureFlags}
+            eventData={{
+              button_id: "upsell_cta_story",
+            }}
+          >
             Get continuous protection
           </UpsellLinkButton>
         )}

--- a/src/app/components/client/toolbar/UpsellBadge.tsx
+++ b/src/app/components/client/toolbar/UpsellBadge.tsx
@@ -25,17 +25,19 @@ import { FeatureFlagName } from "../../../../db/tables/featureFlags";
 import { WaitlistDialog } from "../SubscriberWaitlistDialog";
 import { GleanMetricMap } from "../../../../telemetry/generated/_map";
 import { TelemetryButton } from "../TelemetryButton";
+import { Props as ButtonProps } from "../Button";
 
 export type UpsellLinkButtonProps = {
   enabledFeatureFlags: FeatureFlagName[];
 };
 
 export function UpsellLinkButton(
-  props: UpsellLinkButtonProps & {
-    eventData: GleanMetricMap["upgradeIntent"]["click"];
-    children?: ReactNode;
-    className?: string;
-  },
+  props: ButtonProps &
+    UpsellLinkButtonProps & {
+      eventData: GleanMetricMap["upgradeIntent"]["click"];
+      children?: ReactNode;
+      className?: string;
+    },
 ) {
   const pathname = usePathname();
 
@@ -66,8 +68,8 @@ export function UpsellLinkButton(
           }
         }}
         className={props.className}
-        variant="primary"
-        small
+        variant={props.variant}
+        small={props.small}
         href={showWaitlist ? undefined : "/subscription-plans"}
         target="_blank"
         event={{
@@ -112,6 +114,8 @@ function UpsellToggleLinkButton(props: UpsellToggleLinkButtonProps) {
     <div className={styles.upsellWrapper}>
       <UpsellLinkButton
         {...buttonProps}
+        variant="primary"
+        small
         className={`${styles.upsellBadge} ${
           state.isSelected ? styles.isSelected : ""
         }`}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-4582](https://mozilla-hub.atlassian.net/browse/MNTOR-4582)

<!-- When adding a new feature: -->

# Description

There were two remaining issues with the upsell CTAs:
1. Not all of the upsell CTAs were simple links and did not respect the feature flag `DisableOneRepScans`. All upsell CTAs were replaced by `UpsellLinkButton`.
2. Some upsell CTAs did not attempt to open the `/subscription-plans` page in a new tab


# How to test

When the feature flag `DisableOneRepScans` is enabled all upsell CTA should show the waitlist dialog instead of linking out to `/subscription-plans`.

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [x] All acceptance criteria are met.
