### PR TITLE
fix(auth): stop unhandled rejections from FxA sign-in

### DIFF
--- a/src/app/[locale]/(redesign)/(public)/HeresHowWeHelp.tsx
+++ b/src/app/[locale]/(redesign)/(public)/HeresHowWeHelp.tsx
@@ -4,7 +4,7 @@
 
 "use client";
 
-import { signIn } from "next-auth/react";
+import { signInToFxa } from "../../../functions/client/signInToFxa";
 import { Button } from "../../../components/client/Button";
 import { useL10n } from "../../../hooks/l10n";
 import styles from "./LandingView.module.scss";
@@ -40,7 +40,7 @@ export const HeresHowWeHelp = () => {
         className={styles.heresHowWeHelpCta}
         variant="primary"
         onPress={() => {
-          void signIn("fxa");
+          signInToFxa("fxa");
           record("ctaButton", "click", {
             button_id: "clicked_get_scan_fifth",
           });

--- a/src/app/[locale]/(redesign)/(public)/SignUpForm.tsx
+++ b/src/app/[locale]/(redesign)/(public)/SignUpForm.tsx
@@ -5,7 +5,7 @@
 "use client";
 
 import { FormEventHandler, ReactNode, RefObject, useState } from "react";
-import { signIn } from "next-auth/react";
+import { signInToFxa } from "../../../functions/client/signInToFxa";
 import { useL10n } from "../../../hooks/l10n";
 import { Button } from "../../../components/client/Button";
 import styles from "./SignUpForm.module.scss";
@@ -38,7 +38,7 @@ export const SignUpForm = (props: Props) => {
 
   const onSubmit: FormEventHandler = (event) => {
     event.preventDefault();
-    void signIn(
+    signInToFxa(
       "fxa",
       { callbackUrl: props.signUpCallbackUrl },
       `email=${encodeURIComponent(emailInput)}`,

--- a/src/app/[locale]/(redesign)/(public)/how-it-works/components/DataBreaches.tsx
+++ b/src/app/[locale]/(redesign)/(public)/how-it-works/components/DataBreaches.tsx
@@ -5,7 +5,7 @@
 "use client";
 
 import Image from "next/image";
-import { signIn } from "next-auth/react";
+import { signInToFxa } from "../../../../../functions/client/signInToFxa";
 import { TelemetryButton } from "../../../../../components/client/TelemetryButton";
 import { Resolve } from "../images";
 import styles from "../HowItWorksView.module.scss";
@@ -39,7 +39,7 @@ export const DataBreaches = () => {
               href="/user/dashboard"
               variant="primary"
               onPress={() => {
-                void signIn("fxa");
+                signInToFxa("fxa");
               }}
               event={{
                 module: "ctaButton",
@@ -113,7 +113,7 @@ export const DataBreaches = () => {
           href="/user/dashboard"
           variant="primary"
           onPress={() => {
-            void signIn("fxa");
+            signInToFxa("fxa");
           }}
           event={{
             module: "ctaButton",

--- a/src/app/[locale]/unsubscribe/breach-alerts/UnsubscribeBreachAlertsView.tsx
+++ b/src/app/[locale]/unsubscribe/breach-alerts/UnsubscribeBreachAlertsView.tsx
@@ -11,7 +11,7 @@ import Image from "next/image";
 import { useL10n } from "../../../hooks/l10n";
 import { toast, ToastOptions } from "react-toastify";
 import { TelemetryButton } from "../../../components/client/TelemetryButton";
-import { signIn } from "next-auth/react";
+import { signInToFxa } from "../../../functions/client/signInToFxa";
 
 export const UnsubscribeBreachAlertsView = ({ token }: { token: string }) => {
   const l10n = useL10n();
@@ -86,7 +86,7 @@ export const UnsubscribeBreachAlertsView = ({ token }: { token: string }) => {
           if (!unsubscribeSuccess) {
             void handleUnsubscribe();
           } else {
-            void signIn("fxa", { callbackUrl: "/user/dashboard" });
+            signInToFxa("fxa", { callbackUrl: "/user/dashboard" });
           }
         }}
       >

--- a/src/app/components/client/AutoSignIn.tsx
+++ b/src/app/components/client/AutoSignIn.tsx
@@ -4,12 +4,12 @@
 
 "use client";
 
-import { signIn } from "next-auth/react";
+import { signInToFxa } from "../../functions/client/signInToFxa";
 import { ReactNode, useEffect } from "react";
 
 export const AutoSignIn = (): ReactNode => {
   useEffect(() => {
-    void signIn("fxa");
+    signInToFxa("fxa");
   }, []);
 
   return null;

--- a/src/app/components/client/PromptNoneAuth.tsx
+++ b/src/app/components/client/PromptNoneAuth.tsx
@@ -6,7 +6,7 @@
 
 import { ReactNode, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
-import { signIn } from "next-auth/react";
+import { signInToFxa } from "../../functions/client/signInToFxa";
 import { containsExpectedSearchParams } from "../../functions/universal/attributions";
 
 export const PromptNoneAuth = (): ReactNode => {
@@ -19,7 +19,7 @@ export const PromptNoneAuth = (): ReactNode => {
       searchParams,
     );
     if (isPromptNoneAuthAttempt) {
-      void signIn("fxa", { callbackUrl: "/user/dashboard" }, authParams);
+      signInToFxa("fxa", { callbackUrl: "/user/dashboard" }, authParams);
     }
     // This effect should only run once
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/app/components/client/SignInButton.tsx
+++ b/src/app/components/client/SignInButton.tsx
@@ -4,7 +4,8 @@
 
 "use client";
 
-import { signIn, useSession } from "next-auth/react";
+import { useSession } from "next-auth/react";
+import { signInToFxa } from "../../functions/client/signInToFxa";
 import { useL10n } from "../../hooks/l10n";
 import { Button, ButtonProps } from "./Button";
 import { useTelemetry } from "../../hooks/useTelemetry";
@@ -28,7 +29,7 @@ export const SignInButton = (props: ButtonProps) => {
         recordTelemetry("ctaButton", "click", {
           button_id: "sign_in",
         });
-        void signIn("fxa", { callbackUrl: "/user/dashboard" });
+        signInToFxa("fxa", { callbackUrl: "/user/dashboard" });
       }}
     >
       {l10n.getString("sign-in")}

--- a/src/app/functions/client/signInToFxa.ts
+++ b/src/app/functions/client/signInToFxa.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { signIn } from "next-auth/react";
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * Start the FxA sign-in flow, swallowing the network errors that are expected
+ * when the browser redirects away.
+ *
+ * `signIn` runs a few `fetch` calls and then sends the whole page to FxA with
+ * `window.location.href`. When the browser aborts one of those in-flight
+ * fetches — navigation starting, the tab closing, or a connection blip —
+ * Firefox rejects with `TypeError: NetworkError when attempting to fetch
+ * resource`. Every call site used to `void` the promise, so every rejection
+ * was sent as an unhandled rejection into Sentry (MNTOR-3923).
+ *
+ * A `TypeError` from `fetch` is expected and unactionable here, so we drop it.
+ * Anything else is a real failure, so we report it to Sentry as handled.
+ */
+export function signInToFxa(...args: Parameters<typeof signIn>): void {
+  signIn(...args).catch((error: unknown) => {
+    if (error instanceof TypeError) {
+      return;
+    }
+    Sentry.captureException(error);
+  });
+}


### PR DESCRIPTION
`signIn` fetches and then redirects the page to FxA. When the browser aborts an in-flight fetch during that redirect, it rejects with a network `TypeError`. Every call site voided the promise, so the rejection surfaced as an unhandled rejection in Sentry.

A shared `signInToFxa` wrapper catches the rejection. It drops the expected network `TypeError` and reports anything else as handled.

# References:

Jira: MNTOR-3923