### PR TITLE
Don't show waitlist if /stats/ endpoint fails

### DIFF
--- a/src/app/(proper_react)/(redesign)/(public)/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/page.tsx
@@ -70,8 +70,8 @@ export default async function Page() {
   );
   const oneRepActivations = profileStats?.total_active;
   const scanLimitReached =
-    typeof oneRepActivations === "undefined" ||
-    oneRepActivations > monthlySubscribersQuota ||
+    (typeof oneRepActivations !== "undefined" &&
+      oneRepActivations > monthlySubscribersQuota) ||
     (enabledFeatureFlags.includes("DisableOneRepScans") && eligibleForPremium);
 
   return (


### PR DESCRIPTION
This is a safer failure mode given Monitor's current state.