### PR TITLE
Fix fresh building of cronjobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build-storybook": "npm run build-glean && npm run build-nimbus && storybook build",
     "create-location-data": "node src/scripts/build/uploadAutoCompleteLocations.js",
     "get-location-data": "node src/scripts/build/getAutoCompleteLocations.js",
-    "build-cronjobs": "node esbuild.cronjobs.js",
+    "build-cronjobs": "npm run build-nimbus && node esbuild.cronjobs.js",
     "build-nimbus": "node src/scripts/build/nimbusTypes.js",
     "build-frontend-glean": "glean translate src/telemetry/metrics.yaml --format typescript --output src/telemetry/generated && npm run build-glean-types",
     "build-backend-glean": "glean translate src/telemetry/backend-metrics.yaml --format typescript --output src/telemetry/generated/backend && npm run build-glean-types",


### PR DESCRIPTION
(As done in the `lighthouse_cron` CI job, e.g. here: https://github.com/mozilla/blurts-server/actions/runs/17723727543/job/50360427028)

We now have cronjobs that call `getExperiments`, which requires the Nimbus data in src/telemetry/generated/nimbus/experiments to be available.
