### PR TITLE
Don't inspect request headers in cron jobs

### DIFF
--- a/.env
+++ b/.env
@@ -106,7 +106,7 @@ ADMINS=
 MONTHLY_CRON_ENABLED=
 
 # Functional tests
-E2E_TEST_ENV=local
+E2E_TEST_ENV="not running e2e tests"
 E2E_TEST_SECRET=test-secret
 E2E_TEST_ACCOUNT_BASE_EMAIL=test-account
 E2E_TEST_ACCOUNT_BASE_PASSWORD=test-password

--- a/src/app/functions/server/getExperiments.test.ts
+++ b/src/app/functions/server/getExperiments.test.ts
@@ -99,6 +99,7 @@ describe("getExperiments", () => {
   });
 
   it("calls Cirrus V2 when feature flag is enabled with preview param", async () => {
+    process.env.NEXT_RUNTIME = "test";
     process.env.NIMBUS_SIDECAR_URL = "https://cirrus.example";
     getEnabledFeatureFlagsMock.mockReturnValue([
       "CirrusV2",
@@ -150,6 +151,8 @@ describe("getExperiments", () => {
         previewMode: true,
       }),
     );
+
+    delete process.env.NEXT_RUNTIME;
   });
 
   it("calls Cirrus V1 when featurn flag is disabled", async () => {
@@ -188,7 +191,8 @@ describe("getExperiments", () => {
     );
   });
 
-  it("fallsback to defaultExperimentData when not experiment data is returned by Cirrus", async () => {
+  it("fallsback to defaultExperimentData when no experiment data is returned by Cirrus", async () => {
+    process.env.NEXT_RUNTIME = "test";
     process.env.NIMBUS_SIDECAR_URL = "https://cirrus.example";
     getEnabledFeatureFlagsMock.mockReturnValue([
       "CirrusV2",
@@ -235,6 +239,7 @@ describe("getExperiments", () => {
         previewMode: true,
       }),
     );
+    delete process.env.NEXT_RUNTIME;
   });
 
   it("logs error, captures exception, and returns defaultExperimentData on error response", async () => {

--- a/src/app/functions/server/getExperiments.ts
+++ b/src/app/functions/server/getExperiments.ts
@@ -59,7 +59,13 @@ export async function getExperiments(params: {
     serverUrl.pathname += "v1/features";
   }
 
-  const nextHeaders = await loadNextHeaders();
+  const nextHeaders =
+    // We also check for experiments in cron jobs, where there are
+    // no HTTP requests. Skip the headers there; we don't need to
+    // force-enable experiments in cronjobs.
+    typeof process.env.NEXT_RUNTIME === "string"
+      ? await loadNextHeaders()
+      : null;
   let previewMode = false;
   if (nextHeaders) {
     const headersList = await nextHeaders.headers();

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -92,7 +92,16 @@ export async function getEnabledFeatureFlags(
   options: { isSignedOut?: false; email: string } | { isSignedOut: true },
 ): Promise<FeatureFlagName[]> {
   // Force feature flags for E2E tests via URL query params
-  if (process.env.E2E_TEST_ENV === "local") {
+  if (
+    // Check that we're running under Next.js; in cronjobs
+    // there's no request to inspect. We're not force-enabling
+    // feature flags in that environment anyway.
+    typeof process.env.NEXT_RUNTIME === "string" &&
+    // When running end-to-end tests locally or in a PR,
+    // we can force-enable feature flags that haven't been enabled
+    // yet on stage or on prod:
+    process.env.E2E_TEST_ENV === "local"
+  ) {
     const { headers } = await import("next/headers");
     const forcedFeatureFlags = (await headers()).get("x-forced-feature-flags");
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-5071
Figma:

<!-- When adding a new feature: -->

# Description

I could not reproduce the _exact_ issue that we're seeing in our logs, but I could trigger the code path that imports `next/headers` locally, and that shouldn't be possible.

Possibly the error in the logs are because `next` isn't installed for some reason, or we're using a version of Node that doesn't support importing from `next/headers` rather than just `next`?

# How to test

Follow [the readme instructions on pubsub](https://github.com/mozilla/blurts-server?tab=readme-ov-file#pubsub), but for the `curl` request, find a user's `primary_sha1`, take the first six characters and use that as the `hashPrefix`, and the rest as a `hashSuffix`.

Also, after you do this once, be sure to `DELETE FROM "email_notifications";` if you want to try again.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
