### PR TITLE
fix(e2e): bypass Fastly CAPTCHA on FxA stage with fxa-ci header

### DIFF
--- a/.github/workflows/functional_tests_cron.yml
+++ b/.github/workflows/functional_tests_cron.yml
@@ -67,6 +67,7 @@ jobs:
           E2E_TEST_SECRET: ${{ secrets.E2E_TEST_SECRET }}
           E2E_TEST_ACCOUNT_BASE_EMAIL: ${{ secrets.E2E_TEST_ACCOUNT_BASE_EMAIL }}
           E2E_TEST_ACCOUNT_BASE_PASSWORD: ${{ secrets.E2E_TEST_ACCOUNT_BASE_PASSWORD }}
+          FXA_CI_SECRET: ${{ secrets.FXA_CI_SECRET }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:

--- a/functional-tests/fixtures/baseTest.ts
+++ b/functional-tests/fixtures/baseTest.ts
@@ -6,6 +6,7 @@ import { test as baseTest, expect } from "@playwright/test";
 import { FeatureFlagName } from "../../src/db/tables/featureFlags";
 import { createTestClientRegionToken } from "../../src/app/functions/server/testCountryCodeToken";
 import { getBaseTestEnvUrl } from "../utils/environment";
+import { setupFxaCiRoutes } from "../utils/fxa";
 
 // Feature flags that are enabled by default locally
 export const defaultLocalForcedFeatureFlags: FeatureFlagName[] = [
@@ -40,7 +41,8 @@ const test = baseTest.extend<{
     await use(mergedFlags);
   },
   sharedBeforeEach: [
-    async ({ context, localForcedFeatureFlags }, use, testInfo) => {
+    async ({ context, page, localForcedFeatureFlags }, use, testInfo) => {
+      await setupFxaCiRoutes(page);
       await context.route("**/*", async (route) => {
         const request = route.request();
         const requestUrl = request.url();

--- a/functional-tests/playwright.config.ts
+++ b/functional-tests/playwright.config.ts
@@ -117,6 +117,9 @@ export const projects = locations.flatMap((geo) =>
             "x-forced-client-region-token": createTestClientRegionToken(
               geo.name.toLowerCase(),
             ),
+            ...(process.env.FXA_CI_SECRET
+              ? { "fxa-ci": process.env.FXA_CI_SECRET }
+              : {}),
           },
         },
       }) as const satisfies Project,

--- a/functional-tests/tests/global-setup.ts
+++ b/functional-tests/tests/global-setup.ts
@@ -10,7 +10,12 @@ import {
   type E2E_TEST_ENV_VALUE,
   getBaseTestEnvUrl,
 } from "../utils/environment";
-import { goToFxA, signUpUser } from "../utils/fxa";
+import {
+  getFxaCiHeaders,
+  goToFxA,
+  setupFxaCiRoutes,
+  signUpUser,
+} from "../utils/fxa";
 import { getTestUserSessionFilePath } from "../utils/user";
 import { projects } from "../playwright.config";
 
@@ -48,8 +53,10 @@ async function setupUserAccount(browser: Browser) {
       geolocation: project.use.geolocation,
       locale: project.use.locale,
       permissions: ["geolocation"],
+      extraHTTPHeaders: getFxaCiHeaders(),
     });
     const page = await context.newPage();
+    await setupFxaCiRoutes(page);
 
     // Sign up flow
     const timestamp = Date.now();

--- a/functional-tests/tests/global-teardown.ts
+++ b/functional-tests/tests/global-teardown.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from "url";
 import { test as teardown } from "../fixtures/authenticatedTest";
 import { getTestUserSessionFilePath } from "../utils/user";
 import { getBaseTestEnvUrl } from "../utils/environment";
+import { getFxaCiHeaders, setupFxaCiRoutes } from "../utils/fxa";
 import { projects } from "../playwright.config";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -25,8 +26,12 @@ function removeTestStorage() {
 async function deleteTestUserAccounts(browser: Browser) {
   for (const project of projects) {
     const storageState = getTestUserSessionFilePath(project.name);
-    const context = await browser.newContext({ storageState });
+    const context = await browser.newContext({
+      storageState,
+      extraHTTPHeaders: getFxaCiHeaders(),
+    });
     const page = await context.newPage();
+    await setupFxaCiRoutes(page);
 
     await page.goto(`${getBaseTestEnvUrl()}/user/settings/manage-account`);
 

--- a/functional-tests/utils/fxa.ts
+++ b/functional-tests/utils/fxa.ts
@@ -2,13 +2,45 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Page } from "@playwright/test";
+import { Page, Route } from "@playwright/test";
 import { getBaseTestEnvUrl } from "./environment";
 import { fetchRestmailVerificationCode } from "./user";
 
+// Strip fxa-ci from third-party domains to avoid CORS preflight failures.
+// extraHTTPHeaders sends fxa-ci on ALL requests (needed because page.route()
+// can't intercept navigation requests after server-side redirects).
+// FxA domains (accounts, api-accounts, oauth, profile on *.mozaws.net)
+// are NOT listed — they need the header to bypass Fastly's CAPTCHA.
+const STRIP_FXA_CI_PATTERNS = [
+  "**/accounts-cdn*/**",
+  "**/*.sentry.io/**",
+  "**/*.stripe.com/**",
+  "**/*.stripe.network/**",
+  "**/www.google-analytics.com/**",
+  "**/www.googletagmanager.com/**",
+];
+
+export async function setupFxaCiRoutes(page: Page) {
+  if (!process.env.FXA_CI_SECRET) return;
+  const stripFxaCi = (route: Route) => {
+    const headers = { ...route.request().headers() };
+    delete headers["fxa-ci"];
+    return route.continue({ headers });
+  };
+  for (const pattern of STRIP_FXA_CI_PATTERNS) {
+    await page.route(pattern, stripFxaCi);
+  }
+}
+
+export function getFxaCiHeaders(): Record<string, string> {
+  return process.env.FXA_CI_SECRET
+    ? { "fxa-ci": process.env.FXA_CI_SECRET }
+    : {};
+}
+
 async function waitForFxa(page: Page) {
-  // Loading FxA can take a while
-  await page.waitForURL("**/oauth**", { timeout: 60_000 });
+  // Loading FxA can take a while. FxA uses /authorization for the OAuth flow.
+  await page.waitForURL("**/authorization**", { timeout: 60_000 });
 }
 
 async function goToFxA(


### PR DESCRIPTION
# References:

Jira: https://mozilla-hub.atlassian.net/browse/MNTOR-5273

# Description

Fastly's dynamic CAPTCHA blocks headless Chromium on FxA stage. The fxa-ci header bypasses it, but Playwright's extraHTTPHeaders sends it on all requests. Third-party domains reject the custom header in CORS preflight, breaking the OAuth flow.

Send fxa-ci globally via extraHTTPHeaders, then strip it from non-FxA domains with page.route() handlers.

# Screenshot (if applicable)

<img width="358" height="344" alt="image" src="https://github.com/user-attachments/assets/fb5ae271-9a44-4248-966b-2c7223fd6452" />


# How to test
https://github.com/mozilla/blurts-server/actions/runs/25343631607

# Checklist (Definition of Done)

- [x] ~Localization strings (if needed) have been added.~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] ~I've added or updated the relevant sections in readme and/or code comments~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.~
- [x] ~If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set~
- [x] ~Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.~
- [x] ~All acceptance criteria are met.~
- [x] Jira ticket has been updated (if needed) to match changes made during the development process.
- [x] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.