### PR TITLE
MNTOR-5264: add active user filter to subscriber queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8430,6 +8430,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8469,6 +8470,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8489,6 +8491,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8509,6 +8512,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8529,6 +8533,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8549,6 +8554,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8569,6 +8575,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8589,6 +8596,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8609,6 +8617,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8629,6 +8638,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8649,6 +8659,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8669,6 +8680,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8689,6 +8701,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8709,6 +8722,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -22504,6 +22518,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },

--- a/src/db/models/BreachNotificationSubscriber.integration.ts
+++ b/src/db/models/BreachNotificationSubscriber.integration.ts
@@ -10,7 +10,11 @@ import { getBreachNotificationSubscribersByHashes } from "./BreachNotificationSu
 import type { SubscriberRow } from "knex/types/tables";
 
 describe("BreachNotificationSubscriber", () => {
-  const subscriber = seeds.subscribers({ primary_verified: true });
+  const recentSession = new Date();
+  const subscriber = seeds.subscribers({
+    primary_verified: true,
+    fxa_session_expiry: recentSession,
+  });
   const chaffSubs = Array.from(Array(10).keys()).map((_) =>
     seeds.subscribers(),
   );
@@ -111,6 +115,7 @@ describe("BreachNotificationSubscriber", () => {
           seeds.subscribers({
             primary_verified: true,
             all_emails_to_primary: true,
+            fxa_session_expiry: recentSession,
           }),
         )
         .returning("*")
@@ -142,6 +147,7 @@ describe("BreachNotificationSubscriber", () => {
           seeds.subscribers({
             primary_verified: true,
             all_emails_to_primary: false,
+            fxa_session_expiry: recentSession,
           }),
         )
         .returning("*")
@@ -164,6 +170,115 @@ describe("BreachNotificationSubscriber", () => {
           notification_email: insertedEmails[0].email,
         }),
       ]),
+    );
+  });
+
+  it("excludes subscribers with null fxa_session_expiry", async () => {
+    const inactiveSub = (
+      await conn("subscribers")
+        .insert(
+          seeds.subscribers({
+            primary_verified: true,
+            fxa_session_expiry: null,
+          }),
+        )
+        .returning("*")
+    )[0];
+    const hashes = [inactiveSub.primary_sha1];
+    const actual = await getBreachNotificationSubscribersByHashes(hashes);
+    expect(actual.length).toEqual(0);
+  });
+
+  it("excludes subscribers with fxa_session_expiry older than 1 year", async () => {
+    const twoYearsAgo = new Date(Date.now() - 2 * 365.25 * 24 * 60 * 60 * 1000);
+    const expiredSub = (
+      await conn("subscribers")
+        .insert(
+          seeds.subscribers({
+            primary_verified: true,
+            fxa_session_expiry: twoYearsAgo,
+          }),
+        )
+        .returning("*")
+    )[0];
+    const hashes = [expiredSub.primary_sha1];
+    const actual = await getBreachNotificationSubscribersByHashes(hashes);
+    expect(actual.length).toEqual(0);
+  });
+
+  it("includes subscribers with fxa_session_expiry within the last year", async () => {
+    const sixMonthsAgo = new Date(
+      Date.now() - 0.5 * 365.25 * 24 * 60 * 60 * 1000,
+    );
+    const activeSub = (
+      await conn("subscribers")
+        .insert(
+          seeds.subscribers({
+            primary_verified: true,
+            fxa_session_expiry: sixMonthsAgo,
+          }),
+        )
+        .returning("*")
+    )[0];
+    const hashes = [activeSub.primary_sha1];
+    const actual = await getBreachNotificationSubscribersByHashes(hashes);
+    expect(actual.length).toEqual(1);
+    expect(actual[0]).toEqual(
+      expect.objectContaining({
+        subscriber_id: activeSub.id,
+        breached_email: activeSub.primary_email,
+      }),
+    );
+  });
+
+  it("excludes inactive subscribers via secondary email path", async () => {
+    const inactiveSub = (
+      await conn("subscribers")
+        .insert(
+          seeds.subscribers({
+            primary_verified: true,
+            fxa_session_expiry: null,
+          }),
+        )
+        .returning("*")
+    )[0];
+    const insertedEmails = await conn("email_addresses")
+      .insert([seeds.emails(inactiveSub.id, { verified: true })])
+      .returning("*");
+    const hashes = [insertedEmails[0].sha1];
+    const actual = await getBreachNotificationSubscribersByHashes(hashes);
+    expect(actual.length).toEqual(0);
+  });
+
+  it("returns only active subscribers when mixed with inactive ones", async () => {
+    const activeSub = (
+      await conn("subscribers")
+        .insert(
+          seeds.subscribers({
+            primary_verified: true,
+            fxa_session_expiry: recentSession,
+          }),
+        )
+        .returning("*")
+    )[0];
+    const inactiveSub = (
+      await conn("subscribers")
+        .insert(
+          seeds.subscribers({
+            primary_verified: true,
+            fxa_session_expiry: null,
+          }),
+        )
+        .returning("*")
+    )[0];
+    const hashes = [activeSub.primary_sha1, inactiveSub.primary_sha1];
+    const actual = await getBreachNotificationSubscribersByHashes(hashes);
+    expect(actual.length).toEqual(1);
+    expect(actual[0]).toEqual(
+      expect.objectContaining({
+        subscriber_id: activeSub.id,
+        breached_email: activeSub.primary_email,
+      }),
     );
   });
 });

--- a/src/db/models/BreachNotificationSubscriber.ts
+++ b/src/db/models/BreachNotificationSubscriber.ts
@@ -6,6 +6,8 @@ import { EmailAddressRow, SubscriberRow } from "knex/types/tables";
 import { getEmailAddressesByHashes } from "../tables/emailAddresses";
 import { getSubscribersByHashes } from "../tables/subscribers";
 
+const ACTIVE_USER_MAX_AGE_MS = 365.25 * 24 * 60 * 60 * 1000; // 1 year
+
 // Covered by integration tests but report is not combined
 // TODO: MNTOR-5117
 /* c8 ignore start */
@@ -23,32 +25,37 @@ export type BreachNotificationSubscriber = {
 export async function getBreachNotificationSubscribersByHashes(
   hashes: string[],
 ): Promise<BreachNotificationSubscriber[]> {
+  const activeFilter = { activeWithinMs: ACTIVE_USER_MAX_AGE_MS };
   // 2 sources of email address - the subscribers table and
   // email address table (containing additional emails)
   // First query if the primary email has been breached
-  const primary = (await getSubscribersByHashes(hashes)).map((row) => ({
-    subscriber_id: row.id,
-    all_emails_to_primary: row.all_emails_to_primary,
-    primary_email: row.primary_email,
-    breached_email: row.primary_email,
-    notification_email: row.primary_email,
-    signup_language: row.signup_language,
-    fxa_profile_json: row.fxa_profile_json,
-    fxa_uid: row.fxa_uid,
-  }));
+  const primary = (await getSubscribersByHashes(hashes, activeFilter)).map(
+    (row) => ({
+      subscriber_id: row.id,
+      all_emails_to_primary: row.all_emails_to_primary,
+      primary_email: row.primary_email,
+      breached_email: row.primary_email,
+      notification_email: row.primary_email,
+      signup_language: row.signup_language,
+      fxa_profile_json: row.fxa_profile_json,
+      fxa_uid: row.fxa_uid,
+    }),
+  );
   // Second for secondary emails (joined to subscriber record)
-  const secondary = (await getEmailAddressesByHashes(hashes)).map((row) => ({
-    subscriber_id: row.subscriber_id,
-    all_emails_to_primary: row.all_emails_to_primary,
-    primary_email: row.primary_email,
-    breached_email: row.email,
-    notification_email: row.all_emails_to_primary
-      ? row.primary_email
-      : row.email,
-    signup_language: row.signup_language,
-    fxa_profile_json: row.fxa_profile_json,
-    fxa_uid: row.fxa_uid,
-  }));
+  const secondary = (await getEmailAddressesByHashes(hashes, activeFilter)).map(
+    (row) => ({
+      subscriber_id: row.subscriber_id,
+      all_emails_to_primary: row.all_emails_to_primary,
+      primary_email: row.primary_email,
+      breached_email: row.email,
+      notification_email: row.all_emails_to_primary
+        ? row.primary_email
+        : row.email,
+      signup_language: row.signup_language,
+      fxa_profile_json: row.fxa_profile_json,
+      fxa_uid: row.fxa_uid,
+    }),
+  );
   return primary.concat(secondary);
 }
 /* c8 ignore stop */

--- a/src/db/tables/emailAddresses.ts
+++ b/src/db/tables/emailAddresses.ts
@@ -328,11 +328,22 @@ async function removeOneSecondaryEmail(emailId: number, subscriberId: number) {
 
 // Not covered by tests; mostly side-effects. See test-coverage.md#mock-heavy
 /* c8 ignore start */
-async function getEmailAddressesByHashes(hashes: string[]) {
-  return await knex("email_addresses")
+async function getEmailAddressesByHashes(
+  hashes: string[],
+  options?: { activeWithinMs?: number },
+) {
+  const query = knex("email_addresses")
     .join("subscribers", "email_addresses.subscriber_id", "=", "subscribers.id")
     .whereIn("email_addresses.sha1", hashes)
     .andWhere("email_addresses.verified", "=", true);
+  if (options?.activeWithinMs !== undefined) {
+    query.andWhere(
+      "subscribers.fxa_session_expiry",
+      ">",
+      new Date(Date.now() - options.activeWithinMs),
+    );
+  }
+  return await query;
 }
 /* c8 ignore stop */
 

--- a/src/db/tables/subscribers.ts
+++ b/src/db/tables/subscribers.ts
@@ -16,10 +16,21 @@ const knex = createDbConnection();
 
 // Not covered by tests; mostly side-effects. See test-coverage.md#mock-heavy
 /* c8 ignore start */
-async function getSubscribersByHashes(hashes: string[]) {
-  return await knex("subscribers")
+async function getSubscribersByHashes(
+  hashes: string[],
+  options?: { activeWithinMs?: number },
+) {
+  const query = knex("subscribers")
     .whereIn("primary_sha1", hashes)
     .andWhere("primary_verified", "=", true);
+  if (options?.activeWithinMs !== undefined) {
+    query.andWhere(
+      "fxa_session_expiry",
+      ">",
+      new Date(Date.now() - options.activeWithinMs),
+    );
+  }
+  return await query;
 }
 /* c8 ignore stop */
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-5264
Figma:

<!-- When adding a new feature: -->

# Description
* rework the `getBreachNotificationSubscribersByHashes` function to include an `activeWithinMs` filter for subscribers and email addresses. This change ensures that only active users within the specified timeframe are retrieved, capping the amount of emails sent for breaches
*  corresponding database query functions to accept this new filter option.

# Screenshot (if applicable)

Not applicable.

# How to test

# Checklist (Definition of Done)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [x] All acceptance criteria are met.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
