### PR TITLE
fix(functional-tests): guard teardown against slow stage navigation

### DIFF
--- a/functional-tests/tests/global-teardown.ts
+++ b/functional-tests/tests/global-teardown.ts
@@ -35,7 +35,11 @@ async function deleteTestUserAccounts(browser: Browser) {
 
     await page.goto(`${getBaseTestEnvUrl()}/user/settings/manage-account`);
 
-    await page.getByRole("button", { name: "Open user menu" }).click();
+    // Stage can redirect slowly. Wait for the menu button before clicking so
+    // we don't race an in-flight navigation.
+    const userMenuButton = page.getByRole("button", { name: "Open user menu" });
+    await userMenuButton.waitFor({ state: "visible" });
+    await userMenuButton.click();
     const manageAccountLink = page.getByRole("menuitem", {
       name: "Manage your ⁨Mozilla account⁩",
       exact: false,
@@ -52,7 +56,10 @@ async function deleteTestUserAccounts(browser: Browser) {
       name: "Delete account",
     });
     await deleteButtonConfirm.click();
-    await page.waitForURL(`${getBaseTestEnvUrl()}/en`);
+    // After deletion the app redirects to the localized home page. Match the
+    // /en prefix instead of an exact URL so a trailing path or query does not
+    // abort the wait.
+    await page.waitForURL(`${getBaseTestEnvUrl()}/en**`);
 
     await page.goto(manageFxaAccountUrl!);
     await page.getByRole("link", { name: "Delete Account" }).click();


### PR DESCRIPTION
The "Delete test user accounts" teardown fails the same way across runs. Line 38 clicks "Open user menu" before the page settles, so a slow stage redirect detaches the frame. Line 55 waits for an exact /en URL, which aborts when the app lands on a path with a trailing segment.

Wait for the menu button to be visible before clicking. Loosen the post-delete URL wait to match the /en prefix.

- [x] ~Localization strings (if needed) have been added.~
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
- [x] ~I've added or updated the relevant sections in readme and/or code comments~
- [x] ~I've added a unit test to test for potential regressions of this bug.~
- [x] ~If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off.~
- [x] ~If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set~
- [x] ~Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.~
- [x] ~All acceptance criteria are met.~
- [x] ~Jira ticket has been updated (if needed) to match changes made during the development process.~
- [x] ~Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.~