### PR TITLE
MNTOR-4586/recent authentication before deletion

### DIFF
--- a/locales/en/settings.ftl
+++ b/locales/en/settings.ftl
@@ -58,6 +58,8 @@ settings-delete-monitor-free-account-dialog-cta-label = Delete account
 settings-delete-monitor-free-account-dialog-cancel-button-label = Never mind, take me back
 settings-delete-monitor-account-confirmation-toast-label-2 = Your { -brand-monitor } account is now deleted.
 settings-delete-monitor-account-confirmation-toast-dismiss-label = Dismiss
+settings-delete-account-recent-auth-required = For your safety, please sign in again (within the last hour) before deleting your account.
+settings-delete-account-error-generic = Something went wrong while trying to delete your account. Try again.
 
 ## Monthly Monitor Report
 

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/DeleteAccountButton.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/DeleteAccountButton.tsx
@@ -9,6 +9,7 @@ import { signOut } from "next-auth/react";
 import { Button } from "../../../../../../components/client/Button";
 import { type onDeleteAccount } from "./actions";
 import { useTelemetry } from "../../../../../../hooks/useTelemetry";
+import { useL10n } from "../../../../../../hooks/l10n";
 
 /**
  * Since <Button> is a client component, the `onDeleteAccount` handler can only
@@ -21,29 +22,57 @@ export const DeleteAccountButton = (
     onDeleteAccount: typeof onDeleteAccount;
   },
 ) => {
+  const l10n = useL10n();
   const recordTelemetry = useTelemetry();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   return (
-    <Button
-      {...props}
-      isLoading={isSubmitting}
-      isDisabled={isSubmitting}
-      onPress={() => {
-        recordTelemetry("ctaButton", "click", {
-          button_id: "confirm_delete_account",
-        });
-        setIsSubmitting(true);
-        // It's currently unclear if and how we should mock our server action:
-        /* c8 ignore next 8 */
-        void props
-          .onDeleteAccount()
-          .then(() => {
-            void signOut({ callbackUrl: "/" });
-          })
-          .catch(() => {
-            setIsSubmitting(false);
+    <>
+      <Button
+        {...props}
+        isLoading={isSubmitting}
+        isDisabled={isSubmitting}
+        onPress={() => {
+          recordTelemetry("ctaButton", "click", {
+            button_id: "confirm_delete_account",
           });
-      }}
-    />
+          setIsSubmitting(true);
+          setErrorMessage(null);
+          // It's currently unclear if and how we should mock our server action:
+          /* c8 ignore next 13 */
+          void props
+            .onDeleteAccount()
+            .then((result) => {
+              if (result && typeof result === "object" && "success" in result) {
+                if (result.success === false) {
+                  setIsSubmitting(false);
+                  setErrorMessage(
+                    result.errorMessage ??
+                      l10n.getString("settings-delete-account-error-generic"),
+                  );
+                  return;
+                }
+              }
+              void signOut({ callbackUrl: "/" });
+            })
+            .catch(() => {
+              setIsSubmitting(false);
+              setErrorMessage(
+                l10n.getString("settings-delete-account-error-generic"),
+              );
+            });
+        }}
+      />
+      {errorMessage && (
+        <p
+          role="status"
+          style={{
+            marginTop: "0.5rem",
+          }}
+        >
+          {errorMessage}
+        </p>
+      )}
+    </>
   );
 };

--- a/src/app/api/utils/auth.tsx
+++ b/src/app/api/utils/auth.tsx
@@ -118,6 +118,9 @@ export const authOptions: AuthOptions = {
     },
     // Unused arguments also listed to show what's available:
     async jwt({ token, account, profile, trigger }) {
+      if (account) {
+        token.authenticatedAt = Date.now();
+      }
       if (trigger === "update") {
         // Refresh the user data from FxA, in case e.g. new subscriptions got added:
         const subscriberFromDb = await getSubscriberByFxaUid(
@@ -297,6 +300,9 @@ export const authOptions: AuthOptions = {
             session.error = "RefreshAccessTokenError";
           }
         }
+      }
+      if (token.authenticatedAt) {
+        session.authenticatedAt = new Date(token.authenticatedAt).toISOString();
       }
 
       return session;

--- a/src/next-auth.d.ts
+++ b/src/next-auth.d.ts
@@ -46,6 +46,7 @@ declare module "next-auth" {
   /** Session data available after deserialising the JWT */
   interface Session {
     error?: "RefreshAccessTokenError";
+    authenticatedAt?: ISO8601DateString;
     user: {
       fxa?: {
         /** The value of the Accept-Language header when the user signed up for their Firefox Account */
@@ -76,5 +77,6 @@ declare module "next-auth/jwt" {
       subscriptions: Array<string>;
     };
     subscriber?: SerializedSubscriber;
+    authenticatedAt?: number;
   }
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-4586

<!-- When adding a new feature: -->

# Description

Require recent authentication before deleting account via Settings menu.

# How to test

There is a unit test, if you want to test manually you can modify `RECENT_AUTH_WINDOW_MS` in `src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/settings/actions.ts` to something very short (e.g. 1 ms) and you should see a message "For your safety, please sign in again (within the last hour) before deleting your account" when trying to delete your account.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
