### PR TITLE
MNTOR-5289 - Support per env FXA CI bypass tokens

### DIFF
--- a/.github/workflows/functional_tests_cron.yml
+++ b/.github/workflows/functional_tests_cron.yml
@@ -68,6 +68,8 @@ jobs:
           E2E_TEST_ACCOUNT_BASE_EMAIL: ${{ secrets.E2E_TEST_ACCOUNT_BASE_EMAIL }}
           E2E_TEST_ACCOUNT_BASE_PASSWORD: ${{ secrets.E2E_TEST_ACCOUNT_BASE_PASSWORD }}
           FXA_CI_SECRET: ${{ secrets.FXA_CI_SECRET }}
+          FXA_CI_SECRET_STAGE: ${{ secrets.FXA_CI_SECRET_STAGE }}
+          FXA_CI_SECRET_PROD: ${{ secrets.FXA_CI_SECRET_PROD }}
       - name: Send GitHub Action trigger data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3

--- a/.github/workflows/functional_tests_cron.yml
+++ b/.github/workflows/functional_tests_cron.yml
@@ -67,7 +67,6 @@ jobs:
           E2E_TEST_SECRET: ${{ secrets.E2E_TEST_SECRET }}
           E2E_TEST_ACCOUNT_BASE_EMAIL: ${{ secrets.E2E_TEST_ACCOUNT_BASE_EMAIL }}
           E2E_TEST_ACCOUNT_BASE_PASSWORD: ${{ secrets.E2E_TEST_ACCOUNT_BASE_PASSWORD }}
-          FXA_CI_SECRET: ${{ secrets.FXA_CI_SECRET }}
           FXA_CI_SECRET_STAGE: ${{ secrets.FXA_CI_SECRET_STAGE }}
           FXA_CI_SECRET_PROD: ${{ secrets.FXA_CI_SECRET_PROD }}
       - name: Send GitHub Action trigger data to Slack workflow

--- a/.github/workflows/functional_tests_pr.yml
+++ b/.github/workflows/functional_tests_pr.yml
@@ -75,6 +75,7 @@ jobs:
           E2E_TEST_ACCOUNT_BASE_PASSWORD: ${{ secrets.E2E_TEST_ACCOUNT_BASE_PASSWORD }}
           E2E_TEST_ENV: local
           FXA_CI_SECRET: ${{ secrets.FXA_CI_SECRET }}
+          FXA_CI_SECRET_STAGE: ${{ secrets.FXA_CI_SECRET_STAGE }}
           HIBP_API_TOKEN: ${{ secrets.HIBP_API_TOKEN }}
           HIBP_KANON_API_ROOT: "http://localhost:6060/api/mock/hibp"
           HIBP_KANON_API_TOKEN: ${{ secrets.HIBP_KANON_API_TOKEN }}

--- a/.github/workflows/functional_tests_pr.yml
+++ b/.github/workflows/functional_tests_pr.yml
@@ -74,7 +74,6 @@ jobs:
           E2E_TEST_ACCOUNT_BASE_EMAIL: ${{ secrets.E2E_TEST_ACCOUNT_BASE_EMAIL }}
           E2E_TEST_ACCOUNT_BASE_PASSWORD: ${{ secrets.E2E_TEST_ACCOUNT_BASE_PASSWORD }}
           E2E_TEST_ENV: local
-          FXA_CI_SECRET: ${{ secrets.FXA_CI_SECRET }}
           FXA_CI_SECRET_STAGE: ${{ secrets.FXA_CI_SECRET_STAGE }}
           HIBP_API_TOKEN: ${{ secrets.HIBP_API_TOKEN }}
           HIBP_KANON_API_ROOT: "http://localhost:6060/api/mock/hibp"

--- a/functional-tests/playwright.config.ts
+++ b/functional-tests/playwright.config.ts
@@ -13,6 +13,7 @@ import { FeatureFlagName } from "../src/db/tables/featureFlags";
 import "../src/config";
 import { createTestClientRegionToken } from "../src/app/functions/server/testCountryCodeToken";
 import { getBaseTestEnvUrl } from "./utils/environment";
+import { getFxaCiHeaders } from "./utils/fxa";
 
 /**
  * @see https://playwright.dev/docs/test-configuration
@@ -117,9 +118,7 @@ export const projects = locations.flatMap((geo) =>
             "x-forced-client-region-token": createTestClientRegionToken(
               geo.name.toLowerCase(),
             ),
-            ...(process.env.FXA_CI_SECRET
-              ? { "fxa-ci": process.env.FXA_CI_SECRET }
-              : {}),
+            ...getFxaCiHeaders(),
           },
         },
       }) as const satisfies Project,

--- a/functional-tests/utils/fxa.ts
+++ b/functional-tests/utils/fxa.ts
@@ -21,16 +21,15 @@ const STRIP_FXA_CI_PATTERNS = [
 ];
 
 // FxA's bypass token has different values per environment. Pick by E2E_TEST_ENV.
-// Falls back to FXA_CI_SECRET if the env-specific secret isn't set, so legacy
-// configs keep working during the rollout of the per-env secrets.
-// TODO(MNTOR-5290): remove FXA_CI_SECRET fallback once per-env secrets are stable.
+// Local CI runs Monitor at localhost but points OAuth at stage FxA (see .env.ci),
+// so "local" needs the stage token too.
 export function getActiveFxaCiSecret(): string | undefined {
   const env = process.env.E2E_TEST_ENV;
   if (env === "production") {
-    return process.env.FXA_CI_SECRET_PROD ?? process.env.FXA_CI_SECRET;
+    return process.env.FXA_CI_SECRET_PROD;
   }
   // stage + local both hit stage FxA.
-  return process.env.FXA_CI_SECRET_STAGE ?? process.env.FXA_CI_SECRET;
+  return process.env.FXA_CI_SECRET_STAGE;
 }
 
 export async function setupFxaCiRoutes(page: Page) {

--- a/functional-tests/utils/fxa.ts
+++ b/functional-tests/utils/fxa.ts
@@ -23,6 +23,7 @@ const STRIP_FXA_CI_PATTERNS = [
 // FxA's bypass token has different values per environment. Pick by E2E_TEST_ENV.
 // Falls back to FXA_CI_SECRET if the env-specific secret isn't set, so legacy
 // configs keep working during the rollout of the per-env secrets.
+// TODO(MNTOR-5290): remove FXA_CI_SECRET fallback once per-env secrets are stable.
 export function getActiveFxaCiSecret(): string | undefined {
   const env = process.env.E2E_TEST_ENV;
   if (env === "stage") {

--- a/functional-tests/utils/fxa.ts
+++ b/functional-tests/utils/fxa.ts
@@ -26,13 +26,11 @@ const STRIP_FXA_CI_PATTERNS = [
 // TODO(MNTOR-5290): remove FXA_CI_SECRET fallback once per-env secrets are stable.
 export function getActiveFxaCiSecret(): string | undefined {
   const env = process.env.E2E_TEST_ENV;
-  if (env === "stage") {
-    return process.env.FXA_CI_SECRET_STAGE ?? process.env.FXA_CI_SECRET;
-  }
   if (env === "production") {
     return process.env.FXA_CI_SECRET_PROD ?? process.env.FXA_CI_SECRET;
   }
-  return process.env.FXA_CI_SECRET;
+  // stage + local both hit stage FxA.
+  return process.env.FXA_CI_SECRET_STAGE ?? process.env.FXA_CI_SECRET;
 }
 
 export async function setupFxaCiRoutes(page: Page) {

--- a/functional-tests/utils/fxa.ts
+++ b/functional-tests/utils/fxa.ts
@@ -20,8 +20,22 @@ const STRIP_FXA_CI_PATTERNS = [
   "**/www.googletagmanager.com/**",
 ];
 
+// FxA's bypass token has different values per environment. Pick by E2E_TEST_ENV.
+// Falls back to FXA_CI_SECRET if the env-specific secret isn't set, so legacy
+// configs keep working during the rollout of the per-env secrets.
+export function getActiveFxaCiSecret(): string | undefined {
+  const env = process.env.E2E_TEST_ENV;
+  if (env === "stage") {
+    return process.env.FXA_CI_SECRET_STAGE ?? process.env.FXA_CI_SECRET;
+  }
+  if (env === "production") {
+    return process.env.FXA_CI_SECRET_PROD ?? process.env.FXA_CI_SECRET;
+  }
+  return process.env.FXA_CI_SECRET;
+}
+
 export async function setupFxaCiRoutes(page: Page) {
-  if (!process.env.FXA_CI_SECRET) return;
+  if (!getActiveFxaCiSecret()) return;
   const stripFxaCi = (route: Route) => {
     const headers = { ...route.request().headers() };
     delete headers["fxa-ci"];
@@ -33,9 +47,8 @@ export async function setupFxaCiRoutes(page: Page) {
 }
 
 export function getFxaCiHeaders(): Record<string, string> {
-  return process.env.FXA_CI_SECRET
-    ? { "fxa-ci": process.env.FXA_CI_SECRET }
-    : {};
+  const secret = getActiveFxaCiSecret();
+  return secret ? { "fxa-ci": secret } : {};
 }
 
 async function waitForFxa(page: Page) {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: MNTOR-5289


<!-- When adding a new feature: -->

# Description

FxA's `fxa-ci` bypass header requires different token values for stage and prod. Previously `FXA_CI_SECRET` could only hold one value, so functional tests passed on whichever env matched the current secret and failed on the other.


# Screenshot (if applicable)

Not applicable.

# How to test

# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.
