### PR TITLE
Mntor 5342

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npx @redocly/cli@2 lint                              # validate, should report z
 npx @redocly/cli@2 build-docs openapi.yml -o /tmp/api.html  # read it as the client team will
 ```
 
-`lint` needs no arguments because `redocly.yaml` names the description and turns off two rules we ignore on purpose, each with a comment saying why. Anything it reports is worth fixing.
+`lint` needs no arguments because `redocly.yaml` names the description. It turns off one rule we ignore on purpose, with a comment saying why. Anything it reports is worth fixing.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ the "what" and "why" of data breach alerts.
 
 ![Image of Monitor architecture](docs/monitor-architecture.png "Firefox Monitor")
 
+## API contract
+
+`openapi.yml` is the contract for the Firefox-facing API (`/api/firefox/v1`), consumed by the Firefox privacy panel. Validate it with [Redocly CLI](https://redocly.com/docs/cli), which supports OpenAPI 3.1:
+
+```sh
+npx @redocly/cli@2 lint                              # validate, should report zero problems
+npx @redocly/cli@2 build-docs openapi.yml -o /tmp/api.html  # read it as the client team will
+```
+
+`lint` needs no arguments because `redocly.yaml` names the description and turns off two rules we ignore on purpose, each with a comment saying why. Anything it reports is worth fixing.
+
 ## Development
 
 ### Requirements

--- a/openapi.yml
+++ b/openapi.yml
@@ -48,6 +48,7 @@ components:
             - invalid-request
             - not-found
             - rate-limited
+            - internal-error
             - unavailable
         message:
           type: string
@@ -135,6 +136,15 @@ components:
           example:
             code: rate-limited
             message: Too many requests. Retry after 60 seconds.
+    InternalError:
+      description: Something failed on our side. The request may not have been applied. Retry, and keep any state you already hold.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            code: internal-error
+            message: Monitor could not complete this request.
     ServiceUnavailable:
       description: Monitor is unavailable. Safe to retry, after the interval in `Retry-After` when it is present.
       headers:
@@ -223,6 +233,8 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "429":
           $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
           description: We could not check this user against HIBP, so we do not know what they are affected by. Keep the breaches you already hold, do not clear them, and retry.
@@ -330,5 +342,7 @@ paths:
                 message: One or more of the referenced breaches or email addresses was not found.
         "429":
           $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalError"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"

--- a/openapi.yml
+++ b/openapi.yml
@@ -2,11 +2,16 @@ openapi: "3.1.1"
 info:
   title: Monitor Breach Alerts API
   description: Monitor's external API for Firefox clients
-  version: "1.0"
+  version: "1.0.0"
+# The web app already owns /api/v1.
 servers:
-  - url: https://monitor.mozilla.org/api/v1
+  - url: https://monitor.mozilla.org/api/firefox/v1
     description: Production endpoint
-  - url: http://localhost:6060/api/v1
+  - url: https://monitor-stage.allizom.org/api/firefox/v1
+    description: Stage endpoint
+  - url: https://dev.monitor.nonprod.webservices.mozgcp.net/api/firefox/v1
+    description: Dev endpoint
+  - url: http://localhost:6060/api/firefox/v1
     description: Local development server
 security:
   - bearerAuth: []

--- a/openapi.yml
+++ b/openapi.yml
@@ -161,6 +161,8 @@ paths:
       description: |
         Breaches that leaked passwords or email addresses, with resolution state for each monitored email the breach affected.
 
+        Sensitive breaches, as HIBP marks them, are never returned. The privacy panel must not surface one, so there is no parameter to ask for them. Remote Settings does carry them, flagged, because the credential manager is allowed to.
+
         **Freshness.** When HIBP is unavailable we serve the last known breach data as a normal `200`, with no staleness signal.
 
         **Cadence.** Poll no more than hourly, and once a day is enough. Breaches reach HIBP weeks or months after the incident, so polling harder gains nothing, and the `429` threshold is set with this range in mind.
@@ -177,14 +179,6 @@ paths:
             example:
               summary: Example domain
               value: example.com
-        - name: includeSensitive
-          in: query
-          required: false
-          description: Include breaches marked sensitive.
-          schema:
-            type: boolean
-            default: false
-
       responses:
         "200":
           description: |

--- a/openapi.yml
+++ b/openapi.yml
@@ -53,7 +53,7 @@ components:
       description: A data class we report as resolved. `passwords` and `email-addresses` today, but this is an open set, so accept a value you do not recognise instead of rejecting the response.
       type: string
     BreachResolution:
-      description: One item of a `POST /user/breaches/resolutions` body. Names a breach and the data classes to mark resolved, applied to every address in `emails`, or to every address the breach affected when `emails` is omitted.
+      description: One entry of a `POST /user/breaches/resolutions` body. Names a breach, the data classes to mark resolved, and the addresses to target.
       type: object
       additionalProperties: false
       required:
@@ -63,7 +63,7 @@ components:
         emails:
           type: array
           minItems: 1
-          description: Monitored email addresses to apply the update to. If omitted, applies to every monitored address the referenced breach affected.
+          description: Email addresses to target. Omit it to target every monitored address the breach affected.
           items:
             type: string
             format: email
@@ -271,11 +271,11 @@ paths:
       description: |
         Mark data classes resolved for one or more breaches. Resolutions only move one way, this API cannot unresolve a data class.
 
+        Each entry targets the addresses in `emails`, or every monitored address the breach affected when `emails` is omitted. Every address you list in `emails` must be monitored by this user and affected by that breach.
+
         Idempotent per `(email, dataClass, breachId)`. Repeated `breachId` entries merge, and order does not matter.
 
         Atomic: every targeted email and data class updates, or none does.
-
-        Every address in `emails` must be monitored by the authenticated user, and affected by the referenced breach.
 
       requestBody:
         required: true
@@ -310,7 +310,7 @@ paths:
         "204":
           description: Resolution state updated successfully.
         "400":
-          description: Invalid request, for example an empty batch, an empty `dataClasses` array, a malformed email address, or a data class the referenced breach never leaked.
+          description: Invalid request, for example an empty batch, an empty `emails` or `dataClasses` array, a malformed email address, or a data class the referenced breach never leaked.
           content:
             application/json:
               schema:
@@ -341,7 +341,8 @@ paths:
 
             - an unknown `breachId`, or a breach this endpoint does not serve
             - an address this user does not monitor, including one they own but have not verified
-            - a monitored address the referenced breach did not affect
+            - an address the referenced breach did not affect
+            - an entry that targets nothing: `emails` omitted, and the breach affected no monitored address
 
             All give the same code and message, so the response does not say which of them applied.
           content:
@@ -350,7 +351,7 @@ paths:
                 $ref: "#/components/schemas/Error"
               example:
                 code: not-found
-                message: One or more of the referenced breaches or email addresses was not found.
+                message: Nothing matched for one or more entries.
         "429":
           $ref: "#/components/responses/TooManyRequests"
         "500":

--- a/openapi.yml
+++ b/openapi.yml
@@ -33,7 +33,7 @@ components:
   schemas:
     Error:
       type: object
-      description: Body of every non-2xx response. Branch on `code`. `message` is for logs and bug reports, it is not stable, so do not match on it.
+      description: Body of every non-2xx response we generate. Our WAF can answer first, and those responses carry neither this body nor a `code`. Branch on `code`. `message` is for logs and bug reports, it is not stable, so do not match on it.
       required:
         - code
         - message
@@ -120,11 +120,12 @@ components:
               value:
                 code: no-monitor-account
                 message: This Firefox account has no Monitor subscriber.
+    # TODO(MNTOR-4119): set the threshold, and decide app or edge.
     TooManyRequests:
-      description: Rate limited. Wait the interval in `Retry-After`, then retry.
+      description: Rate limited. Wait the interval in `Retry-After` if it is present, otherwise back off and retry.
       headers:
         Retry-After:
-          required: true
+          required: false
           description: Seconds to wait before retrying.
           schema:
             type: integer
@@ -177,7 +178,7 @@ paths:
 
         **Joining.** Almost every `id` resolves in `fxmonitor-breaches`, but the collection is slower than this API. It publishes daily, and each batch is signed only after a person reviews it, deliberately, because it ships to every Firefox. So a breach can be live here for days before Firefox sees it, and a HIBP rename retires an id. Skip an id you cannot resolve rather than erroring, and pick it up on a later poll.
 
-        **Cadence.** Poll no more than hourly, and once a day is enough. Breaches reach HIBP weeks or months after the incident, so polling harder gains nothing, and the `429` threshold is set with this range in mind.
+        **Cadence.** Poll no more than hourly, and once a day is enough. Breaches reach HIBP weeks or months after the incident, so polling harder gains nothing.
 
       parameters:
         - name: domain

--- a/openapi.yml
+++ b/openapi.yml
@@ -52,7 +52,7 @@ components:
         message:
           type: string
     DataClass:
-      description: A kind of data leaked in a breach. Remote Settings serves the same values in HIBP's Title Case, `Passwords` and `Email addresses`. Expect more values later, so treat this as an open set rather than generating a closed type from it.
+      description: A kind of data leaked in a breach. Remote Settings serves the same values in HIBP's Title Case, `Passwords` and `Email addresses`.
       type: string
       enum:
         - passwords
@@ -70,7 +70,7 @@ components:
           format: email
         resolvedDataClasses:
           # No timestamp, we store a checked list.
-          description: Data classes this user has marked resolved for this breach, in the privacy panel or on the Monitor website. Limited to the data classes this API serves, so resolutions of other exposures on the Monitor website are not reported here.
+          description: Data classes this user has marked resolved for this breach, in the privacy panel or on the Monitor website. A breach is resolved once this array holds every `Passwords` or `Email addresses` the Remote Settings record lists. That record can carry other data classes, and none of them ever appears here.
           type: array
           items:
             $ref: "#/components/schemas/DataClass"
@@ -165,7 +165,7 @@ paths:
 
         **Freshness.** Breach metadata comes from a catalog we refresh every 10 minutes, so a new breach can take that long to appear. The per user match is live on every request and is not cached, so there is no last known result to serve when it fails.
 
-        **Joining.** Almost every `id` resolves in `fxmonitor-breaches`, but the collection is slower than this API: it publishes daily, and each batch is signed only after a person reviews it, deliberately, because it ships to every Firefox. So a breach can be live here for days before Firefox sees it, and a HIBP rename retires an id. Skip an id you cannot resolve rather than erroring, and pick it up on a later poll.
+        **Joining.** Almost every `id` resolves in `fxmonitor-breaches`, but the collection is slower than this API. It publishes daily, and each batch is signed only after a person reviews it, deliberately, because it ships to every Firefox. So a breach can be live here for days before Firefox sees it, and a HIBP rename retires an id. Skip an id you cannot resolve rather than erroring, and pick it up on a later poll.
 
         **Cadence.** Poll no more than hourly, and once a day is enough. Breaches reach HIBP weeks or months after the incident, so polling harder gains nothing, and the `429` threshold is set with this range in mind.
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -138,7 +138,7 @@ components:
             code: rate-limited
             message: Too many requests. Retry after 60 seconds.
     InternalError:
-      description: Something failed on our side. The request may not have been applied. Retry, and keep any state you already hold.
+      description: Something failed on our side. Retry, and keep any state you already hold.
       content:
         application/json:
           schema:
@@ -352,5 +352,6 @@ paths:
           $ref: "#/components/responses/TooManyRequests"
         "500":
           $ref: "#/components/responses/InternalError"
+          description: Something failed on our side. Treat the batch as not applied and retry it, repeats are safe.
         "503":
           $ref: "#/components/responses/ServiceUnavailable"

--- a/openapi.yml
+++ b/openapi.yml
@@ -333,7 +333,14 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          description: An unknown `breachId`, a breach this endpoint does not serve, or an email address this user does not monitor, which includes an address the user owns but has not verified. All give the same code and message, so the response does not say which of them applied.
+          description: |
+            Nothing here to resolve, for one of:
+
+            - an unknown `breachId`, or a breach this endpoint does not serve
+            - an address this user does not monitor, including one they own but have not verified
+            - a monitored address the referenced breach did not affect
+
+            All give the same code and message, so the response does not say which of them applied.
           content:
             application/json:
               schema:

--- a/openapi.yml
+++ b/openapi.yml
@@ -4,11 +4,13 @@ info:
   description: |
     Monitor's external API for Firefox clients.
 
-    Remote Settings owns breach facts, this API owns per-user resolution state. The client
-    joins them on the HIBP breach name, returned here as `id`.
+    Remote Settings owns breach facts, this API owns per-user resolution state. The client joins them on the HIBP breach name, returned here as `id`.
 
     "Monitored" means the account's verified primary and secondary email addresses.
   version: "1.0.0"
+  license:
+    name: MPL-2.0
+    identifier: MPL-2.0
 # The web app already owns /api/v1.
 servers:
   - url: https://monitor.mozilla.org/api/firefox/v1
@@ -27,9 +29,7 @@ components:
       type: http
       scheme: bearer
       # We introspect the token with FxA.
-      description: >
-        An OAuth token granted by Firefox Accounts (FxA), carrying the
-        `https://identity.mozilla.com/apps/monitor` scope. Treat it as opaque.
+      description: An OAuth token granted by Firefox Accounts (FxA), carrying the `https://identity.mozilla.com/apps/monitor` scope. Treat it as opaque.
   schemas:
     Error:
       type: object
@@ -41,9 +41,7 @@ components:
           type: string
     DataClass:
       # Enum so new values stay compatible.
-      description: >
-        A kind of data leaked in a breach. This API handles `passwords` alone. Remote Settings
-        serves the same value in HIBP's Title Case, `Passwords`.
+      description: A kind of data leaked in a breach. This API handles `passwords` alone. Remote Settings serves the same value in HIBP's Title Case, `Passwords`.
       type: string
       enum:
         - passwords
@@ -60,10 +58,7 @@ components:
           format: email
         resolvedDataClasses:
           # No timestamp, we store a checked list.
-          description: >
-            Data classes this user has marked resolved for this breach, in the privacy panel
-            or on the Monitor website. Scoped to `passwords`, so resolutions of other
-            exposures are not reported here.
+          description: Data classes this user has marked resolved for this breach, in the privacy panel or on the Monitor website. Scoped to `passwords`, so resolutions of other exposures are not reported here.
           type: array
           items:
             $ref: "#/components/schemas/DataClass"
@@ -77,9 +72,7 @@ components:
       properties:
         id:
           # Not the internal numeric breach id.
-          description: >
-            The HIBP breach name, for example `Adobe`. Firefox joins the breach metadata
-            locally from the `fxmonitor-breaches` Remote Settings collection.
+          description: The HIBP breach name, for example `Adobe`. Firefox joins the breach metadata locally from the `fxmonitor-breaches` Remote Settings collection.
           type: string
         breachedAccounts:
           type: array
@@ -88,9 +81,7 @@ components:
 
   responses:
     Unauthorized:
-      description: >
-        No usable token. The `Authorization` header is missing or malformed, or FxA reports
-        the token as inactive or expired.
+      description: No usable token. The `Authorization` header is missing or malformed, or FxA reports the token as inactive or expired.
       content:
         application/json:
           schema:
@@ -98,10 +89,8 @@ components:
           example:
             message: FxA reports this token as inactive.
     Forbidden:
-      description: >
-        The token is valid but does not grant access: either it lacks the Monitor scope, or
-        the account has no Monitor subscriber. Monitor serves existing accounts only and
-        never creates one.
+      description: |
+        The token is valid but does not grant access: either it lacks the Monitor scope, or the account has no Monitor subscriber. Monitor serves existing accounts only and never creates one.
       content:
         application/json:
           schema:
@@ -145,19 +134,15 @@ paths:
       summary: List password breaches affecting this user
       # Passwords only, the panel's one action.
       description: |
-        Breaches that leaked passwords, with `passwords` resolution state for each monitored
-        email the breach affected.
+        Breaches that leaked passwords, with `passwords` resolution state for each monitored email the breach affected.
 
-        **Freshness.** When HIBP is unavailable we serve the last known breach data as a
-        normal `200`, with no staleness signal.
+        **Freshness.** When HIBP is unavailable we serve the last known breach data as a normal `200`, with no staleness signal.
 
       parameters:
         - name: domain
           in: query
           required: false
-          description: >
-            Filter by the breached site's primary domain, matched exactly. A breach filed
-            under `twitter.com` does not match `x.com`.
+          description: Filter by the breached site's primary domain, matched exactly. A breach filed under `twitter.com` does not match `x.com`.
           schema:
             type: string
             minLength: 1
@@ -178,9 +163,7 @@ paths:
           description: |
             Breaches affecting emails this user is monitoring.
 
-            Absence is authoritative. A breach missing from this list means we checked and
-            this user is not affected by it, not that we failed to look. An empty array means
-            the same for every breach.
+            Absence is authoritative. A breach missing from this list means we checked and this user is not affected by it, not that we failed to look. An empty array means the same for every breach.
           content:
             application/json:
               schema:
@@ -219,11 +202,9 @@ paths:
     post:
       summary: Mark password breaches resolved
       description: |
-        Mark data classes resolved for one or more breaches. Resolutions only move one way,
-        this API cannot unresolve a data class.
+        Mark data classes resolved for one or more breaches. Resolutions only move one way, this API cannot unresolve a data class.
 
-        Idempotent per `(email, dataClass, breachId)`. Repeated `breachId` entries merge, and
-        order does not matter.
+        Idempotent per `(email, dataClass, breachId)`. Repeated `breachId` entries merge, and order does not matter.
 
         Atomic: every targeted email and data class updates, or none does.
 
@@ -246,9 +227,7 @@ paths:
                   emails:
                     type: array
                     minItems: 1
-                    description: >
-                      Monitored email addresses to apply the update to. If omitted, applies to
-                      every monitored address the referenced breach affected.
+                    description: Monitored email addresses to apply the update to. If omitted, applies to every monitored address the referenced breach affected.
                     items:
                       type: string
                       format: email
@@ -280,8 +259,7 @@ paths:
         "204":
           description: Resolution state updated successfully.
         "400":
-          description: Invalid request, for example an empty batch, an empty `dataClasses` array,
-            or a malformed email address.
+          description: Invalid request, for example an empty batch, an empty `dataClasses` array, or a malformed email address.
           content:
             application/json:
               schema:
@@ -300,10 +278,7 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          description: >
-            An unknown `breachId`, a breach this endpoint does not serve, or an email address
-            this user does not monitor. All give the same message on purpose, so the response
-            cannot be used to work out which addresses exist on an account.
+          description: An unknown `breachId`, a breach this endpoint does not serve, or an email address this user does not monitor. All give the same message on purpose, so the response cannot be used to work out which addresses exist on an account.
           content:
             application/json:
               schema:

--- a/openapi.yml
+++ b/openapi.yml
@@ -197,7 +197,7 @@ paths:
           description: |
             Breaches affecting emails this user is monitoring.
 
-            A breach missing from this list means we checked and this user is not affected by it. An empty array means that that is true for every breach. A `200` is never a partial answer, i.e when the lookup fails we send a `503` instead.
+            A breach missing from this list means we checked and this user is not affected by it. An empty array means that is true for every breach. A `200` is never a partial answer, so when the lookup fails we send a `503` instead.
           content:
             application/json:
               schema:

--- a/openapi.yml
+++ b/openapi.yml
@@ -251,7 +251,7 @@ paths:
 
         Atomic: every targeted email and data class updates, or none does.
 
-        Every address in `emails` must be monitored by the authenticated user.
+        Every address in `emails` must be monitored by the authenticated user, and affected by the referenced breach.
 
       requestBody:
         required: true

--- a/openapi.yml
+++ b/openapi.yml
@@ -217,6 +217,11 @@ paths:
             Breaches affecting emails this user is monitoring.
 
             A breach missing from this list means we checked and this user is not affected by it. An empty array means that is true for every breach. A `200` is never a partial answer, so when the lookup fails we send a `503` instead.
+          headers:
+            Cache-Control:
+              description: Always `private, no-store`. This response is scoped to one user and must never be cached by a shared intermediary.
+              schema:
+                type: string
           content:
             application/json:
               schema:

--- a/openapi.yml
+++ b/openapi.yml
@@ -33,10 +33,22 @@ components:
   schemas:
     Error:
       type: object
-      description: Body of every non-2xx response. `message` is not stable, do not match on it.
+      description: Body of every non-2xx response. Branch on `code`. `message` is for logs and bug reports, it is not stable, so do not match on it.
       required:
+        - code
         - message
       properties:
+        code:
+          description: Stable, machine-readable cause. Kebab-case, like the data class values.
+          type: string
+          enum:
+            - token-invalid
+            - missing-scope
+            - no-monitor-account
+            - invalid-request
+            - not-found
+            - rate-limited
+            - unavailable
         message:
           type: string
     DataClass:
@@ -87,6 +99,7 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
+            code: token-invalid
             message: FxA reports this token as inactive.
     Forbidden:
       description: |
@@ -99,10 +112,12 @@ components:
             missingScope:
               summary: Token does not carry the Monitor scope
               value:
+                code: missing-scope
                 message: This token lacks the https://identity.mozilla.com/apps/monitor scope.
             noMonitorAccount:
               summary: FxA account has never signed up for Monitor
               value:
+                code: no-monitor-account
                 message: This Firefox account has no Monitor subscriber.
     TooManyRequests:
       description: Rate limited. Wait the interval in `Retry-After`, then retry.
@@ -118,6 +133,7 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
+            code: rate-limited
             message: Too many requests. Retry after 60 seconds.
     ServiceUnavailable:
       description: Monitor is unavailable.
@@ -126,6 +142,7 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
           example:
+            code: unavailable
             message: Monitor is temporarily unavailable.
 
 paths:
@@ -188,6 +205,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
               example:
+                code: invalid-request
                 message: "domain must not be empty."
         "401":
           $ref: "#/components/responses/Unauthorized"
@@ -268,22 +286,25 @@ paths:
                 unknownDataClass:
                   summary: Data class outside the accepted set
                   value:
+                    code: invalid-request
                     message: "dataClasses[0] must be one of: passwords."
                 malformedEmail:
                   summary: Email is not a valid address
                   value:
+                    code: invalid-request
                     message: "emails[0] is not a valid email address."
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          description: An unknown `breachId`, a breach this endpoint does not serve, or an email address this user does not monitor. All give the same message on purpose, so the response cannot be used to work out which addresses exist on an account.
+          description: An unknown `breachId`, a breach this endpoint does not serve, or an email address this user does not monitor. All give the same code and message on purpose, so the response cannot be used to work out which addresses exist on an account.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
               example:
+                code: not-found
                 message: One or more of the referenced breaches or email addresses was not found.
         "429":
           $ref: "#/components/responses/TooManyRequests"

--- a/openapi.yml
+++ b/openapi.yml
@@ -39,25 +39,19 @@ components:
         - message
       properties:
         code:
-          description: Stable, machine-readable cause. Kebab-case, like the data class values.
+          description: Stable, machine-readable cause, kebab-case. Today `token-invalid`, `missing-scope`, `no-monitor-account`, `invalid-request`, `not-found`, `rate-limited`, `internal-error`, `unavailable`. We may add values in the future, so fall back to the status code for one you do not recognise.
           type: string
-          enum:
-            - token-invalid
-            - missing-scope
-            - no-monitor-account
-            - invalid-request
-            - not-found
-            - rate-limited
-            - internal-error
-            - unavailable
         message:
           type: string
     DataClass:
-      description: A kind of data leaked in a breach. Remote Settings serves the same values in HIBP's Title Case, `Passwords` and `Email addresses`.
+      description: A data class you can mark resolved. Closed set, we reject anything else with a `400`. Remote Settings serves the same values in HIBP's Title Case, `Passwords` and `Email addresses`.
       type: string
       enum:
         - passwords
         - email-addresses
+    ResolvedDataClass:
+      description: A data class we report as resolved. `passwords` and `email-addresses` today, but this is an open set, so accept a value you do not recognise instead of rejecting the response.
+      type: string
     BreachResolution:
       description: One item of a `POST /user/breaches/resolutions` body. Names a breach and the data classes to mark resolved, applied to every address in `emails`, or to every address the breach affected when `emails` is omitted.
       type: object
@@ -95,10 +89,10 @@ components:
           format: email
         resolvedDataClasses:
           # No timestamp, we store a checked list.
-          description: Data classes this user has marked resolved for this breach, in the privacy panel or on the Monitor website. A breach is resolved once this array holds every `Passwords` or `Email addresses` the Remote Settings record lists. That record can carry other data classes, and none of them ever appears here.
+          description: Data classes this user has marked resolved for this breach, in the privacy panel or on the Monitor website. A breach is resolved once this array holds every `Passwords` or `Email addresses` the Remote Settings record lists. That record can carry other data classes, and only the ones this API serves appear here.
           type: array
           items:
-            $ref: "#/components/schemas/DataClass"
+            $ref: "#/components/schemas/ResolvedDataClass"
 
     UserBreach:
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -163,7 +163,7 @@ paths:
 
         Sensitive breaches, as HIBP marks them, are never returned. The privacy panel must not surface one, so there is no parameter to ask for them. Remote Settings does carry them, flagged, because the credential manager is allowed to.
 
-        **Freshness.** When HIBP is unavailable we serve the last known breach data as a normal `200`, with no staleness signal.
+        **Freshness.** Breach metadata comes from a catalog we refresh every 10 minutes, so a new breach can take that long to appear. The per user match is live on every request and is not cached, so there is no last known result to serve when it fails.
 
         **Cadence.** Poll no more than hourly, and once a day is enough. Breaches reach HIBP weeks or months after the incident, so polling harder gains nothing, and the `429` threshold is set with this range in mind.
 
@@ -184,7 +184,7 @@ paths:
           description: |
             Breaches affecting emails this user is monitoring.
 
-            Absence is authoritative. A breach missing from this list means we checked and this user is not affected by it, not that we failed to look. An empty array means the same for every breach.
+            A breach missing from this list means we checked and this user is not affected by it. An empty array means that that is true for every breach. A `200` is never a partial answer, i.e when the lookup fails we send a `503` instead.
           content:
             application/json:
               schema:
@@ -223,6 +223,7 @@ paths:
           $ref: "#/components/responses/TooManyRequests"
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
+          description: We could not check this user against HIBP, so we do not know what they are affected by. Keep the breaches you already hold, do not clear them, and retry.
 
   /user/breaches/resolutions:
     post:

--- a/openapi.yml
+++ b/openapi.yml
@@ -4,15 +4,10 @@ info:
   description: |
     Monitor's external API for Firefox clients.
 
-    Two systems own two halves of the picture, in two different vocabularies.
-    Remote Settings owns breach facts and serves HIBP's Title Case, for example
-    `Passwords`. This API owns per-user resolution state and uses kebab-case, for
-    example `passwords`. The client joins the two on the HIBP breach name, which
-    this API returns as `id`.
+    Remote Settings owns breach facts, this API owns per-user resolution state. The client
+    joins them on the HIBP breach name, returned here as `id`.
 
-    "Monitored", used throughout, means the account's primary email address plus any
-    secondary addresses, verified ones only. An unverified address is not monitored:
-    it is never returned here, and a resolution sent for one is rejected.
+    "Monitored" means the account's verified primary and secondary email addresses.
   version: "1.0.0"
 # The web app already owns /api/v1.
 servers:
@@ -31,39 +26,30 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
-      # FxA owns the token format.
-      description: |
+      # We introspect the token with FxA.
+      description: >
         An OAuth token granted by Firefox Accounts (FxA), carrying the
-        `https://identity.mozilla.com/apps/monitor` scope.
-
-        We introspect the token with FxA, so this contract asserts no token format: do not
-        rely on it being a JWT. Requests are scoped to the token's subject and never touch
-        another user's data.
+        `https://identity.mozilla.com/apps/monitor` scope. Treat it as opaque.
   schemas:
     Error:
       type: object
-      description: >
-        Body of every non-2xx response. `message` explains the particular case, for logs and
-        bug reports. It is not stable, so do not match on it.
+      description: Body of every non-2xx response. `message` is not stable, do not match on it.
       required:
         - message
       properties:
         message:
           type: string
     DataClass:
+      # Enum so new values stay compatible.
       description: >
-        A kind of data leaked in a breach. This API handles `passwords` alone, since
-        the privacy panel's one action is "Mark as done" on a password breach. Note
-        that this API uses kebab-case while Remote Settings serves HIBP's Title Case,
-        for example `Passwords`, so clients map between the two. This is staying an enum,
-        even though we only have one value right now, as adding values later stays backwards
-        compatible.
+        A kind of data leaked in a breach. This API handles `passwords` alone. Remote Settings
+        serves the same value in HIBP's Title Case, `Passwords`.
       type: string
       enum:
         - passwords
     UserBreachState:
       type: object
-      description: Object describing the current breach state and resolutions
+      description: Per-email resolution state for one breach.
       required:
         - email
         - resolvedDataClasses
@@ -73,28 +59,27 @@ components:
           type: string
           format: email
         resolvedDataClasses:
+          # No timestamp, we store a checked list.
           description: >
-            Data classes this user has marked resolved for this breach, whether in the
-            privacy panel or on the Monitor website. Monitor stores a checked list and
-            nothing more, so this array carries the data classes alone with no timestamp.
-            Scoped to `passwords`, matching the breaches this endpoint returns; a user's
-            resolutions of other exposures on the Monitor website are not reported here.
+            Data classes this user has marked resolved for this breach, in the privacy panel
+            or on the Monitor website. Scoped to `passwords`, so resolutions of other
+            exposures are not reported here.
           type: array
           items:
             $ref: "#/components/schemas/DataClass"
 
     UserBreach:
       type: object
-      description: A breach affecting 1 or more email addresses tracked by a Monitor User, and resolution actions taken
+      description: One breach affecting this user, with resolution state per affected email.
       required:
         - id
         - breachedAccounts
       properties:
         id:
+          # Not the internal numeric breach id.
           description: >
-            The HIBP breach name, for example `Adobe`. Firefox already holds this key
-            from the `fxmonitor-breaches` Remote Settings collection, so it joins the
-            breach metadata locally. This is not Monitor's internal numeric breach id.
+            The HIBP breach name, for example `Adobe`. Firefox joins the breach metadata
+            locally from the `fxmonitor-breaches` Remote Settings collection.
           type: string
         breachedAccounts:
           type: array
@@ -114,9 +99,8 @@ components:
             message: FxA reports this token as inactive.
     Forbidden:
       description: >
-        The token is valid but does not grant access, for one of two reasons. Either it lacks
-        the `https://identity.mozilla.com/apps/monitor` scope, or the FxA account behind it
-        has no Monitor subscriber. This integration serves existing Monitor accounts only and
+        The token is valid but does not grant access: either it lacks the Monitor scope, or
+        the account has no Monitor subscriber. Monitor serves existing accounts only and
         never creates one.
       content:
         application/json:
@@ -147,10 +131,7 @@ components:
           example:
             message: Too many requests. Retry after 60 seconds.
     ServiceUnavailable:
-      description: >
-        Monitor is unavailable. This covers our own failures only; an unreachable HIBP is not
-        one of them, since we serve last known breach data as a normal `200` instead. Safe to
-        retry.
+      description: Monitor is unavailable.
       content:
         application/json:
           schema:
@@ -161,30 +142,22 @@ components:
 paths:
   /user/breaches:
     get:
+      summary: List password breaches affecting this user
+      # Passwords only, the panel's one action.
       description: |
-        Get breaches for an authenticated user. Returns a list of breaches; each item includes
-        per-email user state for monitored emails affected by that breach.
-
-        Scoped to breaches that leaked passwords, and to `passwords` resolution state. The
-        privacy panel acts on passwords alone, and a breach exposure reveals that a person
-        holds an account on a site, so this endpoint returns the narrowest answer that
-        serves the panel rather than the user's full exposure history. Firefox holds every
-        breach's data classes locally via Remote Settings, so it needs no filter to narrow
-        this further.
+        Breaches that leaked passwords, with `passwords` resolution state for each monitored
+        email the breach affected.
 
         **Freshness.** When HIBP is unavailable we serve the last known breach data as a
-        normal `200`. The response carries no staleness signal. A client has no useful
-        action to take on one. Breaches typically reach HIBP weeks or months after the incident,
-        so data that is hours behind is not meaningfully worse.
+        normal `200`, with no staleness signal.
 
       parameters:
         - name: domain
           in: query
           required: false
           description: >
-            Filter breaches by the breached site's primary domain, matched exactly, for example
-            "example.com". Site renames are out of scope for this contract: a breach filed under
-            `twitter.com` does not match `x.com`.
+            Filter by the breached site's primary domain, matched exactly. A breach filed
+            under `twitter.com` does not match `x.com`.
           schema:
             type: string
             minLength: 1
@@ -195,15 +168,10 @@ paths:
         - name: includeSensitive
           in: query
           required: false
-          description: >
-            When set to `true`, includes breaches marked as sensitive in the response.
-            By default, sensitive breaches are excluded.
+          description: Include breaches marked sensitive.
           schema:
             type: boolean
-          examples:
-            include:
-              summary: Include sensitive breaches
-              value: true
+            default: false
 
       responses:
         "200":
@@ -211,9 +179,8 @@ paths:
             Breaches affecting emails this user is monitoring.
 
             Absence is authoritative. A breach missing from this list means we checked and
-            this user is not affected by it, not that we failed to look. An empty array
-            means the same for every breach. This is what lets a client confidently render
-            a "your info was not in this breach" state.
+            this user is not affected by it, not that we failed to look. An empty array means
+            the same for every breach.
           content:
             application/json:
               schema:
@@ -250,37 +217,17 @@ paths:
 
   /user/breaches/resolutions:
     post:
+      summary: Mark password breaches resolved
       description: |
-        Bulk endpoint for breach resolutions.
+        Mark data classes resolved for one or more breaches. Resolutions only move one way,
+        this API cannot unresolve a data class.
 
-        Mark data classes resolved for one or more breaches across one or more monitored
-        email addresses. Resolutions only move one way: there is no way to unresolve a
-        data class through this API.
+        Idempotent per `(email, dataClass, breachId)`. Repeated `breachId` entries merge, and
+        order does not matter.
 
-        This operation is idempotent per `(email, dataClass, breachId)`. Repeating the same
-        request results in the same stored state and does not produce an error.
+        Atomic: every targeted email and data class updates, or none does.
 
-        If `emails` is omitted within an individual resolution item, 
-        the update applies to all monitored email addresses affected by the breach referenced by `breachId`
-        for the authenticated user.
-
-        **Authorization and privacy**
-        - All `emails` provided must be monitored by the authenticated user.
-        - For privacy reasons, if any provided email address is not associated with the authenticated
-          user, the server treats the request as if the resource does not exist and returns
-          `404 Not Found`.
-        - An address the user owns but has not verified gets that same `404`. It is not a
-          monitored address, and answering identically for both cases keeps the response
-          from revealing which addresses exist on the account.
-
-        **Atomicity**
-        - Requests are atomic: the update is applied to all targeted emails and dataclasses, or to none.
-
-        **Repeated input**
-        - Repeated `breachId` entries are accepted and merged, taking the union of the
-          `(email, dataClass)` pairs they imply. An item that omits `emails` contributes every
-          monitored address affected by that breach. Resolutions only move one way, so
-          duplicates cannot contradict each other and the result does not depend on order.
+        Every address in `emails` must be monitored by the authenticated user.
 
       requestBody:
         required: true
@@ -300,8 +247,8 @@ paths:
                     type: array
                     minItems: 1
                     description: >
-                      Monitored email addresses to apply the update to. If omitted, applies to all
-                      monitored email addresses affected by the referenced breach.
+                      Monitored email addresses to apply the update to. If omitted, applies to
+                      every monitored address the referenced breach affected.
                     items:
                       type: string
                       format: email
@@ -312,10 +259,7 @@ paths:
                     items:
                       $ref: "#/components/schemas/DataClass"
                   breachId:
-                    description: >
-                      The HIBP breach name, for example `Adobe`. The same identifier
-                      the `GET /user/breaches` response returns as `id`, not Monitor's
-                      internal numeric breach id.
+                    description: The HIBP breach name, as returned by `GET /user/breaches` in `id`.
                     type: string
             examples:
               resolveMultipleBreaches:

--- a/openapi.yml
+++ b/openapi.yml
@@ -27,6 +27,17 @@ components:
         authenticated user from the token subject (`sub`). All `/user/*` endpoints are scoped
         to the authenticated subject and never return or modify data for any other user.
   schemas:
+    DataClass:
+      description: >
+        A kind of data leaked in a breach. This API handles `passwords` alone, since
+        the privacy panel's one action is "Mark as done" on a password breach. Note
+        that this API uses kebab-case while Remote Settings serves HIBP's Title Case,
+        for example `Passwords`, so clients map between the two. This is staying an enum,
+        even though we only have one value right now, as adding values later stays backwards
+        compatible.
+      type: string
+      enum:
+        - passwords
     UserBreachState:
       type: object
       description: Object describing the current breach state and resolutions
@@ -40,13 +51,14 @@ components:
           format: email
         resolvedDataClasses:
           description: >
-            Data classes this user has marked resolved for this breach, for example after
-            changing their password. Monitor stores a checked list and nothing more. There
-            is no resolution timestamp in the database to expose, so this array carries the
-            data classes alone.
+            Data classes this user has marked resolved for this breach, whether in the
+            privacy panel or on the Monitor website. Monitor stores a checked list and
+            nothing more, so this array carries the data classes alone with no timestamp.
+            Scoped to `passwords`, matching the breaches this endpoint returns; a user's
+            resolutions of other exposures on the Monitor website are not reported here.
           type: array
           items:
-            type: string
+            $ref: "#/components/schemas/DataClass"
 
     UserBreach:
       type: object
@@ -73,6 +85,13 @@ paths:
         Get breaches for an authenticated user. Returns a list of breaches; each item includes
         per-email user state for monitored emails affected by that breach.
 
+        Scoped to breaches that leaked passwords, and to `passwords` resolution state. The
+        privacy panel acts on passwords alone, and a breach exposure reveals that a person
+        holds an account on a site, so this endpoint returns the narrowest answer that
+        serves the panel rather than the user's full exposure history. Firefox holds every
+        breach's data classes locally via Remote Settings, so it needs no filter to narrow
+        this further.
+
       parameters:
         - name: domain
           in: query
@@ -86,46 +105,6 @@ paths:
             example:
               summary: Example domain
               value: example.com
-        - name: dataClasses
-          in: query
-          required: false
-          description: >
-            Filter breaches to those that leaked any (but not necessarily all) of the specified
-            data classes. This filters on the breach's own data classes, which the response no
-            longer carries; Firefox reads them from Remote Settings.
-          schema:
-            type: array
-            items:
-              type: string
-          style: form
-          explode: true
-          examples:
-            passwords:
-              summary: Breaches that include passwords
-              value: ["passwords"]
-            pii:
-              summary: Breaches that include passwords or email addresses
-              value: ["passwords", "email-addresses"]
-        - name: unresolvedDataClasses
-          in: query
-          required: false
-          description: >
-            Filter breaches to those where one or more of the specified dataclasses
-            are still unresolved for the authenticated user, for at least one breached account.
-            A breach matches if any of the specified dataclasses are unresolved 
-            for at least one monitored email. Note that the breached accounts in the response are
-            not filtered by this parameter; the client will receive the complete set of breached account states
-            for the given breach.
-          schema:
-            type: array
-            items:
-              type: string
-          style: form
-          explode: true
-          examples:
-            passwords:
-              summary: Breaches with unresolved passwords
-              value: ["passwords"]
         - name: includeSensitive
           in: query
           required: false
@@ -216,7 +195,7 @@ paths:
                     minItems: 1
                     description: Data classes to mark resolved for the selected emails.
                     items:
-                      type: string
+                      $ref: "#/components/schemas/DataClass"
                   breachId:
                     description: >
                       The HIBP breach name, for example `Adobe`. The same identifier

--- a/openapi.yml
+++ b/openapi.yml
@@ -90,7 +90,7 @@ components:
         - resolvedDataClasses
       properties:
         email:
-          description: The impacted email address
+          description: A monitored address the breach affected.
           type: string
           format: email
         resolvedDataClasses:
@@ -113,6 +113,7 @@ components:
           type: string
         breachedAccounts:
           type: array
+          minItems: 1
           items:
             $ref: "#/components/schemas/UserBreachState"
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -39,16 +39,14 @@ components:
           type: string
           format: email
         resolvedDataClasses:
-          description: Data classes that have been resolved by user action, e.g. changing their password. Key-value object where key is the dataclass and the value is the timestamp of the resolution action.
-          type: object
-          # Right now we're not tracking things like timestamp or source (monitor vs. fx)
-          # but having an object gives flexibility in the future
-          additionalProperties:
-            type: object
-            properties:
-              resolvedAt:
-                type: string
-                format: date-time
+          description: >
+            Data classes this user has marked resolved for this breach, for example after
+            changing their password. Monitor stores a checked list and nothing more. There
+            is no resolution timestamp in the database to expose, so this array carries the
+            data classes alone.
+          type: array
+          items:
+            type: string
 
     UserBreach:
       type: object
@@ -157,8 +155,7 @@ paths:
                     - id: "Adobe"
                       breachedAccounts:
                         - email: "alice@example.com"
-                          resolvedDataClasses:
-                            passwords: {}
+                          resolvedDataClasses: ["passwords"]
                 noResults:
                   summary: No breaches found
                   value: []
@@ -172,7 +169,9 @@ paths:
       description: |
         Bulk endpoint for breach resolutions.
 
-        Upsert resolution state for one or more breaches across one or more monitored email addresses.
+        Mark data classes resolved for one or more breaches across one or more monitored
+        email addresses. Resolutions only move one way: there is no way to unresolve a
+        data class through this API.
 
         This operation is idempotent per `(email, dataClass, breachId)`. Repeating the same
         request results in the same stored state and does not produce an error.
@@ -201,7 +200,6 @@ paths:
                 additionalProperties: false
                 required:
                   - dataClasses
-                  - resolved
                   - breachId
                 properties:
                   emails:
@@ -216,7 +214,7 @@ paths:
                   dataClasses:
                     type: array
                     minItems: 1
-                    description: Dataclasses to mark resolved/unresolved for the selected emails.
+                    description: Data classes to mark resolved for the selected emails.
                     items:
                       type: string
                   breachId:
@@ -225,36 +223,21 @@ paths:
                       the `GET /user/breaches` response returns as `id`, not Monitor's
                       internal numeric breach id.
                     type: string
-                  resolved:
-                    type: boolean
-                    description: True to mark resolved; false to mark unresolved.
             examples:
               resolveMultipleBreaches:
                 summary: Resolve multiple breaches
                 value:
                   - breachId: "Adobe"
                     dataClasses: ["passwords"]
-                    resolved: true
                   - breachId: "LinkedIn"
                     dataClasses: ["passwords"]
                     emails: ["alice@example.com"]
-                    resolved: true
               resolvePasswordsOneEmail:
-                summary: Resolve Passwords for one email in one breach
+                summary: Resolve passwords for one email in one breach
                 value:
                   - emails: ["alice@example.com"]
                     dataClasses: ["passwords"]
                     breachId: "Adobe"
-                    resolved: true
-              undoPasswordsAllEmailsInBreach:
-                summary: Unresolve Passwords resolution for all affected emails in multiple breaches
-                value:
-                  - dataClasses: ["passwords"]
-                    resolved: false
-                    breachId: "Adobe"
-                  - dataClasses: ["passwords"]
-                    resolved: false
-                    breachId: "LinkedIn"
       responses:
         "204":
           description: Resolution state updated successfully.

--- a/openapi.yml
+++ b/openapi.yml
@@ -102,6 +102,20 @@ components:
         the `https://identity.mozilla.com/apps/monitor` scope, or the FxA account behind it
         has no Monitor subscriber. This integration serves existing Monitor accounts only and
         never creates one.
+    TooManyRequests:
+      description: Rate limited. Wait the interval in `Retry-After`, then retry.
+      headers:
+        Retry-After:
+          required: true
+          description: Seconds to wait before retrying.
+          schema:
+            type: integer
+            minimum: 1
+    ServiceUnavailable:
+      description: >
+        Monitor is unavailable. This covers our own failures only; an unreachable HIBP is not
+        one of them, since we serve last known breach data as a normal `200` instead. Safe to
+        retry.
 
 paths:
   /user/breaches:
@@ -180,6 +194,10 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /user/breaches/resolutions:
     post:
@@ -283,3 +301,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           description: Breach or email not found (or not visible to this user)
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"

--- a/openapi.yml
+++ b/openapi.yml
@@ -9,6 +9,10 @@ info:
     `Passwords`. This API owns per-user resolution state and uses kebab-case, for
     example `passwords`. The client joins the two on the HIBP breach name, which
     this API returns as `id`.
+
+    "Monitored", used throughout, means the account's primary email address plus any
+    secondary addresses, verified ones only. An unverified address is not monitored:
+    it is never returned here, and a resolution sent for one is rejected.
   version: "1.0.0"
 # The web app already owns /api/v1.
 servers:
@@ -184,6 +188,9 @@ paths:
         - For privacy reasons, if any provided email address is not associated with the authenticated
           user, the server treats the request as if the resource does not exist and returns
           `404 Not Found`.
+        - An address the user owns but has not verified gets that same `404`. It is not a
+          monitored address, and answering identically for both cases keeps the response
+          from revealing which addresses exist on the account.
 
         **Atomicity**
         - Requests are atomic: the update is applied to all targeted emails and dataclasses, or to none.

--- a/openapi.yml
+++ b/openapi.yml
@@ -52,8 +52,7 @@ components:
         message:
           type: string
     DataClass:
-      # Enum so new values stay compatible.
-      description: A kind of data leaked in a breach. This API handles `passwords` alone. Remote Settings serves the same value in HIBP's Title Case, `Passwords`.
+      description: A kind of data leaked in a breach. This API handles `passwords` alone. Remote Settings serves the same value in HIBP's Title Case, `Passwords`. Expect more values later, so treat this as an open set rather than generating a closed type from it.
       type: string
       enum:
         - passwords
@@ -298,7 +297,7 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          description: An unknown `breachId`, a breach this endpoint does not serve, or an email address this user does not monitor. All give the same code and message on purpose, so the response cannot be used to work out which addresses exist on an account.
+          description: An unknown `breachId`, a breach this endpoint does not serve, or an email address this user does not monitor, which includes an address the user owns but has not verified. All give the same code and message on purpose, so the response cannot be used to work out which addresses exist on an account.
           content:
             application/json:
               schema:

--- a/openapi.yml
+++ b/openapi.yml
@@ -333,7 +333,7 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          description: An unknown `breachId`, a breach this endpoint does not serve, or an email address this user does not monitor, which includes an address the user owns but has not verified. All give the same code and message on purpose, so the response cannot be used to work out which addresses exist on an account.
+          description: An unknown `breachId`, a breach this endpoint does not serve, or an email address this user does not monitor, which includes an address the user owns but has not verified. All give the same code and message, so the response does not say which of them applied.
           content:
             application/json:
               schema:

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,7 +1,14 @@
 openapi: "3.1.1"
 info:
   title: Monitor Breach Alerts API
-  description: Monitor's external API for Firefox clients
+  description: |
+    Monitor's external API for Firefox clients.
+
+    Two systems own two halves of the picture, in two different vocabularies.
+    Remote Settings owns breach facts and serves HIBP's Title Case, for example
+    `Passwords`. This API owns per-user resolution state and uses kebab-case, for
+    example `passwords`. The client joins the two on the HIBP breach name, which
+    this API returns as `id`.
   version: "1.0.0"
 # The web app already owns /api/v1.
 servers:

--- a/openapi.yml
+++ b/openapi.yml
@@ -27,52 +27,6 @@ components:
         authenticated user from the token subject (`sub`). All `/user/*` endpoints are scoped
         to the authenticated subject and never return or modify data for any other user.
   schemas:
-    Breach:
-      type: object
-      required:
-        - id
-        - domain
-        - addedDate
-        - breachDate
-        - modifiedDate
-        - dataClasses
-        - isSensitive
-      properties:
-        id:
-          description: A unique identifier for the breach
-          type: string
-        domain:
-          description: |
-            The domain of the primary website the breach occurred on. 
-            This may be used for identifying other assets external systems may have for the site.
-            This value comes from HIBP. See (their API docs)[https://haveibeenpwned.com/api/v3#BreachModel] for more information.
-          type: string
-        breachDate:
-          description: The date (with no time) the breach originally occurred on in ISO 8601 format. This is not always accurate — frequently breaches are discovered and reported long after the original incident. Use this attribute as a guide only.
-          type: string
-          format: date
-        addedDate:
-          description: The date and time (precision to the minute) the breach was added to the system in ISO 8601 format.
-          type: string
-          format: date-time
-        modifiedDate:
-          description: >
-            The date and time (precision to the minute) the breach was modified in ISO 8601 format. 
-            This will only differ from the AddedDate attribute if other attributes represented here are changed 
-            or data in the breach itself is changed (i.e. additional data is identified and loaded). 
-            It is always either equal to or greater then the AddedDate attribute, never less than.
-          type: string
-          format: date-time
-        dataClasses:
-          description: >
-            This attribute describes the nature of the data compromised in the breach and contains an alphabetically
-            ordered string array of impacted data classes. See https://haveibeenpwned.com/api/v3/dataclasses for list of dataclasses.
-          type: array
-          items:
-            type: string
-        isSensitive:
-          description: Indicates if the breach is considered [sensitive](https://haveibeenpwned.com/FAQs#SensitiveBreach)
-          type: boolean
     UserBreachState:
       type: object
       description: Object describing the current breach state and resolutions
@@ -100,11 +54,15 @@ components:
       type: object
       description: A breach affecting 1 or more email addresses tracked by a Monitor User, and resolution actions taken
       required:
-        - breach
+        - id
         - breachedAccounts
       properties:
-        breach:
-          $ref: "#/components/schemas/Breach"
+        id:
+          description: >
+            The HIBP breach name, for example `Adobe`. Firefox already holds this key
+            from the `fxmonitor-breaches` Remote Settings collection, so it joins the
+            breach metadata locally. This is not Monitor's internal numeric breach id.
+          type: string
         breachedAccounts:
           type: array
           items:
@@ -134,7 +92,9 @@ paths:
           in: query
           required: false
           description: >
-            Filter breaches to those whose breach.dataClasses includes any (but not necessarily all) of the specified values.
+            Filter breaches to those that leaked any (but not necessarily all) of the specified
+            data classes. This filters on the breach's own data classes, which the response no
+            longer carries; Firefox reads them from Remote Settings.
           schema:
             type: array
             items:
@@ -194,20 +154,11 @@ paths:
                 hasBreaches:
                   summary: Breaches found
                   value:
-                    - breach:
-                        id: "Breach1"
-                        domain: "example.com"
-                        breachDate: "2023-04-10"
-                        addedDate: "2023-05-01T12:34:00Z"
-                        modifiedDate: "2023-05-01T12:34:00Z"
-                        dataClasses:
-                          - "email-addresses"
-                          - "passwords"
-                        isSensitive: false
+                    - id: "Adobe"
                       breachedAccounts:
                         - email: "alice@example.com"
                           resolvedDataClasses:
-                            Passwords: {}
+                            passwords: {}
                 noResults:
                   summary: No breaches found
                   value: []
@@ -269,7 +220,10 @@ paths:
                     items:
                       type: string
                   breachId:
-                    description: The unique breach identifier
+                    description: >
+                      The HIBP breach name, for example `Adobe`. The same identifier
+                      the `GET /user/breaches` response returns as `id`, not Monitor's
+                      internal numeric breach id.
                     type: string
                   resolved:
                     type: boolean
@@ -278,10 +232,10 @@ paths:
               resolveMultipleBreaches:
                 summary: Resolve multiple breaches
                 value:
-                  - breachId: "Breach1"
+                  - breachId: "Adobe"
                     dataClasses: ["passwords"]
                     resolved: true
-                  - breachId: "Breach2"
+                  - breachId: "LinkedIn"
                     dataClasses: ["passwords"]
                     emails: ["alice@example.com"]
                     resolved: true
@@ -290,17 +244,17 @@ paths:
                 value:
                   - emails: ["alice@example.com"]
                     dataClasses: ["passwords"]
-                    breachId: "Breach1"
+                    breachId: "Adobe"
                     resolved: true
               undoPasswordsAllEmailsInBreach:
                 summary: Unresolve Passwords resolution for all affected emails in multiple breaches
                 value:
                   - dataClasses: ["passwords"]
                     resolved: false
-                    breachId: "Breach1"
+                    breachId: "Adobe"
                   - dataClasses: ["passwords"]
                     resolved: false
-                    breachId: "Breach2"
+                    breachId: "LinkedIn"
       responses:
         "204":
           description: Resolution state updated successfully.

--- a/openapi.yml
+++ b/openapi.yml
@@ -106,21 +106,6 @@ components:
             $ref: "#/components/schemas/UserBreachState"
 
 paths:
-  /user:
-    post:
-      description: >
-        Create a new Monitor user using FxA token; links the new Monitor user to the FxA account
-        specified in the token. Must only be used when terms have been accepted.
-      responses:
-        "201":
-          description: User created successfully.
-        "202":
-          description: Accepted; returned when user already exists
-        "401":
-          description: Authentication required
-        "403":
-          description: Not authorized, or FxA account no longer exists
-
   /user/breaches:
     get:
       description: >

--- a/openapi.yml
+++ b/openapi.yml
@@ -31,12 +31,14 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
-      bearerFormat: JWT
-      description: >
-        Token granted by Firefox Accounts (FxA).
-        The server validates the token (signature, issuer, audience, expiry) and derives the
-        authenticated user from the token subject (`sub`). All `/user/*` endpoints are scoped
-        to the authenticated subject and never return or modify data for any other user.
+      # FxA owns the token format.
+      description: |
+        An OAuth token granted by Firefox Accounts (FxA), carrying the
+        `https://identity.mozilla.com/apps/monitor` scope.
+
+        We introspect the token with FxA, so this contract asserts no token format: do not
+        rely on it being a JWT. Requests are scoped to the token's subject and never touch
+        another user's data.
   schemas:
     DataClass:
       description: >
@@ -88,6 +90,18 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/UserBreachState"
+
+  responses:
+    Unauthorized:
+      description: >
+        No usable token. The `Authorization` header is missing or malformed, or FxA reports
+        the token as inactive or expired.
+    Forbidden:
+      description: >
+        The token is valid but does not grant access, for one of two reasons. Either it lacks
+        the `https://identity.mozilla.com/apps/monitor` scope, or the FxA account behind it
+        has no Monitor subscriber. This integration serves existing Monitor accounts only and
+        never creates one.
 
 paths:
   /user/breaches:
@@ -163,9 +177,9 @@ paths:
                   summary: No breaches found
                   value: []
         "401":
-          description: Authentication required
+          $ref: "#/components/responses/Unauthorized"
         "403":
-          description: Not authorized
+          $ref: "#/components/responses/Forbidden"
 
   /user/breaches/resolutions:
     post:
@@ -264,8 +278,8 @@ paths:
           description: Invalid request, for example an empty batch, an empty `dataClasses` array,
             a malformed email address, or a data class the referenced breach never leaked.
         "401":
-          description: Authentication required
+          $ref: "#/components/responses/Unauthorized"
         "403":
-          description: Not authorized
+          $ref: "#/components/responses/Forbidden"
         "404":
           description: Breach or email not found (or not visible to this user)

--- a/openapi.yml
+++ b/openapi.yml
@@ -52,10 +52,11 @@ components:
         message:
           type: string
     DataClass:
-      description: A kind of data leaked in a breach. This API handles `passwords` alone. Remote Settings serves the same value in HIBP's Title Case, `Passwords`. Expect more values later, so treat this as an open set rather than generating a closed type from it.
+      description: A kind of data leaked in a breach. Remote Settings serves the same values in HIBP's Title Case, `Passwords` and `Email addresses`. Expect more values later, so treat this as an open set rather than generating a closed type from it.
       type: string
       enum:
         - passwords
+        - email-addresses
     UserBreachState:
       type: object
       description: Per-email resolution state for one breach.
@@ -69,7 +70,7 @@ components:
           format: email
         resolvedDataClasses:
           # No timestamp, we store a checked list.
-          description: Data classes this user has marked resolved for this breach, in the privacy panel or on the Monitor website. Scoped to `passwords`, so resolutions of other exposures are not reported here.
+          description: Data classes this user has marked resolved for this breach, in the privacy panel or on the Monitor website. Limited to the data classes this API serves, so resolutions of other exposures on the Monitor website are not reported here.
           type: array
           items:
             $ref: "#/components/schemas/DataClass"
@@ -83,7 +84,7 @@ components:
       properties:
         id:
           # Not the internal numeric breach id.
-          description: The HIBP breach name, for example `Adobe`. Firefox joins the breach metadata locally from the `fxmonitor-breaches` Remote Settings collection.
+          description: The HIBP breach name, for example `Adobe`. Firefox joins the breach metadata locally from the `fxmonitor-breaches` Remote Settings collection. Every `id` returned here is present in that collection, so a client can always resolve one.
           type: string
         breachedAccounts:
           type: array
@@ -155,10 +156,10 @@ paths:
   /user/breaches:
     get:
       operationId: listUserBreaches
-      summary: List password breaches affecting this user
-      # Passwords only, the panel's one action.
+      summary: List breaches affecting this user
+      # Passwords and emails, what the panel acts on.
       description: |
-        Breaches that leaked passwords, with `passwords` resolution state for each monitored email the breach affected.
+        Breaches that leaked passwords or email addresses, with resolution state for each monitored email the breach affected.
 
         **Freshness.** When HIBP is unavailable we serve the last known breach data as a normal `200`, with no staleness signal.
 
@@ -204,6 +205,10 @@ paths:
                       breachedAccounts:
                         - email: "alice@example.com"
                           resolvedDataClasses: ["passwords"]
+                    - id: "Facebook"
+                      breachedAccounts:
+                        - email: "alice@example.com"
+                          resolvedDataClasses: []
                 noResults:
                   summary: No breaches found
                   value: []
@@ -228,7 +233,7 @@ paths:
   /user/breaches/resolutions:
     post:
       operationId: createBreachResolutions
-      summary: Mark password breaches resolved
+      summary: Mark breach data classes resolved
       description: |
         Mark data classes resolved for one or more breaches. Resolutions only move one way, this API cannot unresolve a data class.
 
@@ -262,7 +267,7 @@ paths:
                   dataClasses:
                     type: array
                     minItems: 1
-                    description: Data classes to mark resolved for the selected emails.
+                    description: Data classes to mark resolved for the selected emails. Each must be one the referenced breach actually leaked, so a breach that leaked only email addresses takes `email-addresses`, not `passwords`.
                     items:
                       $ref: "#/components/schemas/DataClass"
                   breachId:
@@ -283,6 +288,11 @@ paths:
                   - emails: ["alice@example.com"]
                     dataClasses: ["passwords"]
                     breachId: "Adobe"
+              resolveEmailOnlyBreach:
+                summary: A breach that leaked no passwords takes email-addresses
+                value:
+                  - breachId: "Facebook"
+                    dataClasses: ["email-addresses"]
       responses:
         "204":
           description: Resolution state updated successfully.
@@ -297,7 +307,7 @@ paths:
                   summary: Data class outside the accepted set
                   value:
                     code: invalid-request
-                    message: "dataClasses[0] must be one of: passwords."
+                    message: "dataClasses[0] must be one of: passwords, email-addresses."
                 malformedEmail:
                   summary: Email is not a valid address
                   value:

--- a/openapi.yml
+++ b/openapi.yml
@@ -154,6 +154,7 @@ components:
 paths:
   /user/breaches:
     get:
+      operationId: listUserBreaches
       summary: List password breaches affecting this user
       # Passwords only, the panel's one action.
       description: |
@@ -226,6 +227,7 @@ paths:
 
   /user/breaches/resolutions:
     post:
+      operationId: createBreachResolutions
       summary: Mark password breaches resolved
       description: |
         Mark data classes resolved for one or more breaches. Resolutions only move one way, this API cannot unresolve a data class.

--- a/openapi.yml
+++ b/openapi.yml
@@ -195,12 +195,19 @@ paths:
         **Atomicity**
         - Requests are atomic: the update is applied to all targeted emails and dataclasses, or to none.
 
+        **Repeated input**
+        - Repeated `breachId` entries are accepted and merged, taking the union of the
+          `(email, dataClass)` pairs they imply. An item that omits `emails` contributes every
+          monitored address affected by that breach. Resolutions only move one way, so
+          duplicates cannot contradict each other and the result does not depend on order.
+
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: array
+              minItems: 1
               items:
                 type: object
                 additionalProperties: false
@@ -248,7 +255,8 @@ paths:
         "204":
           description: Resolution state updated successfully.
         "400":
-          description: Invalid request (e.g., empty dataClasses, invalid email string format, non-unique breach IDs).
+          description: Invalid request, for example an empty batch, an empty `dataClasses` array,
+            or a malformed email address.
         "401":
           description: Authentication required
         "403":

--- a/openapi.yml
+++ b/openapi.yml
@@ -88,7 +88,7 @@ components:
 paths:
   /user/breaches:
     get:
-      description: >
+      description: |
         Get breaches for an authenticated user. Returns a list of breaches; each item includes
         per-email user state for monitored emails affected by that breach.
 
@@ -99,12 +99,19 @@ paths:
         breach's data classes locally via Remote Settings, so it needs no filter to narrow
         this further.
 
+        **Freshness.** When HIBP is unavailable we serve the last known breach data as a
+        normal `200`. The response carries no staleness signal. A client has no useful
+        action to take on one. Breaches typically reach HIBP weeks or months after the incident,
+        so data that is hours behind is not meaningfully worse.
+
       parameters:
         - name: domain
           in: query
           required: false
           description: >
-            Filter breaches by the breached site's primary domain (exact match), e.g. "example.com".
+            Filter breaches by the breached site's primary domain, matched exactly, for example
+            "example.com". Site renames are out of scope for this contract: a breach filed under
+            `twitter.com` does not match `x.com`.
           schema:
             type: string
             minLength: 1
@@ -127,7 +134,13 @@ paths:
 
       responses:
         "200":
-          description: List of breaches associated with emails the user is monitoring
+          description: |
+            Breaches affecting emails this user is monitoring.
+
+            Absence is authoritative. A breach missing from this list means we checked and
+            this user is not affected by it, not that we failed to look. An empty array
+            means the same for every breach. This is what lets a client confidently render
+            a "your info was not in this breach" state.
           content:
             application/json:
               schema:

--- a/openapi.yml
+++ b/openapi.yml
@@ -135,7 +135,14 @@ components:
             code: rate-limited
             message: Too many requests. Retry after 60 seconds.
     ServiceUnavailable:
-      description: Monitor is unavailable.
+      description: Monitor is unavailable. Safe to retry, after the interval in `Retry-After` when it is present.
+      headers:
+        Retry-After:
+          required: false
+          description: Seconds to wait before retrying.
+          schema:
+            type: integer
+            minimum: 1
       content:
         application/json:
           schema:
@@ -153,6 +160,8 @@ paths:
         Breaches that leaked passwords, with `passwords` resolution state for each monitored email the breach affected.
 
         **Freshness.** When HIBP is unavailable we serve the last known breach data as a normal `200`, with no staleness signal.
+
+        **Cadence.** Poll no more than hourly, and once a day is enough. Breaches reach HIBP weeks or months after the incident, so polling harder gains nothing, and the `429` threshold is set with this range in mind.
 
       parameters:
         - name: domain

--- a/openapi.yml
+++ b/openapi.yml
@@ -40,6 +40,16 @@ components:
         rely on it being a JWT. Requests are scoped to the token's subject and never touch
         another user's data.
   schemas:
+    Error:
+      type: object
+      description: >
+        Body of every non-2xx response. `message` explains the particular case, for logs and
+        bug reports. It is not stable, so do not match on it.
+      required:
+        - message
+      properties:
+        message:
+          type: string
     DataClass:
       description: >
         A kind of data leaked in a breach. This API handles `passwords` alone, since
@@ -96,12 +106,31 @@ components:
       description: >
         No usable token. The `Authorization` header is missing or malformed, or FxA reports
         the token as inactive or expired.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            message: FxA reports this token as inactive.
     Forbidden:
       description: >
         The token is valid but does not grant access, for one of two reasons. Either it lacks
         the `https://identity.mozilla.com/apps/monitor` scope, or the FxA account behind it
         has no Monitor subscriber. This integration serves existing Monitor accounts only and
         never creates one.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          examples:
+            missingScope:
+              summary: Token does not carry the Monitor scope
+              value:
+                message: This token lacks the https://identity.mozilla.com/apps/monitor scope.
+            noMonitorAccount:
+              summary: FxA account has never signed up for Monitor
+              value:
+                message: This Firefox account has no Monitor subscriber.
     TooManyRequests:
       description: Rate limited. Wait the interval in `Retry-After`, then retry.
       headers:
@@ -111,11 +140,23 @@ components:
           schema:
             type: integer
             minimum: 1
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            message: Too many requests. Retry after 60 seconds.
     ServiceUnavailable:
       description: >
         Monitor is unavailable. This covers our own failures only; an unreachable HIBP is not
         one of them, since we serve last known breach data as a normal `200` instead. Safe to
         retry.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            message: Monitor is temporarily unavailable.
 
 paths:
   /user/breaches:
@@ -190,6 +231,14 @@ paths:
                 noResults:
                   summary: No breaches found
                   value: []
+        "400":
+          description: A query parameter failed validation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: "domain must not be empty."
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -295,12 +344,38 @@ paths:
         "400":
           description: Invalid request, for example an empty batch, an empty `dataClasses` array,
             a malformed email address, or a data class the referenced breach never leaked.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                unknownDataClass:
+                  summary: Data class outside the accepted set
+                  value:
+                    message: "dataClasses[0] must be one of: passwords."
+                malformedEmail:
+                  summary: Email is not a valid address
+                  value:
+                    message: "emails[0] is not a valid email address."
+                dataClassNotInBreach:
+                  summary: Breach never leaked the requested data class
+                  value:
+                    message: The Adobe breach did not leak passwords.
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
-          description: Breach or email not found (or not visible to this user)
+          description: >
+            An unknown `breachId`, or an email address this user does not monitor. Both give the
+            same code and the same message on purpose, so the response cannot be used to work
+            out which addresses exist on an account.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                message: One or more of the referenced breaches or email addresses was not found.
         "429":
           $ref: "#/components/responses/TooManyRequests"
         "503":

--- a/openapi.yml
+++ b/openapi.yml
@@ -84,7 +84,7 @@ components:
       properties:
         id:
           # Not the internal numeric breach id.
-          description: The HIBP breach name, for example `Adobe`. Firefox joins the breach metadata locally from the `fxmonitor-breaches` Remote Settings collection. Every `id` returned here is present in that collection, so a client can always resolve one.
+          description: The HIBP breach name, for example `Adobe`. It is the `Name` of the matching `fxmonitor-breaches` record, matched exactly and case sensitively.
           type: string
         breachedAccounts:
           type: array
@@ -164,6 +164,8 @@ paths:
         Sensitive breaches, as HIBP marks them, are never returned. The privacy panel must not surface one, so there is no parameter to ask for them. Remote Settings does carry them, flagged, because the credential manager is allowed to.
 
         **Freshness.** Breach metadata comes from a catalog we refresh every 10 minutes, so a new breach can take that long to appear. The per user match is live on every request and is not cached, so there is no last known result to serve when it fails.
+
+        **Joining.** Almost every `id` resolves in `fxmonitor-breaches`, but the collection is slower than this API: it publishes daily, and each batch is signed only after a person reviews it, deliberately, because it ships to every Firefox. So a breach can be live here for days before Firefox sees it, and a HIBP rename retires an id. Skip an id you cannot resolve rather than erroring, and pick it up on a later poll.
 
         **Cadence.** Poll no more than hourly, and once a day is enough. Breaches reach HIBP weeks or months after the incident, so polling harder gains nothing, and the `429` threshold is set with this range in mind.
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -195,6 +195,11 @@ paths:
         **Atomicity**
         - Requests are atomic: the update is applied to all targeted emails and dataclasses, or to none.
 
+        **Validation**
+        - A data class the referenced breach never leaked is a `400`, not a silent skip.
+          Firefox holds every breach's data classes locally via Remote Settings, so it can
+          avoid sending one, and accepting it would write state no interface ever surfaces.
+
         **Repeated input**
         - Repeated `breachId` entries are accepted and merged, taking the union of the
           `(email, dataClass)` pairs they imply. An item that omits `emails` contributes every
@@ -254,9 +259,10 @@ paths:
       responses:
         "204":
           description: Resolution state updated successfully.
+        # Matches the web app's per-breach resolve.
         "400":
           description: Invalid request, for example an empty batch, an empty `dataClasses` array,
-            or a malformed email address.
+            a malformed email address, or a data class the referenced breach never leaked.
         "401":
           description: Authentication required
         "403":

--- a/openapi.yml
+++ b/openapi.yml
@@ -58,9 +58,33 @@ components:
       enum:
         - passwords
         - email-addresses
+    BreachResolution:
+      description: One item of a `POST /user/breaches/resolutions` body. Names a breach and the data classes to mark resolved, applied to every address in `emails`, or to every address the breach affected when `emails` is omitted.
+      type: object
+      additionalProperties: false
+      required:
+        - dataClasses
+        - breachId
+      properties:
+        emails:
+          type: array
+          minItems: 1
+          description: Monitored email addresses to apply the update to. If omitted, applies to every monitored address the referenced breach affected.
+          items:
+            type: string
+            format: email
+        dataClasses:
+          type: array
+          minItems: 1
+          description: Data classes to mark resolved for the selected emails. Each must be one the referenced breach actually leaked, so a breach that leaked only email addresses takes `email-addresses`, not `passwords`. Sending one it did not leak is a `400`, so refresh your Remote Settings copy before retrying.
+          items:
+            $ref: "#/components/schemas/DataClass"
+        breachId:
+          description: The HIBP breach name, as returned by `GET /user/breaches` in `id`.
+          type: string
     UserBreachState:
       type: object
-      description: Per-email resolution state for one breach.
+      description: One entry of `breachedAccounts`. What a single address has resolved for the breach holding it. Each address carries its own list, so two addresses in the same breach can differ.
       required:
         - email
         - resolvedDataClasses
@@ -78,7 +102,7 @@ components:
 
     UserBreach:
       type: object
-      description: One breach affecting this user, with resolution state per affected email.
+      description: One item of the `GET /user/breaches` response. A breach, plus one `UserBreachState` for each monitored address it affected.
       required:
         - id
         - breachedAccounts
@@ -261,28 +285,7 @@ paths:
               type: array
               minItems: 1
               items:
-                type: object
-                additionalProperties: false
-                required:
-                  - dataClasses
-                  - breachId
-                properties:
-                  emails:
-                    type: array
-                    minItems: 1
-                    description: Monitored email addresses to apply the update to. If omitted, applies to every monitored address the referenced breach affected.
-                    items:
-                      type: string
-                      format: email
-                  dataClasses:
-                    type: array
-                    minItems: 1
-                    description: Data classes to mark resolved for the selected emails. Each must be one the referenced breach actually leaked, so a breach that leaked only email addresses takes `email-addresses`, not `passwords`. Sending one it did not leak is a `400`, so refresh your Remote Settings copy before retrying.
-                    items:
-                      $ref: "#/components/schemas/DataClass"
-                  breachId:
-                    description: The HIBP breach name, as returned by `GET /user/breaches` in `id`.
-                    type: string
+                $ref: "#/components/schemas/BreachResolution"
             examples:
               resolveMultipleBreaches:
                 summary: Resolve multiple breaches

--- a/openapi.yml
+++ b/openapi.yml
@@ -276,11 +276,6 @@ paths:
         **Atomicity**
         - Requests are atomic: the update is applied to all targeted emails and dataclasses, or to none.
 
-        **Validation**
-        - A data class the referenced breach never leaked is a `400`, not a silent skip.
-          Firefox holds every breach's data classes locally via Remote Settings, so it can
-          avoid sending one, and accepting it would write state no interface ever surfaces.
-
         **Repeated input**
         - Repeated `breachId` entries are accepted and merged, taking the union of the
           `(email, dataClass)` pairs they imply. An item that omits `emails` contributes every
@@ -340,10 +335,9 @@ paths:
       responses:
         "204":
           description: Resolution state updated successfully.
-        # Matches the web app's per-breach resolve.
         "400":
           description: Invalid request, for example an empty batch, an empty `dataClasses` array,
-            a malformed email address, or a data class the referenced breach never leaked.
+            or a malformed email address.
           content:
             application/json:
               schema:
@@ -357,19 +351,15 @@ paths:
                   summary: Email is not a valid address
                   value:
                     message: "emails[0] is not a valid email address."
-                dataClassNotInBreach:
-                  summary: Breach never leaked the requested data class
-                  value:
-                    message: The Adobe breach did not leak passwords.
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
         "404":
           description: >
-            An unknown `breachId`, or an email address this user does not monitor. Both give the
-            same code and the same message on purpose, so the response cannot be used to work
-            out which addresses exist on an account.
+            An unknown `breachId`, a breach this endpoint does not serve, or an email address
+            this user does not monitor. All give the same message on purpose, so the response
+            cannot be used to work out which addresses exist on an account.
           content:
             application/json:
               schema:

--- a/openapi.yml
+++ b/openapi.yml
@@ -262,7 +262,7 @@ paths:
                   dataClasses:
                     type: array
                     minItems: 1
-                    description: Data classes to mark resolved for the selected emails. Each must be one the referenced breach actually leaked, so a breach that leaked only email addresses takes `email-addresses`, not `passwords`.
+                    description: Data classes to mark resolved for the selected emails. Each must be one the referenced breach actually leaked, so a breach that leaked only email addresses takes `email-addresses`, not `passwords`. Sending one it did not leak is a `400`, so refresh your Remote Settings copy before retrying.
                     items:
                       $ref: "#/components/schemas/DataClass"
                   breachId:
@@ -292,7 +292,7 @@ paths:
         "204":
           description: Resolution state updated successfully.
         "400":
-          description: Invalid request, for example an empty batch, an empty `dataClasses` array, or a malformed email address.
+          description: Invalid request, for example an empty batch, an empty `dataClasses` array, a malformed email address, or a data class the referenced breach never leaked.
           content:
             application/json:
               schema:
@@ -308,6 +308,11 @@ paths:
                   value:
                     code: invalid-request
                     message: "emails[0] is not a valid email address."
+                dataClassNotInBreach:
+                  summary: Breach never leaked the requested data class
+                  value:
+                    code: invalid-request
+                    message: The Facebook breach did not leak passwords.
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":

--- a/openapi.yml
+++ b/openapi.yml
@@ -53,24 +53,17 @@ components:
       description: A data class we report as resolved. `passwords` and `email-addresses` today, but this is an open set, so accept a value you do not recognise instead of rejecting the response.
       type: string
     BreachResolution:
-      description: One entry of a `POST /user/breaches/resolutions` body. Names a breach, the data classes to mark resolved, and the addresses to target.
+      description: One entry of a `POST /user/breaches/resolutions` body. Names a breach and the data classes to mark resolved.
       type: object
       additionalProperties: false
       required:
         - dataClasses
         - breachId
       properties:
-        emails:
-          type: array
-          minItems: 1
-          description: Email addresses to target. Omit it to target every monitored address the breach affected.
-          items:
-            type: string
-            format: email
         dataClasses:
           type: array
           minItems: 1
-          description: Data classes to mark resolved for the selected emails. Each must be one the referenced breach actually leaked, so a breach that leaked only email addresses takes `email-addresses`, not `passwords`. Sending one it did not leak is a `400`, so refresh your Remote Settings copy before retrying.
+          description: Data classes to mark resolved for every monitored address the breach affected. Each must be one the referenced breach actually leaked, so a breach that leaked only email addresses takes `email-addresses`, not `passwords`. Sending one it did not leak is a `400`, so refresh your Remote Settings copy before retrying.
           items:
             $ref: "#/components/schemas/DataClass"
         breachId:
@@ -271,11 +264,11 @@ paths:
       description: |
         Mark data classes resolved for one or more breaches. Resolutions only move one way, this API cannot unresolve a data class.
 
-        Each entry targets the addresses in `emails`, or every monitored address the breach affected when `emails` is omitted. Every address you list in `emails` must be monitored by this user and affected by that breach.
+        Each entry applies to every monitored address the breach affected. There is no way to target one address, as the privacy panel resolves a breach for the whole account.
 
-        Idempotent per `(email, dataClass, breachId)`. Repeated `breachId` entries merge, and order does not matter.
+        Idempotent per `(breachId, dataClass)`. Repeated `breachId` entries merge, and order does not matter.
 
-        Atomic: every targeted email and data class updates, or none does.
+        Atomic: every affected address and data class updates, or none does.
 
       requestBody:
         required: true
@@ -294,13 +287,6 @@ paths:
                     dataClasses: ["passwords"]
                   - breachId: "LinkedIn"
                     dataClasses: ["passwords"]
-                    emails: ["alice@example.com"]
-              resolvePasswordsOneEmail:
-                summary: Resolve passwords for one email in one breach
-                value:
-                  - emails: ["alice@example.com"]
-                    dataClasses: ["passwords"]
-                    breachId: "Adobe"
               resolveEmailOnlyBreach:
                 summary: A breach that leaked no passwords takes email-addresses
                 value:
@@ -310,7 +296,7 @@ paths:
         "204":
           description: Resolution state updated successfully.
         "400":
-          description: Invalid request, for example an empty batch, an empty `emails` or `dataClasses` array, a malformed email address, or a data class the referenced breach never leaked.
+          description: Invalid request, for example an empty batch, an empty `dataClasses` array, an unknown property, or a data class the referenced breach never leaked.
           content:
             application/json:
               schema:
@@ -321,11 +307,6 @@ paths:
                   value:
                     code: invalid-request
                     message: "dataClasses[0] must be one of: passwords, email-addresses."
-                malformedEmail:
-                  summary: Email is not a valid address
-                  value:
-                    code: invalid-request
-                    message: "emails[0] is not a valid email address."
                 dataClassNotInBreach:
                   summary: Breach never leaked the requested data class
                   value:
@@ -340,11 +321,9 @@ paths:
             Nothing here to resolve, for one of:
 
             - an unknown `breachId`, or a breach this endpoint does not serve
-            - an address this user does not monitor, including one they own but have not verified
-            - an address the referenced breach did not affect
-            - an entry that targets nothing: `emails` omitted, and the breach affected no monitored address
+            - a breach that affected no address this user monitors
 
-            All give the same code and message, so the response does not say which of them applied.
+            Both give the same code and message, so the response does not say which of them applied.
           content:
             application/json:
               schema:

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,9 @@
+# Redocly CLI config. See README, "API contract".
+apis:
+  firefox-v1:
+    root: openapi.yml
+rules:
+  # Local development server is deliberate.
+  no-server-example.com: off
+  # No client codegen from this description.
+  operation-operationId: off

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -5,5 +5,3 @@ apis:
 rules:
   # Local development server is deliberate.
   no-server-example.com: off
-  # No client codegen from this description.
-  operation-operationId: off


### PR DESCRIPTION
# References:

Jira: [MNTOR-5342](https://mozilla-hub.atlassian.net/browse/MNTOR-5342)

# Description

Rewrites `openapi.yml`, the contract between Monitor and the Firefox privacy panel. This is to support the Firefox Breach Integration Phase 2

Must not be merged until #6818 is merged, and deployed

The substantive changes:

- **Thin response.** `{ id, breachedAccounts }` only. Firefox already has breach metadata from Remote Settings and joins on the HIBP name.
- **Scoped server-side**, no data-class filters.
- **Serves email-only breaches**, not just password breaches. (This is what depends on #6818 )
- **Errors have a stable `code`** to branch on, a documented body, and examples.
- **A failed HIBP lookup is a `503`.** It used to be an empty `200`, which would have told the panel to clear a user's breach state during an outage.

Also adds `redocly.yaml` and a README section on validating the contract.

# How to test

`npx @redocly/cli@2 lint` passes. No code changes, nothing to run.

Render the docs to read it as Firefox will: `npx @redocly/cli@2 preview-docs openapi.yml`

OR use something like [editor.swagger.io](https://editor.swagger.io/)

# Checklist (Definition of Done)

- [x] Commits in this PR are minimal and have descriptive commit messages.
- [x] I've added or updated the relevant sections in readme and/or code comments

[MNTOR-5342]: https://mozilla-hub.atlassian.net/browse/MNTOR-5342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ