### PR TITLE
MNTOR-5282 - Add email dark mode per guide

### DIFF
--- a/src/emails/components/EmailFooter.tsx
+++ b/src/emails/components/EmailFooter.tsx
@@ -122,6 +122,7 @@ export const RedesignedEmailFooter = (props: Props) => {
       full-width="full-width"
       padding="50px 32px"
       background-color="#F9F9FA"
+      css-class="dm-section-footer"
     >
       <mj-section>
         <mj-column>

--- a/src/emails/components/EmailHero.tsx
+++ b/src/emails/components/EmailHero.tsx
@@ -26,6 +26,7 @@ export const EmailHero = (props: Props) => {
         padding="10px 12px"
         border-radius="16px 16px 0 0"
         background-color="#F5EAFF"
+        css-class="dm-section-hero"
       >
         <mj-group>
           <mj-column
@@ -53,7 +54,11 @@ export const EmailHero = (props: Props) => {
           </mj-column>
         </mj-group>
       </mj-section>
-      <mj-section background-color="#F5EAFF" border-radius="0 0 16px 16px">
+      <mj-section
+        background-color="#F5EAFF"
+        border-radius="0 0 16px 16px"
+        css-class="dm-section-hero"
+      >
         <mj-column>
           <mj-text font-size="20px" line-height="38px">
             <h2>{props.heading}</h2>

--- a/src/emails/components/HeaderStyles.tsx
+++ b/src/emails/components/HeaderStyles.tsx
@@ -12,9 +12,68 @@ export const MetaTags = () => {
   );
 };
 
-// Dark mode email technique reference:
-// https://www.emailonacid.com/blog/article/email-development/advanced-mjml-coding/
+// Dark mode email technique references:
+//   - https://www.emailonacid.com/blog/article/email-development/advanced-mjml-coding/
+//   - https://www.litmus.com/blog/the-ultimate-guide-to-dark-mode-for-email-marketers
+//
+// Two targeting mechanisms are used:
+//   1. `@media (prefers-color-scheme: dark)` — honored by Apple Mail, iOS Mail,
+//      Proton, and some Outlook variants.
+//   2. `[data-ogsc]` (color scheme) and `[data-ogsb]` (background scheme)
+//      attributes — injected by Outlook on Android / iOS on an ancestor
+//      element, used as descendant selectors here.
+//
+// All overrides are opt-in via CSS classes so individual templates can choose
+// which surfaces participate (`dm-body`, `dm-section-hero`, `dm-section-card`,
+// `dm-section-footer`, `dm-img-light` / `dm-img-dark`).
 export const HeaderStyles = () => {
+  const bodyBg = "#1c1b22";
+  const heroBg = "#2b2438";
+  const cardBg = "#2b2a33";
+  const textColor = "#fbfbfe";
+
+  const darkModeRules = (scope: string) => `
+        ${scope} .dm-img-light { display: none !important; }
+        ${scope} .dm-img-dark {
+          display: block !important;
+          max-height: none !important;
+          overflow: visible !important;
+        }
+
+        ${scope} .dm-body,
+        ${scope} .dm-body > div,
+        ${scope} .dm-body > table {
+          background-color: ${bodyBg} !important;
+        }
+
+        ${scope} .dm-body p,
+        ${scope} .dm-body h1,
+        ${scope} .dm-body h2,
+        ${scope} .dm-body h3,
+        ${scope} .dm-body span,
+        ${scope} .dm-body strong {
+          color: ${textColor} !important;
+        }
+
+        ${scope} .dm-section-hero,
+        ${scope} .dm-section-hero > table,
+        ${scope} .dm-section-hero > table > tbody > tr > td {
+          background-color: ${heroBg} !important;
+        }
+
+        ${scope} .dm-section-card,
+        ${scope} .dm-section-card > table,
+        ${scope} .dm-section-card > table > tbody > tr > td {
+          background-color: ${cardBg} !important;
+        }
+
+        ${scope} .dm-section-footer,
+        ${scope} .dm-section-footer > table,
+        ${scope} .dm-section-footer > table > tbody > tr > td {
+          background-color: ${cardBg} !important;
+        }
+      `;
+
   const styles = `
       :root {
         color-scheme: light dark;
@@ -24,15 +83,12 @@ export const HeaderStyles = () => {
       .dm-img-dark { display: none; }
 
       @media (prefers-color-scheme: dark) {
-        .dm-img-light {
-          display: none !important;
-        }
-        .dm-img-dark {
-          display: block !important;
-          max-height: none !important;
-          overflow: visible !important;
-        }
+        ${darkModeRules("")}
       }
+
+      ${darkModeRules("[data-ogsc]")}
+
+      ${darkModeRules("[data-ogsb]")}
     `;
 
   return <mj-style>{styles}</mj-style>;

--- a/src/emails/templates/breachAlert/BreachAlertEmail.tsx
+++ b/src/emails/templates/breachAlert/BreachAlertEmail.tsx
@@ -42,7 +42,7 @@ export const BreachAlertEmail = (props: BreachAlertEmailProps) => {
         <HeaderStyles />
         <mj-style>{`p { margin: 0 0 4px 0; }`}</mj-style>
       </mj-head>
-      <mj-body>
+      <mj-body css-class="dm-body">
         <EmailHero
           l10n={l10n}
           utm_campaign={utmCampaignId}

--- a/src/emails/templates/breachAlert/BreachAlertEmailVer2.tsx
+++ b/src/emails/templates/breachAlert/BreachAlertEmailVer2.tsx
@@ -48,12 +48,13 @@ export const BreachAlertEmail = (props: BreachAlertEmailProps) => {
       `}
         </mj-style>
       </mj-head>
-      <mj-body background-color="#fff">
+      <mj-body background-color="#fff" css-class="dm-body">
         {/* <!-- Hero --> */}
         <mj-section
           padding="32px 24px"
           background-color="#F5EAFF"
           border-radius="20px 20px 0px 0px"
+          css-class="dm-section-hero"
         >
           <mj-column width="100%">
             <mj-image

--- a/src/emails/templates/breachAlert/BreachAlertEmailVer3.tsx
+++ b/src/emails/templates/breachAlert/BreachAlertEmailVer3.tsx
@@ -40,7 +40,7 @@ export const BreachAlertEmail = (props: BreachAlertEmailProps) => {
         <MetaTags />
         <HeaderStyles />
       </mj-head>
-      <mj-body background-color="#ffffff">
+      <mj-body background-color="#ffffff" css-class="dm-body">
         {/* Logo */}
         <mj-section padding="24px 24px 0 24px">
           <mj-column>
@@ -114,7 +114,11 @@ export const BreachAlertEmail = (props: BreachAlertEmailProps) => {
 
         {/* Breach info card — grey background, no border-radius for max client compat */}
         <mj-section padding="20px 24px 0 24px">
-          <mj-column background-color="#f5f5f5" padding="20px">
+          <mj-column
+            background-color="#f5f5f5"
+            padding="20px"
+            css-class="dm-section-card"
+          >
             <mj-text
               font-size="12px"
               font-weight="700"

--- a/src/emails/templates/breachAlert/BreachAlertEmailVer4.tsx
+++ b/src/emails/templates/breachAlert/BreachAlertEmailVer4.tsx
@@ -40,7 +40,7 @@ export const BreachAlertEmail = (props: BreachAlertEmailProps) => {
         <MetaTags />
         <HeaderStyles />
       </mj-head>
-      <mj-body background-color="#ffffff">
+      <mj-body background-color="#ffffff" css-class="dm-body">
         {/* Narrow purple accent bar at top */}
         <mj-section background-color="#592ACB" padding="0">
           <mj-column>


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-5282
Figma:

<!-- When adding a new feature: -->

# Description

QA identified that the new work-arounds introduced more negative changes. I reviewed a few pieces of documentation
https://www.emailonacid.com/blog/article/email-development/advanced-mjml-coding/
https://www.litmus.com/blog/the-ultimate-guide-to-dark-mode-for-email-marketers
to guide me on adding dark mode support, e.g. swap to white-text variants, and the hero/card/footer/body backgrounds darken so the swapped logos and body text remain readable instead of sitting on light-colored "fields."

# How to test

We can't really test this until it's on stage.

# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
