### PR TITLE
Mntor 5319

### DIFF
--- a/src/db/redis/client.test.ts
+++ b/src/db/redis/client.test.ts
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
-import { createRedisInstance } from "./util";
-import { redisClient } from "./client";
 import MockRedis from "ioredis-mock";
 import type { Redis } from "ioredis";
 
@@ -13,9 +11,33 @@ vi.mock("@sentry/core", () => ({
     debug: vi.fn(),
   },
 }));
+// Stubs out the only code that builds a real client.
 vi.mock("./util", () => ({
   createRedisInstance: vi.fn(),
 }));
+
+/**
+ * Import a fresh copy of the client module.
+ *
+ * `redisClient()` caches its client in module-level state, which lives as
+ * long as the module registry entry. Import `./client` once at the top of
+ * this file and the first test to call it would fix the client for every
+ * later test. `vi.resetModules()` drops the registry, so the next import
+ * re-runs the module body with `singleton` unset.
+ *
+ * The imports have to be dynamic and have to live in here. A static
+ * top-level import binds before any test runs and `vi.resetModules()` does
+ * not rebind it, so it would keep pointing at the stale copy. `./util` is
+ * re-imported for the same reason: its `vi.mock` factory returns a new
+ * `vi.fn()` per registry, and the test has to assert on the same spy the
+ * client called.
+ */
+async function loadClient() {
+  vi.resetModules();
+  const { createRedisInstance } = await import("./util");
+  const { redisClient } = await import("./client");
+  return { redisClient, createRedisInstance: vi.mocked(createRedisInstance) };
+}
 
 describe("redisClient", () => {
   const originalEnv = process.env;
@@ -27,18 +49,21 @@ describe("redisClient", () => {
     process.env = originalEnv;
   });
 
-  it('returns a MockRedis instance when REDIS_URL includes "redis.mock"', () => {
+  it('returns a MockRedis instance when REDIS_URL includes "redis.mock"', async () => {
     process.env.REDIS_URL = "redis.mock://localhost";
+    const { redisClient, createRedisInstance } = await loadClient();
+
     const client = redisClient();
 
     expect(client).toBeInstanceOf(MockRedis);
     expect(createRedisInstance).not.toHaveBeenCalled();
   });
 
-  it("uses createRedisInstance when REDIS_URL is not defined", () => {
+  it("uses createRedisInstance when REDIS_URL is not defined", async () => {
     delete process.env.REDIS_URL;
+    const { redisClient, createRedisInstance } = await loadClient();
     const fakeClient = {} as unknown as Redis;
-    vi.mocked(createRedisInstance).mockReturnValue(fakeClient);
+    createRedisInstance.mockReturnValue(fakeClient);
 
     const client = redisClient();
 
@@ -46,14 +71,36 @@ describe("redisClient", () => {
     expect(client).toBe(fakeClient);
   });
 
-  it('uses createRedisInstance when REDIS_URL does not include "redis.mock"', () => {
-    process.env.REDIS_URL = "redis://localhost:6379";
+  it('uses createRedisInstance when REDIS_URL does not include "redis.mock"', async () => {
+    // Only string-matched by client.ts; nothing ever dials it.
+    process.env.REDIS_URL = "redis://redis.invalid:6379";
+    const { redisClient, createRedisInstance } = await loadClient();
     const fakeClient = {} as unknown as Redis;
-    vi.mocked(createRedisInstance).mockReturnValue(fakeClient);
+    createRedisInstance.mockReturnValue(fakeClient);
 
     const client = redisClient();
 
     expect(createRedisInstance).toHaveBeenCalledTimes(1);
     expect(client).toBe(fakeClient);
+  });
+
+  it("opens one connection no matter how many times it is called", async () => {
+    process.env.REDIS_URL = "redis://redis.invalid:6379";
+    const { redisClient, createRedisInstance } = await loadClient();
+    createRedisInstance.mockReturnValue({} as unknown as Redis);
+
+    const clients = Array.from({ length: 100 }, () => redisClient());
+
+    expect(createRedisInstance).toHaveBeenCalledTimes(1);
+    expect(new Set(clients).size).toBe(1);
+  });
+
+  it("reuses the mock client too", async () => {
+    process.env.REDIS_URL = "redis.mock://localhost";
+    const { redisClient } = await loadClient();
+
+    const clients = Array.from({ length: 100 }, () => redisClient());
+
+    expect(new Set(clients).size).toBe(1);
   });
 });

--- a/src/db/redis/client.test.ts
+++ b/src/db/redis/client.test.ts
@@ -6,11 +6,10 @@ import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
 import MockRedis from "ioredis-mock";
 import type { Redis } from "ioredis";
 
-vi.mock("@sentry/core", () => ({
-  logger: {
-    debug: vi.fn(),
-  },
-}));
+vi.mock("../../app/functions/server/logging", async () => {
+  const { mockLogger } = await import("../../test/helpers/mockLogger");
+  return { logger: mockLogger() };
+});
 // Stubs out the only code that builds a real client.
 vi.mock("./util", () => ({
   createRedisInstance: vi.fn(),
@@ -27,16 +26,21 @@ vi.mock("./util", () => ({
  *
  * The imports have to be dynamic and have to live in here. A static
  * top-level import binds before any test runs and `vi.resetModules()` does
- * not rebind it, so it would keep pointing at the stale copy. `./util` is
- * re-imported for the same reason: its `vi.mock` factory returns a new
- * `vi.fn()` per registry, and the test has to assert on the same spy the
- * client called.
+ * not rebind it, so it would keep pointing at the stale copy. `./util` and
+ * the logger are re-imported for the same reason: their `vi.mock` factories
+ * return new spies per registry, and the test has to assert on the same
+ * spies the client called.
  */
 async function loadClient() {
   vi.resetModules();
   const { createRedisInstance } = await import("./util");
+  const { logger } = await import("../../app/functions/server/logging");
   const { redisClient } = await import("./client");
-  return { redisClient, createRedisInstance: vi.mocked(createRedisInstance) };
+  return {
+    redisClient,
+    createRedisInstance: vi.mocked(createRedisInstance),
+    logger,
+  };
 }
 
 describe("redisClient", () => {
@@ -51,12 +55,15 @@ describe("redisClient", () => {
 
   it('returns a MockRedis instance when REDIS_URL includes "redis.mock"', async () => {
     process.env.REDIS_URL = "redis.mock://localhost";
-    const { redisClient, createRedisInstance } = await loadClient();
+    const { redisClient, createRedisInstance, logger } = await loadClient();
 
     const client = redisClient();
 
     expect(client).toBeInstanceOf(MockRedis);
     expect(createRedisInstance).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith("redis_client_created", {
+      mock: true,
+    });
   });
 
   it("uses createRedisInstance when REDIS_URL is not defined", async () => {
@@ -93,6 +100,19 @@ describe("redisClient", () => {
 
     expect(createRedisInstance).toHaveBeenCalledTimes(1);
     expect(new Set(clients).size).toBe(1);
+  });
+
+  it("logs its creation once at info", async () => {
+    process.env.REDIS_URL = "redis://redis.invalid:6379";
+    const { redisClient, createRedisInstance, logger } = await loadClient();
+    createRedisInstance.mockReturnValue({} as unknown as Redis);
+
+    Array.from({ length: 100 }, () => redisClient());
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith("redis_client_created", {
+      mock: false,
+    });
   });
 
   it("reuses the mock client too", async () => {

--- a/src/db/redis/client.ts
+++ b/src/db/redis/client.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { logger } from "@sentry/core";
 import { createRedisInstance } from "./util";
+import { logger } from "../../app/functions/server/logging";
 import type { Redis } from "ioredis";
 import MockRedis from "ioredis-mock";
 
@@ -18,12 +18,9 @@ export const redisClient = () => {
     return singleton;
   }
 
-  if (process.env.REDIS_URL?.includes("redis.mock")) {
-    singleton = new MockRedis();
-    logger.debug("redis_mock_client_created_success");
-  } else {
-    singleton = createRedisInstance();
-    logger.debug("redis_client_created_success");
-  }
+  const useMock = process.env.REDIS_URL?.includes("redis.mock") ?? false;
+  singleton = useMock ? new MockRedis() : createRedisInstance();
+  // One line per process, so prod logs prove the reuse.
+  logger.info("redis_client_created", { mock: useMock });
   return singleton;
 };

--- a/src/db/redis/client.ts
+++ b/src/db/redis/client.ts
@@ -11,8 +11,13 @@ export const REDIS_ALL_BREACHES_KEY = "breaches";
 export const REDIS_ALL_DATA_BROKERS_KEY = "dataBrokers";
 export const BREACHES_EXPIRY_SECONDS = 3600 * 12; // 12 hour
 
-let singleton: Redis;
+let singleton: Redis | undefined;
 export const redisClient = () => {
+  // Reuse the connection; a new one would cause a leak
+  if (singleton) {
+    return singleton;
+  }
+
   if (process.env.REDIS_URL?.includes("redis.mock")) {
     singleton = new MockRedis();
     logger.debug("redis_mock_client_created_success");

--- a/src/db/redis/util.test.ts
+++ b/src/db/redis/util.test.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from "vitest";
+import { retryStrategy } from "./util";
+
+describe("retryStrategy", () => {
+  it("waits longer after each attempt", () => {
+    expect(retryStrategy(1)).toBe(200);
+    expect(retryStrategy(2)).toBe(400);
+    expect(retryStrategy(3)).toBe(600);
+  });
+
+  it("caps the wait so a long outage keeps retrying", () => {
+    expect(retryStrategy(25)).toBe(5000);
+    expect(retryStrategy(100_000)).toBe(5000);
+  });
+
+  it("never throws, so a refused connection cannot kill the process", () => {
+    // The old implementation threw once times > 3.
+    for (const times of [4, 5, 50, 100_000]) {
+      expect(() => retryStrategy(times)).not.toThrow();
+      expect(retryStrategy(times)).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/db/redis/util.test.ts
+++ b/src/db/redis/util.test.ts
@@ -13,8 +13,14 @@ describe("retryStrategy", () => {
   });
 
   it("caps the wait so a long outage keeps retrying", () => {
-    expect(retryStrategy(25)).toBe(5000);
-    expect(retryStrategy(100_000)).toBe(5000);
+    expect(retryStrategy(5)).toBe(1000);
+    expect(retryStrategy(100_000)).toBe(1000);
+  });
+
+  it("keeps the cap low enough to bound a request stall", () => {
+    // enableOfflineQueue is on, so this cap is also how long a page render
+    // waits before it can fall back to Postgres.
+    expect(retryStrategy(100_000)).toBeLessThanOrEqual(1000);
   });
 
   it("never throws, so a refused connection cannot kill the process", () => {

--- a/src/db/redis/util.ts
+++ b/src/db/redis/util.ts
@@ -6,7 +6,24 @@ import { Redis, RedisOptions } from "ioredis";
 import { redisConfiguration } from "./configuration";
 import { logger } from "../../app/functions/server/logging";
 
-// TODO: Testing
+// Long enough to stop hammering, short enough to recover.
+const MAX_RETRY_DELAY_MS = 5000;
+
+/**
+ * How long ioredis waits before retrying a lost connection.
+ *
+ * This must never throw. ioredis calls it outside any try/catch, so a throw
+ * here escapes as an uncaught exception and takes the process down instead
+ * of letting the connection heal. Returning a delay every time means a
+ * refused connection keeps retrying until Redis comes back.
+ *
+ * @param times how many reconnect attempts have already been made
+ * @returns milliseconds to wait before the next attempt
+ */
+export function retryStrategy(times: number): number {
+  return Math.min(times * 200, MAX_RETRY_DELAY_MS);
+}
+
 /* c8 ignore start */
 function getRedisConfiguration(): {
   port: number;
@@ -24,13 +41,7 @@ export function createRedisInstance(config = getRedisConfiguration()) {
       showFriendlyErrorStack: true,
       enableAutoPipelining: true,
       maxRetriesPerRequest: 0,
-      retryStrategy: (times: number) => {
-        if (times > 3) {
-          throw new Error(`Redis Could not connect after ${times} attempts`);
-        }
-
-        return Math.min(times * 200, 1000);
-      },
+      retryStrategy,
     };
 
     if (config.port) {

--- a/src/db/redis/util.ts
+++ b/src/db/redis/util.ts
@@ -6,8 +6,7 @@ import { Redis, RedisOptions } from "ioredis";
 import { redisConfiguration } from "./configuration";
 import { logger } from "../../app/functions/server/logging";
 
-// Long enough to stop hammering, short enough to recover.
-const MAX_RETRY_DELAY_MS = 5000;
+const MAX_RETRY_DELAY_MS = 1000;
 
 /**
  * How long ioredis waits before retrying a lost connection.
@@ -16,6 +15,11 @@ const MAX_RETRY_DELAY_MS = 5000;
  * here escapes as an uncaught exception and takes the process down instead
  * of letting the connection heal. Returning a delay every time means a
  * refused connection keeps retrying until Redis comes back.
+ *
+ * The cap doubles as the worst-case per-request stall. `enableOfflineQueue`
+ * is on, so a command issued while Redis is down is only rejected when the
+ * next reconnect attempt fails. Raising the cap would leave every render
+ * holding a request slot for that long before it can fall back to Postgres.
  *
  * @param times how many reconnect attempts have already been made
  * @returns milliseconds to wait before the next attempt


### PR DESCRIPTION
# References:

Jira: [MNTOR-5319](https://mozilla-hub.atlassian.net/browse/MNTOR-5319)

Incident doc: [2026-09-03 Monitor Website Unresponsive](https://docs.google.com/document/d/1arUsmpbZwPQZtPT1zu0RsOKNXcePvE0pRMbVil877zA/edit)

# Description

[`redisClient()`](https://github.com/mozilla/blurts-server/blob/783560d3aee8f583c62ac0cab6cacb52d0c99e4b/src/db/redis/client.ts#L14-L23) declared a module-level `singleton` but never read it, so every call opened a new ioredis connection and abandoned the previous one. [`getAllBreachesFromDb()`](https://github.com/mozilla/blurts-server/blob/783560d3aee8f583c62ac0cab6cacb52d0c99e4b/src/utils/hibp.ts#L278-L280) calls it per request, so the web tier leaked roughly one socket per request until Memorystore hit its 64,998 `maxclients` ceiling.

Deploys and pod restarts have been silently protecting prod from this, as the connections would be cleared out.

Scope note: this PR was originally larger. The breach read-path hardening moved out to [MNTOR-5378](https://mozilla-hub.atlassian.net/browse/MNTOR-5378) with its own PR, and the per-request catalogue parse to [MNTOR-5380](https://mozilla-hub.atlassian.net/browse/MNTOR-5380), so this one touches `src/db/redis/` only.

# Testing Before and After

Built for production twice, once on `main` and once on this branch, pointed `REDIS_URL` at a throwaway `docker run -d --name redis-demo -p 6379:6379 redis:7-alpine`, then fired 300 requests at `/en/breaches` with concurrency 10 while sampling `redis-cli info clients` once a second.

Redis connections:

| sec | main | this branch |
| --- | ---- | ----------- |
| 1 | 0 | 1 |
| 5 | 60 | 1 |
| 10 | 134 | 1 |
| 15 | 210 | 1 |
| 20 | 283 | 1 |
| 22, load ends | 300 | 1 |
| 30 | 300 | 1 |

One socket per request, and they are never released. That last row is the incident in miniature: nothing reclaims them until the pod dies.

Response times, same 300 requests. Sharing one connection instead of 300 was the thing I was most worried about, and it turns out to be slightly faster, because removing a TCP handshake per request more than pays for the serialised reply.

| | p50 | p95 | p99 | max |
| --- | --- | --- | --- | --- |
| main | 688ms | 807ms | 977ms | 996ms |
| this branch | 683ms | 763ms | 831ms | 966ms |

Separately, stopping Redis for 8 seconds under a live client: `main` dies at t≈1.2s with `Redis Could not connect after 4 attempts`.

# How to test

```sh
npx vitest run src/db/redis
```

Each regression case fails on `main`, which reports:

- [`client.test.ts`](https://github.com/mozilla/blurts-server/blob/783560d3aee8f583c62ac0cab6cacb52d0c99e4b/src/db/redis/client.test.ts): 100 connections for 100 calls
- `util.test.ts`: throws at `retryStrategy(4)`

# Checklist (Definition of Done)

- [x] Localization strings (if needed) have been added. Not applicable, no user-facing strings.
- [x] Commits in this PR are minimal and have descriptive commit messages. Four commits, each with its own tests.
- [x] I've added or updated the relevant sections in readme and/or code comments. `retryStrategy` carries a doc comment explaining why it must never throw, and why the cap doubles as the worst-case per-request stall.
- [x] I've added a unit test to test for potential regressions of this bug. One per commit, each verified to fail on `main`.
- [x] If this PR implements a feature flag or experimentation, I've checked that it still works with the flag both on, and with the flag off. Not applicable, see above for why there is no flag.
- [x] If this PR implements a feature flag or experimentation, the Ship Behind Feature Flag status in Jira has been set. Not applicable.
- [ ] Product Owner accepted the User Story (demo of functionality completed) or waived the privilege.
- [ ] All acceptance criteria are met. Two of three in code. The third, Sentry FIREFOX-MONITOR-D5H and 6HV no longer recurring, is confirmed post-deploy.
- [ ] Jira ticket has been updated (if needed) to match changes made during the development process.
- [ ] Jira ticket has been updated (if needed) with suggestions for QA when this PR is deployed to stage.

# Follow Up Action

Watch `redis.googleapis.com/clients/connected` for 24 to 48h after deploy. It should stay near its ~450 floor instead of climbing.


[MNTOR-5319]: https://mozilla-hub.atlassian.net/browse/MNTOR-5319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[MNTOR-5378]: https://mozilla-hub.atlassian.net/browse/MNTOR-5378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ