### PR TITLE
fix(ci): stop leaking secrets in Playwright artifacts

### DIFF
--- a/.github/workflows/functional_tests_cron.yml
+++ b/.github/workflows/functional_tests_cron.yml
@@ -68,19 +68,6 @@ jobs:
           E2E_TEST_ACCOUNT_BASE_EMAIL: ${{ secrets.E2E_TEST_ACCOUNT_BASE_EMAIL }}
           E2E_TEST_ACCOUNT_BASE_PASSWORD: ${{ secrets.E2E_TEST_ACCOUNT_BASE_PASSWORD }}
           FXA_CI_SECRET: ${{ secrets.FXA_CI_SECRET }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
-        with:
-          name: playwright-report-${{ github.event_name == 'workflow_dispatch' && inputs.test_env || matrix.test_env }}
-          path: playwright-report/
-          retention-days: 30
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
-        with:
-          name: test-results-${{ github.event_name == 'workflow_dispatch' && inputs.test_env || matrix.test_env }}
-          path: src/functional-tests/test-results/
-          retention-days: 30
-
       - name: Send GitHub Action trigger data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2

--- a/.github/workflows/functional_tests_pr.yml
+++ b/.github/workflows/functional_tests_pr.yml
@@ -85,15 +85,3 @@ jobs:
           SENTRY_DSN: "Unused for the test run, but required to be present when loading env vars"
           EMAIL_FROM: "Unused for the test run, but required to be present when loading env vars"
           S3_BUCKET: "Unused for the test run, but required to be present when loading env vars"
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
-        with:
-          name: test-results
-          path: src/functional-tests/test-results/
-          retention-days: 30

--- a/.github/workflows/functional_tests_pr.yml
+++ b/.github/workflows/functional_tests_pr.yml
@@ -74,6 +74,7 @@ jobs:
           E2E_TEST_ACCOUNT_BASE_EMAIL: ${{ secrets.E2E_TEST_ACCOUNT_BASE_EMAIL }}
           E2E_TEST_ACCOUNT_BASE_PASSWORD: ${{ secrets.E2E_TEST_ACCOUNT_BASE_PASSWORD }}
           E2E_TEST_ENV: local
+          FXA_CI_SECRET: ${{ secrets.FXA_CI_SECRET }}
           HIBP_API_TOKEN: ${{ secrets.HIBP_API_TOKEN }}
           HIBP_KANON_API_ROOT: "http://localhost:6060/api/mock/hibp"
           HIBP_KANON_API_TOKEN: ${{ secrets.HIBP_KANON_API_TOKEN }}

--- a/functional-tests/playwright.config.ts
+++ b/functional-tests/playwright.config.ts
@@ -164,8 +164,8 @@ export default defineConfig({
         : "only-on-failure",
     /* Video and trace disabled in CI to prevent secret leakage in artifacts */
     video: process.env.CI ? "off" : "retain-on-failure",
-    /* Collect trace when retrying. See https://playwright.dev/docs/trace-viewer */
-    trace: process.env.CI ? "off" : "on-first-retry",
+    /* Collect trace when tests fail. See https://playwright.dev/docs/trace-viewer */
+    trace: process.env.CI ? "off" : "retain-on-failure",
   },
   /* Configure projects for major browsers */
   projects: [

--- a/functional-tests/playwright.config.ts
+++ b/functional-tests/playwright.config.ts
@@ -150,7 +150,7 @@ export default defineConfig({
   /* Use a custom percentage of available workers in CI and default locally */
   workers: process.env.CI ? "75%" : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? [["github"], ["html"]] : "html",
+  reporter: process.env.CI ? [["github"]] : "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
@@ -162,13 +162,10 @@ export default defineConfig({
       process.env.GITHUB_EVENT_NAME === "workflow_dispatch"
         ? "on"
         : "only-on-failure",
-    /* Automatically record video when tests fail */
-    video: "retain-on-failure",
-    /* Collect trace when tests fail, or if it's a manually-triggered run. See https://playwright.dev/docs/trace-viewer */
-    trace:
-      process.env.GITHUB_EVENT_NAME === "workflow_dispatch"
-        ? "on"
-        : "retain-on-failure",
+    /* Video and trace disabled in CI to prevent secret leakage in artifacts */
+    video: process.env.CI ? "off" : "retain-on-failure",
+    /* Collect trace when retrying. See https://playwright.dev/docs/trace-viewer */
+    trace: process.env.CI ? "off" : "on-first-retry",
   },
   /* Configure projects for major browsers */
   projects: [


### PR DESCRIPTION
Trace files, videos, and HTML reports exposed credentials in plain text. Uploaded artifacts persisted for 30 days on a public repo.

- Disable trace and video recording in CI
- Drop HTML reporter in CI, keep github reporter
- Remove all upload-artifact steps from both workflows

# References:

Jira: [MPP-4662](https://mozilla-hub.atlassian.net/browse/MPP-4662)

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] I've added or updated the relevant sections in readme and/or code comments

[MPP-4662]: https://mozilla-hub.atlassian.net/browse/MPP-4662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ