### PR TITLE
MNTOR-5112: Control banner state using feature flags

### DIFF
--- a/.env
+++ b/.env
@@ -139,7 +139,6 @@ MOZILLA_VPN_LANDING_URL=https://www-dev.allizom.org/products/vpn
 # have seen data breach results before, will be able to see their known breaches
 # first:
 BROKER_SCAN_RELEASE_DATE=2024-02-06
-BROKER_SCAN_SHUTDOWN_DATE=2025-12-17
 
 MONTHLY_SUBSCRIBERS_QUOTA=
 MONTHLY_SCANS_QUOTA=

--- a/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/[[...slug]]/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/user/(dashboard)/dashboard/[[...slug]]/page.tsx
@@ -202,7 +202,7 @@ export default async function DashboardPage(props: Props) {
       )) !== "undefined"
     : false;
 
-  const shutdownState = getPlusShutdownState(subscriber);
+  const shutdownState = getPlusShutdownState(subscriber, enabledFeatureFlags);
 
   return (
     <View

--- a/src/app/functions/server/getPlusShutdownState.ts
+++ b/src/app/functions/server/getPlusShutdownState.ts
@@ -4,6 +4,7 @@
 
 import { SubscriberRow } from "knex/types/tables";
 import { hasPremium } from "../universal/user";
+import { FeatureFlagName } from "../../../db/tables/featureFlags";
 
 export type ShutdownState = {
   currentMoment: "ye-olden-days" | "runup" | "shutdown";
@@ -11,35 +12,16 @@ export type ShutdownState = {
   ranScan: boolean;
 };
 
-const [shutdownYearString, shutdownMonthString, shutdownDayString] =
-  process.env.BROKER_SCAN_SHUTDOWN_DATE!.split("-");
-const shutdownTimestamp = Date.UTC(
-  Number.parseInt(shutdownYearString, 10),
-  Number.parseInt(shutdownMonthString, 10) - 1,
-  Number.parseInt(shutdownDayString, 10),
-);
-
-/** Number of days before the shutdown in which the banner should be visible: */
-const parsedDaysRunUp = Number.parseInt(
-  process.env.BROKER_SCAN_SHUTDOWN_RUNUP_DAYS ?? "",
-  10,
-);
-const daysRunUp = Number.isNaN(parsedDaysRunUp) ? 29 : parsedDaysRunUp;
-
-const today = new Date(Date.now());
-const todayTimestamp = Date.UTC(
-  today.getFullYear(),
-  today.getMonth(),
-  today.getDate(),
-);
-const daysOut = (shutdownTimestamp - todayTimestamp) / 1000 / 60 / 60 / 24;
-
-const currentMoment =
-  daysOut >= daysRunUp ? "ye-olden-days" : daysOut <= 0 ? "shutdown" : "runup";
-
-export function getPlusShutdownState(user: SubscriberRow): ShutdownState {
+export function getPlusShutdownState(
+  user: SubscriberRow,
+  enabledFeatureFlags: FeatureFlagName[],
+): ShutdownState {
   return {
-    currentMoment: currentMoment,
+    currentMoment: enabledFeatureFlags.includes("PostShutdownBanner")
+      ? "shutdown"
+      : enabledFeatureFlags.includes("ShutdownBanner")
+        ? "runup"
+        : "ye-olden-days",
     hasPremium: hasPremium(user),
     ranScan: user.onerep_profile_id !== null,
   };

--- a/src/db/tables/featureFlags.ts
+++ b/src/db/tables/featureFlags.ts
@@ -73,6 +73,7 @@ export const featureFlagNames = [
   "IncreasedFreeMaxBreachEmails",
   "FreeOnly",
   "ShutdownBanner",
+  "PostShutdownBanner",
 ] as const;
 
 export const adminOnlyFlags: FeatureFlagName[] = [


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-5112
Figma:

<!-- When adding a new feature: -->

# Description

The previous code had a bug: the current date was determined in the module scope of `getPlusShutdownState.ts`, which meant that it only ran the first time the function was imported.

In other words, if this runs on a long-running pod, and at runtime we hit one of the transition dates (to runup or shutdown), then that code will have a current date of yesterday in memory, and thus not properly transition. And because we're running multiple pods that can be restarted, you could be redirected to a different pod on every refresh and thus inconsistently hit different banner states.

I could've fixed that by just pulling the date calculation code into the `getPlusShutdownState` function, but I figured it's best to minimise risk and just accept that we'll have to do some manual work on the specific dates, by flipping feature flags instead.

# How to test

Flip the relevant flags and view your dashboard with a US user (free and Plus).

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
