### PR TITLE
MNTOR-4818 — next auth error and logging (#6037)

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -7,35 +7,12 @@ import { NextRequest, NextResponse } from "next/server";
 import NextAuth from "next-auth";
 import { authOptions } from "../../utils/auth";
 
-type SafeOAuthClientError =
-  | "access_denied"
-  | "login_required"
-  | "interaction_required"
-  | "invalid_request"
-  | "invalid_scope"
-  | "unsupported_response_type";
-
-const safeClientErrors = new Set<SafeOAuthClientError>([
-  "access_denied",
-  "login_required",
-  "interaction_required",
-  "invalid_request",
-  "invalid_scope",
-  "unsupported_response_type",
-]);
-
-function isSafeClientError(error: string): error is SafeOAuthClientError {
-  return safeClientErrors.has(error as SafeOAuthClientError);
-}
-
 const handler = async (req: NextRequest, res: unknown) => {
+  // There is currently no support for handling OAuth provider callback errors:
+  // https://github.com/nextauthjs/next-auth/discussions/8209
   if (req.method === "GET") {
-    const searchParams = req.nextUrl.searchParams;
-    const pathname = req.nextUrl.pathname;
-
-    const error = searchParams.get("error");
-    const errorDescription = searchParams.get("error_description");
-
+    const requestSearchParams = req.nextUrl.searchParams;
+    const requestErrorQuery = requestSearchParams.get("error");
     // Handle the "login_required" error from the FxA OAuth callback.
     // This error typically occurs during silent authentication (e.g. prompt=none) when no user session is present.
     // In cases like clicking through the Relay Bento menu with no FxA login,
@@ -43,9 +20,8 @@ const handler = async (req: NextRequest, res: unknown) => {
     // we redirect the user to the originally intended callback URL (if present) or to the base URL.
     // This ensures the user sees the correct landing page and is guided to explicitly sign in if needed.
     // See: FXA-11730 for upstream fix discussion.
-    if (error === "login_required") {
+    if (requestErrorQuery === "login_required") {
       const cookieStore = req.cookies;
-
       const callbackUrl = cookieStore.get("next-auth.callback-url")?.value;
       const redirectUrl =
         callbackUrl && callbackUrl.startsWith(process.env.SERVER_URL as string)
@@ -53,27 +29,6 @@ const handler = async (req: NextRequest, res: unknown) => {
           : (process.env.SERVER_URL as string);
 
       return NextResponse.redirect(redirectUrl);
-    }
-
-    if (
-      pathname.includes("/callback") &&
-      error &&
-      errorDescription &&
-      isSafeClientError(error)
-    ) {
-      // By default, Next-Auth handles OAuth callback exceptions internally,
-      // which results in HTTP 500 response and multi-line errors that are difficult to filter for.
-      // This turns it into a 400 response that can more easily be distinguished from actual internal server errors.
-      return new NextResponse(
-        JSON.stringify({ error, detail: errorDescription }),
-        {
-          status: 400,
-          headers: {
-            "Content-Type": "application/json",
-            "X-App-Error-Code": `oauth_callback_${error}`,
-          },
-        },
-      );
     }
   }
 

--- a/src/app/api/utils/auth.tsx
+++ b/src/app/api/utils/auth.tsx
@@ -312,17 +312,32 @@ export const authOptions: AuthOptions = {
     },
   },
   logger: {
-    error(code: string, metadata: unknown) {
-      logger.error(code, metadata);
+    error(code: string, metadata?: unknown) {
+      logger.error(code, ensureWinstonMetadata(metadata));
     },
-    warn(code: string) {
-      logger.warn(code);
+    warn(code: string, metadata?: unknown) {
+      logger.warn(code, ensureWinstonMetadata(metadata));
     },
-    debug(code: string, metadata: unknown) {
-      logger.debug(code, metadata);
+    debug(code: string, metadata?: unknown) {
+      logger.debug(code, ensureWinstonMetadata(metadata));
     },
   } satisfies LoggerInstance,
 };
+
+function ensureWinstonMetadata(metadata: unknown): Record<string, unknown> {
+  if (!metadata) return {};
+  if (metadata instanceof Error) {
+    return {
+      message: metadata.message,
+      name: metadata.name,
+      stack: metadata.stack,
+    };
+  }
+  if (typeof metadata === "object") {
+    return metadata as Record<string, unknown>;
+  }
+  return { value: metadata };
+}
 
 /**
  * Converts an FxAProfile to a Next-Auth user object


### PR DESCRIPTION
Revert change to error page, too late to be useful. Leave the larger comment in place for `login_required` behavior.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-4818

<!-- When adding a new feature: -->

# Description

Revert change to error page. I've been testing on stage and it is too late in the process to do anything helpful, so it's effectively a no-op.

# How to test

The log handling part of the previous PR is still in-place but this reverts to the previous behavior (leaving the longer comment about the existing behavior in place).

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
