### PR TITLE
Expose detected region on stage

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -42,6 +42,11 @@ export function middleware(request: NextRequest) {
     },
   });
 
+  const gcpDetectedRegion = request.headers.get("X-Client-Region");
+  if (gcpDetectedRegion && process.env.APP_ENV === "stage") {
+    response.headers.append("X-Client-Region", gcpDetectedRegion);
+  }
+
   if (!existingExperimentationId) {
     response.cookies.set({
       name: "experimentationId",


### PR DESCRIPTION
It's not always clear which region someone is detected to be in. Exposing it on stage makes it easier to debug issues with location detection.

Just trying to debug why I never see the US version of the website on stage.