### PR TITLE
Generate Software Bill of Materials

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -1,0 +1,22 @@
+name: ssdlc-sbom
+
+permissions: {}
+
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  sbom:
+    uses: mozilla/ssdlc-actions/.github/workflows/ssdlc-sbom.yml@5cc2b20e42d53d1643853f12244fbec9ed2f2e0c
+    with:
+      sbom_name: ${{ github.event.release.tag_name || github.sha }}
+    permissions:
+      actions: read
+      contents: write


### PR DESCRIPTION
See [this Slack message](https://mozilla.slack.com/archives/C495VS94P/p1775585860312129) where I volunteered us to try out this new tooling, described [here](https://docs.google.com/document/d/1hYl72p6a8v3B9Iv2TeyRHw0m0A-x1R-8uiQperbj7zI/edit?usp=sharing) :) (Edit: haha, I see @groovecoder volunteered us as well.)

Essentially, all this does is generate a JSON file on every release listing all our dependencies in a standard format that will give the security team more insights across Mozilla projects. [Here's a test run](https://github.com/mozilla/blurts-server/actions/runs/26091299163) if you want to see what the output looks like. Dependabot is already configured to update the Action to a new version if one is released.