### PR TITLE
MNTOR-5071

### DIFF
--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -109,7 +109,7 @@ export async function getEnabledFeatureFlags(
       }
     } catch (error) {
       // next/headers not available (e.g., running in cronjob context)
-      console.debug(`next/headers not available: ${JSON.stringify(error)}`);
+      console.info(`next/headers not available: ${JSON.stringify(error)}`);
     }
   }
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-5071
Figma:

<!-- When adding a new feature: -->

# Description
We are getting this error when running a cronjob:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/node_modules/next/headers' imported from /app/dist/scripts/cronjobs/emailBreachAlerts.js"
```

The issue seems to be introduced recently via an import:
```
emailBreachAlerts.tsx calls getExperiments()
getExperiments() calls getEnabledFeatureFlags()
getEnabledFeatureFlags() has an unprotected import("next/headers") (line 96)
```

getEnabledFeatureFlags() had await import("next/headers") with NO error handling. Here we wrap it so that it's "protected"

# Screenshot (if applicable)

Not applicable.

# How to test

# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
