### PR TITLE
MNTOR-4926: Ensure we check the full origin of callback URLs

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -24,7 +24,7 @@ const handler = async (req: NextRequest, res: unknown) => {
       const cookieStore = req.cookies;
       const callbackUrl = cookieStore.get("next-auth.callback-url")?.value;
       const redirectUrl =
-        callbackUrl && callbackUrl.startsWith(process.env.SERVER_URL as string)
+        callbackUrl && isValidCallbackUrl(callbackUrl)
           ? callbackUrl
           : (process.env.SERVER_URL as string);
 
@@ -38,5 +38,11 @@ const handler = async (req: NextRequest, res: unknown) => {
     authOptions,
   ) as Promise<Response>;
 };
+
+function isValidCallbackUrl(callbackUrlString: string): boolean {
+  const serverUrl = new URL(process.env.SERVER_URL!);
+  const callbackUrl = new URL(callbackUrlString);
+  return serverUrl.origin === callbackUrl.origin;
+}
 
 export { handler as GET, handler as POST };


### PR DESCRIPTION
This ensures that someone can't just register a domain and make it start with the same URL as ours.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-4926
Figma:

<!-- When adding a new feature: -->

# Description

This ensures that someone can't just register a domain and make it start with the same URL as ours.

# How to test

Log in. I did not write a unit test for it since the specific function is almost trivial, and I'd either have to export it just for the test, or somehow mock the Next Auth API.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
