### PR TITLE
debug(MNTOR-4908): Force dynamic rendering for /user/dashboard

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/[[...slug]]/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/[[...slug]]/page.tsx
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { getServerSession } from "../../../../../../../functions/server/getServerSession";
@@ -55,6 +58,7 @@ import {
   getScansCountForProfile,
   isEligibleForFreeScan,
 } from "../../../../../../../functions/server/moscary";
+import { connection } from "next/server";
 
 const dashboardTabSlugs = ["action-needed", "fixed"];
 
@@ -68,6 +72,7 @@ type Props = {
 };
 
 export default async function DashboardPage(props: Props) {
+  await connection();
   const searchParams = await props.searchParams;
   if (searchParams.dialog === "subscriptions") {
     return redirect("/subscription-plans");


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-4908](https://mozilla-hub.atlassian.net/browse/MNTOR-4908)

<!-- When adding a new feature: -->

# Description

It seems like [MNTOR-4908](https://mozilla-hub.atlassian.net/browse/MNTOR-4908) is inconsistently on `stage`. I would like to rule out/confirm that it is a caching issue for the route `/user/dashboard`.