### PR TITLE
MNTOR-4875: 1-click support `dev-` prefix

### DIFF
--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -13,6 +13,7 @@ on:
         options:
           - stage
           - prod
+          - dev
       originalImageTag:
         description: 'The original image tag that has been deployed'
         required: true
@@ -32,7 +33,7 @@ jobs:
       DOCKERHUB_IMAGE: mozilla/blurts-server # Define Docker Hub image name
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-4875

# Description
chore: update 1-click deploy workflow to include 'dev' stage

# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
