### PR TITLE
fix(getBreaches): don't cache breaches in variable

### DIFF
--- a/src/app/functions/server/getBreaches.ts
+++ b/src/app/functions/server/getBreaches.ts
@@ -10,12 +10,8 @@ import {
 } from "../../../utils/hibp";
 import { upsertBreaches } from "../../../db/tables/breaches";
 
-let breaches: Array<HibpLikeDbBreach>;
-
 export async function getBreaches(): Promise<HibpLikeDbBreach[]> {
-  if (breaches) {
-    return breaches;
-  }
+  let breaches: Array<HibpLikeDbBreach>;
   breaches = await getAllBreachesFromDb();
   logger.debug("loaded_breaches_from_database", {
     breachesLength: breaches.length,


### PR DESCRIPTION
# References:

Jira: MNTOR-5251

# Description
- We are having an issue w/ icons not showing up on the breaches page and also sometimes w/ 404s when you click tiles
- The icons _are_ populated in the DB as of 5/5 sync
- The current logic essentially creates a permanent local cache for the lifetime of each pod. All of the pods except one are more than 3 days old, meaning the data they've cached is likely stale.
- This logic is unnecessary because `getAllBreachesFromDb()` is already using a Redis cache to reduce calls to the DB / HIBP
- The `syncBreaches` cronjob will update this cache, so users should get new info as soon as it's populated
- We should consider a follow-on PR in the infra repo to set a `Cache-Control: no-cache` header on this page

# Changes
- Don't use a global var for storing breaches, and instead rely on the Redis cache

# How to test
- I tested locally with 60s cache expiry in redis by updating logos and seeing them change on expiration
