### PR TITLE
Mntor 5363

### DIFF
--- a/src/app/functions/universal/breach.ts
+++ b/src/app/functions/universal/breach.ts
@@ -6,6 +6,11 @@ import { DataClassEffected } from "../../../utils/subscriberBreaches";
 
 // TODO: Move pure functions that operate on breaches to this file
 
+/**
+ * Every kind of data a breach can leak, in Monitor's own kebab-case spelling.
+ * This is what we store, what a HibpLikeDbBreach carries, and what our APIs
+ * speak. See HibpLabelByDataType for how HIBP spells the same things.
+ */
 export const BreachDataTypes = {
   Passwords: "passwords",
   Email: "email-addresses",
@@ -22,6 +27,39 @@ export const BreachDataTypes = {
   General: "general",
 } as const;
 
+/**
+ * The same data types, spelled the way HIBP spells them. Use these only against
+ * a raw HibpGetBreachesResponse. Anything that came from our database already
+ * speaks BreachDataTypes, because formatDataClass converts it at ingestion.
+ *
+ * Keys match BreachDataTypes, so one data type's two spellings line up on one
+ * key. This cannot be a transform, the difference is not mechanical: `pins` is
+ * `PINs` and `ip-addresses` is `IP addresses`. `General` is ours alone with no
+ * HIBP counterpart, hence the Omit.
+ */
+export const HibpLabelByDataType = {
+  Passwords: "Passwords",
+  Email: "Email addresses",
+  SSN: "Social security numbers",
+  CreditCard: "Partial credit card data",
+  BankAccount: "Bank account numbers",
+  PIN: "PINs",
+  IP: "IP addresses",
+  Address: "Physical addresses",
+  DoB: "Dates of birth",
+  Phone: "Phone numbers",
+  SecurityQuestions: "Security questions and answers",
+  HistoricalPasswords: "Historical passwords",
+} as const satisfies Omit<
+  Record<keyof typeof BreachDataTypes, string>,
+  "General"
+>;
+
+/**
+ * The subset of BreachDataTypes that Monitor asks a user to act on, and so the
+ * only ones that appear in the guided resolution flow and in breach alert
+ * emails. The rest are shown as context only.
+ */
 export const ResolutionRelevantBreachDataTypes = {
   Passwords: BreachDataTypes.Passwords,
   Email: BreachDataTypes.Email,

--- a/src/app/functions/universal/breach.ts
+++ b/src/app/functions/universal/breach.ts
@@ -7,9 +7,14 @@ import { DataClassEffected } from "../../../utils/subscriberBreaches";
 // TODO: Move pure functions that operate on breaches to this file
 
 /**
- * Every kind of data a breach can leak, in Monitor's own kebab-case spelling.
- * This is what we store, what a HibpLikeDbBreach carries, and what our APIs
- * speak. See HibpLabelByDataType for how HIBP spells the same things.
+ * The data types we name, in our own kebab-case spelling. This is what we
+ * store and what our APIs speak. See HibpLabelByDataType for HIBP's spelling.
+ *
+ * Not the full list. HIBP adds a data type whenever it sees a new kind of
+ * data, and locales/en/data-classes.ftl lists around 170.
+ *
+ * These are roughly the data types the public breach detail page gives advice
+ * for, see getAllPriorityDataClasses in src/utils/recommendations.ts.
  */
 export const BreachDataTypes = {
   Passwords: "passwords",

--- a/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.test.ts
+++ b/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.test.ts
@@ -134,9 +134,16 @@ describe("updateBreachesInRemoteSettings job", () => {
 
       await main(mockLog);
 
-      expect(addBreachSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ Name: emailOnly.Name }),
-      );
+      // Pins the whole record
+      expect(addBreachSpy).toHaveBeenCalledWith({
+        Name: emailOnly.Name,
+        Domain: emailOnly.Domain,
+        BreachDate: emailOnly.BreachDate,
+        PwnCount: emailOnly.PwnCount,
+        AddedDate: emailOnly.AddedDate,
+        DataClasses: emailOnly.DataClasses,
+        IsSensitive: false,
+      });
     });
     it("skips a breach that leaked neither passwords nor emails", async () => {
       const neither = {

--- a/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.test.ts
+++ b/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.test.ts
@@ -124,6 +124,48 @@ describe("updateBreachesInRemoteSettings job", () => {
       await main(mockLog);
       expect(reviewSpy).not.toHaveBeenCalled();
     });
+    it("syncs a breach that leaked emails but no passwords", async () => {
+      const emailOnly = HibpData[0] as HIBP.HibpGetBreachesResponse[number];
+      expect(emailOnly.DataClasses).not.toContain("Passwords");
+      vi.mocked(HIBP.fetchHibpBreaches).mockResolvedValue([emailOnly]);
+      fetchBreachesSpy.mockResolvedValueOnce(new Set([]));
+      addBreachSpy.mockResolvedValue(undefined);
+      reviewSpy.mockResolvedValue(undefined);
+
+      await main(mockLog);
+
+      expect(addBreachSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ Name: emailOnly.Name }),
+      );
+    });
+    it("skips a breach that leaked neither passwords nor emails", async () => {
+      const neither = {
+        ...(HibpData[0] as HIBP.HibpGetBreachesResponse[number]),
+        Name: "NoUsableDataClasses",
+        DataClasses: ["Names", "Phone numbers"],
+      };
+      vi.mocked(HIBP.fetchHibpBreaches).mockResolvedValue([neither]);
+      fetchBreachesSpy.mockResolvedValueOnce(new Set([]));
+
+      await main(mockLog);
+
+      expect(addBreachSpy).not.toHaveBeenCalled();
+    });
+    it("carries IsSensitive so clients can filter on it", async () => {
+      const sensitive = HibpData.find(
+        (breach) => breach.IsSensitive,
+      ) as HIBP.HibpGetBreachesResponse[number];
+      vi.mocked(HIBP.fetchHibpBreaches).mockResolvedValue([sensitive]);
+      fetchBreachesSpy.mockResolvedValueOnce(new Set([]));
+      addBreachSpy.mockResolvedValue(undefined);
+      reviewSpy.mockResolvedValue(undefined);
+
+      await main(mockLog);
+
+      expect(addBreachSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ Name: sensitive.Name, IsSensitive: true }),
+      );
+    });
     it("happy path: logs counts, posts filtered breaches, requests review, and exits", async () => {
       const breaches = HibpData.slice(0, 3) as HIBP.HibpGetBreachesResponse;
       vi.mocked(HIBP.fetchHibpBreaches).mockResolvedValue(breaches);
@@ -133,8 +175,7 @@ describe("updateBreachesInRemoteSettings job", () => {
 
       await main(mockLog);
       expect(vi.mocked(HIBP.fetchHibpBreaches)).toHaveBeenCalledTimes(1);
-      // First mock breach is ignored because of no passwords
-      expect(addBreachSpy).toHaveBeenCalledTimes(2);
+      expect(addBreachSpy).toHaveBeenCalledTimes(3);
       expect(reviewSpy).toHaveBeenCalledTimes(1);
     });
     it("happy path: exits with code 1 if review fails", async () => {
@@ -149,7 +190,7 @@ describe("updateBreachesInRemoteSettings job", () => {
 
       await main(mockLog);
       expect(vi.mocked(HIBP.fetchHibpBreaches)).toHaveBeenCalledTimes(1);
-      expect(addBreachSpy).toHaveBeenCalledTimes(2);
+      expect(addBreachSpy).toHaveBeenCalledTimes(3);
       expect(reviewSpy).toHaveBeenCalledTimes(1);
       expect(process.exitCode).toEqual(1);
 

--- a/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.test.ts
+++ b/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.test.ts
@@ -142,7 +142,6 @@ describe("updateBreachesInRemoteSettings job", () => {
         PwnCount: emailOnly.PwnCount,
         AddedDate: emailOnly.AddedDate,
         DataClasses: emailOnly.DataClasses,
-        IsSensitive: false,
       });
     });
     it("skips a breach that leaked neither passwords nor emails", async () => {
@@ -157,21 +156,6 @@ describe("updateBreachesInRemoteSettings job", () => {
       await main(mockLog);
 
       expect(addBreachSpy).not.toHaveBeenCalled();
-    });
-    it("carries IsSensitive so clients can filter on it", async () => {
-      const sensitive = HibpData.find(
-        (breach) => breach.IsSensitive,
-      ) as HIBP.HibpGetBreachesResponse[number];
-      vi.mocked(HIBP.fetchHibpBreaches).mockResolvedValue([sensitive]);
-      fetchBreachesSpy.mockResolvedValueOnce(new Set([]));
-      addBreachSpy.mockResolvedValue(undefined);
-      reviewSpy.mockResolvedValue(undefined);
-
-      await main(mockLog);
-
-      expect(addBreachSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ Name: sensitive.Name, IsSensitive: true }),
-      );
     });
     it("happy path: logs counts, posts filtered breaches, requests review, and exits", async () => {
       const breaches = HibpData.slice(0, 3) as HIBP.HibpGetBreachesResponse;

--- a/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.ts
+++ b/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.ts
@@ -12,10 +12,17 @@ import * as HIBP from "../../../utils/hibp";
 import { RemoteSettingsClient } from "../../../utils/remoteSettingsClient";
 import { type Logger } from "winston";
 import { config } from "../../../config";
+import { HibpLabelByDataType } from "../../../app/functions/universal/breach";
 
 type RemoteSettingsBreach = Pick<
   HIBP.HibpGetBreachesResponse[number],
-  "Name" | "Domain" | "BreachDate" | "PwnCount" | "AddedDate" | "DataClasses"
+  | "Name"
+  | "Domain"
+  | "BreachDate"
+  | "PwnCount"
+  | "AddedDate"
+  | "DataClasses"
+  | "IsSensitive"
 >;
 
 export type UpdateBreachesJobConfig = {
@@ -75,7 +82,7 @@ export async function main(parentLogger: Logger) {
   });
   const allHibpBreaches = await HIBP.fetchHibpBreaches();
   const remoteBreaches = await remoteSettings.fetchRemoteBreachNames();
-  // Get all valid password breaches that aren't currently in remote settings
+  // Get all valid password or email breaches that aren't currently in remote settings
   const newBreaches = allHibpBreaches.filter((breach) => {
     return (
       !breach.IsRetired &&
@@ -83,7 +90,8 @@ export async function main(parentLogger: Logger) {
       !breach.IsFabricated &&
       breach.IsVerified &&
       breach.Domain !== "" &&
-      breach.DataClasses.includes("Passwords") &&
+      (breach.DataClasses.includes(HibpLabelByDataType.Passwords) ||
+        breach.DataClasses.includes(HibpLabelByDataType.Email)) &&
       !remoteBreaches.has(breach.Name)
     );
   });
@@ -103,6 +111,8 @@ export async function main(parentLogger: Logger) {
       PwnCount: breach.PwnCount,
       AddedDate: breach.AddedDate,
       DataClasses: breach.DataClasses,
+      // The panel hides these, the credential manager may not.
+      IsSensitive: breach.IsSensitive,
     };
 
     try {

--- a/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.ts
+++ b/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.ts
@@ -9,21 +9,13 @@
 
 import * as Sentry from "@sentry/node";
 import * as HIBP from "../../../utils/hibp";
-import { RemoteSettingsClient } from "../../../utils/remoteSettingsClient";
+import {
+  RemoteSettingsClient,
+  type RemoteSettingsBreach,
+} from "../../../utils/remoteSettingsClient";
 import { type Logger } from "winston";
 import { config } from "../../../config";
 import { HibpLabelByDataType } from "../../../app/functions/universal/breach";
-
-type RemoteSettingsBreach = Pick<
-  HIBP.HibpGetBreachesResponse[number],
-  | "Name"
-  | "Domain"
-  | "BreachDate"
-  | "PwnCount"
-  | "AddedDate"
-  | "DataClasses"
-  | "IsSensitive"
->;
 
 export type UpdateBreachesJobConfig = {
   user: string;

--- a/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.ts
+++ b/src/scripts/cronjobs/updateBreachesInRemoteSettings/updateBreachesInRemoteSettings.ts
@@ -103,8 +103,6 @@ export async function main(parentLogger: Logger) {
       PwnCount: breach.PwnCount,
       AddedDate: breach.AddedDate,
       DataClasses: breach.DataClasses,
-      // The panel hides these, the credential manager may not.
-      IsSensitive: breach.IsSensitive,
     };
 
     try {

--- a/src/utils/hibp.ts
+++ b/src/utils/hibp.ts
@@ -127,7 +127,9 @@ export type HibpGetBreachesResponse = Array<{
   Domain: string;
   AddedDate: ISO8601DateString;
   BreachDate: ISO8601DateString;
-  DataClasses: Array<keyof HibpBreachDataTypes>;
+  // Raw from HIBP, so Title Case: "Email addresses".
+  // See HibpLabelByDataType, and HibpLikeDbBreach below.
+  DataClasses: string[];
   Description: string;
   LogoPath: string;
   IsFabricated: boolean;
@@ -203,7 +205,7 @@ export function formatDataClass(dataClass: string): string {
  */
 // TODO: Add unit test when changing this code:
 /* c8 ignore start */
-function formatDataClassesArray(dataClasses: Array<keyof HibpBreachDataTypes>) {
+function formatDataClassesArray(dataClasses: string[]) {
   return dataClasses.map((dataClass) => formatDataClass(dataClass)) as Array<
     HibpBreachDataTypes[keyof HibpBreachDataTypes]
   >;
@@ -232,6 +234,7 @@ export type HibpLikeDbBreach = {
   PwnCount: BreachRow["pwn_count"];
   Description: BreachRow["description"];
   LogoPath: BreachRow["logo_path"];
+  // Converted at ingestion, so kebab-case: "email-addresses".
   DataClasses: BreachRow["data_classes"];
   IsVerified: BreachRow["is_verified"];
   IsFabricated: BreachRow["is_fabricated"];

--- a/src/utils/hibp.ts
+++ b/src/utils/hibp.ts
@@ -128,7 +128,9 @@ export type HibpGetBreachesResponse = Array<{
   AddedDate: ISO8601DateString;
   BreachDate: ISO8601DateString;
   // Raw from HIBP, so Title Case: "Email addresses".
-  // See HibpLabelByDataType, and HibpLikeDbBreach below.
+  // Stays string[] because HIBP sends far more data types
+  // than HibpLabelByDataType names, and HIBP invents new ones.
+  // See HibpLikeDbBreach below for the kebab-case version.
   DataClasses: string[];
   Description: string;
   LogoPath: string;

--- a/src/utils/remoteSettingsClient.ts
+++ b/src/utils/remoteSettingsClient.ts
@@ -5,9 +5,16 @@
 import type { Logger } from "winston";
 import type { HibpGetBreachesResponse } from "./hibp";
 
-type RemoteSettingsBreach = Pick<
+/** The fields we publish to Remote Settings. */
+export type RemoteSettingsBreach = Pick<
   HibpGetBreachesResponse[number],
-  "Name" | "Domain" | "BreachDate" | "PwnCount" | "AddedDate" | "DataClasses"
+  | "Name"
+  | "Domain"
+  | "BreachDate"
+  | "PwnCount"
+  | "AddedDate"
+  | "DataClasses"
+  | "IsSensitive"
 >;
 
 type RemoteSettingsClientOpts = {

--- a/src/utils/remoteSettingsClient.ts
+++ b/src/utils/remoteSettingsClient.ts
@@ -8,13 +8,7 @@ import type { HibpGetBreachesResponse } from "./hibp";
 /** The fields we publish to Remote Settings. */
 export type RemoteSettingsBreach = Pick<
   HibpGetBreachesResponse[number],
-  | "Name"
-  | "Domain"
-  | "BreachDate"
-  | "PwnCount"
-  | "AddedDate"
-  | "DataClasses"
-  | "IsSensitive"
+  "Name" | "Domain" | "BreachDate" | "PwnCount" | "AddedDate" | "DataClasses"
 >;
 
 type RemoteSettingsClientOpts = {


### PR DESCRIPTION
# References:

Jira: [MNTOR-5363](https://mozilla-hub.atlassian.net/browse/MNTOR-5363)

# Description

We are going to be iterating on our [openapi.yml](https://github.com/mozilla/blurts-server/blob/main/openapi.yml) contract, which is defined between the frontend and the backend for a breach integration. To achieve that with a thin and simple API, we'll be relying on Remote Settings data that is already being pushed. That dataset was missing records.

The sync previously only carried breaches that leaked passwords, so a breach that leaked a user's email but not their password would be invisible to Firefox and the privacy panel could never render it. This PR widens the periodic cron that pushes this data.

The rest of the PR is the types and doc strings that came with that change. HIBP spells data classes differently to us, and nothing in the codebase recorded that.

## Changed since the first review: no `IsSensitive`

This PR originally also wrote an `IsSensitive` field onto each new record. [Vincent and I agreed it is not needed](https://mozilla-hub.atlassian.net/browse/MNTOR-5363?focusedCommentId=1715164): phase 2 only shows breach alerts for breaches the API returns as affecting the user, and the API does not return sensitive breaches, so Firefox never sees one to hide.

# How to test

```sh
npx vitest run src/scripts/cronjobs/updateBreachesInRemoteSettings/ src/utils/hibp.test.ts
```

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added. Not applicable, no user-facing strings.
- [x] Commits in this PR are minimal and have descriptive commit messages.
- [x] I've added or updated the relevant sections in readme and/or code comments. Block comments added to `BreachDataTypes`, `ResolutionRelevantBreachDataTypes` and `HibpLabelByDataType`, which sit together and were easy to confuse.
- [x] I've added a unit test to test for potential regressions of this bug.
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off. Not applicable.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set. Not applicable.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met. The remaining AC is a post-deploy check on the live collection.
- [x] Jira ticket has been updated (if needed) to match changes made during the development process. Summary, description and AC updated to drop `IsSensitive`.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.



[MNTOR-5363]: https://mozilla-hub.atlassian.net/browse/MNTOR-5363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ