### PR TITLE
Bump e2e test timeout by five more seconds

### DIFF
--- a/functional-tests/tests/onboarding.spec.ts
+++ b/functional-tests/tests/onboarding.spec.ts
@@ -60,9 +60,9 @@ test.describe(`Verify authentication [${process.env.E2E_TEST_ENV}]`, () => {
 
       const progressBarRuntime = 60 * 1000;
       test.setTimeout(progressBarRuntime + 30 * 1000);
-      // A scan takes 60 seconds, plus 20 seconds for the navigation back to the dashboard:
+      // A scan takes 60 seconds, plus 25 seconds for the navigation back to the dashboard:
       await page.waitForURL("**/user/dashboard*", {
-        timeout: progressBarRuntime + 20 * 1000,
+        timeout: progressBarRuntime + 25 * 1000,
       });
       await expect(
         page.getByRole("heading", {


### PR DESCRIPTION
On prod, it often succeedes, but sometimes literally fails at 100% progress. So five extra seconds should do it, hopefully 🤞

From the report:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f0ac194a-fd1f-43a4-8be2-493157c268e5" />
