### PR TITLE
MNTOR-5140: Remove unused dependency react-toastify

### DIFF
--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -205,12 +205,6 @@ This is used for the small confetti animation when completing the guided
 resolution flow. This can be seen in action in Storybook, in the story
 `Logged in / Guided resolution / 4. Security recommendations / 4d. Done`.
 
-### `react-toastify`
-
-Used to display toast notifications, e.g. the error message when you try to
-unsubscribe via the following page, which uses an invalid unsubscription
-token: http://localhost:6060/unsubscribe-email/monthly-report-free?token=wrong (DEPRECATED)
-
 ### `husky` and `lint-staged`
 
 Used to run basic code formatting when committing. You can verify that these

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "react-dom": "^19.2.3",
         "react-intersection-observer": "^10.0.0",
         "react-stately": "^3.42.0",
-        "react-toastify": "^11.0.5",
         "server-only": "^0.0.1",
         "sharp": "^0.34.5",
         "uuid": "^11.1.0",
@@ -27560,19 +27559,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/react-toastify": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
-      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "react-dom": "^19.2.3",
     "react-intersection-observer": "^10.0.0",
     "react-stately": "^3.42.0",
-    "react-toastify": "^11.0.5",
     "server-only": "^0.0.1",
     "sharp": "^0.34.5",
     "uuid": "^11.1.0",

--- a/src/app/(proper_react)/(redesign)/(public)/PublicShell.module.scss
+++ b/src/app/(proper_react)/(redesign)/(public)/PublicShell.module.scss
@@ -4,22 +4,6 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-
-  // See https://fkhadra.github.io/react-toastify/how-to-style#override-css-variabless
-  --toastify-color-light: #{tokens.$color-white};
-  --toastify-color-dark: #{tokens.$color-grey-50};
-  --toastify-color-info: #{tokens.$color-blue-50};
-  --toastify-color-success: #{tokens.$color-green-50};
-  --toastify-color-warning: #{tokens.$color-yellow-50};
-  --toastify-color-error: #{tokens.$color-red-60};
-
-  --toastify-text-color-info: #{tokens.$color-white};
-  --toastify-text-color-success: #{tokens.$color-grey-50};
-  --toastify-text-color-warning: #{tokens.$color-grey-50};
-  --toastify-text-color-error: #{tokens.$color-white};
-
-  --toastify-toast-min-height: $layout-md;
-  --toastify-toast-max-height: $layout-md;
 }
 
 .nav {

--- a/src/app/(proper_react)/(redesign)/(public)/PublicShell.tsx
+++ b/src/app/(proper_react)/(redesign)/(public)/PublicShell.tsx
@@ -10,8 +10,6 @@ import MonitorLogo from "../../images/monitor-logo.svg";
 import { ExtendedReactLocalization } from "../../../functions/l10n";
 import { SignInButton } from "../../../components/client/SignInButton";
 import { Footer } from "../Footer";
-import { ToastContainer } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
 import { FeatureFlagName } from "../../../../db/tables/featureFlags";
 import { ExperimentData } from "../../../../telemetry/generated/nimbus/experiments";
 
@@ -26,12 +24,6 @@ export type Props = {
 export const PublicShell = (props: Props) => {
   return (
     <div className={styles.wrapper}>
-      <ToastContainer
-        toastClassName={styles.toastBody}
-        position="top-center"
-        theme="colored"
-        autoClose={false}
-      />
       <nav className={styles.nav}>
         <h1>
           <Link href="/">

--- a/src/app/(proper_react)/(redesign)/Shell/Shell.tsx
+++ b/src/app/(proper_react)/(redesign)/Shell/Shell.tsx
@@ -10,8 +10,6 @@ import { ExtendedReactLocalization } from "../../../functions/l10n";
 import { FeatureFlagName } from "../../../../db/tables/featureFlags";
 import styles from "./Shell.module.scss";
 import { UserAnnouncementWithDetails } from "../../../../db/tables/user_announcements";
-import { ToastContainer } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
 import { config } from "../../../../config";
 
 export type Props = {
@@ -32,7 +30,6 @@ export const Shell = (props: Props) => {
       server session and is not being mounted when running unit tests. */}
       {/* c8 ignore next */}
       {config.nodeEnv !== "test" && <SubscriptionCheck />}
-      <ToastContainer position="top-center" theme="colored" autoClose={false} />
       <ShellRedesign
         countryCode={props.countryCode}
         session={props.session}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-5140
Figma:

<!-- When adding a new feature: -->

# Description

We're no longer using toasts anywhere, so we can save on a dependency and some unused code by removing it.

# How to test

Search for `toastify` in the codebase, find nothing.

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug. - N/A, unused code
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
