### PR TITLE
Revamp admin/emails UI and add trigger buttons with Storybook references

### DIFF
--- a/src/app/[locale]/(redesign)/(authenticated)/admin/emails/EmailTrigger.module.scss
+++ b/src/app/[locale]/(redesign)/(authenticated)/admin/emails/EmailTrigger.module.scss
@@ -3,25 +3,29 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  gap: tokens.$spacing-2xl;
+  gap: tokens.$spacing-xl;
   background-color: tokens.$color-grey-05;
-  height: 100%;
+  min-height: 100%;
   padding: tokens.$layout-lg tokens.$layout-2xl;
 
   @media screen and (max-width: tokens.$screen-lg) {
     padding: tokens.$spacing-lg;
+  }
+
+  h1 {
+    font: tokens.$text-title-md;
   }
 }
 
 .addressSection {
   display: flex;
   flex-direction: column;
-  gap: tokens.$spacing-sm;
+  gap: tokens.$spacing-xs;
 
   .addressPicker {
     display: flex;
     align-items: center;
-    gap: tokens.$spacing-md;
+    gap: tokens.$spacing-sm;
 
     label {
       font: tokens.$text-body-lg;
@@ -29,13 +33,84 @@
     }
 
     select {
-      padding: tokens.$spacing-sm;
+      padding: tokens.$spacing-xs tokens.$spacing-sm;
+      border: 1px solid tokens.$color-grey-20;
+      border-radius: tokens.$border-radius-sm;
+      font: tokens.$text-body-md;
     }
   }
 }
 
-.triggers {
+// Sections
+
+.section {
   display: flex;
-  flex-wrap: wrap;
-  gap: tokens.$spacing-lg;
+  flex-direction: column;
+  gap: tokens.$spacing-md;
+}
+
+.sectionLabel {
+  font: tokens.$text-body-sm;
+  font-weight: 700;
+  color: tokens.$color-grey-40;
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: tokens.$spacing-md;
+}
+
+// Cards
+
+.card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: tokens.$spacing-md;
+  padding: tokens.$spacing-md;
+  background-color: tokens.$color-white;
+  border: 1px solid tokens.$color-grey-20;
+  border-radius: tokens.$border-radius-md;
+}
+
+.cardBody {
+  display: flex;
+  flex-direction: column;
+  gap: tokens.$spacing-xs;
+}
+
+.cardTitle {
+  font: tokens.$text-body-md;
+  font-weight: 700;
+  margin: 0;
+  color: tokens.$color-grey-60;
+}
+
+.cardDescription {
+  font: tokens.$text-body-sm;
+  color: tokens.$color-grey-40;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.cardFooter {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: tokens.$spacing-sm;
+}
+
+.storybookLink {
+  font: tokens.$text-body-sm;
+  color: tokens.$color-grey-40;
+  text-decoration: none;
+
+  &:hover {
+    color: tokens.$color-grey-60;
+    text-decoration: underline;
+  }
 }

--- a/src/app/[locale]/(redesign)/(authenticated)/admin/emails/EmailTrigger.tsx
+++ b/src/app/[locale]/(redesign)/(authenticated)/admin/emails/EmailTrigger.tsx
@@ -89,23 +89,21 @@ export const EmailTrigger = (props: Props) => {
 
   function triggerCard(card: EmailCard) {
     setSendingCard(card.title);
-    const toastId = toast.loading(`Sending ${card.title}…`);
+    const toastLoading = toast.loading(`Sending ${card.title}…`);
     void card
       .action(selectedEmailAddress)
       .then(() => {
         setSendingCard(null);
-        toast.update(toastId, {
-          render: `${card.title} sent!`,
-          type: "success",
+        toast.dismiss(toastLoading);
+        toast.success(`${card.title} sent!`, {
           isLoading: false,
           autoClose: 3000,
         });
       })
       .catch(() => {
         setSendingCard(null);
-        toast.update(toastId, {
-          render: `Failed to send ${card.title}`,
-          type: "error",
+        toast.dismiss(toastLoading);
+        toast.error(`Failed to send ${card.title}`, {
           isLoading: false,
           autoClose: 5000,
         });
@@ -176,7 +174,7 @@ export const EmailTrigger = (props: Props) => {
         <p className={styles.sectionLabel}>Breach alert variants</p>
         <div className={styles.grid}>{breachAlertVariants.map(renderCard)}</div>
       </div>
-      <ToastContainer position="bottom-right" />
+      <ToastContainer position="top-center" />
     </main>
   );
 };

--- a/src/app/[locale]/(redesign)/(authenticated)/admin/emails/EmailTrigger.tsx
+++ b/src/app/[locale]/(redesign)/(authenticated)/admin/emails/EmailTrigger.tsx
@@ -6,9 +6,14 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { toast, ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 import styles from "./EmailTrigger.module.scss";
 import {
   triggerBreachAlert,
+  triggerBreachAlertVer2,
+  triggerBreachAlertVer3,
+  triggerBreachAlertVer4,
   triggerSignupReportEmail,
   triggerVerificationEmail,
 } from "./actions";
@@ -18,13 +23,123 @@ export type Props = {
   emailAddresses: string[];
 };
 
+const STORYBOOK_BASE = "http://localhost:6006/?path=/story";
+
+type EmailCard = {
+  title: string;
+  description: string;
+  storybookId: string;
+  action: (email: string) => Promise<unknown>;
+};
+
+const otherEmails: EmailCard[] = [
+  {
+    title: "Signup report",
+    description:
+      "Summary email listing all known breaches for a monitored address.",
+    storybookId: "emails-signup-report--signup-report-email-no-breaches-story",
+    action: triggerSignupReportEmail,
+  },
+  {
+    title: "Verify email address",
+    description:
+      "Confirmation email sent when adding a new address to monitor.",
+    storybookId:
+      "emails-verify-email-address--verify-email-address-email-story",
+    action: triggerVerificationEmail,
+  },
+];
+
+const breachAlertVariants: EmailCard[] = [
+  {
+    title: "Default",
+    description:
+      "Light purple hero banner, plain-text breach details, inline Q&A FAQs.",
+    storybookId: "emails-breach-alert--breach-alert-email-default-story",
+    action: triggerBreachAlert,
+  },
+  {
+    title: "Version 2",
+    description:
+      "Rounded purple hero, source label badge on breach details, FAQs separated by dividers.",
+    storybookId: "emails-breach-alert--breach-alert-email-version-2-story",
+    action: triggerBreachAlertVer2,
+  },
+  {
+    title: "Version 3",
+    description:
+      "No hero, logo with a thin divider, breach details in a grey card, stacked Q&A FAQs.",
+    storybookId: "emails-breach-alert--breach-alert-email-version-3-story",
+    action: triggerBreachAlertVer3,
+  },
+  {
+    title: "Version 4",
+    description:
+      "Thin purple accent bar at top, centered heading, breach details in a bordered card, numbered FAQs.",
+    storybookId: "emails-breach-alert--breach-alert-email-version-4-story",
+    action: triggerBreachAlertVer4,
+  },
+];
+
 export const EmailTrigger = (props: Props) => {
   const [selectedEmailAddress, setSelectedEmailAddress] = useState(
     props.emailAddresses[0],
   );
-  const [isSendingSignupReport, setIsSendingSignupReport] = useState(false);
-  const [isSendingVerification, setIsSendingVerification] = useState(false);
-  const [isSendingBreachAlert, setIsSendingBreachAlert] = useState(false);
+  const [sendingCard, setSendingCard] = useState<string | null>(null);
+
+  function triggerCard(card: EmailCard) {
+    setSendingCard(card.title);
+    const toastId = toast.loading(`Sending ${card.title}…`);
+    void card
+      .action(selectedEmailAddress)
+      .then(() => {
+        setSendingCard(null);
+        toast.update(toastId, {
+          render: `${card.title} sent!`,
+          type: "success",
+          isLoading: false,
+          autoClose: 3000,
+        });
+      })
+      .catch(() => {
+        setSendingCard(null);
+        toast.update(toastId, {
+          render: `Failed to send ${card.title}`,
+          type: "error",
+          isLoading: false,
+          autoClose: 5000,
+        });
+      });
+  }
+
+  function renderCard(card: EmailCard) {
+    return (
+      <div key={card.title} className={styles.card}>
+        <div className={styles.cardBody}>
+          <p className={styles.cardTitle}>{card.title}</p>
+          <p className={styles.cardDescription}>{card.description}</p>
+        </div>
+        <div className={styles.cardFooter}>
+          <Button
+            variant="primary"
+            small
+            isLoading={sendingCard === card.title}
+            onPress={() => triggerCard(card)}
+          >
+            Send
+          </Button>
+          <a
+            href={`${STORYBOOK_BASE}/${card.storybookId}`}
+            target="_blank"
+            rel="noreferrer"
+            className={styles.storybookLink}
+          >
+            View in Storybook ↗
+          </a>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <main className={styles.wrapper}>
@@ -51,44 +166,17 @@ export const EmailTrigger = (props: Props) => {
           </Link>
         </small>
       </div>
-      <div className={styles.triggers}>
-        <Button
-          variant="primary"
-          isLoading={isSendingSignupReport}
-          onPress={() => {
-            setIsSendingSignupReport(true);
-            void triggerSignupReportEmail(selectedEmailAddress).then(() => {
-              setIsSendingSignupReport(false);
-            });
-          }}
-        >
-          Signup report
-        </Button>
-        <Button
-          variant="primary"
-          isLoading={isSendingVerification}
-          onPress={() => {
-            setIsSendingVerification(true);
-            void triggerVerificationEmail(selectedEmailAddress).then(() => {
-              setIsSendingVerification(false);
-            });
-          }}
-        >
-          Verify email address
-        </Button>
-        <Button
-          variant="primary"
-          isLoading={isSendingBreachAlert}
-          onPress={() => {
-            setIsSendingBreachAlert(true);
-            void triggerBreachAlert(selectedEmailAddress).then(() => {
-              setIsSendingBreachAlert(false);
-            });
-          }}
-        >
-          Breach alert
-        </Button>
+
+      <div className={styles.section}>
+        <p className={styles.sectionLabel}>Other emails</p>
+        <div className={styles.grid}>{otherEmails.map(renderCard)}</div>
       </div>
+
+      <div className={styles.section}>
+        <p className={styles.sectionLabel}>Breach alert variants</p>
+        <div className={styles.grid}>{breachAlertVariants.map(renderCard)}</div>
+      </div>
+      <ToastContainer position="bottom-right" />
     </main>
   );
 };

--- a/src/app/[locale]/(redesign)/(authenticated)/admin/emails/actions.tsx
+++ b/src/app/[locale]/(redesign)/(authenticated)/admin/emails/actions.tsx
@@ -20,6 +20,9 @@ import { SubscriberRow } from "knex/types/tables";
 import { getUserEmails } from "../../../../../../db/tables/emailAddresses";
 import { createRandomHibpListing } from "../../../../../../apiMocks/mockData";
 import { BreachAlertEmail } from "../../../../../../emails/templates/breachAlert/BreachAlertEmail";
+import { BreachAlertEmail as BreachAlertEmailVer2 } from "../../../../../../emails/templates/breachAlert/BreachAlertEmailVer2";
+import { BreachAlertEmail as BreachAlertEmailVer3 } from "../../../../../../emails/templates/breachAlert/BreachAlertEmailVer3";
+import { BreachAlertEmail as BreachAlertEmailVer4 } from "../../../../../../emails/templates/breachAlert/BreachAlertEmailVer4";
 import { SignupReportEmail } from "../../../../../../emails/templates/signupReport/SignupReportEmail";
 import { getBreachesForEmail } from "../../../../../../utils/hibp";
 import { getSha1 } from "../../../../../../utils/fxa";
@@ -139,6 +142,87 @@ export async function triggerBreachAlert(emailAddress: string) {
     emailAddress,
     l10n.getString("email-breach-alert-all-subject"),
     <BreachAlertEmail
+      subscriber={subscriber}
+      breachedEmail={emailAddress}
+      breach={createRandomHibpListing()}
+      utmCampaignId={UTM_CAMPAIGN_ID_BREACH_ALERT}
+      l10n={l10n}
+      unsubscribeLink={unsubscribeLink}
+    />,
+    { oneClickUrl },
+  );
+}
+
+export async function triggerBreachAlertVer2(emailAddress: string) {
+  const session = await getServerSession();
+  const subscriber = await getAdminSubscriber();
+  if (!subscriber || !session?.user) {
+    return false;
+  }
+
+  const acceptLangHeader = await getAcceptLangHeaderInServerComponents();
+  const l10n = getL10n(acceptLangHeader);
+  const { footer: unsubscribeLink, oneClick: oneClickUrl } =
+    await getBreachAlertsUnsubscribeLink(subscriber);
+
+  await send(
+    emailAddress,
+    l10n.getString("email-breach-alert-all-subject"),
+    <BreachAlertEmailVer2
+      subscriber={subscriber}
+      breachedEmail={emailAddress}
+      breach={createRandomHibpListing()}
+      utmCampaignId={UTM_CAMPAIGN_ID_BREACH_ALERT}
+      l10n={l10n}
+      unsubscribeLink={unsubscribeLink}
+    />,
+    { oneClickUrl },
+  );
+}
+
+export async function triggerBreachAlertVer3(emailAddress: string) {
+  const session = await getServerSession();
+  const subscriber = await getAdminSubscriber();
+  if (!subscriber || !session?.user) {
+    return false;
+  }
+
+  const acceptLangHeader = await getAcceptLangHeaderInServerComponents();
+  const l10n = getL10n(acceptLangHeader);
+  const { footer: unsubscribeLink, oneClick: oneClickUrl } =
+    await getBreachAlertsUnsubscribeLink(subscriber);
+
+  await send(
+    emailAddress,
+    l10n.getString("email-breach-alert-all-subject"),
+    <BreachAlertEmailVer3
+      subscriber={subscriber}
+      breachedEmail={emailAddress}
+      breach={createRandomHibpListing()}
+      utmCampaignId={UTM_CAMPAIGN_ID_BREACH_ALERT}
+      l10n={l10n}
+      unsubscribeLink={unsubscribeLink}
+    />,
+    { oneClickUrl },
+  );
+}
+
+export async function triggerBreachAlertVer4(emailAddress: string) {
+  const session = await getServerSession();
+  const subscriber = await getAdminSubscriber();
+  if (!subscriber || !session?.user) {
+    return false;
+  }
+
+  const acceptLangHeader = await getAcceptLangHeaderInServerComponents();
+  const l10n = getL10n(acceptLangHeader);
+  const { footer: unsubscribeLink, oneClick: oneClickUrl } =
+    await getBreachAlertsUnsubscribeLink(subscriber);
+
+  await send(
+    emailAddress,
+    l10n.getString("email-breach-alert-all-subject"),
+    <BreachAlertEmailVer4
       subscriber={subscriber}
       breachedEmail={emailAddress}
       breach={createRandomHibpListing()}


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-5269

This PR updates the `/admin/emails` route by adding trigger buttons for the new breach alerts variants and revamping the overall styling/UI for better usability and consistency. I also added Storybook story links within each card to make it easier to preview and validate email templates.

<img width="1109" height="708" alt="image" src="https://github.com/user-attachments/assets/b0b50e62-ae89-4b38-8f98-54e2db38eb3c" />




<!-- When adding a new feature: -->

# Description

# Screenshot (if applicable)

Not applicable.

# How to test

# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
