### PR TITLE
Correctly check for having run a scan

### DIFF
--- a/src/app/functions/server/getPlusShutdownState.ts
+++ b/src/app/functions/server/getPlusShutdownState.ts
@@ -41,6 +41,6 @@ export function getPlusShutdownState(user: SubscriberRow): ShutdownState {
   return {
     currentMoment: currentMoment,
     hasPremium: hasPremium(user),
-    ranScan: typeof user.onerep_profile_id !== "undefined",
+    ranScan: user.onerep_profile_id !== null,
   };
 }


### PR DESCRIPTION
When a user doesn't have a OneRep profile, `onerep_profile_id` is `null`, not `undefined` 🤦
