### PR TITLE
Fix: Dynamically import next/headers in getExperiments

### DIFF
--- a/src/app/functions/server/getExperiments.ts
+++ b/src/app/functions/server/getExperiments.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { headers } from "next/headers";
 import { captureException } from "@sentry/node";
 import { logger } from "./logging";
 import {
@@ -12,6 +11,7 @@ import {
 } from "../../../telemetry/generated/nimbus/experiments";
 import { ExperimentationId } from "./getExperimentationId";
 import { getEnabledFeatureFlags } from "../../../db/tables/featureFlags";
+import { loadNextHeaders } from "./loadNextHeaders";
 
 /**
  * After we removing the `CirrusV2` flag, we can return the full `ExperimentData`/
@@ -59,10 +59,16 @@ export async function getExperiments(params: {
     serverUrl.pathname += "v1/features";
   }
 
-  const headersList = await headers();
-  // Check if the Nimbus preview mode has been set by the middleware.
-  const nimbusPreviewMode = headersList.get("x-nimbus-preview-mode");
-  const previewMode = nimbusPreviewMode === "true";
+  const nextHeaders = await loadNextHeaders();
+  let previewMode = false;
+  if (nextHeaders) {
+    const headersList = await nextHeaders.headers();
+    // Check if the Nimbus preview mode has been set by the middleware.
+    const nimbusPreviewMode = headersList.get("x-nimbus-preview-mode");
+    if (nimbusPreviewMode === "true") {
+      previewMode = true;
+    }
+  }
 
   try {
     if (previewMode === true) {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [MNTOR-4908](https://mozilla-hub.atlassian.net/browse/MNTOR-4908)

<!-- When adding a new feature: -->

# Description

PR https://github.com/mozilla/blurts-server/pull/6062 added imports to some of the cronjobs that are importing `next/headers`. This PR updates `getExperiments` to import `next/headers` dynamically so that it is safe to use in our cronjobs.

[MNTOR-4908]: https://mozilla-hub.atlassian.net/browse/MNTOR-4908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ