### PR TITLE
MNTOR-5089: Consolidate configuration settings

### DIFF
--- a/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/page.tsx
+++ b/src/app/(proper_react)/(redesign)/(authenticated)/admin/dev/page.tsx
@@ -7,13 +7,14 @@ import { notFound } from "next/navigation";
 import { isAdmin } from "../../../../../api/utils/auth";
 import { getEnabledFeatureFlags } from "../../../../../../db/tables/featureFlags";
 import { UserAdmin } from "./UserAdmin";
+import { config } from "../../../../../../config";
 
 export default async function DevPage() {
   const session = await getServerSession();
   if (
     !session?.user?.email ||
     !isAdmin(session.user.email) ||
-    process.env.APP_ENV === "production"
+    config.appEnv === "production"
   ) {
     return notFound();
   }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from "@jest/globals";
+import { getEnvEnum, getEnvInt, getEnvString } from "./config";
+
+describe("getEnvString", () => {
+  it("throws an error when attempting to access an undefined environment variable", () => {
+    expect(() => getEnvString("UNDEFINED_ENV_VAR")).toThrow(
+      "Variable $UNDEFINED_ENV_VAR is not defined in `.env`, `.env.test`, `.env.local` and `.env.test.local`, nor as an environment variable.",
+    );
+  });
+
+  it("returns the fallback value when no value is defined and a fallback value is given", () => {
+    expect(
+      getEnvString("UNDEFINED_ENV_VAR", {
+        fallbackValue: "Some fallback value",
+      }),
+    ).toBe("Some fallback value");
+  });
+
+  it("returns the value when defined", () => {
+    expect(getEnvString("NODE_ENV")).toBe("test");
+  });
+});
+
+describe("getEnvInt", () => {
+  it("throws an error when attempting to access an undefined environment variable", () => {
+    expect(() => getEnvInt("UNDEFINED_ENV_VAR")).toThrow(
+      "Variable $UNDEFINED_ENV_VAR is not defined in `.env`, `.env.test`, `.env.local` and `.env.test.local`, nor as an environment variable.",
+    );
+  });
+
+  it("returns the fallback value when attempting to access an undefined environment variable and one is given", () => {
+    expect(getEnvInt("UNDEFINED_ENV_VAR", { fallbackValue: 1337 })).toBe(1337);
+  });
+
+  it("throws an error when attempting to access an environment variable that is set to something other than a valid integer", () => {
+    process.env.TEST_INVALID_VAR = "Not a number";
+
+    expect(() => getEnvInt("TEST_INVALID_VAR")).toThrow(
+      "Variable $TEST_INVALID_VAR is set to [Not a number], which is not a valid number.",
+    );
+
+    delete process.env.TEST_INVALID_VAR;
+  });
+
+  it("returns the fallback value when attempting to access an environment variable that is set to something other than a valid integer and one is given", () => {
+    process.env.TEST_INVALID_VAR = "Not a number";
+
+    expect(getEnvInt("TEST_INVALID_VAR", { fallbackValue: 1337 })).toBe(1337);
+
+    delete process.env.TEST_INVALID_VAR;
+  });
+
+  it("returns the integer value when defined", () => {
+    process.env.TEST_INT_VAR = "42";
+
+    expect(getEnvInt("TEST_INT_VAR")).toBe(42);
+    expect(getEnvInt("TEST_INT_VAR")).not.toBe("42");
+
+    delete process.env.TEST_INT_VAR;
+  });
+});
+
+describe("getEnvEnum", () => {
+  it("throws an error when attempting to access an undefined environment variable", () => {
+    expect(() =>
+      getEnvEnum("UNDEFINED_ENV_VAR", ["Valid value 1", "Valid value 2"]),
+    ).toThrow(
+      "Variable $UNDEFINED_ENV_VAR is not defined in `.env`, `.env.test`, `.env.local` and `.env.test.local`, nor as an environment variable.",
+    );
+  });
+
+  it("returns the fallback value when attempting to access an undefined environment variable and one is given", () => {
+    expect(
+      getEnvEnum("UNDEFINED_ENV_VAR", ["Valid value 1", "Valid value 2"], {
+        fallbackValue: "Valid value 1",
+      }),
+    ).toBe("Valid value 1");
+  });
+
+  it("throws an error when attempting to access an environment variable that is set to something other than one of the valid values", () => {
+    process.env.TEST_INVALID_VAR = "Not a valid value";
+
+    expect(() =>
+      getEnvEnum("TEST_INVALID_VAR", ["Valid value 1", "Valid value 2"]),
+    ).toThrow(
+      'Variable $TEST_INVALID_VAR is set to [Not a valid value], which is not one of the allowed values: ["Valid value 1","Valid value 2"].',
+    );
+
+    delete process.env.TEST_INVALID_VAR;
+  });
+
+  it("returns the fallback value when attempting to access an environment variable that is set to something other than one of the valid values and one is given", () => {
+    process.env.TEST_INVALID_VAR = "Not a valid value";
+
+    expect(
+      getEnvEnum("TEST_INVALID_VAR", ["Valid value 1", "Valid value 2"], {
+        fallbackValue: "Valid value 1",
+      }),
+    ).toBe("Valid value 1");
+
+    delete process.env.TEST_INVALID_VAR;
+  });
+
+  it("returns the integer value when defined", () => {
+    process.env.TEST_ENUM_VAR = "Valid value 2";
+
+    expect(
+      getEnvEnum("TEST_ENUM_VAR", ["Valid value 1", "Valid value 2"]),
+    ).toBe("Valid value 2");
+
+    delete process.env.TEST_ENUM_VAR;
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Only process.env variables starting with `NEXT_PUBLIC_` will be shipped to the client:
+import "./app/functions/server/notInClientComponent";
+import * as dotenvFlow from "dotenv-flow";
+
+if (typeof process.env.NEXT_RUNTIME !== "string") {
+  // If we're in Next.js, our `.env` files are already set up to be loaded.
+  // Outside of Next.js (e.g. in cron jobs), however, we need to explicitly load them.
+  dotenvFlow.config();
+}
+
+/**
+ * Environment-specific values
+ *
+ * Use this object to access values that differ per environment (e.g. running
+ * locally, on stage, or in production).
+ *
+ * Prefer using this object over `process.env`, as this object validates values
+ * at app startup, ensuring that their values are something we expect, optionally
+ * falling back to sensible values (for running locally) if not.
+ */
+export const config = {
+  appEnv: getEnvEnum("APP_ENV", ["local", "stage", "production"], {
+    fallbackValue: "local",
+  }),
+  monthlyActivityFreeEmailBatchSize: getEnvInt(
+    "MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE",
+    { fallbackValue: 10 },
+  ),
+};
+
+/**
+ * Like {@link getEnvString}, but also ensures the value is a valid integer
+ *
+ * @param key Key whose value to look up in the environment.
+ * @param options.fallbackValue If specified, value to return if no integer value for the given `key` was found. If not provided, this function will throw an error if the value is not found.
+ * @returns Value for the given `key`, `options.fallbackValue` if no value is found (or throws an error if that is not set).
+ */
+export function getEnvInt(
+  key: string,
+  options: Partial<{ fallbackValue: number }> = {},
+): number {
+  try {
+    const valueString = getEnvString(key);
+    const value = Number.parseInt(valueString, 10);
+    if (Number.isNaN(value)) {
+      throw new Error(
+        `Variable $${key} is set to [${valueString}], which is not a valid number.`,
+      );
+    }
+    return value;
+  } catch (e) {
+    if (typeof options.fallbackValue === "number") {
+      return options.fallbackValue;
+    }
+    throw e;
+  }
+}
+
+/**
+ * Like {@link getEnvString}, but also checks that the value is one of `possibleValues`
+ *
+ * @param key Key whose value to look up in the environment.
+ * @param possibleValues Allowed values for the given key.
+ * @param options.fallbackValue If specified, value to return if no value matching `possibleValues` for the given `key` was found. If not provided, this function will throw an error if the value is not found.
+ * @returns Value for the given `key`, `options.fallbackValue` if no value is found (or throws an error if that is not set).
+ */
+export function getEnvEnum<T extends string>(
+  key: string,
+  possibleValues: Array<T>,
+  options: Partial<{ fallbackValue: T }> = {},
+): T {
+  try {
+    const value = getEnvString(key);
+    if (!possibleValues.includes(value as T)) {
+      throw new Error(
+        `Variable $${key} is set to [${value}], which is not one of the allowed values: ${JSON.stringify(possibleValues)}.`,
+      );
+    }
+    return value as T;
+  } catch (e) {
+    if (typeof options.fallbackValue === "string") {
+      return options.fallbackValue;
+    }
+    throw e;
+  }
+}
+
+/**
+ * Reads an environment variable, returning a fallback value if it's not set, or throws an error if no fallback value was provided.
+ *
+ * Environment variables are looked up by `key` from the following places,
+ * in order, stopping when the variable is found:
+ *
+ * - Environment variables
+ * - `.env.<$NODE_ENV>.local`
+ * - `.env.local`
+ * - `.env.<$NODE_ENV>`
+ * - `.env`
+ *
+ * @param key Key whose value to look up in the environment.
+ * @param options.fallbackValue If specified, value to return if no value for the given `key` was found. If not provided, this function will throw an error if the value is not found.
+ * @returns Value for the given `key`, `options.fallbackValue` if no value is found (or throws an error if that is not set).
+ */
+export function getEnvString(
+  key: string,
+  options: Partial<{ fallbackValue: string }> = {},
+): string {
+  const value = process.env[key];
+  if (typeof value !== "string" || value === "") {
+    if (typeof options.fallbackValue === "string") {
+      return options.fallbackValue;
+    }
+    throw new Error(
+      `Variable $${key} is not defined in \`.env\`, \`.env.${process.env.NODE_ENV}\`, \`.env.local\` and \`.env.${process.env.NODE_ENV}.local\`, nor as an environment variable.`,
+    );
+  }
+
+  return value;
+}

--- a/src/scripts/cronjobs/monthlyActivityFree.tsx
+++ b/src/scripts/cronjobs/monthlyActivityFree.tsx
@@ -41,6 +41,7 @@ import { getBreaches } from "../../app/functions/server/getBreaches";
 import { getExperimentationIdFromSubscriber } from "../../app/functions/server/getExperimentationId";
 import { getExperiments } from "../../app/functions/server/getExperiments";
 import { getLocale } from "../../app/functions/universal/getLocale";
+import { config } from "../../config";
 
 let sentEmails = 0;
 process.on("SIGINT", () => {
@@ -61,20 +62,11 @@ async function tearDown() {
 }
 
 async function run() {
-  let batchSize = Number.parseInt(
-    process.env.MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE ?? "10",
-    10,
+  logger.info(
+    `Getting free subscribers with batch size: ${config.monthlyActivityFreeEmailBatchSize}`,
   );
-  if (Number.isNaN(batchSize)) {
-    batchSize = 10;
-    logger.warn(
-      `Could not send monthly activity emails, because the env var MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE has a non-numeric value: [${process.env.MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE}].`,
-    );
-  }
-
-  logger.info(`Getting free subscribers with batch size: ${batchSize}`);
   const subscribersToEmail = await getFreeSubscribersWaitingForMonthlyEmail(
-    batchSize,
+    config.monthlyActivityFreeEmailBatchSize,
     ["US"],
   );
   // Using `getFeatureFlagData` instead of `getEnabledFeatureFlags` here to prevent fetching them for every subscriber.


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-5089
Figma:

<!-- When adding a new feature: -->

# Description

This is a proposal for how to centralise our environment-specific configuration. If you both agree with this approach, I can do a sweep over the codebase for all references to `process.env`, and replace them by references to `config`.

One other thing we might consider is adopting [`@next/env`](https://www.npmjs.com/package/@next/env) instead of `dotenv-flow` - behaviour should be the same I think, but then we're using the exact same code Next.js is using to load env vars, so that's technically one fewer dependency, and less risk of divergence. (Plus, I'm not sure if dotenv-flow is being very actively maintained, and we need [a fix](https://github.com/kerimdzhanov/dotenv-flow/pull/97) there for the Next.js upgrade.)

# How to test

I've included two examples where `config` are used:

- [On `/admin/dev`](https://github.com/mozilla/blurts-server/pull/6324/files#diff-42f12eb13ebc217640abbbf898fe2ef8ff3c4b80fad604abf5018d3ff3eba068). To verify that this works, access that page with an admin account locally, then run using e.g. `APP_ENV="production" npm run dev` or by setting that in your `.env.local`, and verify that you now get a 404 on that page with the same account.
- To verify that it also works in non-Next.js environments, I also [added it](https://github.com/mozilla/blurts-server/pull/6324/files#diff-47d4e3c33416f920b3aa863b27d66d2b07af24e45d449d09e17fbbb2f27d4e1f) to `npm run dev:cron:monthly-activity-free`. Likewise, if you set `MONTHLY_ACTIVITY_FREE_EMAIL_BATCH_SIZE` to a value other than 10, you should see that referenced in the logs:

```
{"level":"info","message":"Getting free subscribers with batch size: 10"}
```

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
