### PR TITLE
FELTPY-54 - Data aggregator definition missing strings fix

### DIFF
--- a/locales/en/app.ftl
+++ b/locales/en/app.ftl
@@ -61,6 +61,8 @@ delayed-reporting-copy = It can sometimes take months or years for credentials e
 
 what-is-a-website-breach = What is a website breach?
 website-breach-blurb = A website data breach happens when cyber criminals steal, copy, or expose personal information from online accounts. It’s usually a result of hackers finding a weak spot in the website’s security. Breaches can also happen when account information gets leaked by accident.
+what-is-data-agg = What is a data aggregator?
+what-is-data-agg-blurb = Data aggregators, or data brokers, collect information from public records and other sources, including data purchased from companies. They compile this information to create detailed consumer profiles, which are sold to businesses for marketing purposes. Hackers could use this data for profiling, impersonation, or other forms of fraud. You may not recognize some of these companies because data aggregators often collect information about people without them ever creating an account or signing up for a service.
 
 # This is a section headline on the breach detail page that appears above
 # a short summary about the breach.


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

# References:

Jira: [FELTPY-54](https://mozilla-hub.atlassian.net/browse/FELTPY-54)


<!-- When adding a new feature: -->

# Description

These strings were accidentally pruned in https://github.com/mozilla/blurts-server/pull/6384/

They are currently being used on the data breaches page so they should be restored.

# Screenshot (if applicable)

Not applicable.

# How to test

# Checklist (Definition of Done)

- [ ] Localization strings (if needed) have been added.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [ ] I've added or updated the relevant sections in readme and/or code comments
- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.
- [ ] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.


[FELTPY-54]: https://mozilla-hub.atlassian.net/browse/FELTPY-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ