### PR TITLE
Show has_run_scan announcements to users who have run a scan regardless of current region

### DIFF
--- a/src/db/tables/user_announcements.ts
+++ b/src/db/tables/user_announcements.ts
@@ -130,7 +130,7 @@ export async function initializeUserAnnouncements(
         case "free_users":
           return !isPremium && isUS;
         case "has_run_scan":
-          return !isPremium && hasRunScan && isUS;
+          return !isPremium && hasRunScan;
         case "has_not_run_scan":
           return !isPremium && !hasRunScan && isUS;
         case "non_us":


### PR DESCRIPTION

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-5116


<!-- When adding a new feature: -->

# Description
Historically we gated both "has_run_scan" and "has_not_run_scan" audiences behind an `isUS` check. While debugging the shutdown banner logic in PR #6285, I realized that this incorrectly prevents non-US users who *previously* ran a data broker scan (i.e. have a valid `onerep_profile_id`) from seeing "has_run_scan" announcements.

Product behavior treats scan history as persistent: users who have ever run a scan should continue to see scan-related announcements even if they later move out of the US. The `isUS` guard is only appropriate for "has_not_run_scan", where we are nudging *eligible* users who have never scanned.

# Screenshot (if applicable)

Not applicable.

# How to test

# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
