### PR TITLE
Also log response after storing breaches in Remote Settings

### DIFF
--- a/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.ts
+++ b/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.ts
@@ -106,7 +106,8 @@ export async function main(parentLogger: Logger) {
     };
 
     try {
-      await remoteSettings.addNewBreach(data);
+      const responseJson = await remoteSettings.addNewBreach(data);
+      logger.info("Breach alert stored in Remote Settings.", responseJson);
     } catch (e) {
       failed += 1;
       logger.error("POSTing new breach to collection failed", {


### PR DESCRIPTION
I don't [see](https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/fxmonitor-breaches/changeset?_expected=0) recent breaches listed in Remote Settings, even though [the logs](https://console.cloud.google.com/logs/query;aroundTime=2026-04-01T14:36:28.570Z;cursorTimestamp=2026-04-04T00:00:06.306993945Z;duration=P7D;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22moz-fx-webservices-high-prod%22%0Aresource.labels.location%3D%22us-west1%22%0Aresource.labels.cluster_name%3D%22webservices-high-prod%22%0Aresource.labels.namespace_name%3D%22monitor-prod%22%0Aresource.labels.container_name%3D%22remote-settings-pull-breaches%22%0Atimestamp%3D%222026-04-02T00:00:19.993743432Z%22%0AinsertId%3D%2228xi4aafmwm20e2q%22;storageScope=project?project=moz-fx-webservices-high-prod) show no errors. It looks like we have sufficient logging set up for error responses, but I'm wondering if maybe the Remote Settings API returns a success response while still showing an error message in the response body, maybe?