### PR TITLE
Fix padding for button variant link

### DIFF
--- a/src/app/components/client/Button.module.scss
+++ b/src/app/components/client/Button.module.scss
@@ -216,6 +216,10 @@
     line-height: 1.5;
     padding: tokens.$spacing-sm tokens.$spacing-md;
 
+    &.link {
+      padding: 0;
+    }
+
     &.icon {
       padding: tokens.$spacing-sm;
     }

--- a/src/app/components/client/exposure_card/ScanResultCard.tsx
+++ b/src/app/components/client/exposure_card/ScanResultCard.tsx
@@ -177,7 +177,7 @@ export const ScanResultCard = (props: ScanResultCardProps) => {
                 data_broker_profile: dataBrokerProfileLink,
                 upsell_link: (
                   <UpsellLinkButton
-                    variant="primary"
+                    variant="link"
                     small
                     enabledFeatureFlags={props.enabledFeatureFlags}
                     eventData={{


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-4782](https://mozilla-hub.atlassian.net/browse/MNTOR-4782)

<!-- When adding a new feature: -->

# Description

Fixes the padding for buttons with `variant="link"`.

# Screenshot

| Before | After |
| --- | --- |
| <img width="545" height="108" alt="image" src="https://github.com/user-attachments/assets/0ba474f0-9819-4ef5-8638-6e34fc50cc04" /> | <img width="546" height="97" alt="image" src="https://github.com/user-attachments/assets/b84879e2-1c8c-4091-a8c0-bde238e9bd8f" /> |



[MNTOR-4782]: https://mozilla-hub.atlassian.net/browse/MNTOR-4782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ