### PR TITLE
Add date to load test report filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ LOAD_TEST_FEATURES="scan,activate" npm run loadtest:moscary
 If you run the tests against stage, you should be able to see the load coming in
 [in Grafana](https://yardstick.mozilla.org/d/aemrrye0kvrb4d/monitor-scan-remove-backend?orgId=1&from=now-3h&to=now&timezone=browser&var-env=nonprod&var-datasource=edq6thuke248we&refresh=auto).
 
+An HTML report of the test results will be saved in `src/scripts/loadtest/reports/`.
+
 ##### HIBP breach alerts
 
 To test the HIBP breach alerts endpoint, use:

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "build-glean-backend-docs": "glean translate src/telemetry/backend-metrics.yaml --format markdown --output docs/telemetry/backend",
     "build-moscary-types": "node src/scripts/build/regenerateMoscaryTypes.js",
     "loadtest:hbibp-webhook": "echo 'Ensure k6 is installed; see:\n\thttps://grafana.com/docs/k6/latest/set-up/install-k6/\n' && k6 run src/scripts/loadtest/hibp.js",
-    "loadtest:moscary": "echo 'Ensure k6 is installed; see:\n\thttps://grafana.com/docs/k6/latest/set-up/install-k6/\n' && K6_WEB_DASHBOARD=true K6_WEB_DASHBOARD_EXPORT=src/scripts/loadtest/reports/moscary-report.html k6 run --out json=src/scripts/loadtest/reports/moscary-results.json src/scripts/loadtest/moscary.ts",
+    "loadtest:moscary": "echo 'Ensure k6 is installed; see:\n\thttps://grafana.com/docs/k6/latest/set-up/install-k6/\n' && K6_WEB_DASHBOARD=true K6_WEB_DASHBOARD_EXPORT=src/scripts/loadtest/reports/$(date +'%Y-%m-%d')-moscary-report.html k6 run --out json=src/scripts/loadtest/reports/$(date +'%Y-%m-%d')-moscary-results.json src/scripts/loadtest/moscary.ts",
     "validate-nimbus": "sh src/scripts/build/validate-nimbus-file.sh",
     "lighthouse": "lhci autorun",
     "prepare": "husky",


### PR DESCRIPTION
This helps avoid accidentally overwriting previous reports when uploading them to the wiki.