### PR TITLE
MNTOR-5031: Remove (and permanently enable) the PromptNoneAuthFlow flag

### DIFF
--- a/functional-tests/fixtures/baseTest.ts
+++ b/functional-tests/fixtures/baseTest.ts
@@ -12,7 +12,6 @@ export const defaultLocalForcedFeatureFlags: FeatureFlagName[] = [
   "CancellationFlow",
   "AutomaticRemovalCsatSurvey",
   "AdditionalRemovalStatuses",
-  "PromptNoneAuthFlow",
   "DataBrokerRemovalTimeEstimateLabel",
   "LandingPageRedesign",
   "CirrusV2",

--- a/src/app/(proper_react)/layout.tsx
+++ b/src/app/(proper_react)/layout.tsx
@@ -15,7 +15,6 @@ import { ReactAriaI18nProvider } from "../../contextProviders/react-aria";
 import { CountryCodeProvider } from "../../contextProviders/country-code";
 import { getCountryCode } from "../functions/server/getCountryCode";
 import { PageLoadEvent } from "../components/client/PageLoadEvent";
-import { getEnabledFeatureFlags } from "../../db/tables/featureFlags";
 import { PromptNoneAuth } from "../components/client/PromptNoneAuth";
 import { addClientIdForSubscriber } from "../../db/tables/google_analytics_clients";
 import { logger } from "../functions/server/logging";
@@ -30,13 +29,6 @@ export default async function Layout({ children }: { children: ReactNode }) {
   const headersList = await headers();
   const countryCode = getCountryCode(headersList);
   const session = await getServerSession();
-  const enabledFlags = await getEnabledFeatureFlags(
-    session === null
-      ? { isSignedOut: true }
-      : {
-          email: session.user.email,
-        },
-  );
   const billing = getSubscriptionBillingAmount();
 
   const cookieStore = await cookies();
@@ -72,9 +64,7 @@ export default async function Layout({ children }: { children: ReactNode }) {
         <CountryCodeProvider countryCode={countryCode}>
           <CookiesProvider>
             <SubscriptionBillingProvider value={billing}>
-              {enabledFlags.includes("PromptNoneAuthFlow") && !session && (
-                <PromptNoneAuth />
-              )}
+              {!session && <PromptNoneAuth />}
               {children}
             </SubscriptionBillingProvider>
             <PageLoadEvent />

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -58,7 +58,6 @@ export const featureFlagNames = [
   "LatestScanDateCsatSurvey",
   "AutomaticRemovalCsatSurvey",
   "AdditionalRemovalStatuses",
-  "PromptNoneAuthFlow",
   "GA4SubscriptionEvents",
   "DataBrokerRemovalTimeEstimateLabel",
   "DataBrokerRemovalTimeEstimateCsat",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-5031
Figma:

<!-- When adding a new feature: -->

# How to test

Visit http://localhost:6060/?prompt=none. You should automatically get redirected to FxA.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
